### PR TITLE
[5336870] AutoCast: Unblock LSTM from conversion

### DIFF
--- a/modelopt/onnx/autocast/precisionconverter.py
+++ b/modelopt/onnx/autocast/precisionconverter.py
@@ -68,7 +68,7 @@ ONNX_TYPES = [t.onnx_type for t in PRECISION_MAP.values()]
 OP_TYPES_NOT_SUPPORTED_IN_LOW_PRECISION = ["Upsample", "NonMaxSuppression", "Celu"]
 
 # Temporarily block these ops in low precision, as they are not supported yet
-OP_TYPES_NOT_SUPPORTED_IN_LOW_PRECISION.extend(["Scan", "If", "Loop", "LSTM"])
+OP_TYPES_NOT_SUPPORTED_IN_LOW_PRECISION.extend(["Scan", "If", "Loop"])
 
 # Mapping of op types to indices of inputs that should not be converted to low precision.
 SKIP_LOW_PRECISION_MAPPING_FP16 = {"Resize": {2}}


### PR DESCRIPTION
Blocking was added as a WAR for TensorRT bug 5336870, fixed in TensorRT 10.14

## What does this PR do?

**Type of change:** Bug fix <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

**Overview:**     Unblock LSTM from conversion to 16-bit in AutoCast. Blocking was added as a WAR for TensorRT bug 5336870 (TRT only supported FP32 LSTM). Bug was fixed in TensorRT 10.14 which is now released.


## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: No
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->
