### PR TITLE
[NVBUG: 5472822] Skip memory monitoring if not available

### DIFF
--- a/modelopt/torch/utils/memory_monitor.py
+++ b/modelopt/torch/utils/memory_monitor.py
@@ -131,7 +131,7 @@ class GPUMemoryMonitor:
         nvmlShutdown()
 
 
-def launch_memory_monitor(monitor_interval: float = 1.0) -> GPUMemoryMonitor:
+def launch_memory_monitor(monitor_interval: float = 1.0) -> GPUMemoryMonitor | None:
     """Launch a GPU memory monitor in a separate thread.
 
     Args:
@@ -140,6 +140,11 @@ def launch_memory_monitor(monitor_interval: float = 1.0) -> GPUMemoryMonitor:
     Returns:
         GPUMemoryMonitor: The monitor instance that was launched
     """
+    try:
+        nvmlDeviceGetMemoryInfo(nvmlDeviceGetHandleByIndex(0))
+    except Exception as e:
+        print(f"Failed to get GPU memory info: {e}. Stopping GPU memory monitor.")
+        return None
     monitor = GPUMemoryMonitor(monitor_interval)
     monitor.start()
     atexit.register(monitor.stop)  # Ensure the monitor stops when the program exits


### PR DESCRIPTION
## What does this PR do?

Bug fix

**Overview:** ?

In some platforms, the memory monitor will hit the following issue:

```
  File "/usr/local/lib/python3.12/dist-packages/modelopt/torch/utils/memory_monitor.py", line 95, in _monitor_loop                                              
    gpu_memory = nvmlDeviceGetMemoryInfo(handle)                                                                                                                
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                
  File "/usr/local/lib/python3.12/dist-packages/pynvml.py", line 3522, in nvmlDeviceGetMemoryInfo                                                               
    _nvmlCheckReturn(ret)                                                                                                                                       
  File "/usr/local/lib/python3.12/dist-packages/pynvml.py", line 1059, in _nvmlCheckReturn                                                                      
    raise NVMLError(ret)                                                                                                                                        
pynvml.NVMLError_NotSupported: Not Supported
```

We should skip memory monitoring if it's not available.

## Testing
Test on the target platform:
scripts/huggingface_example.sh --model "Qwen/Qwen2.5-Coder-0.5B-Instruct" --quant nvfp4 --tp 1 --export_fmt hf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents crashes during startup when GPU memory info cannot be retrieved (e.g., missing or misconfigured NVML).
  - Adds a preliminary check before enabling GPU memory monitoring; if unavailable, monitoring is skipped and a clear error is logged.
  - No change for users with working GPU monitoring; behavior remains the same.
  - Improves robustness across diverse environments, ensuring smoother operation on systems without accessible GPU metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->