### PR TITLE
[NVBUG: 5701937]Clear GPU cache for 3D weight tensors

### DIFF
--- a/modelopt/torch/export/quant_utils.py
+++ b/modelopt/torch/export/quant_utils.py
@@ -756,6 +756,11 @@ def to_quantized_weight(
     if isinstance(weight, QTensorWrapper):
         return weight.data
 
+    if weight.dim() == 3:
+        # for MOE stacked weights
+        # Clear GPU cache to avoid pontential GPU OOM issues for large models.
+        clear_cuda_cache()
+
     if quantization == QUANTIZATION_FP8:
         # Fix RuntimeError: Promotion for Float8 Types is not supported, attempted to promote Float8_e4m3fn and Float
         # in speculative decoding fp8 model export
@@ -764,9 +769,6 @@ def to_quantized_weight(
             return weight
 
         if weight.dim() == 3:
-            # for MOE stacked weights
-            # Clear GPU cache to avoid pontential GPU OOM issues for large models.
-            clear_cuda_cache()
             return (weight / weights_scaling_factor.unsqueeze(-1)).to(torch.float8_e4m3fn)
         return (weight / weights_scaling_factor).to(torch.float8_e4m3fn)
 


### PR DESCRIPTION
Add GPU cache clearing for 3D weight tensors to prevent OOM issues.

## What does this PR do?

**Type of change:** ? Bug fix

## Testing
python hf_ptq.py --dataset cnn_dailymail --pyt_ckpt_path Llama-4-Maverick-17B-128E-Instruct --qformat nvfp4 --kv_cache_qformat fp8 --batch_size 1 --calib_size 32 --use_seq_device_map --gpu_max_mem_percentage 0.6 --trust_remote_code

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/TensorRT-Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->
