### PR TITLE
Update ReadMe for torch_quant_to_onnx.py example

### DIFF
--- a/examples/onnx_ptq/README.md
+++ b/examples/onnx_ptq/README.md
@@ -152,6 +152,8 @@ python torch_quant_to_onnx.py \
     --onnx_save_path=<path to save the exported ONNX model>
 ```
 
+> *Note: TensorRT has limited support for Convolution layers with certain precision formats. FP8 Convolution layers remain restricted to specific kernel sizes and channel multiples, and there are no NVFP4 convolution kernels today—NVFP4 export is effectively limited to GEMM-heavy Transformer-style models (e.g., ViT). Convolution-centric CNNs such as ResNet, ConvNeXt, or MobileNet will fail when exported with `quantize_mode=nvfp4|int4_awq`.*
+
 ### Evaluation
 
 If the input model is of type image classification, use the following script to evaluate it.


### PR DESCRIPTION
## What does this PR do?

**Type of change:** documentation

**Overview:** 
- Updated ReadMe for torch_quant_to_onnx.py example
- Resolves #362 

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Did you add or update any necessary documentation?**: Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified TensorRT limitations in the ONNX PTQ example README.
  * Noted FP8 convolution restrictions (kernel sizes, channel multiples) and lack of NVFP4 convolution kernels.
  * Stated NVFP4 export is effectively limited to GEMM-heavy Transformer-style models (e.g., ViT); convolution-heavy CNNs may fail with nvfp4/int4_awq.
  * Documentation-only guidance; no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->