### PR TITLE
Changing gitlab pipeline and jobs to be manually triggered

### DIFF
--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -1,9 +1,8 @@
 # NOTE: Make sure this file is consistent with .github/workflows/{unit,gpu}_tests.yml
 .tests-default:
   stage: tests
+  when: manual # Default manual trigger
   rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
-      when: manual
     - if: $CI_PIPELINE_SOURCE != "web"
       when: never
 

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -2,7 +2,10 @@
 .tests-default:
   stage: tests
   rules:
-    - if: $CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "external_pull_request_event"
+    - if: $CI_PIPELINE_SOURCE == "web"
+      when: manual
+    - if: $CI_PIPELINE_SOURCE != "web"
+      when: never
 
 ##### Unit Tests #####
 unit:
@@ -65,7 +68,7 @@ example-ada:
       - TEST: [onnx_ptq]
         TEST_TYPE: bash
 
-##### [WIP] Megatron / NeMo Integration Tests #####
+##### Megatron / NeMo Integration Tests #####
 megatron-nemo-integration:
   extends: .tests-default
   variables:

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -1,10 +1,11 @@
 # NOTE: Make sure this file is consistent with .github/workflows/{unit,gpu}_tests.yml
 .tests-default:
   stage: tests
-  when: manual # Default manual trigger
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: always
+    - if: $CI_PIPELINE_SOURCE != "schedule"
+      when: manual
 
 ##### Unit Tests #####
 unit:

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -5,7 +5,7 @@
     - if: $JET_ONLY != null
       when: never
     - if: $CI_COMMIT_TAG =~ /^\d+\.\d+\.\d+$/
-    - if: $CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "external_pull_request_event"
 
 ##### Unit Tests #####
 unit:

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -68,7 +68,7 @@ example-ada:
       - TEST: [onnx_ptq]
         TEST_TYPE: bash
 
-##### Megatron / NeMo Integration Tests #####
+##### [WIP] Megatron / NeMo Integration Tests #####
 megatron-nemo-integration:
   extends: .tests-default
   variables:

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -2,9 +2,6 @@
 .tests-default:
   stage: tests
   rules:
-    - if: $JET_ONLY != null
-      when: never
-    - if: $CI_COMMIT_TAG =~ /^\d+\.\d+\.\d+$/
     - if: $CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "external_pull_request_event"
 
 ##### Unit Tests #####

--- a/.gitlab/tests.yml
+++ b/.gitlab/tests.yml
@@ -3,8 +3,8 @@
   stage: tests
   when: manual # Default manual trigger
   rules:
-    - if: $CI_PIPELINE_SOURCE != "web"
-      when: never
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+      when: always
 
 ##### Unit Tests #####
 unit:


### PR DESCRIPTION
## What does this PR do?

**Type of change:** new tests <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

**Overview:** When GH PR is created or updated. Maintainer wait or pull in gitlab mirror. Before merging in GH, maintainers can manually trigger gitlab CI on the mirrored branch. All jobs in the pipeline also need to be triggered manually.

## Testing
<!-- Mention how have you tested your change if applicable. -->
N/A

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: No
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated CI test job triggers: scheduled pipelines now run tests automatically; non-scheduled pipelines require manual initiation. Auto-triggering based on tags and web events was removed.

- Tests
  - No changes to test content or coverage; only how and when test jobs are executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->