### PR TITLE
Implement OpenAI Whisper Model

### DIFF
--- a/modelopt/torch/export/model_config.py
+++ b/modelopt/torch/export/model_config.py
@@ -516,13 +516,6 @@ class MedusaHeadConfig:
 
 
 @dataclass
-class FeatureExtractorConfig:
-    """The feature extractor config."""
-
-    layers: list[ConvConfig] = field(default_factory=list)
-
-
-@dataclass
 class ModelConfig:
     """The full LLM model config that includes the full information needed for tensorrt_llm engine building.
 
@@ -566,7 +559,7 @@ class ModelConfig:
     encoder_head_size: int = 0
 
     # For decoder of Encoder-Decoder model that has encoder feature extractor
-    feature_extractor: FeatureExtractorConfig = FeatureExtractorConfig()
+    feature_extractor: list[ConvConfig] = field(default_factory=list)
 
     @property
     def vocab_size_padded(self):

--- a/modelopt/torch/export/model_config.py
+++ b/modelopt/torch/export/model_config.py
@@ -516,6 +516,13 @@ class MedusaHeadConfig:
 
 
 @dataclass
+class FeatureExtractorConfig:
+    """The feature extractor config."""
+
+    layers: list[ConvConfig] = field(default_factory=list)
+
+
+@dataclass
 class ModelConfig:
     """The full LLM model config that includes the full information needed for tensorrt_llm engine building.
 
@@ -557,6 +564,9 @@ class ModelConfig:
     encoder_hidden_size: int = 0
     encoder_num_heads: int = 0
     encoder_head_size: int = 0
+
+    # For decoder of Encoder-Decoder model that has encoder feature extractor
+    feature_extractor: FeatureExtractorConfig = FeatureExtractorConfig()
 
     @property
     def vocab_size_padded(self):

--- a/modelopt/torch/export/model_config_export.py
+++ b/modelopt/torch/export/model_config_export.py
@@ -325,7 +325,7 @@ def torch_to_tensorrt_llm_checkpoint(
                     update_lm_head_quantization(config, module, inference_pipeline_parallel)
                     config.lm_head = build_linear_config(module, "column")
             elif is_conv(module):
-                config.feature_extractor.layers.append(build_conv_config(module))
+                config.feature_extractor.append(build_conv_config(module))
 
         # For decoder of Encoder-Decoder model, it needs some encoder information
         if decoder_type in ["t5"]:
@@ -517,8 +517,8 @@ def export_tensorrt_llm_checkpoint(
                             "transformer.position_embedding", "position_embedding"
                         )
                         module = module.replace("transformer.ln_f", "ln_post")
-                        module = module.replace("transformer.feature_extractor.layers.0", "conv1")
-                        module = module.replace("transformer.feature_extractor.layers.1", "conv2")
+                        module = module.replace("transformer.feature_extractor.0", "conv1")
+                        module = module.replace("transformer.feature_extractor.1", "conv2")
                         new_exclude_modules.append(module)
                     else:
                         module = module.replace("transformer.layers", "decoder_layers")
@@ -589,8 +589,8 @@ def export_tensorrt_llm_checkpoint(
                             "transformer.position_embedding", "position_embedding"
                         )
                         new_key = new_key.replace("transformer.ln_f", "ln_post")
-                        new_key = new_key.replace("transformer.feature_extractor.layers.0", "conv1")
-                        new_key = new_key.replace("transformer.feature_extractor.layers.1", "conv2")
+                        new_key = new_key.replace("transformer.feature_extractor.0", "conv1")
+                        new_key = new_key.replace("transformer.feature_extractor.1", "conv2")
                     else:
                         new_key = key.replace("transformer.layers", "decoder_layers")
                         new_key = new_key.replace(


### PR DESCRIPTION
This PR aims to enable exporting HF Whisper implementation to TRT-LLM checkpoint.
Although TRT already has a conversion script for both HF and original implementation, but implementing it here enables users to use `modelopt` for optimization and quantization techniques that aren't available yet in TRT-LLM

There are some sharp edges in this implementation, mostly because this is the second Enc-Dec model to be implemented after T5 so they are handled as edge cases, perhaps having a generalized Enc-Dec path can be better, also there might be some code duplication between whisper and T5 in TRT-LLM config creation that can be unified