### PR TITLE
[Bug fix] remove  max_memory from from_config init in hf_ptq

### DIFF
--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -206,9 +206,7 @@ def get_model(
                 if auto_model_module != AutoModelForCausalLM:
                     model_kwargs2.pop("trust_remote_code", None)
                 model_kwargs2["torch_dtype"] = torch_dtype
-                # DeciLMForCausalLM does not support max_memory argument
-                if "architectures" in hf_config and "DeciLMForCausalLM" in hf_config.architectures:
-                    model_kwargs2.pop("max_memory", None)
+                model_kwargs2.pop("max_memory", None)
                 model = from_config(hf_config, **model_kwargs2)
 
             max_memory = get_max_memory()


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ? Bug fix

**Overview:** ?

## Usage
NA

## Testing
docker: nvcr.io/nvidia/tensorrt-llm/release:1.1.0rc2.post2
I can run the following:
```
python hf_ptq.py --pyt_ckpt_path Qwen/Qwen3-1.7B \
    --export_path test --qformat fp8 \
    --calib_size 16 --trust_remote_code --kv_cache_qformat fp8 --use_seq_device_map
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of model initialization via auto-configuration across architectures by standardizing how memory constraints are handled. This prevents failures caused by incompatible memory parameters during setup, resulting in smoother loading and fewer edge-case initialization errors for non-VILA models. No configuration changes required; existing workflows should work more consistently and more predictable performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->