### PR TITLE
[OMNIML-2244] Add support for auto quantizing a model

### DIFF
--- a/examples/onnx_ptq/torch_quant_to_onnx.py
+++ b/examples/onnx_ptq/torch_quant_to_onnx.py
@@ -178,7 +178,7 @@ def get_model_input_shape(model):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Quantize timm models to MXFP8, NVFP4, INT4_AWQ, or use AUTO quantization"
+        description="Quantize timm models to FP8, MXFP8, INT8, NVFP4, INT4_AWQ, or use AUTO quantization"
     )
 
     # Model hyperparameters
@@ -192,12 +192,12 @@ def main():
         "--quantize_mode",
         choices=["fp8", "mxfp8", "int8", "nvfp4", "int4_awq", "auto"],
         default="mxfp8",
-        help="Type of quantization to apply (fp8, mxfp8, int8, nvfp4, int4_awq, auto)",
+        help="Type of quantization to apply. Default is MXFP8.",
     )
     parser.add_argument(
         "--onnx_save_path",
         required=True,
-        help="The path to save the ONNX model.",
+        help="The save path to save the ONNX model.",
         type=str,
     )
     parser.add_argument(
@@ -228,6 +228,13 @@ def main():
     parser.add_argument(
         "--auto_quantization_formats",
         nargs="+",
+        choices=[
+            "NVFP4_AWQ_LITE_CFG",
+            "FP8_DEFAULT_CFG",
+            "MXFP8_DEFAULT_CFG",
+            "INT8_DEFAULT_CFG",
+            "INT4_AWQ_CFG",
+        ],
         default=["NVFP4_AWQ_LITE_CFG", "FP8_DEFAULT_CFG"],
         help="Quantization formats to search from for auto mode (e.g., NVFP4_AWQ_LITE_CFG FP8_DEFAULT_CFG)",
     )
@@ -235,13 +242,13 @@ def main():
         "--effective_bits",
         type=float,
         default=4.8,
-        help="Target effective bits for auto quantization constraint",
+        help="Target effective bits for auto quantization constraint. Default is 4.8.",
     )
     parser.add_argument(
         "--num_score_steps",
         type=int,
         default=128,
-        help="Number of scoring steps for auto quantization",
+        help="Number of scoring steps for auto quantization. Default is 128.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## What does this PR do?

**Type of change:** 
Example update

**Overview:** 
- Added option to quantize a model with `mtq.auto_quantize()`

## Usage

```python
python torch_quant_to_onnx.py \
    --timm_model_name vit_small_patch16_224 \
    --quantize_mode auto \
    --onnx_save_path models/vit_auto_quant.onnx \
    --calibration_data_size 512 \
    --batch_size 8 \
    --auto_quantization_formats NVFP4_AWQ_LITE_CFG FP8_DEFAULT_CFG INT8_DEFAULT_CFG \
    --effective_bits 4.8 \
    --num_score_steps 128
```

## Testing
Able to auto quantize ViT model

```
AutoQuantize best recipe for patch_embed.proj: NONE(effective-bits: 16.0)                                                 
AutoQuantize best recipe for blocks.0.attn.qkv: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for blocks.0.attn.proj: FP8_DEFAULT_CFG(effective-bits: 8.0)                                     
AutoQuantize best recipe for blocks.0.mlp.fc1: FP8_DEFAULT_CFG(effective-bits: 8.0)                                       
AutoQuantize best recipe for blocks.0.mlp.fc2: FP8_DEFAULT_CFG(effective-bits: 8.0)                                       
AutoQuantize best recipe for blocks.1.attn.qkv: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for blocks.1.attn.proj: FP8_DEFAULT_CFG(effective-bits: 8.0)                                     
AutoQuantize best recipe for blocks.1.mlp.fc1: FP8_DEFAULT_CFG(effective-bits: 8.0)                                       
AutoQuantize best recipe for blocks.1.mlp.fc2: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.2.attn.qkv: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for blocks.2.attn.proj: FP8_DEFAULT_CFG(effective-bits: 8.0)                                     
AutoQuantize best recipe for blocks.2.mlp.fc1: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.2.mlp.fc2: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.3.attn.qkv: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for blocks.3.attn.proj: FP8_DEFAULT_CFG(effective-bits: 8.0)                                     
AutoQuantize best recipe for blocks.3.mlp.fc1: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.3.mlp.fc2: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.4.attn.qkv: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for blocks.4.attn.proj: FP8_DEFAULT_CFG(effective-bits: 8.0)                                     
AutoQuantize best recipe for blocks.4.mlp.fc1: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.4.mlp.fc2: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.5.attn.qkv: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for blocks.5.attn.proj: FP8_DEFAULT_CFG(effective-bits: 8.0)                                     
AutoQuantize best recipe for blocks.5.mlp.fc1: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.5.mlp.fc2: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.6.attn.qkv: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for blocks.6.attn.proj: FP8_DEFAULT_CFG(effective-bits: 8.0)                                     
AutoQuantize best recipe for blocks.6.mlp.fc1: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.6.mlp.fc2: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.7.attn.qkv: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for blocks.7.attn.proj: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                  
AutoQuantize best recipe for blocks.7.mlp.fc1: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.7.mlp.fc2: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.8.attn.qkv: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for blocks.8.attn.proj: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                  
AutoQuantize best recipe for blocks.8.mlp.fc1: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.8.mlp.fc2: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.9.attn.qkv: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for blocks.9.attn.proj: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                  
AutoQuantize best recipe for blocks.9.mlp.fc1: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.9.mlp.fc2: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                    
AutoQuantize best recipe for blocks.10.attn.qkv: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                  
AutoQuantize best recipe for blocks.10.attn.proj: FP8_DEFAULT_CFG(effective-bits: 8.0)                                    
AutoQuantize best recipe for blocks.10.mlp.fc1: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for blocks.10.mlp.fc2: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for blocks.11.attn.qkv: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                  
AutoQuantize best recipe for blocks.11.attn.proj: FP8_DEFAULT_CFG(effective-bits: 8.0)                                    
AutoQuantize best recipe for blocks.11.mlp.fc1: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for blocks.11.mlp.fc2: NVFP4_AWQ_LITE_CFG(effective-bits: 4.0)                                   
AutoQuantize best recipe for head: FP8_DEFAULT_CFG(effective-bits: 8.0)                                                   
AutoQuantize effective bits from search:  4.80
```

Accuracy comparison for the ViT model

|                                                      | Top-1 accuracy | Top-5 accuracy |
|------------------------------------------------------|----------------|----------------|
| Original model (FP32)                                | 85.102%        | 97.526%        |
| Auto Quantized (FP8 + NVFP4, 4.78 effective bits)   | 84.726%        | 97.434%        |
| MXFP8 Quantized                                      | 85.02%         | 97.53%         |
| NVFP4 Quantized                                      | 84.558%        | 97.36%         |
| INT4 Quantized                                       | 84.23%         | 97.22%         |

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: No
- **Did you add or update any necessary documentation?**: Yes
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->
