### PR TITLE
bug fix: loss_mask should not be shifted. only labels needs shifting

### DIFF
--- a/examples/speculative_decoding/eagle_utils.py
+++ b/examples/speculative_decoding/eagle_utils.py
@@ -101,8 +101,7 @@ def preprocess(examples, tokenizer):
                 labels[indices] = input_ids[indices]
                 loss_mask[indices] = 1
 
-        # Shift loss_mask and labels to the left by 1 token
-        loss_mask = torch.cat([loss_mask[1:], torch.zeros(1, dtype=loss_mask.dtype)])
+        # Shift labels to the left by 1 token
         labels = torch.cat([labels[1:], torch.tensor([IGNORE_TOKEN_ID], dtype=labels.dtype)])
 
         new_examples["input_ids"].append(input_ids)


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ? Bug fix

**Overview:** 
loss mask should not be shifted. Only labels need to be shifted by 1 token.

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected label alignment in speculative decoding examples, preventing unintended shifting of the loss mask and loss on incorrect positions.
  * Ensures loss is computed on the intended tokens, improving training stability, convergence, and metric reliability.
  * Reduces accidental inclusion of padding/shifted tokens in loss calculations.
  * No changes to public APIs or user-facing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->