### PR TITLE
Contribution baseten.co / engine builder: better dataloader in trt-llm

### DIFF
--- a/modelopt/torch/utils/dataset_utils.py
+++ b/modelopt/torch/utils/dataset_utils.py
@@ -302,7 +302,6 @@ def create_forward_loop(
         if batch_size == 0:
             batch_size = get_max_batch_size(model, max_sample_length)
             print(f"Update calib batch {batch_size}")
-
         dataloader = get_dataset_dataloader(
             dataset_name=dataset_name,
             tokenizer=tokenizer,


### PR DESCRIPTION
Contribution by baseten.co (running the https://docs.baseten.co/performance/engine-builder-overview engine-builder product)

This PR:
- guarantees OOM-free quantization as fallback, by sequentially lowering the batch size - its a superset of the current "lower by 2 once" low_mem_mode.

In my opinion, this PR should not be required. However the following circumstances have made it necessary:
- https://github.com/NVIDIA/TensorRT-LLM/blob/2ea17cdad28bed0f30e80eea5b1380726a7c6493/tensorrt_llm/quantization/quantize_by_modelopt.py#L458 is currently commented out - the ModelOPT code path is not used.
- max_batch_size is an `external / non-default` argument. 
```
def quantize_and_export(*,
                        model_dir,
                        device,
                        calib_dataset: str
                        batch_size: int,
```
at the time of setting this 
- to determine the batch_size, we need to load the model. In trt-llm, the model is typically not loaded. Loading the model twice (e.g. 70B llama) would likely lead to a long loading time or an OOM if the model is not freed. A size based on the model safetensors is not possible, as this depends entirely on.g. if the weights will be loaded from fp32 -> fp16

How to solve it:
- tensorrt-llm should use the modelopt workflow - this would not fix the problem, as it does not use `batch_size = get_max_batch_size(model, max_sample_length)` function yet.
-  this PR needs to be implemented in trt-llm or here, best both.
