### PR TITLE
[BUG] LayerNorm without affine params causes errors

### DIFF
--- a/modelopt/torch/quantization/qtensor/base_qtensor.py
+++ b/modelopt/torch/quantization/qtensor/base_qtensor.py
@@ -149,7 +149,7 @@ def pack_real_quantize_weight(module, force_quantize: bool = False):
 
     with SequentialQuantizer.convert_to_single_quantizer(module), torch.no_grad():
         for _, m in module.named_modules():
-            if hasattr(m, "weight") and m.weight.is_meta:
+            if hasattr(m, "weight") or (m.weight is None and m.weight.is_meta):
                 continue
             if (
                 hasattr(m, "weight_quantizer")


### PR DESCRIPTION
## What does this PR do?

Error occurs when we check `m.weights.is_meta` [here](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/modelopt/torch/quantization/qtensor/base_qtensor.py#L152) for module of type `nn.LayerNorm` with affine params as False, because it initializes weights as None [see here](https://github.com/pytorch/pytorch/blob/main/torch/nn/modules/normalization.py#L205) 

This change checks for weights being None and bypasses the module if it holds true