### PR TITLE
[Bugfix] Enable essential python files export in llm_ptq examples by adding a customized copy function

### DIFF
--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -345,7 +345,11 @@ def _resolve_model_path(model_name_or_path: str, trust_remote_code: bool = False
 
 
 def copy_custom_model_files(source_path: str, export_path: str, trust_remote_code: bool = False):
-    """Copy custom model files (configuration_*.py, modeling_*.py, etc.) from source to export directory.
+    """Copy custom model files (configuration_*.py, modeling_*.py, *.json, etc.) from source to export directory.
+
+    This function copies custom Python files and JSON configuration files that are needed for
+    models with custom code. It excludes config.json and model.safetensors.index.json as these
+    are typically handled separately by the model export process.
 
     Args:
         source_path: Path to the original model directory or HuggingFace model ID
@@ -383,12 +387,16 @@ def copy_custom_model_files(source_path: str, export_path: str, trust_remote_cod
         "processing_*.py",
         "image_processing_*.py",
         "feature_extraction_*.py",
+        "*.json",
     ]
 
     copied_files = []
     for pattern in custom_file_patterns:
         for file_path in source_dir.glob(pattern):
             if file_path.is_file():
+                # Skip config.json and model.safetensors.index.json as they're handled separately
+                if file_path.name in ["config.json", "model.safetensors.index.json"]:
+                    continue
                 dest_path = export_dir / file_path.name
                 try:
                     shutil.copy2(file_path, dest_path)

--- a/examples/llm_ptq/hf_ptq.py
+++ b/examples/llm_ptq/hf_ptq.py
@@ -612,7 +612,7 @@ def main(args):
                 inference_pipeline_parallel=args.inference_pipeline_parallel,
             )
 
-            # Copy custom model files for TensorRT-LLM export as well
+            # Copy custom model files (Python files and JSON configs) for TensorRT-LLM export
             copy_custom_model_files(args.pyt_ckpt_path, export_path, args.trust_remote_code)
         else:
             # Check arguments for unified_hf export format and set to default if unsupported arguments are provided
@@ -631,7 +631,7 @@ def main(args):
                 export_dir=export_path,
             )
 
-        # Copy custom model files (configuration_*.py, modeling_*.py, etc.) if trust_remote_code is used
+        # Copy custom model files (Python files and JSON configs) if trust_remote_code is used
         copy_custom_model_files(args.pyt_ckpt_path, export_path, args.trust_remote_code)
 
         # Restore default padding and export the tokenizer as well.


### PR DESCRIPTION

## What does this PR do?

**Type of change:** Bug fix

**Overview:** Add a `copy_custom_model_files` function to copy essential python files which cannot be exported with standard HF methods.

Resolve https://nvbugspro.nvidia.com/bug/5528021 

## Usage
<!-- You can potentially add a usage example below. -->

```python
python hf_ptq.py --pyt_ckpt_path /home/scratch.omniml_data_1/models/phi3/Phi-3-medium-4k-instruct --export_path saved_models_Phi-3-medium-4k-instruct_dense_fp8_tp1_pp1 --qformat fp8 --trust_remote_code
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: No
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exported models now include associated custom model files (scripts and configs) when “trust remote code” is enabled across TensorRT-LLM and Hugging Face export flows.

- **Chores**
  - Added robust model-path resolution and safe file-copying to export flows to reliably locate and transfer auxiliary model files while skipping known runtime-only artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->