### PR TITLE
Fix BertSdpaSelfAttention quantization

### DIFF
--- a/tests/_test_utils/torch/transformers_models.py
+++ b/tests/_test_utils/torch/transformers_models.py
@@ -85,6 +85,24 @@ def get_tiny_qwen3_moe(**config_kwargs) -> "Qwen3MoeForCausalLM":
     return tiny_qwen3_moe
 
 
+def get_tiny_bert(**config_kwargs) -> "BertForQuestionAnswering":
+    set_seed(SEED)
+
+    kwargs = {
+        "hidden_size": 32,
+        "intermediate_size": 32,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 2,
+        "max_position_embeddings": 32,
+        "vocab_size": 32,
+    }
+    kwargs.update(**config_kwargs)
+    tiny_bert = BertForQuestionAnswering(BertConfig(**kwargs))
+
+    return tiny_bert
+
+
 def get_tiny_llama(**config_kwargs) -> LlamaForCausalLM:
     set_seed(SEED)
     kwargs = {


### PR DESCRIPTION
## What does this PR do?

**Type of change:**  Bug fix

**Overview:** 
`BertSDPASelfAttention` quantization was failing
Issue: Decorators (e.g., @deprecate_kwarg in BERT) wrap methods and change their free variables. The modified AST needs __class__ for super(), but the decorated wrapper has different freevars (e.g., 'additional_message', 'func').
     
Fix: Search the decorator's closure to find the actual undecorated method with matching free variables, then use its globals and closure for bytecode reconstruction.

## Usage

```
cd examples/chained_optimizations
bash scripts/1_prune.sh
bash scripts/2_int8_quantize.sh
```

## Testing
Added unit test: test_kv_quant_bert

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: Yes
- **Did you add or update any necessary documentation?**: Yes
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: NA
## Additional Information
<!-- E.g. related issue. -->
