### PR TITLE
Enable direct INT8/FP8 input in ONNX graph

### DIFF
--- a/modelopt/onnx/quantization/__main__.py
+++ b/modelopt/onnx/quantization/__main__.py
@@ -36,7 +36,7 @@ def get_parser() -> argparse.ArgumentParser:
         type=str,
         choices=["fp8", "int8", "int4"],
         default="int8",
-        help=("Quantization mode for the given ONNX model."),
+        help="Quantization mode for the given ONNX model.",
     )
     argparser.add_argument(
         "--calibration_method",
@@ -246,7 +246,8 @@ def get_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "If True, the I/O types in the quantized ONNX model will be modified to be lower precision whenever "
-            "possible. Else, they will match the I/O types in the given ONNX model."
+            "possible. Else, they will match the I/O types in the given ONNX model. "
+            "The currently supported precisions are {fp16, int8, fp8}."
         ),
     )
     return argparser

--- a/modelopt/onnx/quantization/quantize.py
+++ b/modelopt/onnx/quantization/quantize.py
@@ -60,7 +60,11 @@ from modelopt.onnx.quantization.graph_utils import (
 from modelopt.onnx.quantization.int4 import quantize as quantize_int4
 from modelopt.onnx.quantization.int8 import quantize as quantize_int8
 from modelopt.onnx.quantization.ort_utils import update_trt_ep_support
-from modelopt.onnx.quantization.qdq_utils import qdq_to_dq, remove_input_dq_and_output_q
+from modelopt.onnx.quantization.qdq_utils import (
+    qdq_to_dq,
+    remove_graph_input_q,
+    remove_input_dq_and_output_q,
+)
 from modelopt.onnx.trt_utils import interpret_trt_plugins_precision_flag, load_onnx_model
 from modelopt.onnx.utils import duplicate_shared_constants, name_onnx_nodes, save_onnx
 
@@ -498,6 +502,8 @@ def quantize(
                 onnx_model = remove_input_dq_and_output_q(
                     onnx_model, quantizable_custom_ops=custom_ops_to_quantize
                 )
+            if direct_io_types:
+                onnx_model = remove_graph_input_q(onnx_model)
             # Sort nodes topologically
             graph = gs.import_onnx(onnx_model)
             graph.toposort().cleanup()


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Expand existing feature

**Overview:** Allows users to generate a quantized ONNX model with direct quantized input via the existing `--direct_io_types` flag. This flag currently only support FP16 as the direct IO type, but this PR extends that to allow INT8 / FP8  precision as the graph input. For example, if the 1st layer if a model is being quantized and the user enables `--direct_io_types`, the graph input would directly connect to the 1st DQ node, thus setting the graph input to the network's `quantize_mode`.

## Usage

```sh
$ python -m modelopt.onnx.quantization --onnx_path=resnet-18.onnx --direct_io_types
```

## Testing

```sh
$ python -m modelopt.onnx.quantization --onnx_path=resnet-18.onnx --direct_io_types
```

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: N/A
- **Did you add or update any necessary documentation?**: Yes
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional cleanup now removes quantize nodes at model inputs when direct_io_types is enabled, producing cleaner ONNX I/O with direct inputs in the desired precision.

- Documentation
  - Updated CLI help to explicitly list supported direct_io_types precisions: fp16, int8, fp8.
  - Minor formatting improvement to quantize_mode help text for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->