### PR TITLE
Fix Qwen2.5-VL FP8

### DIFF
--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -56,7 +56,7 @@ def get_tokenizer(ckpt_path, trust_remote_code=False, **kwargs):
         ckpt_path, trust_remote_code=trust_remote_code, **kwargs
     )
 
-    if "qwen" in type(tokenizer).__name__.lower():
+    if "qwen" in type(tokenizer).__name__.lower() and "vl" not in ckpt_path.lower():
         # qwen use token id 151643 as pad and eos tokens
         tokenizer.pad_token = tokenizer.convert_ids_to_tokens(151643)
         tokenizer.eos_token = tokenizer.convert_ids_to_tokens(151643)

--- a/examples/vlm_ptq/scripts/huggingface_example.sh
+++ b/examples/vlm_ptq/scripts/huggingface_example.sh
@@ -145,6 +145,10 @@ case "${MODEL_TYPE}" in
         VISUAL_FEATURE=576
         VLM_ARGS=" --max_multimodal_len=$((BUILD_MAX_BATCH_SIZE * VISUAL_FEATURE)) "
         ;;
+    "qwen")
+        VISUAL_FEATURE=1280
+        VLM_ARGS=" --max_multimodal_len=$((BUILD_MAX_BATCH_SIZE * VISUAL_FEATURE)) "
+        ;;
     "mllama")
         PTQ_ARGS+=" --kv_cache_qformat none "
         VLM_ARGS=" --max_encoder_input_len=6404 --skip_run"


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

**Overview:** 
1. Fixed the issue that Qwen2.5-VL's eos token was mistakenly modified.

## Usage
<!-- You can potentially add a usage example below. -->

```bash
bash vlm_ptq/scripts/huggingface_example.sh --type qwen --model $HF_PATH --quant fp8 --tp 1 --export_fmt hf
```

## Testing
<!-- Mention how have you tested your change if applicable. -->


## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->


## Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced VLM example script to support Qwen using visual-length parameters, automatically computing max multimodal length based on batch size and visual feature dimension.
- Bug Fixes
  - Adjusted tokenizer behavior to avoid forcing pad/eos tokens for Qwen models when the checkpoint path indicates a VL variant, preventing incorrect token settings.
- Chores
  - Updated configuration logic to align Qwen handling with other VLMs, removing the previous quantization-specific path and standardizing argument computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->