### PR TITLE
[NVBUG: 5373030] Disable the weight adjustment for int32 bias from onnxruntime

### DIFF
--- a/modelopt/onnx/quantization/__main__.py
+++ b/modelopt/onnx/quantization/__main__.py
@@ -255,11 +255,6 @@ def get_parser() -> argparse.ArgumentParser:
             "The currently supported precisions are {fp16, int8, fp8}."
         ),
     )
-    argparser.add_argument(
-        "--disable_int32_weight_adjustment",
-        action="store_true",
-        help="If set, disable weight adjustment for INT32 bias in QDQ quantization.",
-    )
     return argparser
 
 
@@ -303,7 +298,6 @@ def main():
         simplify=args.simplify,
         calibrate_per_node=args.calibrate_per_node,
         direct_io_types=args.direct_io_types,
-        disable_int32_weight_adjustment=args.disable_int32_weight_adjustment,
     )
 
 

--- a/modelopt/onnx/quantization/fp8.py
+++ b/modelopt/onnx/quantization/fp8.py
@@ -181,7 +181,6 @@ def quantize(
     calibrate_per_node: bool = False,
     custom_ops_to_quantize: list[str] = [],
     direct_io_types: bool = False,
-    disable_int32_weight_adjustment: bool = False,
     **kwargs,
 ) -> onnx.ModelProto:
     """Applies FP8 GEMM only quantization to an ONNX file.
@@ -274,9 +273,8 @@ def quantize(
                 logger.debug(f"Grouping QDQ tensors for concat elimination: {group_qdq_tensors}")
 
         # Add disable_int32_weight_adjustment flag to extra options
-        if disable_int32_weight_adjustment:
-            trt_guided_options["QDQDisableWeightAdjustForInt32Bias"] = True
-            logger.debug("Disabled weight adjustment for INT32 bias in QDQ quantization")
+        trt_guided_options["QDQDisableWeightAdjustForInt32Bias"] = True
+        logger.debug("Disabled weight adjustment for INT32 bias in QDQ quantization")
 
         # Create a temp file for intermediate model
         tmp_onnx_file, tmp_onnx_path = tempfile.mkstemp(suffix=".onnx")

--- a/modelopt/onnx/quantization/int8.py
+++ b/modelopt/onnx/quantization/int8.py
@@ -131,7 +131,6 @@ def quantize(
     calibrate_per_node: bool = False,
     custom_ops_to_quantize: list[str] = [],
     direct_io_types: bool = False,
-    disable_int32_weight_adjustment: bool = False,
     **kwargs,
 ) -> onnx.ModelProto:
     """Applies INT8 quantization to an ONNX file using the compiler friendly heuristics.
@@ -239,9 +238,8 @@ def quantize(
                 logger.debug(f"Found {len(group_qdq_tensors)} tensor groups for concat elimination")
 
         # Add disable_int32_weight_adjustment flag to extra options
-        if disable_int32_weight_adjustment:
-            trt_guided_options["QDQDisableWeightAdjustForInt32Bias"] = True
-            logger.debug("Disabled weight adjustment for INT32 bias in QDQ quantization")
+        trt_guided_options["QDQDisableWeightAdjustForInt32Bias"] = True
+        logger.debug("Disabled weight adjustment for INT32 bias in QDQ quantization")
 
         # Create a temp file for intermediate model
         tmp_onnx_file, tmp_onnx_path = tempfile.mkstemp(suffix=".onnx")

--- a/modelopt/onnx/quantization/quantize.py
+++ b/modelopt/onnx/quantization/quantize.py
@@ -238,7 +238,6 @@ def quantize(
     calibrate_per_node: bool = False,
     input_shapes_profile: Sequence[dict[str, str]] | None = None,
     direct_io_types: bool = False,
-    disable_int32_weight_adjustment: bool = False,
     **kwargs: Any,
 ) -> None:
     """Quantizes the provided ONNX model.
@@ -358,8 +357,6 @@ def quantize(
         direct_io_types:
             If True, modify the I/O types in the quantized ONNX model to be lower precision whenever possible.
             If False, keep the I/O types in the quantized ONNX model the same as in the given ONNX model.
-        disable_int32_weight_adjustment:
-            If True, disable weight adjustment for INT32 bias in QDQ quantization.
         kwargs:
             Additional keyword arguments for int4 quantization, including:
             - awqlite_alpha_step (float): Alpha step for lite, range [0, 1].
@@ -500,7 +497,6 @@ def quantize(
             calibrate_per_node=calibrate_per_node,
             custom_ops_to_quantize=list(custom_ops_to_quantize.keys()),
             direct_io_types=direct_io_types,
-            disable_int32_weight_adjustment=disable_int32_weight_adjustment,
             **kwargs,
         )
     elif "int4" in quantize_mode:


### PR DESCRIPTION
## What does this PR do?

**Type of change:** 
Bug Fix

**Overview:** 
- Disable the weight adjustment for int32 bias in onnxruntime by default


## Usage

```python
python -m modelopt.onnx.quantization --onnx_path=code031_gemm_batch.onnx --simplify  --calibration_eps trt --quantize_mode fp8 --disable_mha_qdq --high_precision_dtype fp16
```

## Testing
Able to quantize the code031_gemm_batch.onnx model

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: No
- **Did you add or update any necessary documentation?**: Yes
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No
