### PR TITLE
install: make Dockerfile self-contained

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN ln -s /usr/local/lib/python3.10/dist-packages/tensorrt_libs/libnvinfer.so.* 
 ENV LD_LIBRARY_PATH=$TRT_LIBPATH:$LD_LIBRARY_PATH
 
 # Find and install requirements.txt files for all examples
-COPY . /workspace/TensorRT-Model-Optimizer
+RUN git clone https://github.com/NVIDIA/TensorRT-Model-Optimizer
 RUN find /workspace/TensorRT-Model-Optimizer -name "requirements.txt" | while read req_file; do \
     echo "Installing from $req_file"; \
     pip install -r "$req_file"; \


### PR DESCRIPTION
The current dockerfile makes an assumption about it being built from inside the clone of the repo, and doesn't check that it is so, resulting in a whole step of installing example requirements silently being skipped when it is not so.

This PR replaces the silent assumption and replaces with a solution which will work regardless of where the Dockerfile is run from.

In other words the Dockerfile can now be used outside of this repo.

cc: @cjluo-omniml 