### PR TITLE
Use gesvd as solver

### DIFF
--- a/modelopt/torch/quantization/model_calib.py
+++ b/modelopt/torch/quantization/model_calib.py
@@ -1033,7 +1033,10 @@ def svdquant(
         original_device = weight.device
         original_dtype = weight.dtype
         weight_f64 = weight.to(dtype=torch.float64, device=original_device)
-        u, s, vt = torch.linalg.svd(weight_f64, driver="gesvd", full_matrices=False)
+        if original_device.type == "cuda":
+            u, s, vt = torch.linalg.svd(weight_f64, driver="gesvd", full_matrices=False)
+        else:
+            u, s, vt = torch.linalg.svd(weight_f64, full_matrices=False)
         if u.shape[1] < lowrank or vt.shape[0] < lowrank:
             warnings.warn(
                 "The low-rank dimensions do not match the layer dimensions. "

--- a/modelopt/torch/quantization/model_calib.py
+++ b/modelopt/torch/quantization/model_calib.py
@@ -1033,7 +1033,7 @@ def svdquant(
         original_device = weight.device
         original_dtype = weight.dtype
         weight_f64 = weight.to(dtype=torch.float64, device=original_device)
-        u, s, vt = torch.linalg.svd(weight_f64, full_matrices=False)
+        u, s, vt = torch.linalg.svd(weight_f64, driver="gesvd", full_matrices=False)
         if u.shape[1] < lowrank or vt.shape[0] < lowrank:
             warnings.warn(
                 "The low-rank dimensions do not match the layer dimensions. "


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

Bug fix: default svd solver does not work for ill-conditioned matrixes. Switch to `gesvd` solver as it is more accurate (as per documentation) as does not fails for ill-conditioned matrixes

**Overview:** ?

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: No. as we might not want to test all matrix shapes
- **Did you add or update any necessary documentation?**: No need to change the documentation
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: No

## Additional Information
<!-- E.g. related issue. -->
