### PR TITLE
[5477976] Fix: issue removing Q/DQ nodes around custom ops with constant inputs

### DIFF
--- a/modelopt/onnx/trt_utils.py
+++ b/modelopt/onnx/trt_utils.py
@@ -416,9 +416,10 @@ def interpret_trt_plugins_precision_flag(
             # Will add Q/DQ nodes in the requested I/O indices
             inp_precision_quant = [i for i, p in enumerate(inp_precision) if p in ["int8", "fp8"]]
             out_precision_quant = [i for i, p in enumerate(out_precision) if p in ["int8", "fp8"]]
-            custom_ops_to_quantize[op_type] = {
-                "inp": inp_precision_quant,
-                "out": out_precision_quant,
-            }
+            if inp_precision_quant or out_precision_quant:
+                custom_ops_to_quantize[op_type] = {
+                    "inp": inp_precision_quant,
+                    "out": out_precision_quant,
+                }
 
     return custom_ops_to_cast, custom_ops_to_quantize


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:** Fixed issue when quantizing constant inputs in custom ops. This was caused by the DQ in input and Q in output removal function assuming that there was a node before and after the QDQs for graph edge rewiring. That's fixed by this PR.

## Usage
Can be used with any model with custom ops.

## Testing
1. Follow steps in https://github.com/NVIDIA/DL4AGX/tree/master/AV-Solutions/bevformer-int8-eq to export the ONNX file and compile the plugin.
2. Quantize model:
```sh
python -m modelopt.onnx.quantization \
  --onnx_path=bevformer_tiny_epoch_24_cp2_op13_simp.onnx \
  --calibration_eps trt cuda:0 cpu \
  --trt_plugins ./libs/libtensorrt_ops.so \
  --trt_plugins_precision  MultiScaleDeformableAttnTRT2:[fp16,int64,fp16,fp16,fp16]:[fp16] \
  --high_precision_dtype fp16
```

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: N/A
- **Did you add or update any necessary documentation?**: N/A
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No

## Additional Information
None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness in quantization graph rewiring to handle missing upstream or downstream nodes without errors.
  * Adds defensive fallbacks that preserve original tensor connections when producers or consumers are absent, maintaining processing continuity.
  * Avoids creating empty precision entries for TensorRT plugin handling by only recording ops that actually use int8/fp8 indices.

* **Chores**
  * No changes to public APIs or interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->