### PR TITLE
Add SD3.5-medium quantization support in ModelOpt Diffusers example

### DIFF
--- a/examples/diffusers/quantization/onnx_utils/export.py
+++ b/examples/diffusers/quantization/onnx_utils/export.py
@@ -361,9 +361,7 @@ def get_io_shapes(model_id, onnx_load_path, dynamic_shapes):
 
     if model_id in ["sdxl-1.0", "sdxl-turbo"]:
         io_shapes = {output_name: dynamic_shapes["dynamic_shapes"]["minShapes"]["sample"]}
-    elif model_id in ["sd3-medium"]:
-        io_shapes = {output_name: dynamic_shapes["dynamic_shapes"]["minShapes"]["hidden_states"]}
-    elif model_id in ["sd3.5-medium"]:
+    elif model_id in ["sd3-medium", "sd3.5-medium"]:
         io_shapes = {output_name: dynamic_shapes["dynamic_shapes"]["minShapes"]["hidden_states"]}
     elif model_id in ["flux-dev", "flux-schnell"]:
         io_shapes = {}

--- a/examples/diffusers/quantization/quantize.py
+++ b/examples/diffusers/quantization/quantize.py
@@ -948,7 +948,9 @@ def main() -> None:
             quant_config.format,
             quantize_mha=quant_config.quantize_mha,
         )
-        logger.info(f"Quantization process completed successfully! Time taken = {time.time() - s} seconds")
+        logger.info(
+            f"Quantization process completed successfully! Time taken = {time.time() - s} seconds"
+        )
 
     except Exception as e:
         logger.error(f"Quantization failed: {e}", exc_info=True)


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Diffusers' Example Update

**Overview:** 

Add SD3.5-medium quantization config in quantization and export files of the diffusers example

## Testing

- Locally, ran the max calibration on Windows RTX 5090.

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the sd3.5-medium model across quantization and ONNX export flows, including updated input/output mappings for exports.
  * sd3.5-medium is now handled alongside existing SD3-medium pipelines for model selection and pipeline creation.
* **Bug Fixes / Improvements**
  * Quantization now records and logs operation duration to report total processing time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->