### PR TITLE
Fix: examples/onn_ptq/image_prep.py had fp16 argument that wasn't uti…

### DIFF
--- a/examples/onnx_ptq/image_prep.py
+++ b/examples/onnx_ptq/image_prep.py
@@ -50,6 +50,8 @@ def main():
         calib_tensor.append(transforms(image))
 
     calib_tensor = np.stack(calib_tensor, axis=0)
+    if args.fp16:
+        calib_tensor = calib_tensor.astype(np.float16)
     np.save(args.output_path, calib_tensor)
 
 


### PR DESCRIPTION
Simple bug fix for example at:
examples/onnx_ptq/image_prep.py which had argument for casting array to fp16 but didn't use it anywhere which would cause error when trying to use onnx model with fp16 input. 

## What does this PR do?
Small bug fix in example

**Type of change:** Bug fix

**Overview:** Simple change to properly downcast to np.float16

## Usage
Following command now works properly

```shell
python image_prep.py   --calibration_data_size=500 --output_path=calib.npy --fp16
```

## Testing
Run script with onnx fp16 model which previously failed due to this bug


## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)**
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: No
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No

