### PR TITLE
Add int8_sq back to auto_quant support list

### DIFF
--- a/examples/llm_ptq/hf_ptq.py
+++ b/examples/llm_ptq/hf_ptq.py
@@ -93,6 +93,7 @@ def auto_quantize(
         qformat
         in [
             "fp8",
+            "int8_sq",
             "int4_awq",
             "nvfp4",
             "nvfp4_awq",


### PR DESCRIPTION
## What does this PR do?

minor change

**Overview:** ?

Add int8_sq back to auto_quant support list. We will just export the final checkpoint as the tensorrt_llm checkpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for INT8 SmoothQuant in the auto-quantization workflow, enabling selection of the int8_sq format for model compression. This expands quantization options and can improve performance and memory efficiency on compatible hardware. No changes to public APIs or user-facing workflows; existing configurations continue to work as before, with the new format available as an additional choice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->