### PR TITLE
[OMNIML-2244] Create the MXFP8 quant exporter

### DIFF
--- a/modelopt/onnx/quantization/qdq_utils.py
+++ b/modelopt/onnx/quantization/qdq_utils.py
@@ -33,7 +33,6 @@ from modelopt.onnx.quantization.graph_utils import (
 )
 from modelopt.onnx.quantization.quant_utils import get_num_bits
 
-
 QUANTIZE_NODE_NAME = "QuantizeLinear"
 DEQUANTIZE_NODE_NAME = "DequantizeLinear"
 

--- a/modelopt/onnx/trt_utils.py
+++ b/modelopt/onnx/trt_utils.py
@@ -140,7 +140,6 @@ def infer_types_shapes(model: onnx.ModelProto, all_tensor_info: dict) -> onnx.Mo
             trt.bool: onnx.TensorProto.BOOL,
             trt.fp8: onnx.TensorProto.FLOAT8E4M3FN,
             trt.fp4: onnx.TensorProto.FLOAT4E2M1,
-            trt.e8m0: onnx.TensorProto.UINT8,
         }
         try:
             return trt_to_onnx_dtype_mapping[trt_type]

--- a/modelopt/torch/_deploy/utils/torch_onnx.py
+++ b/modelopt/torch/_deploy/utils/torch_onnx.py
@@ -40,10 +40,7 @@ from modelopt.onnx.export import (
     NVFP4QuantExporter,
     ONNXQuantExporter,
 )
-from modelopt.onnx.quantization.qdq_utils import (
-    qdq_to_dq,
-    replace_zero_scale_with_smallest_nonzero,
-)
+from modelopt.onnx.quantization.qdq_utils import qdq_to_dq, replace_zero_scale_with_smallest_nonzero
 from modelopt.onnx.utils import (
     get_input_names,
     get_input_shapes,

--- a/tests/unit/onnx/test_qdq_utils.py
+++ b/tests/unit/onnx/test_qdq_utils.py
@@ -17,10 +17,8 @@ import numpy as np
 import pytest
 from onnx import TensorProto, helper, numpy_helper
 
-from modelopt.onnx.export import NVFP4QuantExporter
-from modelopt.onnx.export.int4_exporter import INT4QuantExporter
+from modelopt.onnx.export import INT4QuantExporter, MXFP8QuantExporter, NVFP4QuantExporter
 from modelopt.onnx.export.nvfp4_exporter import _cast_fp4, _cast_fp8
-from modelopt.onnx.export.mxfp8_exporter import MXFP8QuantExporter
 
 
 def create_test_model_with_int4_dq_reshape_transpose_matmul(constant_scale: bool = False):


### PR DESCRIPTION
## What does this PR do?

**Type of change:** 
New feature

**Overview:** ?
- Implemented functions for the MXFP8 quant exporter
- Integrated autocast for converting model to fp16
- deprecated quantize_weights_to_mxfp8
- Updated tests

## Usage
```
python torch_quant_to_onnx.py --quantize_mode=mxfp8 --onnx_save_path=vit_base_patch16_224.mxfp8.onnx --calibration_data_size 64 --batch_size 128
```

## Testing
```
python evaluate.py --onnx_path=vit_base_patch16_224.mxfp8.onnx --model_name=vit_base_patch16_224 --results_path=./results.txt --batch_size 128
```

Accuracy and latency results
```
The top1 accuracy of the model is 85.07%
The top5 accuracy of the model is 97.558%
```

Reference accuracy for fp16
```
The top1 accuracy of the model is 85.102%
The top5 accuracy of the model is 97.526%
```

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: No
- deprecated quantize_weights_to_mxfp8
- **Did you write any new necessary tests?**: No
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->
