### PR TITLE
Improve realquant gemm impl

### DIFF
--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -11,7 +11,7 @@
    :recursive:
 {% for item in modules %}
 {% set full_item = fullname + '.' + item.split('.')[-1] %}
-{% if '.plugins.' not in full_item or full_item == 'modelopt.torch.opt.plugins.huggingface' %}
+{% if ('.plugins.' not in full_item or full_item == 'modelopt.torch.opt.plugins.huggingface') and full_item != 'modelopt.torch.quantization.backends.fp8_per_tensor_gemm' %}
    {{ full_item }}
 {% endif %}
 {%- endfor %}

--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -11,7 +11,7 @@
    :recursive:
 {% for item in modules %}
 {% set full_item = fullname + '.' + item.split('.')[-1] %}
-{% if '.plugins.' not in full_item or full_item == 'modelopt.torch.opt.plugins.huggingface' %}
+{% if '.plugins.' not in full_item or full_item == 'modelopt.torch.opt.plugins.huggingface' or full_item == 'modelopt.torch.quantization.backends.fp8_per_tensor_gemm' %}
    {{ full_item }}
 {% endif %}
 {%- endfor %}

--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -11,7 +11,7 @@
    :recursive:
 {% for item in modules %}
 {% set full_item = fullname + '.' + item.split('.')[-1] %}
-{% if '.plugins.' not in full_item or full_item == 'modelopt.torch.opt.plugins.huggingface' or full_item == 'modelopt.torch.quantization.backends.fp8_per_tensor_gemm' %}
+{% if '.plugins.' not in full_item or full_item == 'modelopt.torch.opt.plugins.huggingface' or 'modelopt.torch.quantization.backends' not in full_item %}
    {{ full_item }}
 {% endif %}
 {%- endfor %}

--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -11,7 +11,7 @@
    :recursive:
 {% for item in modules %}
 {% set full_item = fullname + '.' + item.split('.')[-1] %}
-{% if '.plugins.' not in full_item or full_item == 'modelopt.torch.opt.plugins.huggingface' or 'modelopt.torch.quantization.backends' not in full_item %}
+{% if '.plugins.' not in full_item or full_item == 'modelopt.torch.opt.plugins.huggingface' %}
    {{ full_item }}
 {% endif %}
 {%- endfor %}

--- a/modelopt/torch/quantization/backends/__init__.py
+++ b/modelopt/torch/quantization/backends/__init__.py
@@ -15,6 +15,9 @@
 
 """Quantization backends."""
 
-from .fp8_per_tensor_gemm import *
+import platform
+
+if platform.system() != "Windows":
+    from .fp8_per_tensor_gemm import *
 from .gemm_registry import *
 from .nvfp4_gemm import *

--- a/modelopt/torch/quantization/backends/__init__.py
+++ b/modelopt/torch/quantization/backends/__init__.py
@@ -16,3 +16,4 @@
 """Quantization backends."""
 
 from .gemm_registry import *
+from .nvfp4_gemm import *

--- a/modelopt/torch/quantization/backends/__init__.py
+++ b/modelopt/torch/quantization/backends/__init__.py
@@ -15,9 +15,4 @@
 
 """Quantization backends."""
 
-import platform
-
-if platform.system() != "Windows":
-    from .fp8_per_tensor_gemm import *
 from .gemm_registry import *
-from .nvfp4_gemm import *

--- a/modelopt/torch/quantization/plugins/megatron.py
+++ b/modelopt/torch/quantization/plugins/megatron.py
@@ -115,7 +115,7 @@ def real_quant_module_set_extra_state(self, state: Any):
     """
     q_tensor_state = state.get("modelopt_q_tensor_state", None)
 
-    if q_tensor_state is not None:
+    if q_tensor_state:
         q_tensor_metadata = q_tensor_state["metadata"]
         q_tensor_metadata["shape"] = self.weight.shape
         q_tensor_data_dtype = q_tensor_state["quantized_data.dtype"]
@@ -418,8 +418,10 @@ class _RealQuantMegatronParallelLinear(RealQuantLinear):
             while the original forward only takes 1 positional argument. We must above the fallback path
             in RealQuantLinear.forward().
         """
-        if self._should_run_real_quant_gemm and self.get_real_quant_gemm_impl(
-            input, *args, **kwargs
+        if (
+            self._should_run_real_quant_gemm
+            and input.numel() > 1
+            and self.has_real_quant_gemm_impl(input, *args, **kwargs)
         ):
             allreduce_dgrad = kwargs.get("allreduce_dgrad", False)
             tp_group = kwargs.get("tp_group")


### PR DESCRIPTION
## What does this PR do?

Bug fix

**Overview:** ?

- For some QAT usecase, we may mix frozen compressed gemms with fake quant gemms. Though all gemms will be converted to RealQuantLinear after compression, the fake quant gemm's q_tensor_state will be an empty dict
- Move torch.compile ops on the module level to avoid runtime CPU overhead
- Fix realquant gradient compute when the input tensor is 3D.


## Testing
Unittests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FP8 per-tensor GEMM enabled with automatic scale caching and hardware availability checks.
  * Real-quant GEMM routing expanded to apply for more eligible inputs.

* **Refactor**
  * Streamlined gradient and bias-gradient handling to reduce saved context and memory.
  * Performance optimizations via compilation-ready paths, FP8 conversions, and improved matrix ops.
  * More explicit availability checks for quantized GEMM implementations.

* **Chores**
  * Tightened public API and docs to hide the FP8 backend from autosummaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->