### PR TITLE
Do not modify num calib data samples to batch boundary

### DIFF
--- a/modelopt/torch/utils/dataset_utils.py
+++ b/modelopt/torch/utils/dataset_utils.py
@@ -16,7 +16,6 @@
 """Utility functions for getting samples and forward loop function for different datasets."""
 
 import copy
-import math
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 from warnings import warn
@@ -205,8 +204,6 @@ def get_dataset_dataloader(
 
     if isinstance(dataset_name, str):
         dataset_name = [dataset_name]
-
-    num_samples = [math.ceil(num_sample / batch_size) * batch_size for num_sample in num_samples]
 
     assert len(dataset_name) == len(num_samples), (
         "dataset_name and num_samples must be the same length"

--- a/modelopt/torch/utils/speech_dataset_utils.py
+++ b/modelopt/torch/utils/speech_dataset_utils.py
@@ -15,7 +15,6 @@
 
 """Utility functions for getting samples and forward loop function for different speech datasets."""
 
-import math
 from typing import Any
 
 import torch
@@ -100,8 +99,6 @@ def get_speech_dataset_dataloader(
         An instance of dataloader.
     """
     assert processor is not None, "Please provide a valid processor."
-
-    num_samples = math.ceil(num_samples / batch_size) * batch_size
 
     dataset = _get_speech_dataset(dataset_name, num_samples=num_samples)
     first_sample = next(iter(dataset))

--- a/modelopt/torch/utils/vlm_dataset_utils.py
+++ b/modelopt/torch/utils/vlm_dataset_utils.py
@@ -15,7 +15,6 @@
 
 """Utility functions for getting samples and forward loop function for different vlm datasets."""
 
-import math
 from typing import Any
 
 from torch.utils.data import DataLoader
@@ -92,8 +91,6 @@ def get_vlm_dataset_dataloader(
         An instance of dataloader.
     """
     assert processor is not None, "Please provide a valid processor."
-
-    num_samples = math.ceil(num_samples / batch_size) * batch_size
 
     dataset = _get_vlm_dataset(dataset_name, num_samples=num_samples)
     # Apply the preprocessing function to the dataset


### PR DESCRIPTION
## What does this PR do?

Bug Fix

**Overview:** ?

Before this change, the PTQ workflow may consume more samples than specified by the user, which may make the PTQ result not deterministic if the calib batch size is determined by runtime GPU memory size. For example, if I specify the total calib samples to be 512 and I calibrate with batch size of 500, it will end with calibrating 1000 samples. This change makes it deterministic and capped at 512 regardless of the batch size.

## Testing
Run llm_ptq example and observe the total number of samples used.
