### PR TITLE
Bug fix for AutoQuantize: Add quantization skipping back; Add disable_layers to the search; cleaner names for search configs

### DIFF
--- a/modelopt/torch/quantization/model_quant.py
+++ b/modelopt/torch/quantization/model_quant.py
@@ -31,8 +31,7 @@ from modelopt.torch.opt.utils import forward_with_reshard
 from modelopt.torch.quantization.config import QuantizeConfig
 from modelopt.torch.quantization.conversion import set_quantizer_by_cfg
 
-from . import config
-from .algorithms import AutoQuantizeSearcher
+from .algorithms import AutoQuantizeSearcher, QuantRecipe
 from .config import QuantizeAlgoCfgType
 from .conversion import set_quantizer_attribute
 from .mode import QuantizeModeRegistry, get_modelike_from_algo_cfg
@@ -411,14 +410,15 @@ def auto_quantize(
     for i, quant_cfg in enumerate(quantization_formats):
         if quant_cfg is None:
             continue
-        if isinstance(quant_cfg, str):
-            assert quant_cfg in config.choices, f"Invalid quantization format: {quant_cfg}"
-            quant_cfg = getattr(config, quant_cfg)
-        elif not any(quant_cfg is getattr(config, choice) for choice in config.choices):
+
+        name = QuantRecipe.get_auto_name_for_config(quant_cfg)
+        if name is None:
+            name = f"CUSTOM_{i}"
             warnings.warn(
-                "Received custom quantization formats for search, auto_quantize results may not be optimal."
+                f"Received custom quantization formats for search, auto_quantize results may not be optimal. "
+                f"This config will be displayed as {name}"
             )
-        processed_quantization_formats.append(quant_cfg)
+        processed_quantization_formats.append((quant_cfg, name))
 
     assert len(processed_quantization_formats) > 0, "`quantization_formats` should not be empty"
     model = apply_mode(
@@ -435,17 +435,12 @@ def auto_quantize(
         "forward_backward_step": forward_backward_step,
         "num_calib_steps": num_calib_steps,
         "num_score_steps": num_score_steps,
+        "disabled_layers": disabled_layers,
         "verbose": verbose,
     }
     # Disable all quantizers; AutoQuantize will enable the needed ones
     set_quantizer_by_cfg(model, {"*": {"enable": False}})
     searcher.search(model, constraints, config=search_config)  # type: ignore[arg-type]
-
-    if disabled_layers:
-        if isinstance(disabled_layers, str):
-            disabled_layers = [disabled_layers]
-        for layer_pattern in disabled_layers:
-            disable_quantizer(model, layer_pattern)
 
     return model, searcher.state_dict()
 


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ? Bug fix, feature improvement

**Overview:** ?

In the latest main branch, we do not support skipping quantization with auto_quantize (though the doc string says we by default support skipping quantization). 

This PR fixes that. 

The above bug was previously causing Shreyas Misra 's Llama 3.1 8B `auto_quantize` to fail. Basically all layers were quantized after his search because `auto_quantize` was not given the option to skip quantization (well except `lm_head` because we force disabling quantization of `lm_head` after the search). I am not sure when this bug was introduced.  

In addition, this PR does the following too:
1. Add disable_layers configuration to search. This way search process accounts for the disabled layers. Previously layers were disabled at the end of search undermining search and user constraint. 

2. Get Cleaner names for search formats 
Previously AutoQuantize printed the following in output log:
```
AutoQuantize best recipe for model.layers.30.mlp.down_proj: quantization_formats[0]:effective-bits-8.0
AutoQuantize best recipe for model.layers.31.self_attn.q_proj: quantization_formats[0]:effective-bits-8.0
AutoQuantize best recipe for model.layers.31.self_attn.o_proj: quantization_formats[0]:effective-bits-8.0
AutoQuantize best recipe for model.layers.31.mlp.gate_proj: quantization_formats[0]:effective-bits-8.0
AutoQuantize best recipe for model.layers.31.mlp.down_proj: quantization_formats[0]:effective-bits-8.0
AutoQuantize best recipe for lm_head: quantization_formats[0]:effective-bits-8.0
```

This was not helpful and confusing. This caused us to not realize search is broken. After this PR, the output log looks as following
```
AutoQuantize best recipe for model.layers.30.mlp.down_proj: INT8_SMOOTHQUANT_CFG(effective-bits: 8.0)
AutoQuantize best recipe for model.layers.31.self_attn.q_proj: INT8_SMOOTHQUANT_CFG(effective-bits: 8.0)
AutoQuantize best recipe for model.layers.31.self_attn.o_proj: INT8_SMOOTHQUANT_CFG(effective-bits: 8.0)
AutoQuantize best recipe for model.layers.31.mlp.gate_proj: INT8_SMOOTHQUANT_CFG(effective-bits: 8.0)
AutoQuantize best recipe for model.layers.31.mlp.down_proj: None(effective-bits: 16.0)
AutoQuantize best recipe for lm_head: None(effective-bits: 16.0)
```

## Usage

```python
# Add a code snippet demonstrating how to use this
```

## Testing
Results:

Model: Llama-3.1-8B-Instruct
Evaluation: MMLU from `lm_eval`, fake quantization

| Method | Effective bits | MMLU Accuracy |  Other Comments |
|---------|--------------|-----------------|-------------------|
| Naive INT8 SMOOTHQUANT |  8.56  | 52.47  | LM Head is not quantized |
| AutoQuantize, no manual setting | 9.0 |  58.84  |  AutoQuantize quantizes LM Head |
|  AutoQuantize, LM Head disabled explicitly |  9.0 | 58.63 | LM Head quantization disabled by setting `disabled_layers=[*lm_head*]`|

## Additional Information
@Shreyas Misra 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Named/string quantization formats with display names and disabled-layers support to exclude layers from automatic quantization.

* **Improvements**
  * Added a no-quant default option, per-layer recipe choices with deduplication, and search reporting using an effective-bits constraint for size/accuracy tradeoffs.

* **Tests**
  * Unit tests updated to reflect naming, per-layer choices, and effective-bits validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->