### PR TITLE
Support attention quantization for diffusers >= 0.35.0

### DIFF
--- a/examples/diffusers/quantization/quantize.py
+++ b/examples/diffusers/quantization/quantize.py
@@ -760,11 +760,6 @@ class Quantizer:
         self.logger.info("Disabling specific quantizers...")
         mtq.disable_quantizer(backbone, model_filter_func)
 
-        check_conv_and_mha(
-            backbone, self.config.format == QuantFormat.FP4, self.config.quantize_mha
-        )
-        mtq.print_quant_summary(backbone)
-
         self.logger.info("Quantization completed successfully")
 
 
@@ -1118,6 +1113,11 @@ def main() -> None:
                 logger.info("Model compression completed")
 
             export_manager.save_checkpoint(backbone)
+
+        check_conv_and_mha(
+            backbone, quant_config.format == QuantFormat.FP4, quant_config.quantize_mha
+        )
+        mtq.print_quant_summary(backbone)
 
         export_manager.export_onnx(
             pipe,

--- a/modelopt/torch/quantization/plugins/diffusers.py
+++ b/modelopt/torch/quantization/plugins/diffusers.py
@@ -28,13 +28,13 @@ from diffusers.models.lora import LoRACompatibleConv, LoRACompatibleLinear
 from packaging.version import parse as parse_version
 
 if parse_version(diffusers.__version__) >= parse_version("0.35.0"):
-    _diffusers_has_attention_mixin = True
+    from diffusers.models.attention import AttentionModuleMixin
     from diffusers.models.attention_dispatch import AttentionBackendName, attention_backend
     from diffusers.models.transformers.transformer_flux import FluxAttention
     from diffusers.models.transformers.transformer_ltx import LTXAttention
     from diffusers.models.transformers.transformer_wan import WanAttention
 else:
-    _diffusers_has_attention_mixin = False
+    AttentionModuleMixin = type("_dummy_type_no_instance", (), {})  # pylint: disable=invalid-name
 from torch.autograd import Function
 from torch.nn import functional as F
 from torch.onnx import symbolic_helper
@@ -178,7 +178,7 @@ class _QuantAttention(_QuantFunctionalMixin):
 QuantModuleRegistry.register({Attention: "Attention"})(_QuantAttention)
 
 
-if _diffusers_has_attention_mixin:
+if AttentionModuleMixin.__module__.startswith(diffusers.__name__):
 
     class _QuantAttentionModuleMixin(_QuantAttention):
         """Quantized AttentionModuleMixin for performing attention-related computations."""


### PR DESCRIPTION
## What does this PR do?

**Type of change:**

new feature

**Overview:** ?

Attention mechanism has changed from diffusers 0.35.

Many model attentions are now subclass of a new Mixin class:
AttentionModuleMixin, which is not a sub class of Attention

To fix it, patch the mixin class by forcing to use native attention
impl so the existing function monkey patch still work.


## Testing

manual quant of Wan, Flux

