### PR TITLE
Add HF_TOKEN for GPU tests in CICD

### DIFF
--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -67,6 +67,7 @@ jobs:
       env:
         GIT_DEPTH: 1000 # For correct version for tests/gpu/torch/quantization/plugins/test_megatron.py
         PIP_CONSTRAINT: "" # Disable pip constraint for upgrading packages
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
     steps: &gpu_steps
       - uses: actions/checkout@v4
       - uses: nv-gha-runners/setup-proxy-cache@main


### PR DESCRIPTION
Avoid recently imposed rate limiting on HF model and dataset downloads in CICD by using a HF_TOKEN configured in CICD settings