### PR TITLE
Minor change to make KD MCore config bit more flexible

### DIFF
--- a/modelopt/torch/distill/plugins/megatron.py
+++ b/modelopt/torch/distill/plugins/megatron.py
@@ -122,7 +122,7 @@ def setup_distillation_config(
 
     if cfg.criterion is None:
         criterion = {}
-        if student_cfg.pipeline_model_parallel_size == 1 or parallel_state.is_pipeline_last_stage():
+        if parallel_state.is_pipeline_last_stage():
             criterion[tuple(cfg.logit_layers)] = LogitsKLLoss(
                 student_cfg, temperature=cfg.logit_kl_temperature
             )


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Minor code change

**Overview:** Don't change `criterion` and `loss_balancer` fields on distillation config if already set

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Y
- **Did you write any new necessary tests?**: N
- **Did you add or update any necessary documentation?**: N
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: N

## Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed distillation configuration to respect user-provided criterion and loss balancer values instead of overwriting them.
  * Improved initialization logic to only set up distillation components when needed and on the final pipeline stage in distributed training scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->