### PR TITLE
[5643020] AutoCast use onnxscript for opset conversion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ optional_deps = {
         "onnxruntime~=1.22.0 ; platform_machine == 'aarch64' or platform_system == 'Darwin'",
         "onnxruntime-gpu~=1.22.0 ; platform_machine != 'aarch64' and platform_system != 'Darwin' and platform_system != 'Windows'",  # noqa: E501
         "onnxruntime-directml==1.20.0; platform_system == 'Windows'",
-        "onnxscript",  # For test_onnx_dynamo_export unit test
+        "onnxscript",  # For autocast opset conversion and test_onnx_dynamo_export unit test
         "onnxsim ; python_version < '3.12' and platform_machine != 'aarch64'",
         "polygraphy>=0.49.22",
     ],


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

**Overview:** 
Opset conversion for large models (with external data) is not handled well in onnx.
PR https://github.com/onnx/onnx/pull/6847 allows opset conversion if loading the model without weights.
While this is a possible WAR, it requires a major change in AutoCast, reloading the model as part of GraphSanitizer.
Onnxscript handles opset conversion for large models better, and is already a dependency of the ModelOpt ONNX package.

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Not applicable
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->
