### PR TITLE
[5455919] Insert cast nodes for 'FP32 required' ops

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Model Optimizer Changelog (Linux)
 =================================
 
+0.39 (2025-10-xx)
+^^^^^^^^^^^^^^^^^
+
+**Deprecations**
+
+**New Features**
+
+- Add new flag ``op_types_to_exclude_fp16`` in ONNX quantization to block ops from being converted to FP16/BF16. Alternatively, for custom TensorRT ops, this can also be done by indicating ``'fp32'`` precision in ``trt_plugins_precision``.
+
 0.37 (2025-09-xx)
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Model Optimizer Changelog (Linux)
 
 **New Features**
 
-- Add new flag ``op_types_to_exclude_fp16`` in ONNX quantization to block ops from being converted to FP16/BF16. Alternatively, for custom TensorRT ops, this can also be done by indicating ``'fp32'`` precision in ``trt_plugins_precision``.
+- Add flag ``op_types_to_exclude_fp16`` in ONNX quantization to exclude ops from being converted to FP16/BF16. Alternatively, for custom TensorRT ops, this can also be done by indicating ``'fp32'`` precision in ``trt_plugins_precision``.
 
 0.37 (2025-09-xx)
 ^^^^^^^^^^^^^^^^^

--- a/modelopt/onnx/quantization/__main__.py
+++ b/modelopt/onnx/quantization/__main__.py
@@ -107,8 +107,8 @@ def get_parser() -> argparse.ArgumentParser:
         default=[],
         nargs="+",
         help=(
-            "A space-separated list of node types to exclude from FP16 conversion. "
-            "This is only relevant if '--high_precision_dtype != fp32'."
+            "A space-separated list of node types to exclude from FP16/BF16 conversion. "
+            "Relevant when --high_precision_dtype is 'fp16' or 'bf16'."
         ),
     )
     argparser.add_argument(

--- a/modelopt/onnx/quantization/__main__.py
+++ b/modelopt/onnx/quantization/__main__.py
@@ -90,21 +90,18 @@ def get_parser() -> argparse.ArgumentParser:
     argparser.add_argument(
         "--op_types_to_quantize",
         type=str,
-        default=[],
         nargs="+",
         help="A space-separated list of node types to quantize.",
     )
     argparser.add_argument(
         "--op_types_to_exclude",
         type=str,
-        default=[],
         nargs="+",
         help="A space-separated list of node types to exclude from quantization.",
     )
     argparser.add_argument(
         "--op_types_to_exclude_fp16",
         type=str,
-        default=[],
         nargs="+",
         help=(
             "A space-separated list of node types to exclude from FP16/BF16 conversion. "
@@ -114,14 +111,12 @@ def get_parser() -> argparse.ArgumentParser:
     argparser.add_argument(
         "--nodes_to_quantize",
         type=str,
-        default=[],
         nargs="+",
         help="A space-separated list of node names to quantize. Regular expressions are supported.",
     )
     argparser.add_argument(
         "--nodes_to_exclude",
         type=str,
-        default=[],
         nargs="+",
         help="A space-separated list of node names to exclude from quantization. Regular expressions are supported.",
     )

--- a/modelopt/onnx/quantization/__main__.py
+++ b/modelopt/onnx/quantization/__main__.py
@@ -102,6 +102,16 @@ def get_parser() -> argparse.ArgumentParser:
         help="A space-separated list of node types to exclude from quantization.",
     )
     argparser.add_argument(
+        "--op_types_to_exclude_fp16",
+        type=str,
+        default=[],
+        nargs="+",
+        help=(
+            "A space-separated list of node types to exclude from FP16 conversion. "
+            "This is only relevant if '--high_precision_dtype != fp32'."
+        ),
+    )
+    argparser.add_argument(
         "--nodes_to_quantize",
         type=str,
         default=[],
@@ -274,6 +284,7 @@ def main():
         override_shapes=args.override_shapes,
         op_types_to_quantize=args.op_types_to_quantize,
         op_types_to_exclude=args.op_types_to_exclude,
+        op_types_to_exclude_fp16=args.op_types_to_exclude_fp16,
         nodes_to_quantize=args.nodes_to_quantize,
         nodes_to_exclude=args.nodes_to_exclude,
         use_external_data_format=args.use_external_data_format,

--- a/modelopt/onnx/quantization/fp8.py
+++ b/modelopt/onnx/quantization/fp8.py
@@ -178,6 +178,7 @@ def quantize(
     passes: list[str] = ["concat_elimination"],
     log_level: str = "INFO",
     calibrate_per_node: bool = False,
+    custom_ops_to_cast_fp32: list[str] = [],
     custom_ops_to_quantize: list[str] = [],
     direct_io_types: bool = False,
     **kwargs,
@@ -318,7 +319,7 @@ def quantize(
         onnx_model = convert_to_f16(
             onnx_model,
             keep_io_types=not direct_io_types,
-            op_block_list=["Resize"],
+            op_block_list=custom_ops_to_cast_fp32,
             low_precision_type=high_precision_dtype,
             trt_plugins=trt_extra_plugin_lib_paths,
         )

--- a/modelopt/onnx/quantization/fp8.py
+++ b/modelopt/onnx/quantization/fp8.py
@@ -168,6 +168,7 @@ def quantize(
     calibration_eps: list[str] = ["cpu", "cuda:0", "trt"],
     op_types_to_quantize: list[str] | None = None,
     op_types_to_exclude: list[str] | None = None,
+    op_types_to_exclude_fp16: list[str] = [],
     nodes_to_quantize: list[str] | None = None,
     nodes_to_exclude: list[str] | None = None,
     use_external_data_format: bool = False,
@@ -178,7 +179,6 @@ def quantize(
     passes: list[str] = ["concat_elimination"],
     log_level: str = "INFO",
     calibrate_per_node: bool = False,
-    custom_ops_to_cast_fp32: list[str] = [],
     custom_ops_to_quantize: list[str] = [],
     direct_io_types: bool = False,
     **kwargs,
@@ -319,7 +319,7 @@ def quantize(
         onnx_model = convert_to_f16(
             onnx_model,
             keep_io_types=not direct_io_types,
-            op_block_list=custom_ops_to_cast_fp32,
+            op_block_list=op_types_to_exclude_fp16,
             low_precision_type=high_precision_dtype,
             trt_plugins=trt_extra_plugin_lib_paths,
         )

--- a/modelopt/onnx/quantization/fp8.py
+++ b/modelopt/onnx/quantization/fp8.py
@@ -168,7 +168,7 @@ def quantize(
     calibration_eps: list[str] = ["cpu", "cuda:0", "trt"],
     op_types_to_quantize: list[str] | None = None,
     op_types_to_exclude: list[str] | None = None,
-    op_types_to_exclude_fp16: list[str] = [],
+    op_types_to_exclude_fp16: list[str] | None = None,
     nodes_to_quantize: list[str] | None = None,
     nodes_to_exclude: list[str] | None = None,
     use_external_data_format: bool = False,
@@ -319,7 +319,7 @@ def quantize(
         onnx_model = convert_to_f16(
             onnx_model,
             keep_io_types=not direct_io_types,
-            op_block_list=op_types_to_exclude_fp16,
+            op_block_list=op_types_to_exclude_fp16 or [],
             low_precision_type=high_precision_dtype,
             trt_plugins=trt_extra_plugin_lib_paths,
         )

--- a/modelopt/onnx/quantization/int8.py
+++ b/modelopt/onnx/quantization/int8.py
@@ -119,6 +119,7 @@ def quantize(
     calibration_eps: list[str] = ["cpu", "cuda:0", "trt"],
     op_types_to_quantize: list[str] | None = None,
     op_types_to_exclude: list[str] | None = None,
+    op_types_to_exclude_fp16: list[str] = [],
     nodes_to_quantize: list[str] | None = None,
     nodes_to_exclude: list[str] | None = None,
     use_external_data_format: bool = False,
@@ -128,7 +129,6 @@ def quantize(
     passes: list[str] = ["concat_elimination"],
     log_level: str = "INFO",
     calibrate_per_node: bool = False,
-    custom_ops_to_cast_fp32: list[str] = [],
     custom_ops_to_quantize: list[str] = [],
     direct_io_types: bool = False,
     **kwargs,
@@ -280,7 +280,7 @@ def quantize(
         onnx_model = convert_to_f16(
             onnx_model,
             keep_io_types=not direct_io_types,
-            op_block_list=custom_ops_to_cast_fp32,
+            op_block_list=op_types_to_exclude_fp16,
             low_precision_type=high_precision_dtype,
             trt_plugins=trt_extra_plugin_lib_paths,
         )

--- a/modelopt/onnx/quantization/int8.py
+++ b/modelopt/onnx/quantization/int8.py
@@ -119,7 +119,7 @@ def quantize(
     calibration_eps: list[str] = ["cpu", "cuda:0", "trt"],
     op_types_to_quantize: list[str] | None = None,
     op_types_to_exclude: list[str] | None = None,
-    op_types_to_exclude_fp16: list[str] = [],
+    op_types_to_exclude_fp16: list[str] | None = None,
     nodes_to_quantize: list[str] | None = None,
     nodes_to_exclude: list[str] | None = None,
     use_external_data_format: bool = False,
@@ -280,7 +280,7 @@ def quantize(
         onnx_model = convert_to_f16(
             onnx_model,
             keep_io_types=not direct_io_types,
-            op_block_list=op_types_to_exclude_fp16,
+            op_block_list=op_types_to_exclude_fp16 or [],
             low_precision_type=high_precision_dtype,
             trt_plugins=trt_extra_plugin_lib_paths,
         )

--- a/modelopt/onnx/quantization/int8.py
+++ b/modelopt/onnx/quantization/int8.py
@@ -128,6 +128,7 @@ def quantize(
     passes: list[str] = ["concat_elimination"],
     log_level: str = "INFO",
     calibrate_per_node: bool = False,
+    custom_ops_to_cast_fp32: list[str] = [],
     custom_ops_to_quantize: list[str] = [],
     direct_io_types: bool = False,
     **kwargs,
@@ -279,6 +280,7 @@ def quantize(
         onnx_model = convert_to_f16(
             onnx_model,
             keep_io_types=not direct_io_types,
+            op_block_list=custom_ops_to_cast_fp32,
             low_precision_type=high_precision_dtype,
             trt_plugins=trt_extra_plugin_lib_paths,
         )

--- a/modelopt/onnx/quantization/quantize.py
+++ b/modelopt/onnx/quantization/quantize.py
@@ -216,6 +216,7 @@ def quantize(
     override_shapes: str | None = None,
     op_types_to_quantize: list[str] | None = None,
     op_types_to_exclude: list[str] | None = None,
+    op_types_to_exclude_fp16: list[str] | None = None,
     nodes_to_quantize: list[str] | None = None,
     nodes_to_exclude: list[str] | None = None,
     use_external_data_format: bool = False,
@@ -267,6 +268,9 @@ def quantize(
             This flag does not support regular expression.
         op_types_to_exclude:
             List of op types to exclude from quantization. This flag does not support regular expression.
+        op_types_to_exclude_fp16:
+            List of op types to exclude from FP16 conversion.
+            This is only relevant if '--high_precision_dtype != fp32'.
         nodes_to_quantize:
             List of node names to quantize. If None (default), all supported nodes are quantized.
             This flag supports regular expression.
@@ -422,6 +426,8 @@ def quantize(
         quantize_mode,
     )
     trt_plugins = update_trt_ep_support(calibration_eps, has_dds_op, has_custom_op, trt_plugins)  # type: ignore[arg-type]
+    op_types_to_exclude_fp16 = op_types_to_exclude_fp16 or []
+    op_types_to_exclude_fp16.extend(list(custom_ops_to_cast_fp32.keys()))
 
     # Use random scales if calibration data is not supplied
     if calibration_data is None:
@@ -464,6 +470,7 @@ def quantize(
             calibration_eps=calibration_eps,
             op_types_to_quantize=op_types_to_quantize,
             op_types_to_exclude=op_types_to_exclude,
+            op_types_to_exclude_fp16=op_types_to_exclude_fp16,
             nodes_to_quantize=nodes_to_quantize,
             nodes_to_exclude=nodes_to_exclude,
             use_external_data_format=use_external_data_format,
@@ -474,7 +481,6 @@ def quantize(
             passes=passes,
             log_level=log_level,
             calibrate_per_node=calibrate_per_node,
-            custom_ops_to_cast_fp32=list(custom_ops_to_cast_fp32.keys()),
             custom_ops_to_quantize=list(custom_ops_to_quantize.keys()),
             direct_io_types=direct_io_types,
             **kwargs,

--- a/modelopt/onnx/quantization/quantize.py
+++ b/modelopt/onnx/quantization/quantize.py
@@ -426,8 +426,9 @@ def quantize(
         quantize_mode,
     )
     trt_plugins = update_trt_ep_support(calibration_eps, has_dds_op, has_custom_op, trt_plugins)  # type: ignore[arg-type]
-    op_types_to_exclude_fp16 = op_types_to_exclude_fp16 or []
-    op_types_to_exclude_fp16.extend(list(custom_ops_to_cast_fp32.keys()))
+    op_types_to_exclude_fp16 = list(
+        dict.fromkeys((op_types_to_exclude_fp16 or []) + list(custom_ops_to_cast_fp32.keys()))
+    )
 
     # Use random scales if calibration data is not supplied
     if calibration_data is None:

--- a/modelopt/onnx/quantization/quantize.py
+++ b/modelopt/onnx/quantization/quantize.py
@@ -426,9 +426,16 @@ def quantize(
         quantize_mode,
     )
     trt_plugins = update_trt_ep_support(calibration_eps, has_dds_op, has_custom_op, trt_plugins)  # type: ignore[arg-type]
+
+    # Update list with op types to exclude from FP16/BF16 conversion
     op_types_to_exclude_fp16 = list(
         dict.fromkeys((op_types_to_exclude_fp16 or []) + list(custom_ops_to_cast_fp32.keys()))
     )
+    if high_precision_dtype == "fp32" and op_types_to_exclude_fp16:
+        logger.warning(
+            "Nodes were detected for exclusion from FP16/BF16 conversion, but 'high_precision_dtype' is set to FP32. "
+            "Since the model won't be converted to a lower precision, this flag is void."
+        )
 
     # Use random scales if calibration data is not supplied
     if calibration_data is None:

--- a/modelopt/onnx/trt_utils.py
+++ b/modelopt/onnx/trt_utils.py
@@ -367,10 +367,12 @@ def interpret_trt_plugins_precision_flag(
         if trt_plugin_precision.count(":") == 1:
             if precision not in supported_precisions:
                 logger.warning(f"Precision {precision} is not supported. Skipping.")
-            if precision == "fp16":
-                custom_ops_to_cast[op_type] = {
-                    "inp": list(range(num_inps)),
-                    "out": list(range(num_outs)),
+            if precision in ["fp16", "fp32"]:
+                custom_ops_to_cast[precision] = {
+                    op_type: {
+                        "inp": list(range(num_inps)),
+                        "out": list(range(num_outs)),
+                    }
                 }
             if precision in ["int8", "fp8"]:
                 if precision != quantize_mode:
@@ -408,10 +410,14 @@ def interpret_trt_plugins_precision_flag(
                     f"Setting the custom op precision to be the same as quantize mode."
                 )
 
-            # Will cast the inputs to FP16 and the outputs back to FP32
-            inp_precision_cast = [i for i, p in enumerate(inp_precision) if p == "fp16"]
-            out_precision_cast = [i for i, p in enumerate(out_precision) if p in ["fp16", "fp32"]]
-            custom_ops_to_cast[op_type] = {"inp": inp_precision_cast, "out": out_precision_cast}
+            # Will cast the inputs to FP16/FP32 and the outputs back to FP32
+            for precision in ["fp16", "fp32"]:
+                inp_precision_cast = [i for i, p in enumerate(inp_precision) if p == precision]
+                out_precision_cast = [i for i, p in enumerate(out_precision) if p == precision]
+                if inp_precision_cast:
+                    custom_ops_to_cast[precision] = {
+                        op_type: {"inp": inp_precision_cast, "out": out_precision_cast}
+                    }
 
             # Will add Q/DQ nodes in the requested I/O indices
             inp_precision_quant = [i for i, p in enumerate(inp_precision) if p in ["int8", "fp8"]]


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:** Ensure that FP32 custom ops are supported in ModelOpt by blocking their conversion to FP16 in Autocast.

## Usage
```sh
--trt_plugins_precision $CUSTOM_OP_NAME:fp32
```
or
```sh
--op_types_to_exclude_fp16 $CUSTOM_OP_NAME
```

## Testing
```sh
$ python -m modelopt.onnx.quantization --onnx_path=${MODEL_NAME}.onnx \
    --trt_plugins=$PLUGIN_PATH \
    --trt_plugins_precision $CUSTOM_OP_NAME:fp32 \
    --high_precision_dtype fp16
$ trtexec --onnx=${MODEL_NAME}.quant.onnx --staticPlugins=$PLUGIN_PATH --stronglyTyped
```

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: N/A
- **Did you add or update any necessary documentation?**: N/A
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add CLI/API option to exclude specific op types from FP16/BF16 conversion during ONNX quantization.

* **Improvements**
  * Per‑precision (FP16/FP32) cast mappings for custom ops are tracked and respected.
  * FP16 exclusion rules are propagated throughout the quantization flow; a warning appears when exclusions are irrelevant under FP32.
  * Preprocessing and quantization flow updated to support per-op FP16 exclusions.

* **Documentation**
  * Changelog updated with the new option and guidance for custom op precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->