### PR TITLE
[BUG FIX 5616904]: Make VILA codebase importable and import configuration before load model config

### DIFF
--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -270,6 +270,13 @@ def get_model(
     if device == "cpu":
         device_map = "cpu"
 
+    # Add VILA to sys.path before loading config if needed
+    if "vila" in ckpt_path.lower():
+        vila_path = os.path.join(ckpt_path, "..", "VILA")
+        if vila_path not in sys.path:
+            sys.path.append(vila_path)
+        from llava.model import LlavaLlamaConfig, LlavaLlamaModel  # noqa: F401
+
     # Prepare config kwargs for loading
     config_kwargs = {"trust_remote_code": trust_remote_code} if trust_remote_code else {}
 
@@ -295,8 +302,6 @@ def get_model(
         model_kwargs.setdefault("torch_dtype", "auto")
 
     if "vila" in ckpt_path.lower():
-        sys.path.append(os.path.join(ckpt_path, "..", "VILA"))
-        from llava.model import LlavaLlamaConfig, LlavaLlamaModel  # noqa: F401
         from transformers import AutoModel
 
         hf_vila = AutoModel.from_pretrained(


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

But fix

**Overview:** ?
Make VILA codebase importable and import configuration before load model config
Fix https://nvbugspro.nvidia.com/bug/5616904

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->
```
CUDA_VISIBLE_DEVICES=0 bash -e scripts/huggingface_example.sh --model /models/vila1.5-3b --quant int4_awq --tp 1 --pp 1 --trust_remote_code --kv_cache_free_gpu_memory_fraction 0.5
```

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->
