### PR TITLE
Enable Yarn RoPE in minitron pruning for gpt-oss support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Model Optimizer Changelog (Linux)
 
 **New Features**
 
-- Add MoE (e.g. Qwen3-30B-A3B) pruning support for ``num_moe_experts``, ``moe_ffn_hidden_size`` and ``moe_shared_expert_intermediate_size`` parameters in Minitron pruning (``mcore_minitron``).
+- Add MoE (e.g. Qwen3-30B-A3B, gpt-oss-20b) pruning support for ``num_moe_experts``, ``moe_ffn_hidden_size`` and ``moe_shared_expert_intermediate_size`` parameters in Minitron pruning (``mcore_minitron``).
 - Add ``specdec_bench`` example to benchmark speculative decoding performance. See `examples/specdec_bench/README.md <https://github.com/NVIDIA/TensorRT-Model-Optimizer/tree/main/examples/specdec_bench#speculative-decoding-benchmark>`_ for more details.
 - Add FP8/NVFP4 KV cache quantization support for Megatron Core models.
 

--- a/examples/megatron-lm/README.md
+++ b/examples/megatron-lm/README.md
@@ -24,6 +24,7 @@
 | `Qwen/Qwen3-{0.6B, 8B}` | ✅ | **Online** | | ✅ | ✅ |
 | `deepseek-ai/DeepSeek-R1` | ✅ | **Online** | | | |
 | `meta-llama/Llama-{3.1-8B, 3.1-405B, 3.2-1B}-Instruct` | ✅ | **Online** | | ✅ | ✅ |
+| `openai/gpt-oss-{20b, 120b}` | ✅ | **Online** | | ✅ | ✅ |
 
 ## Getting Started in a Local Environment
 

--- a/examples/pruning/README.md
+++ b/examples/pruning/README.md
@@ -6,7 +6,7 @@ Pruning can involve removal (prune) of Linear and Conv layers, and Transformer a
 
 This section focuses on applying Model Optimizer's state-of-the-art complementary pruning modes to enable you to search for the best subnet architecture from your provided base model:
 
-1. [Minitron](https://arxiv.org/pdf/2408.11796): A pruning method developed by NVIDIA Research for pruning GPT, Mamba and Hybrid Transformer Mamba models in NVIDIA NeMo or Megatron-LM framework. It uses the activation magnitudes to prune the embedding hidden size; mlp ffn hidden size; transformer attention heads and GQA query groups; mamba heads and head dimension; MoE number of experts, ffn hidden size, and shared expert intermediate size; and number of layers of the model.
+1. [Minitron](https://arxiv.org/pdf/2408.11796): A pruning method developed by NVIDIA Research for pruning GPT (and later extended to Mamba, MoE, and Hybrid Transformer Mamba) models in NVIDIA Megatron-LM or NeMo framework. It uses the activation magnitudes to prune the embedding hidden size; mlp ffn hidden size; transformer attention heads and GQA query groups; mamba heads and head dimension; MoE number of experts, ffn hidden size, and shared expert intermediate size; and number of layers of the model.
 1. FastNAS: A pruning method recommended for Computer Vision models. Given a pretrained model, FastNAS finds the subnet which maximizes the score function while meeting the given constraints.
 1. GradNAS: A light-weight pruning method recommended for language models like Hugging Face BERT, GPT-J. It uses the gradient information to prune the model's linear layers and attention heads to meet the given constraints.
 
@@ -89,7 +89,7 @@ If your model parameters are already sorted, you can skip the sorting step by se
 
 | **Algorithm** | **Model** | **Pruning Constraints** |
 | :---: | :---: | :---: |
-| Minitron | Megatron-core / NeMo based GPT / Mamba / MoE / Hybrid Models<sup>1</sup> | Export config with width (`hidden_size`, `ffn_hidden_size`, `num_attention_heads`, `num_query_groups`, `mamba_num_heads`, `mamba_head_dim`, `num_moe_experts`, `moe_ffn_hidden_size`, `moe_shared_expert_intermediate_size`) and/or depth (`num_layers`) values |
+| Minitron | Megatron-core / NeMo based GPT / Mamba / MoE / Hybrid LLM Models<sup>1</sup> | Export config with width (`hidden_size`, `ffn_hidden_size`, `num_attention_heads`, `num_query_groups`, `mamba_num_heads`, `mamba_head_dim`, `num_moe_experts`, `moe_ffn_hidden_size`, `moe_shared_expert_intermediate_size`) and/or depth (`num_layers`) values |
 | FastNAS | Computer Vision models | flops, parameters |
 | GradNAS | HuggingFace BERT, GPT-J | flops, parameters |
 

--- a/tests/_test_utils/torch/misc.py
+++ b/tests/_test_utils/torch/misc.py
@@ -21,11 +21,13 @@ import torch
 from modelopt.torch.utils import flatten_tree
 
 
-def compare_outputs(out1, out2, rtol=1e-5, atol=1e-8, debug=False):
+def compare_outputs(out1, out2, rtol=1e-5, atol=1e-8):
     out1, _ = flatten_tree(out1)
     out2, _ = flatten_tree(out2)
     for i, (t1, t2) in enumerate(zip(out1, out2)):
-        if debug:
+        try:
+            assert torch.allclose(t1.to(torch.float32), t2.to(torch.float32), rtol, atol)
+        except AssertionError:  # noqa: PERF203
             diff = torch.abs(t1 - t2)
             print(f"\n{i=}")
             print(f"{t1=}")
@@ -35,7 +37,7 @@ def compare_outputs(out1, out2, rtol=1e-5, atol=1e-8, debug=False):
             print(f"{diff.min()=}")
             print(f"{diff.max()=}")
             print(f"{diff.mean()=}")
-        assert torch.allclose(t1.to(torch.float32), t2.to(torch.float32), rtol, atol)
+            raise
 
 
 def set_seed(seed_value=42):

--- a/tests/gpu/torch/nas/plugins/test_megatron_mamba_dynamic_modules.py
+++ b/tests/gpu/torch/nas/plugins/test_megatron_mamba_dynamic_modules.py
@@ -36,13 +36,13 @@ from modelopt.torch.nas.plugins.megatron import (
     MambaDInnerHp,
     MambaNumHeadsHp,
     _DynamicColumnParallelLinear,
+    _DynamicEmbedding,
     _DynamicExtendedRMSNorm,
     _DynamicLayerNorm,
     _DynamicMambaLayer,
     _DynamicMambaMixer,
     _DynamicMCoreLanguageModel,
     _DynamicRowParallelLinear,
-    _DynamicVocabParallelEmbedding,
 )
 from modelopt.torch.nas.traced_hp import TracedHp
 from modelopt.torch.opt.utils import named_dynamic_modules, search_space_size
@@ -86,7 +86,7 @@ def _test_mamba_search_space(rank, size):
 
     assert isinstance(model, _DynamicMCoreLanguageModel)
     if is_pipeline_first_stage():
-        assert isinstance(model.embedding.word_embeddings, _DynamicVocabParallelEmbedding)
+        assert isinstance(model.embedding.word_embeddings, _DynamicEmbedding)
     for layer in model.decoder.layers:
         assert isinstance(layer, _DynamicMambaLayer)
         assert isinstance(layer.mixer, _DynamicMambaMixer)


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Improve existing feature <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

**Overview:** GPT-OSS model has Yarn RoPE which adds additional nn.Embedding modules that need to be enabled in DynamicModule for Minitron pruning

## Testing
<!-- Mention how have you tested your change if applicable. -->

- gpt-oss-20b pruned using M-LM pruning example and conf scripts.
