### PR TITLE
[Bug Fix]:  Correct block_size in NVFP4_MLP_WEIGHT_ONLY_CFG to support vLLM inference

### DIFF
--- a/modelopt/torch/quantization/config.py
+++ b/modelopt/torch/quantization/config.py
@@ -592,10 +592,10 @@ NVFP4_MLP_WEIGHT_ONLY_CFG = {
         "*mlp*weight_quantizer": {
             "num_bits": (2, 1),
             "block_sizes": {
-                -1: 32,
+                -1: 16,
                 "type": "dynamic",
                 "scale_bits": (4, 3),
-            },  # Note: block_size is 32 here
+            },
             "enable": True,
             "pass_through_bwd": True,
         },


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:** Fixed an issue where NVFP4_MLP_WEIGHT_ONLY_CFG in `modelopt.torch.export.quantization.config.py` was using an incorrect `block_size` of 32. This caused inference failures when running quantized models (I tested Qwen3-8B) in vLLM.

I have updated the block_size to 16, which fixes the crash.

**Error Log**
<img width="935" height="305" alt="image" src="https://github.com/user-attachments/assets/cd4a450e-4d82-4465-961f-b61368d876f1" />




- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: No
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No

## Additional Information
<!-- E.g. related issue. -->
