### PR TITLE
ONNX save fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Model Optimizer Changelog (Linux)
 0.39 (2025-11-07)
 ^^^^^^^^^^^^^^^^^
 
+**Deprecations**
+
+- Deprecated ``modelopt.torch._deploy.utils.get_onnx_bytes`` API. Please use ``modelopt.torch._deploy.utils.get_onnx_bytes_and_metadata`` instead to access the ONNX model bytes with external data. see `examples/onnx_ptq/download_example_onnx.py <https://github.com/NVIDIA/TensorRT-Model-Optimizer/tree/main/examples/onnx_ptq/download_example_onnx.py>`_ for example usage.
+
 **New Features**
 
 - Add flag ``op_types_to_exclude_fp16`` in ONNX quantization to exclude ops from being converted to FP16/BF16. Alternatively, for custom TensorRT ops, this can also be done by indicating ``'fp32'`` precision in ``trt_plugins_precision``.

--- a/tests/unit/torch/deploy/utils/test_torch_onnx_utils.py
+++ b/tests/unit/torch/deploy/utils/test_torch_onnx_utils.py
@@ -29,7 +29,6 @@ from modelopt.torch._deploy.utils import (
     OnnxBytes,
     flatten_tree,
     generate_onnx_input,
-    get_onnx_bytes,
     get_onnx_bytes_and_metadata,
 )
 from modelopt.torch._deploy.utils.torch_onnx import _to_expected_onnx_type
@@ -53,13 +52,13 @@ def test_onnx_dynamo_export(skip_on_windows, model: BaseDeployModel):
         with pytest.raises(AssertionError) if model.compile_fail else nullcontext():
             onnx_bytes, _ = get_onnx_bytes_and_metadata(model, args, dynamo_export=True)
             onnx_bytes_obj = OnnxBytes.from_bytes(onnx_bytes)
-            onnx_bytes = onnx_bytes_obj.onnx_model[f"{onnx_bytes_obj.model_name}.onnx"]
+            model_bytes = onnx_bytes_obj.get_onnx_model_file_bytes()
 
         if model.compile_fail:
             continue
 
-        assert onnx_bytes != b""
-        assert onnx.load_model_from_string(onnx_bytes)
+        assert model_bytes != b""
+        assert onnx.load_model_from_string(model_bytes)
 
 
 @pytest.mark.parametrize("model", deploy_benchmark_all.values(), ids=deploy_benchmark_all.keys())
@@ -160,7 +159,9 @@ class DoubleArgModel(nn.Module):
 )
 def test_get_and_validate_batch_size(model, n_args, batch_size):
     inputs = (torch.randn([batch_size, 3, 32, 32]),) * n_args
-    onnx_bytes = get_onnx_bytes(model, inputs)
+    onnx_bytes, _ = get_onnx_bytes_and_metadata(model, inputs)
+    onnx_bytes_obj = OnnxBytes.from_bytes(onnx_bytes)
+    onnx_bytes = onnx_bytes_obj.onnx_model[f"{onnx_bytes_obj.model_name}.onnx"]
 
     assert validate_batch_size(onnx_bytes, batch_size)
     assert validate_batch_size(onnx_bytes, 3) is False


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

**Overview:** `get_onnx_bytes` api is error prone as it returns only the protobuf info. If model has any external data, they get discarded! We have to use `get_onnx_bytes_and_metadata` and provide example for users to correctly write ONNX model to disk.

## Usage
This would be proper way to save ONNX model bytes with/without external data.
```python
    onnx_bytes, _ = get_onnx_bytes_and_metadata(
        model=model,
        dummy_input=(input_tensor,),
        weights_dtype=weights_dtype,
        model_name=model_name,
    )
    onnx_bytes_obj = OnnxBytes.from_bytes(onnx_bytes)

    # Write the onnx model to the specified directory without cleaning it
    onnx_bytes_obj.write_to_disk(os.path.dirname(onnx_save_path), clean_dir=False)
```

## Testing
N/A. Existing tests are modified.

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes
- **Did you add or update any necessary documentation?**: Yes
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes<!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
https://nvbugspro.nvidia.com/bug/5618246/4
