### PR TITLE
Fix llm_distill example saving issue on new transformers w fsdp2

### DIFF
--- a/examples/llm_distill/main.py
+++ b/examples/llm_distill/main.py
@@ -16,6 +16,8 @@
 import os
 from dataclasses import dataclass
 
+os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
 import datasets
 import torch
 import torch.distributed
@@ -28,7 +30,6 @@ import modelopt.torch.distill as mtd
 import modelopt.torch.opt as mto
 from modelopt.torch.distill.plugins.huggingface import KDTrainer, LMLogitsLoss
 
-os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 logger = get_logger(__name__, log_level="INFO")
 
 

--- a/examples/llm_distill/requirements.txt
+++ b/examples/llm_distill/requirements.txt
@@ -1,3 +1,3 @@
 pyarrow
-transformers<4.57
+transformers<5.0
 trl>=0.23.0

--- a/examples/llm_distill/requirements.txt
+++ b/examples/llm_distill/requirements.txt
@@ -1,2 +1,3 @@
 pyarrow
+transformers<4.57
 trl>=0.23.0


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug Fix

**Overview:** ?

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
Example run

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Y
- **Did you write any new necessary tests?**: N
- **Did you add or update any necessary documentation?**: N
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: N

## Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  - Improved model saving compatibility for distributed training (FSDP), reducing checkpoint failures and simplifying restores.
  - Updated CUDA memory allocator configuration for better GPU stability on fragmented memory.
  - Standardized logging at INFO level for clearer training progress visibility.

* Chores
  - Updated transformers dependency constraint to <5.0 in example requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->