### PR TITLE
Disabled conv1d quantization 

### DIFF
--- a/modelopt/torch/quantization/config.py
+++ b/modelopt/torch/quantization/config.py
@@ -155,6 +155,8 @@ _default_disabled_quantizer_cfg = {
     "*router*": {"enable": False},  # Skip the MOE router
     "*mlp.gate.*": {"enable": False},  # Skip the MOE router
     "*mlp.shared_expert_gate.*": {"enable": False},  # Skip the MOE router
+    "*linear_attn.conv1d*": {"enable": False},
+    "*mixer.conv1d*": {"enable": False},
     "*output_layer*": {"enable": False},
     "output.*": {"enable": False},
     "default": {"enable": False},


### PR DESCRIPTION
## What does this PR do?

**Type of change:**  Bug fix

**Overview:** 
This MR disabled conv1d quantization, specifically `linear_attn.conv1d` is used in qwen3-next and `mixer.conv1d` is used in mamba model. This `conv1d` isn't usually quantized, therefore disabling it explicitly.


## Testing
```python

python hf_ptq.py --pyt_ckpt_path Qwen/Qwen3-Next-80B-A3B-Thinking --qformat fp8 --export_fmt hf --dataset cnn_dailymail --export_path qwen3-next-80b-thinking-fp8-ptq--nokv --trust_remote_code --inference_pipeline_parallel 1 --batch_size 1 --calib_size 4 --kv_cache_qformat none

python /app/tensorrt_llm/examples/llm-api/quickstart_advanced.py --model_dir qwen3-next-80b-thinking-fp8-ptq--nokv --tp_size 1 --disable_kv_cache_reuse
```
## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: NA
- **Did you add or update any necessary documentation?**: NA
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: NA
