### PR TITLE
Add HF_TOKEN secret to example_tests workflow

### DIFF
--- a/.github/workflows/example_tests.yml
+++ b/.github/workflows/example_tests.yml
@@ -69,6 +69,7 @@ jobs:
       image: nvcr.io/nvidia/tensorrt-llm/release:1.1.0rc2.post2
       env:
         PIP_CONSTRAINT: "" # Disable pip constraint for upgrading packages
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps: &example_steps
       - uses: actions/checkout@v4
       - uses: nv-gha-runners/setup-proxy-cache@main


### PR DESCRIPTION
Avoid recently imposed rate limiting on HF model and dataset downloads in CICD by using a HF_TOKEN configured in CICD settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of example test runs in pull requests by securely providing required authentication via CI, with no changes to app behavior.
* **Chores**
  * Updated CI configuration to use repository secrets for sensitive environment variables, enhancing security of automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->