### PR TITLE
[5504719] Fix bypassing of 'Cast' connecting a consumer with multiple outputs a…

### DIFF
--- a/modelopt/onnx/autocast/precisionconverter.py
+++ b/modelopt/onnx/autocast/precisionconverter.py
@@ -579,24 +579,23 @@ class PrecisionConverter:
 
         input_tensor = node.input[0]
         output_tensor = node.output[0]
-        is_output_producer = False
 
-        # If removed cast node is producing a network output, we need to update the node producing the cast
-        # Network output name should not be changed
-        for output in self.model.graph.output:
-            if output.name == output_tensor:
-                is_output_producer = True
-                producers = utils.get_producer_nodes(self.model, input_tensor)
-                for producer in producers:
-                    for i, prod_out in enumerate(producer.output):
-                        if prod_out == input_tensor:
-                            producer.output[i] = output_tensor
-                            consumers = utils.get_consumer_nodes(self.model, prod_out)
-                            if len(consumers) > 1:
-                                self._replace_tensor_name(consumers, prod_out, output_tensor)
-        if (
-            not is_output_producer
-        ):  # Reconnect consumers of the cast output to use the cast input instead
+        # Check if the cast output is also a graph output
+        is_output_producer = any(output.name == output_tensor for output in self.model.graph.output)
+
+        # If the removed cast node is producing a network output, we need to update the node producing the cast, as
+        #   the network output name should not be changed
+        if is_output_producer:
+            producers = utils.get_producer_nodes(self.model, input_tensor)
+            for producer in producers:
+                for i, prod_out in enumerate(producer.output):
+                    if prod_out == input_tensor:
+                        producer.output[i] = output_tensor
+                        consumers = utils.get_consumer_nodes(self.model, prod_out)
+                        if len(consumers) > 1:
+                            self._replace_tensor_name(consumers, prod_out, output_tensor)
+        else:
+            # Reconnect consumers of the cast output to use the cast input instead
             consumers = utils.get_consumer_nodes(self.model, output_tensor)
             for consumer in consumers:
                 for i, input_name in enumerate(consumer.input):

--- a/modelopt/onnx/autocast/precisionconverter.py
+++ b/modelopt/onnx/autocast/precisionconverter.py
@@ -566,7 +566,10 @@ class PrecisionConverter:
                         to_type=self.high_precision_type,
                     )
 
-    def _replace_tensor_name(self, consumers, original_tensor_name, new_tensor_name):
+    def _replace_tensor_name(
+        self, consumers: list[onnx.NodeProto], original_tensor_name: str, new_tensor_name: str
+    ) -> None:
+        """Replace occurrences of a tensor name in the given consumers' inputs with a new tensor name."""
         for consumer in consumers:
             for idx, inp in enumerate(consumer.input):
                 if inp == original_tensor_name:
@@ -583,8 +586,8 @@ class PrecisionConverter:
         # Check if the cast output is also a graph output
         is_output_producer = any(output.name == output_tensor for output in self.model.graph.output)
 
-        # If the removed cast node is producing a network output, we need to update the node producing the cast, as
-        #   the network output name should not be changed
+        # If the removed cast node is producing a network output, update the producer of the cast input so
+        # the network output name is preserved.
         if is_output_producer:
             producers = utils.get_producer_nodes(self.model, input_tensor)
             for producer in producers:


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:** Fixed issue with the function bypassing 'Cast' nodes when they're connected to a consumer with multiple outputs and the model's output.

## Usage
Autocast precision converter

## Testing
Added unittest.

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: Yes
- **Did you add or update any necessary documentation?**: N/A
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No

## Additional Information
Related: https://github.com/NVIDIA/TensorRT-Model-Optimizer/pull/305


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Preserves correct tensor connections when bypassing redundant casts, preventing miswired outputs and conversion errors.

- Refactor
  - Centralized downstream input-rewiring logic for clearer, more maintainable cast-bypass behavior without changing public APIs.

- Tests
  - Added tests for models with multiple consumers and casted outputs to catch regressions (note: test additions were duplicated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->