### PR TITLE
[5532019][AutoCast] Update GraphSanitizer to convert Double to Float32

### DIFF
--- a/examples/onnx_ptq/README.md
+++ b/examples/onnx_ptq/README.md
@@ -26,6 +26,13 @@ Model Optimizer enables highly performant quantization formats including NVFP4, 
 
 Please use the TensorRT docker image (e.g., `nvcr.io/nvidia/tensorrt:25.08-py3`) or visit our [installation docs](https://nvidia.github.io/TensorRT-Model-Optimizer/getting_started/2_installation.html) for more information.
 
+Set the following environment variables inside the TensorRT docker.
+
+```bash
+export CUDNN_LIB_DIR=/usr/lib/x86_64-linux-gnu/
+export LD_LIBRARY_PATH="${CUDNN_LIB_DIR}:${LD_LIBRARY_PATH}"
+```
+
 Also follow the installation steps below to upgrade to the latest version of Model Optimizer and install example-specific dependencies.
 
 ### Local Installation

--- a/modelopt/onnx/autocast/convert.py
+++ b/modelopt/onnx/autocast/convert.py
@@ -179,6 +179,7 @@ def convert_to_f16(
     sanitizer.find_custom_nodes()
     sanitizer.convert_opset()
     sanitizer.ensure_graph_name_exists()
+    sanitizer.convert_fp64_to_fp32()
     model = sanitizer.model
 
     # Setup internal mappings

--- a/modelopt/onnx/autocast/precisionconverter.py
+++ b/modelopt/onnx/autocast/precisionconverter.py
@@ -215,29 +215,19 @@ class PrecisionConverter:
 
     def _restore_original_io_types(self):
         """Restore original I/O types."""
-        # Restore input types
-        for input_tensor in self.model.graph.input:
-            if input_tensor.name in self.original_network_io:
-                original_type = self.original_network_io[input_tensor.name]
-                if input_tensor.type.tensor_type.elem_type != original_type:
-                    input_tensor.type.tensor_type.elem_type = original_type
-                    # Update value_info_map if tensor exists there
-                    if input_tensor.name in self.value_info_map:
-                        self.value_info_map[
-                            input_tensor.name
-                        ].type.tensor_type.elem_type = original_type
 
-        # Restore output types
-        for output_tensor in self.model.graph.output:
-            if output_tensor.name in self.original_network_io:
-                original_type = self.original_network_io[output_tensor.name]
-                if output_tensor.type.tensor_type.elem_type != original_type:
-                    output_tensor.type.tensor_type.elem_type = original_type
+        def restore_tensor_type(tensor):
+            if tensor.name in self.original_network_io:
+                original_type = self.original_network_io[tensor.name]
+                if tensor.type.tensor_type.elem_type != original_type:
+                    tensor.type.tensor_type.elem_type = original_type
                     # Update value_info_map if tensor exists there
-                    if output_tensor.name in self.value_info_map:
-                        self.value_info_map[
-                            output_tensor.name
-                        ].type.tensor_type.elem_type = original_type
+                    if tensor.name in self.value_info_map:
+                        self.value_info_map[tensor.name].type.tensor_type.elem_type = original_type
+
+        # Restore input and output types
+        for tensor in self.model.graph.input + self.model.graph.output:
+            restore_tensor_type(tensor)
 
     def _propagate_types_shapes_custom_ops(self, model):
         """Propagate types and shapes after insertion of 'Cast' nodes or other graph modifications."""

--- a/modelopt/onnx/autocast/precisionconverter.py
+++ b/modelopt/onnx/autocast/precisionconverter.py
@@ -200,9 +200,6 @@ class PrecisionConverter:
         # Remove redundant casts
         self._cleanup()
 
-        if self.keep_io_types:
-            self._restore_original_io_types()
-
         self._sanity_check()
 
         return self.model
@@ -212,22 +209,6 @@ class PrecisionConverter:
         for vi in self.model.graph.value_info:
             if vi.type.tensor_type.elem_type == onnx.TensorProto.UNDEFINED:
                 vi.type.tensor_type.elem_type = self.low_precision_type.onnx_type
-
-    def _restore_original_io_types(self):
-        """Restore original I/O types."""
-
-        def restore_tensor_type(tensor):
-            if tensor.name in self.original_network_io:
-                original_type = self.original_network_io[tensor.name]
-                if tensor.type.tensor_type.elem_type != original_type:
-                    tensor.type.tensor_type.elem_type = original_type
-                    # Update value_info_map if tensor exists there
-                    if tensor.name in self.value_info_map:
-                        self.value_info_map[tensor.name].type.tensor_type.elem_type = original_type
-
-        # Restore input and output types
-        for tensor in self.model.graph.input + self.model.graph.output:
-            restore_tensor_type(tensor)
 
     def _propagate_types_shapes_custom_ops(self, model):
         """Propagate types and shapes after insertion of 'Cast' nodes or other graph modifications."""

--- a/modelopt/onnx/autocast/precisionconverter.py
+++ b/modelopt/onnx/autocast/precisionconverter.py
@@ -181,12 +181,11 @@ class PrecisionConverter:
                 for idx, d in enumerate(vi.type.tensor_type.shape.dim):
                     if d.dim_value:
                         vi.type.tensor_type.shape.dim[idx].dim_param = "unk"
-            if not self.keep_io_types:
-                for out in self.model.graph.output:
-                    out.type.tensor_type.elem_type = onnx.TensorProto.UNDEFINED
-                    for idx, d in enumerate(out.type.tensor_type.shape.dim):
-                        if d.dim_value:
-                            out.type.tensor_type.shape.dim[idx].dim_param = "unk"
+            for out in self.model.graph.output:
+                out.type.tensor_type.elem_type = onnx.TensorProto.UNDEFINED
+                for idx, d in enumerate(out.type.tensor_type.shape.dim):
+                    if d.dim_value:
+                        out.type.tensor_type.shape.dim[idx].dim_param = "unk"
             # Populate type information with inferred types
             self.model = onnx_utils.infer_shapes(self.model, strict_mode=True, check_type=False)
             self._ensure_types_are_defined()
@@ -451,9 +450,8 @@ class PrecisionConverter:
         for node in high_precision_nodes:
             # Add cast up for network inputs
             cast_to_fp32.extend([input for input in node.input if input in network_inputs])
-            # Add cast down for network outputs (only if not keeping I/O types)
-            if not self.keep_io_types:
-                cast_to_fp16.extend([output for output in node.output if output in network_outputs])
+            # Add cast down for network outputs
+            cast_to_fp16.extend([output for output in node.output if output in network_outputs])
 
         # Remove initializers, they are handled separately
         initializers = {init.name for init in self.model.graph.initializer}

--- a/tests/unit/onnx/autocast/test_graphsanitizer.py
+++ b/tests/unit/onnx/autocast/test_graphsanitizer.py
@@ -183,3 +183,227 @@ def test_invalid_layernorm_pattern():
 
     # Verify no LayerNorm transformation occurred
     assert not any(node.op_type == "LayerNormalization" for node in sanitizer.model.graph.node)
+
+
+def test_convert_fp64_initializers():
+    """Test conversion of FP64 initializers to FP32."""
+    # Create a model with FP64 initializers
+    x = helper.make_tensor_value_info("X", TensorProto.FLOAT, [2, 3])
+    y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2, 3])
+
+    # Create FP64 initializers
+    fp64_weights = np.array([[1.5, 2.5, 3.5], [4.5, 5.5, 6.5]], dtype=np.float64)
+    fp64_bias = np.array([0.1, 0.2, 0.3], dtype=np.float64)
+    fp32_weights = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+
+    initializers = [
+        numpy_helper.from_array(fp64_weights, name="fp64_weights"),
+        numpy_helper.from_array(fp64_bias, name="fp64_bias"),
+        numpy_helper.from_array(fp32_weights, name="fp32_weights"),
+    ]
+
+    # Verify the FP64 initializers have correct data type
+    assert initializers[0].data_type == TensorProto.DOUBLE
+    assert initializers[1].data_type == TensorProto.DOUBLE
+    assert initializers[2].data_type == TensorProto.FLOAT
+
+    add_node = helper.make_node("Add", ["X", "fp64_weights"], ["Y"])
+
+    graph = helper.make_graph(
+        nodes=[add_node], name="fp64_test", inputs=[x], outputs=[y], initializer=initializers
+    )
+
+    model = helper.make_model(graph)
+    sanitizer = GraphSanitizer(model)
+
+    # Test the conversion
+    result = sanitizer._convert_fp64_initializers()
+    assert result is True
+
+    # Verify all initializers are now FP32
+    for init in sanitizer.model.graph.initializer:
+        if init.name in ["fp64_weights", "fp64_bias"]:
+            assert init.data_type == TensorProto.FLOAT
+            # Verify data integrity
+            converted_data = numpy_helper.to_array(init)
+            assert converted_data.dtype == np.float32
+        elif init.name == "fp32_weights":
+            assert init.data_type == TensorProto.FLOAT
+
+
+def test_convert_fp64_io_types():
+    """Test conversion of FP64 input/output types to FP32."""
+    # Create inputs and outputs with FP64 types
+    x_fp64 = helper.make_tensor_value_info("X_fp64", TensorProto.DOUBLE, [2, 3])
+    y_fp64 = helper.make_tensor_value_info("Y_fp64", TensorProto.DOUBLE, [2, 3])
+    x_fp32 = helper.make_tensor_value_info("X_fp32", TensorProto.FLOAT, [2, 3])
+
+    # Create value_info with FP64 type
+    value_info_fp64 = helper.make_tensor_value_info("intermediate", TensorProto.DOUBLE, [2, 3])
+    value_info_fp32 = helper.make_tensor_value_info("intermediate2", TensorProto.FLOAT, [2, 3])
+
+    add_node = helper.make_node("Add", ["X_fp64", "X_fp32"], ["Y_fp64"])
+
+    graph = helper.make_graph(
+        nodes=[add_node],
+        name="fp64_io_test",
+        inputs=[x_fp64, x_fp32],
+        outputs=[y_fp64],
+        value_info=[value_info_fp64, value_info_fp32],
+    )
+
+    model = helper.make_model(graph)
+    sanitizer = GraphSanitizer(model)
+
+    # Test the conversion
+    result = sanitizer._convert_fp64_io_types()
+    assert result is True
+
+    # Verify inputs are converted
+    assert sanitizer.model.graph.input[0].type.tensor_type.elem_type == TensorProto.FLOAT
+    assert sanitizer.model.graph.input[1].type.tensor_type.elem_type == TensorProto.FLOAT
+
+    # Verify outputs are converted
+    assert sanitizer.model.graph.output[0].type.tensor_type.elem_type == TensorProto.FLOAT
+
+    # Verify value_info are converted
+    for vi in sanitizer.model.graph.value_info:
+        assert vi.type.tensor_type.elem_type == TensorProto.FLOAT
+
+
+def test_convert_fp64_nodes():
+    """Test conversion of specific node types from FP64 to FP32."""
+    x = helper.make_tensor_value_info("X", TensorProto.FLOAT, [2, 3])
+    y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2, 3])
+
+    # Create FP64 constant tensor for ConstantOfShape and Constant nodes
+    fp64_value = numpy_helper.from_array(np.array([1.5], dtype=np.float64))
+    fp64_shape_value = numpy_helper.from_array(np.array([2.5], dtype=np.float64))
+
+    # Create nodes that use FP64
+    cast_node = helper.make_node("Cast", ["X"], ["cast_out"], to=TensorProto.DOUBLE)
+    constant_node = helper.make_node("Constant", [], ["const_out"], value=fp64_value)
+    constant_shape_node = helper.make_node(
+        "ConstantOfShape", ["shape"], ["shape_out"], value=fp64_shape_value
+    )
+    add_node = helper.make_node("Add", ["cast_out", "const_out"], ["Y"])
+
+    # Shape input for ConstantOfShape
+    shape_init = numpy_helper.from_array(np.array([2, 3], dtype=np.int64), name="shape")
+
+    graph = helper.make_graph(
+        nodes=[cast_node, constant_node, constant_shape_node, add_node],
+        name="fp64_nodes_test",
+        inputs=[x],
+        outputs=[y],
+        initializer=[shape_init],
+    )
+
+    model = helper.make_model(graph)
+    sanitizer = GraphSanitizer(model)
+
+    # Test the conversion
+    result = sanitizer._convert_fp64_nodes()
+    assert result is True
+
+    # Verify Cast node is converted
+    cast_nodes = [n for n in sanitizer.model.graph.node if n.op_type == "Cast"]
+    assert len(cast_nodes) == 1
+    cast_attr = next(attr for attr in cast_nodes[0].attribute if attr.name == "to")
+    assert cast_attr.i == TensorProto.FLOAT
+
+    # Verify Constant node is converted
+    constant_nodes = [n for n in sanitizer.model.graph.node if n.op_type == "Constant"]
+    assert len(constant_nodes) == 1
+    const_attr = next(attr for attr in constant_nodes[0].attribute if attr.name == "value")
+    assert const_attr.t.data_type == TensorProto.FLOAT
+
+    # Verify ConstantOfShape node is converted
+    const_shape_nodes = [n for n in sanitizer.model.graph.node if n.op_type == "ConstantOfShape"]
+    assert len(const_shape_nodes) == 1
+    shape_attr = next(attr for attr in const_shape_nodes[0].attribute if attr.name == "value")
+    assert shape_attr.t.data_type == TensorProto.FLOAT
+
+
+def test_convert_fp64_to_fp32_integration():
+    """Test the main convert_fp64_to_fp32 method with mixed FP64/FP32 content."""
+    # Create a model with mixed FP64 and FP32 content
+    x_fp64 = helper.make_tensor_value_info("X", TensorProto.DOUBLE, [2, 3])
+    y_fp32 = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2, 3])
+
+    # FP64 initializer
+    fp64_weights = numpy_helper.from_array(
+        np.array([[1.5, 2.5], [3.5, 4.5]], dtype=np.float64), name="weights"
+    )
+
+    # FP64 constant value
+    fp64_const_value = numpy_helper.from_array(np.array([0.5], dtype=np.float64))
+
+    # Create nodes
+    cast_node = helper.make_node("Cast", ["X"], ["cast_out"], to=TensorProto.DOUBLE)
+    constant_node = helper.make_node("Constant", [], ["const_out"], value=fp64_const_value)
+    add_node = helper.make_node("Add", ["cast_out", "const_out"], ["Y"])
+
+    graph = helper.make_graph(
+        nodes=[cast_node, constant_node, add_node],
+        name="mixed_fp64_test",
+        inputs=[x_fp64],
+        outputs=[y_fp32],
+        initializer=[fp64_weights],
+    )
+
+    model = helper.make_model(graph)
+    sanitizer = GraphSanitizer(model)
+
+    # Test the main conversion method
+    sanitizer.convert_fp64_to_fp32()
+
+    # Verify all FP64 content has been converted
+    # Check input types
+    assert sanitizer.model.graph.input[0].type.tensor_type.elem_type == TensorProto.FLOAT
+
+    # Check initializers
+    for init in sanitizer.model.graph.initializer:
+        assert init.data_type == TensorProto.FLOAT
+
+    # Check Cast node
+    cast_nodes = [n for n in sanitizer.model.graph.node if n.op_type == "Cast"]
+    cast_attr = next(attr for attr in cast_nodes[0].attribute if attr.name == "to")
+    assert cast_attr.i == TensorProto.FLOAT
+
+    # Check Constant node
+    constant_nodes = [n for n in sanitizer.model.graph.node if n.op_type == "Constant"]
+    const_attr = next(attr for attr in constant_nodes[0].attribute if attr.name == "value")
+    assert const_attr.t.data_type == TensorProto.FLOAT
+
+
+def test_convert_fp64_no_changes_needed():
+    """Test that conversion methods return False when no FP64 content exists."""
+    # Create a model with only FP32 content
+    x = helper.make_tensor_value_info("X", TensorProto.FLOAT, [2, 3])
+    y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2, 3])
+
+    fp32_weights = numpy_helper.from_array(
+        np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32), name="weights"
+    )
+    fp32_const_value = numpy_helper.from_array(np.array([0.5], dtype=np.float32))
+
+    cast_node = helper.make_node("Cast", ["X"], ["cast_out"], to=TensorProto.FLOAT)
+    constant_node = helper.make_node("Constant", [], ["const_out"], value=fp32_const_value)
+    add_node = helper.make_node("Add", ["cast_out", "const_out"], ["Y"])
+
+    graph = helper.make_graph(
+        nodes=[cast_node, constant_node, add_node],
+        name="fp32_only_test",
+        inputs=[x],
+        outputs=[y],
+        initializer=[fp32_weights],
+    )
+
+    model = helper.make_model(graph)
+    sanitizer = GraphSanitizer(model)
+
+    # Test that no conversions are needed
+    assert sanitizer._convert_fp64_initializers() is False
+    assert sanitizer._convert_fp64_io_types() is False
+    assert sanitizer._convert_fp64_nodes() is False


### PR DESCRIPTION
## What does this PR do?

**Type of change:** 
New Feature

**Overview:** 
- Implemented `convert_fp64_to_fp32()` in graph sanitizer.
- This method will be called with `GraphSanitizer.sanitize()` or `convert_to_f16()`.

## Testing
```
python -m modelopt.onnx.quantization --onnx_path=far3d_opset17.onnx  --calibration_eps cuda:0
```
- I/O sanity check passes for this model
- All unit tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated user instructions to include environment variable setup for CUDA/cuDNN libraries when using the TensorRT Docker image.

* **New Features**
  * Added automatic conversion of 64-bit floating point (FP64) tensors to 32-bit (FP32) in ONNX model graphs, enhancing compatibility and standardization during processing.

* **Tests**
  * Introduced new tests to validate correct conversion of FP64 values to FP32 across various graph components and scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->