### PR TITLE
Set git commit signing on in .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,5 +42,7 @@
     "evenBetterToml.schema.enabled": false, // disable toml/json schema since we have custom fields
     "python.analysis.extraPaths": [
         "./tests/" // add tests to python path just like pytest does in pyproject.toml
-    ]
+    ],
+    "git.alwaysSignOff": true,
+    "git.enableCommitSigning": true,
 }


### PR DESCRIPTION
We see first time contributors often forgetting to sign-off their commits hence making commit signing default in vscode workspace settings to reduce such issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated workspace settings to require signed commits and automatically add sign-offs when committing from VS Code. This improves commit integrity and consistency for contributors working in this repository. No impact on application functionality or UI. End users do not need to take any action or change their configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->