### PR TITLE
[NVBUG: 5536887] Check output name map while creating inputs for per node calibration

### DIFF
--- a/modelopt/onnx/quantization/ort_patching.py
+++ b/modelopt/onnx/quantization/ort_patching.py
@@ -1248,15 +1248,12 @@ def _augment_graph_min_max_calibrater_single_node_calibration(calibrater):
             value_info_found = False
             # If a node input is not an initializer, set it as a model input
             if not is_input_initializer:
-                if input_name in value_info_name_map:
-                    single_node_model_inputs.append(value_info_name_map[input_name])
-                    single_node_model_input_names.append(input_name)
-                    value_info_found = True
-
-                if not value_info_found and input_name in input_name_map:
-                    single_node_model_inputs.append(input_name_map[input_name])
-                    single_node_model_input_names.append(input_name)
-                    value_info_found = True
+                for name_map in [value_info_name_map, input_name_map, output_name_map]:
+                    if input_name in name_map:
+                        single_node_model_inputs.append(name_map[input_name])
+                        single_node_model_input_names.append(input_name)
+                        value_info_found = True
+                        break
 
                 if not value_info_found:
                     raise ValueError(
@@ -1266,15 +1263,12 @@ def _augment_graph_min_max_calibrater_single_node_calibration(calibrater):
         # Process each output for node
         for output_name in node.output:
             value_info_found = False
-            if output_name in value_info_name_map:
-                single_node_model_outputs.append(value_info_name_map[output_name])
-                single_node_model_output_names.append(output_name)
-                value_info_found = True
-
-            if not value_info_found and output_name in output_name_map:
-                single_node_model_outputs.append(output_name_map[output_name])
-                single_node_model_output_names.append(output_name)
-                value_info_found = True
+            for name_map in [value_info_name_map, output_name_map]:
+                if output_name in name_map:
+                    single_node_model_outputs.append(name_map[output_name])
+                    single_node_model_output_names.append(output_name)
+                    value_info_found = True
+                    break
 
             if not value_info_found:
                 raise ValueError(


### PR DESCRIPTION
## What does this PR do?

**Type of change:** 
Bug fix

**Overview:** 
- input to a node could be model output
- Hence we also check the `output_name_map` while creating the single node inputs

## Testing
```python
python -m modelopt.onnx.quantization --onnx_path=aurora_model_batch_5.onnx --calibrate_per_node
```

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: Yes
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No
