### PR TITLE
Added check of the output names while removing cast nodes

### DIFF
--- a/modelopt/onnx/quantization/qdq_utils.py
+++ b/modelopt/onnx/quantization/qdq_utils.py
@@ -441,10 +441,20 @@ def qdq_to_dq(
         cast_indices = []
 
         tensor_consumers = get_tensor_consumer_nodes(graph)
+        output_names = [output.name for output in graph.output]
 
         # find all Cast node with same input and output type
         for node_idx, node in enumerate(graph.node):
             if node.op_type != "Cast":
+                continue
+
+            last_node = False
+            for node_output_name in node.output:
+                if node_output_name in output_names:
+                    last_node = True
+                    break
+
+            if last_node:
                 continue
 
             # if input type matches attribute "to", this is a useless Cast node


### PR DESCRIPTION
Added checks for the cast Node when removing unnecessary cast Nodes.

Encountered to an issue where the Cast node is previous node of the model output and the model output is removed with Cast Node too. 

You can find the ONNX model and script to reproduce the bug
https://drive.google.com/drive/folders/1MAu8B0z7nXCccXpVrxv5_B4jB98BQXe6?usp=sharing

The model is the encoder part of stt_en_fastconformer_ctc_large model from NeMo exported to ONNX