### PR TITLE
[5704162] Create a copy to avoid leaking ProcessGroup into state dict

### DIFF
--- a/modelopt/torch/sparsity/weight_sparsity/plugins/megatron.py
+++ b/modelopt/torch/sparsity/weight_sparsity/plugins/megatron.py
@@ -16,39 +16,13 @@
 """Support sparsify and save/resore for Megatron."""
 
 import megatron.core.transformer.mlp as megatron_mlp
-from megatron.core.parallel_state import get_data_parallel_group
 from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
 from megatron.core.transformer.utils import make_sharded_tensors_for_checkpoint
 
-from modelopt.torch.opt.plugins.megatron import _MegatronMLP
+from modelopt.torch.opt.plugins.megatron import _MegatronMLP, ensure_metadata_has_dp_cp_group
 
 from ..config import SparseGPTConfig, SparseMagnitudeConfig
 from ..module import SparseModule, SpDMRegistry
-
-
-def ensure_metadata_has_dp_cp_group(metadata):
-    """Ensure `metadata` is a dict containing `dp_cp_group` entry.
-
-    This function is adapted from megatron-lm's megatron.core.transformer.utils to avoid
-    dependency on megatron-lm's specific version.
-
-    Note:
-        This is a temporary method and will be removed once this function is merged to
-        megatron.core.transformer.utils in the main branch of megatron-lm.
-    """
-    # Create a copy to avoid modifying the original metadata dict
-    # This prevents ProcessGroup from leaking into state dict
-    if metadata is None:
-        new_metadata = {}
-    else:
-        new_metadata = dict(metadata)
-    if "dp_cp_group" not in new_metadata:
-        try:
-            new_metadata["dp_cp_group"] = get_data_parallel_group(with_context_parallel=True)
-        except (AssertionError, RuntimeError):
-            # Fallback if context parallel is not initialized
-            new_metadata["dp_cp_group"] = get_data_parallel_group()
-    return new_metadata
 
 
 class _MegatronParallelLinear(SparseModule):


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ?  Bug Fix

**Overview:** ?

Fixed a TypeError: cannot pickle 'torch._C._distributed_c10d.ProcessGroup' object error that occurs during checkpoint saving when using modelopt==0.40.0 with Megatron-LM.

The ensure_metadata_has_dp_cp_group() function (introduced in #606) modifies the metadata dict in-place by adding a ProcessGroup object. This causes the ProcessGroup to leak into the common_state_dict, which is then broadcast via torch.distributed.broadcast_object_list() during checkpoint validation. Since ProcessGroup objects cannot be pickled, the save fails.

Changed ensure_metadata_has_dp_cp_group() to create a new copy of the metadata dict instead of modifying it in-place.

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->
