### PR TITLE
Move torchvision dependency to optional dev-test group

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ required_deps = [
     "safetensors",
     "torch>=2.6",
     "torchprofile>=0.0.4",
-    "torchvision",
 ]
 
 optional_deps = {
@@ -79,6 +78,7 @@ optional_deps = {
         "pytest-cov",
         "pytest-timeout",
         "timm",
+        "torchvision",
         "tox>4.18",
         "tox-current-env>=0.0.12",
     ],


### PR DESCRIPTION
## What does this PR do?

`torchvision` is only used in tests so we should not make it default dependency
