### PR TITLE
KD example fix for new torch/hf causing FDSP save error

### DIFF
--- a/examples/llm_distill/requirements.txt
+++ b/examples/llm_distill/requirements.txt
@@ -1,3 +1,4 @@
 pyarrow
+torchao>=0.14.1
 transformers<5.0
 trl>=0.23.0


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ? Bug Fix

**Overview:** ? `llm_distill` example was hanging during save since somehow now the weights on other ranks are being deleted during `model.export()` too early. Fixed via synchronizing the processes beforehand.

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->
