### PR TITLE
[Autocast] Optimize `_add_cast` runtime

### DIFF
--- a/modelopt/onnx/autocast/precisionconverter.py
+++ b/modelopt/onnx/autocast/precisionconverter.py
@@ -184,6 +184,8 @@ class PrecisionConverter:
         logger.debug(f"cast down (to {self.low_precision_type.str_full}): {cast_down_tensors}")
         logger.debug(f"cast up (to {self.high_precision_type.str_full}): {cast_up_tensors}")
 
+        # Since we have removed all casts, we can pre-compute the tensor_to_consumers and
+        # tensor_to_producers maps since they will not change for the duration of the conversion.
         tensor_to_consumers = defaultdict(list)
         tensor_to_producers = defaultdict(list)
 
@@ -835,6 +837,10 @@ class PrecisionConverter:
                 If not provided, the map will be computed on the fly.
             tensor_to_producers: Optional pre-computed map of tensor names to their producer nodes.
                 If not provided, the map will be computed on the fly.
+
+        NOTE: It is up to the user to ensure that the tensor_to_consumers and tensor_to_producers
+        maps are up to date before calling this function. Consecutive casts in the graph will break
+        this assumption and the maps must be recomputed.
         """
         # Empty tensors may have special handling in ONNX (e.g. for Resize scales) which can break when redundant casts
         # are injected. Since there's no data, it's safe to only update the metadata.


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:** Optimize the runtime of  the `_add_cast` function. This function will greedily re-compute the producers & consumers of each node, leading to a `O(N^2)` runtime. This new implementation will efficiently pre-compute all the producers and consumers of the graph and look them up at constant time while looping through the tensors. There is no need to greedily compute producers and consumers, since we process each tensor only once, and only affect the consumers of that tensor during each iteration.

Before:
<img width="1952" height="1008" alt="image" src="https://github.com/user-attachments/assets/808b683c-9daf-4a6c-af8c-faaa98f21695" />

After:
<img width="1902" height="1012" alt="image" src="https://github.com/user-attachments/assets/75af5869-d5e5-4096-9bb9-a13036740392" />

## Testing
Precision converter unittest

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: Yes
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No

