### PR TITLE
Minitron pruning refactor [2/2]: De-couple importance estimator from Dynamic Module

### DIFF
--- a/modelopt/torch/prune/plugins/mcore_minitron.py
+++ b/modelopt/torch/prune/plugins/mcore_minitron.py
@@ -25,29 +25,42 @@ Actual dynamic module implementations are at :mod:`modelopt.torch.nas.plugins.me
 """
 
 import copy
+from collections.abc import Callable
+from functools import partial
+from typing import Any
 from warnings import warn
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
+from megatron.core.parallel_state import (
+    get_pipeline_model_parallel_group,
+    get_pipeline_model_parallel_rank,
+    get_pipeline_model_parallel_world_size,
+)
+from megatron.core.tensor_parallel import (
+    gather_from_tensor_model_parallel_region,
+    reduce_from_tensor_model_parallel_region,
+)
 from pydantic import create_model
 
-# isort: off
-# import nas plugin to check if it is enabled else raises an Exception and disables the plugin
-from modelopt.torch.nas.plugins.megatron import *  # noqa: F403
+from modelopt.torch.nas.conversion import NASModeRegistry
 from modelopt.torch.nas.plugins.megatron import (
     HAS_MAMBA,
-    _DynamicMCoreLanguageModel,
     SUPPORTED_MODELS,
-    drop_mcore_language_model_layers,
+    _DynamicMambaLayer,
+    _DynamicMambaMixer,
+    _DynamicMCoreLanguageModel,
+    _DynamicMLP,
+    _DynamicSelfAttention,
+    _DynamicSequentialMLP,
+    _DynamicTransformerLayer,
 )
-# isort: on
-
-from modelopt.torch.nas.conversion import NASModeRegistry
 from modelopt.torch.nas.registry import DMRegistry
 from modelopt.torch.nas.utils import get_subnet_config, sort_parameters
 from modelopt.torch.opt.config import ModeloptBaseConfig, get_kwargs_for_create_model_with_rules
 from modelopt.torch.opt.conversion import ApplyModeError
-from modelopt.torch.opt.dynamic import DynamicSpace
+from modelopt.torch.opt.dynamic import DynamicModule, DynamicSpace
 from modelopt.torch.opt.mode import (
     ConvertEntrypoint,
     ConvertReturnType,
@@ -56,7 +69,8 @@ from modelopt.torch.opt.mode import (
 )
 from modelopt.torch.opt.searcher import BaseSearcher, SearchConfig, SearchStateDict
 from modelopt.torch.opt.utils import named_hparams
-from modelopt.torch.utils import print_rank_0
+from modelopt.torch.utils import distributed as dist
+from modelopt.torch.utils import get_module_device, print_rank_0
 
 from ..pruning import PruneModeRegistry
 
@@ -85,6 +99,71 @@ __all__ = [
     "MCoreMinitronSearcher",
     "drop_mcore_language_model_layers",
 ]
+
+
+def drop_mcore_language_model_layers(model: nn.Module, *, layers_to_drop: list[int]) -> None:
+    """Remove given layers (1-indexed) of the model (works with TP and/or PP).
+
+    If model is a wrapper around GPTModel or MambaModel, it will be unwrapped.
+    """
+    layers_to_drop = sorted(layers_to_drop)
+    assert layers_to_drop[0] >= 1, (
+        f"Layers to drop should be in range 1 to {model.config.num_layers}, got {layers_to_drop}."
+    )
+
+    supported_model_types = tuple(SUPPORTED_MODELS.keys())
+    for n, m in model.named_modules():
+        if isinstance(m, supported_model_types):
+            model = m
+            break
+    assert isinstance(model, supported_model_types), (
+        f"Model should have one of {supported_model_types} submodule, got {model}"
+    )
+    print_rank_0(f"Dropping layers {layers_to_drop} from {n} ({type(model)}).")
+
+    # get the number of layers remaining in each pp rank
+    layers_remaining_per_pp = torch.zeros(
+        get_pipeline_model_parallel_world_size(),
+        dtype=torch.int,
+        device=get_module_device(model),
+    )
+    layers_remaining = torch.tensor(
+        sum(1 for layer in model.decoder.layers if layer.layer_number not in layers_to_drop),
+        dtype=torch.int,
+        device=get_module_device(model),
+    )
+
+    # Below distributed gather requires tensors to be on cuda
+    layers_remaining_per_pp = layers_remaining_per_pp.cuda()
+    layers_remaining = layers_remaining.cuda()
+    torch.distributed.all_gather_into_tensor(
+        layers_remaining_per_pp, layers_remaining, group=get_pipeline_model_parallel_group()
+    )
+    layers_remaining_per_pp = [i.item() for i in layers_remaining_per_pp]
+    new_num_layers = sum(layers_remaining_per_pp)
+
+    # reindex kept layers, exclude sharded state dict for dropped layers
+    layer_offset = sum(layers_remaining_per_pp[: get_pipeline_model_parallel_rank()])
+    layer_number = layer_offset + 1
+    dropped_layers = []
+    for layer in model.decoder.layers:
+        if layer.layer_number in layers_to_drop:
+            layer.layer_number = -1  # should not be used
+            # layer.sharded_state_dict = lambda prefix, sharded_offsets, metadata: {}
+            dropped_layers.append(layer)
+        else:
+            layer.layer_number = layer_number
+            layer.get_transformer_layer_offset = lambda: layer_offset
+            layer_number += 1
+
+    # remove dropped layers from the modulelist
+    model.decoder.layers = nn.ModuleList(
+        [layer for layer in model.decoder.layers if layer.layer_number != -1]
+    )
+    for layer in dropped_layers:
+        del layer
+
+    model.config.num_layers = new_num_layers
 
 
 class MCoreMinitronSearcher(BaseSearcher):
@@ -161,11 +240,10 @@ class MCoreMinitronSearcher(BaseSearcher):
                 break
         assert isinstance(unwrapped_model, _DynamicMCoreLanguageModel), "Model not supported!"
 
+        registry = ImportanceEstimatorRegistry(unwrapped_model)
         if self.layer_scores and self.activations_per_rank:  # Available from checkpoint
             print_rank_0("Loading activations and scores per rank from checkpoint...")
-            unwrapped_model.set_activations_and_layer_scores(
-                self.activations_per_rank, self.layer_scores
-            )
+            registry.set_activations_and_layer_scores(self.activations_per_rank, self.layer_scores)
         elif not self.config["skip_sorting"]:
             print_rank_0("Running forward loop...")
             assert self.forward_loop is not None
@@ -177,7 +255,7 @@ class MCoreMinitronSearcher(BaseSearcher):
 
             # Store activations and layer scores for re-pruning with different export configs
             self.activations_per_rank, self.layer_scores = (
-                unwrapped_model.get_activations_and_layer_scores()
+                registry.get_activations_and_layer_scores()
             )
             self.save_search_checkpoint(verbose=True)
 
@@ -194,6 +272,14 @@ class MCoreMinitronSearcher(BaseSearcher):
             if hp_name in export_config:
                 hp.active = export_config[hp_name]
 
+        # Drop layers if depth pruning is enabled
+        num_layers_hp = unwrapped_model.get_hparam("num_layers")
+        if num_layers_hp.active != num_layers_hp.max:
+            # sort layers by scores and drop the lowest ones
+            sorted_layers = sorted(self.layer_scores.items(), key=lambda x: x[1], reverse=True)
+            layers_to_drop = [layer for layer, _ in sorted_layers[num_layers_hp.active :]]  # type: ignore[misc]
+            drop_mcore_language_model_layers(self.model, layers_to_drop=layers_to_drop)
+
         # kv_channels can be None so we need to save original from original hidden_size and num_attention_heads
         model_cfg = self.model.config
         orig_kv_channels = getattr(model_cfg, "kv_channels")
@@ -205,6 +291,8 @@ class MCoreMinitronSearcher(BaseSearcher):
         for n in SUPPORTED_HPARAMS:
             if n in export_config:
                 setattr(model_cfg, n, export_config[n])
+
+        registry.cleanup()
 
 
 MCoreMinitronConfig: type[ModeloptBaseConfig] = create_model(
@@ -317,3 +405,490 @@ class MCoreMinitronModeDescriptor(ModeDescriptor):
     def restore(self) -> RestoreEntrypoint:
         """The mode's entrypoint for restoring a model with the modelopt_state."""
         return restore_mcore_minitron
+
+
+class ImportanceEstimatorRegistry:
+    """Register importance estimators and forward hooks for all supported modules in the model.
+
+    This class should be instantiated after converting the model to DynamicModule but before
+    running the forward loop for importance estimation.
+    """
+
+    def __init__(self, model: DynamicModule):
+        """Initialize the registry."""
+        assert isinstance(model, _DynamicMCoreLanguageModel), "Model must be a DynamicModule"
+        self.model = model
+        self._hooks: list[tuple[nn.Module, Any]] = []  # List of (module, hook_handle) tuples
+
+        print_rank_0("Registering importance estimators and forward hooks...")
+        for module in self.model.modules():
+            if isinstance(module, _DynamicMCoreLanguageModel):
+                _register_hidden_size_importance(module, self)
+            elif isinstance(module, (_DynamicTransformerLayer, _DynamicMambaLayer)):
+                _register_depth_cosine_importance(module, self)
+            elif isinstance(module, _DynamicSelfAttention):
+                _register_self_attention_importance(module, self)
+            elif isinstance(module, _DynamicMLP):
+                _register_mlp_importance(module, self)
+            elif isinstance(module, _DynamicSequentialMLP):
+                _register_sequential_mlp_importance(module, self)
+            elif isinstance(module, _DynamicMambaMixer):
+                _register_mamba_mixer_importance(module, self)
+
+    def register_hook(
+        self,
+        module: nn.Module,
+        hook_fn: Callable,
+        hook_type: str = "forward",
+        **hook_kwargs,
+    ) -> None:
+        """Register a forward or forward_pre hook on a module.
+
+        Args:
+            module: The module to register the hook on.
+            hook_fn: The hook function to register.
+            hook_type: Type of hook ("forward" or "forward_pre").
+            **hook_kwargs: Additional kwargs for hook registration.
+        """
+        if hook_type == "forward":
+            handle = module.register_forward_hook(hook_fn, **hook_kwargs)
+        elif hook_type == "forward_pre":
+            handle = module.register_forward_pre_hook(hook_fn, **hook_kwargs)
+        else:
+            raise ValueError(f"Unsupported hook_type: {hook_type}")
+
+        self._hooks.append((module, handle))
+
+    def register_importance(
+        self,
+        dynamic_module: DynamicModule,
+        hparam_name: str,
+        importance_fn: Callable,
+        importance_is_order: bool = False,
+    ) -> None:
+        """Register an importance estimator for a hyperparameter.
+
+        Args:
+            dynamic_module: The DynamicModule instance.
+            hparam_name: Name of the hyperparameter to register importance for.
+            importance_fn: Function that returns importance scores.
+            importance_is_order: Whether the importance is a ranking order.
+        """
+        hp = dynamic_module.get_hparam(hparam_name)
+        if importance_is_order:
+            hp._importance_is_order = True
+        hp.register_importance(importance_fn)
+
+    def cleanup(self) -> None:
+        """Remove all registered hooks and temporary attributes."""
+        # Remove all hooks
+        for _, handle in self._hooks:
+            handle.remove()
+        self._hooks.clear()
+
+    def get_layer_scores(self) -> dict[int, torch.Tensor]:
+        """Get the layer scores (1-indexed) from the model.
+
+        Returns:
+            Dictionary mapping layer number to layer score.
+        """
+        num_layers_hp = self.model.get_hparam("num_layers")
+
+        for layer in self.model.decoder.layers:
+            assert layer._scores > 0, "No scores collected for importance estimation."
+
+        # gather layer scores from all PP ranks
+        layer_scores = {}
+        for layer in self.model.decoder.layers:
+            layer_scores[layer.layer_number] = layer._scores
+        all_pp_layer_scores = [None] * get_pipeline_model_parallel_world_size()
+        torch.distributed.all_gather_object(
+            all_pp_layer_scores, layer_scores, group=get_pipeline_model_parallel_group()
+        )
+        layer_scores = {k: v for d in all_pp_layer_scores for k, v in d.items()}  # type: ignore[attr-defined]
+        print_rank_0(f"Layerwise scores (1-indexed, higher is better): {layer_scores}")
+        assert sorted(layer_scores.keys()) == list(range(1, num_layers_hp.max + 1))  # type: ignore[arg-type]
+
+        return layer_scores
+
+    def get_activations_and_layer_scores(
+        self,
+    ) -> tuple[list[dict[str, torch.Tensor]], dict[int, torch.Tensor]]:
+        """Get the per-rank activations and layer scores from the model."""
+        local_activations = {}
+        for n, m in self.model.named_modules():
+            if hasattr(m, "_activations"):
+                local_activations[n] = m._activations
+        activations_per_rank = dist.allgather(
+            local_activations, group=get_pipeline_model_parallel_group()
+        )
+        assert len(activations_per_rank) == get_pipeline_model_parallel_world_size()
+
+        layer_scores = self.get_layer_scores()
+
+        return activations_per_rank, layer_scores
+
+    def set_activations_and_layer_scores(
+        self,
+        activations_per_rank: list[dict[str, torch.Tensor]],
+        layer_scores: dict[int, torch.Tensor],
+    ) -> None:
+        """Set the pre-computed layer_scores and per-rank activations instead of running forward.
+
+        Args:
+            activations_per_rank: List of dicts from module name to activations. Should match PP size.
+            layer_scores: Dict from layer_number (1-indexed) to score.
+        """
+        rank = get_pipeline_model_parallel_rank()
+        pp_size = get_pipeline_model_parallel_world_size()
+        assert len(activations_per_rank) == pp_size, (
+            f"Expected same PP size for stored pruning scores ({len(activations_per_rank)}) as current ({pp_size})!"
+        )
+        for layer in self.model.decoder.layers:
+            layer._scores = layer_scores[layer.layer_number]
+        for n, m in self.model.named_modules():
+            if hasattr(m, "_activations"):
+                m._activations = activations_per_rank[rank][n]
+
+
+# Module-specific registration functions
+def _register_hidden_size_importance(
+    module: _DynamicMCoreLanguageModel, registry: ImportanceEstimatorRegistry
+) -> None:
+    """Register importance estimators for Language Model (GPT/Mamba) modules."""
+    module._register_temp_attribute("_activations", {})
+
+    def _emb_layernorm_forward_hook(mod, module_inner, input, output):
+        """Hook to collect activations for importance estimation.
+
+        Activations are computed as mean over seq_len and then squared and summed over batch_size.
+        Later we take the square root of the sum to get the L2 norm.
+        """
+        # Gather output [seq_len, batch_size, hidden_size] over all TP regions
+        # NOTE: This is not used at the moment since we restrict to TP=1
+        output = gather_from_tensor_model_parallel_region(output).detach()
+
+        output = output.to(torch.float32)  # use full precision to avoid overflow
+        activations = output.abs().mean(dim=0)  # [batch_size, hidden_size]
+        activations = activations.pow(2).sum(dim=0)
+        if id(module_inner) not in mod._activations:
+            mod._activations[id(module_inner)] = activations
+        else:
+            mod._activations[id(module_inner)] += (
+                activations  # aggregate sum instead of mean of scores for simplicity
+            )
+
+    def _estimate_hidden_size_importance(mod):
+        """Return the activation magnitude-based importance of the hidden_size."""
+        assert mod._activations, "No activations collected for importance estimation."
+        # Convert squared sum to L2 norm over global batch size per hook
+        aggregated_activations = [act.pow(0.5) for act in mod._activations.values()]
+        activations = torch.stack(aggregated_activations).sum(dim=0)  # [hidden_size]
+
+        # Reduce over all PP ranks
+        activations = activations.clone()
+        torch.distributed.all_reduce(activations, op=torch.distributed.ReduceOp.SUM)
+        return activations
+
+    # Register hooks for all layers
+    for layer in module.decoder.layers:
+        if isinstance(layer, _DynamicTransformerLayer):
+            if isinstance(layer.self_attention, _DynamicSelfAttention):
+                registry.register_hook(
+                    layer.input_layernorm,
+                    partial(_emb_layernorm_forward_hook, module),
+                    hook_type="forward",
+                )
+
+            if isinstance(layer.mlp, (_DynamicMLP, _DynamicSequentialMLP)):
+                registry.register_hook(
+                    layer.pre_mlp_layernorm,
+                    partial(_emb_layernorm_forward_hook, module),
+                    hook_type="forward",
+                )
+        elif isinstance(layer, _DynamicMambaLayer):
+            registry.register_hook(
+                layer.norm, partial(_emb_layernorm_forward_hook, module), hook_type="forward"
+            )
+
+    registry.register_importance(
+        module, "hidden_size", lambda: _estimate_hidden_size_importance(module)
+    )
+
+
+def _register_depth_cosine_importance(
+    module: _DynamicTransformerLayer | _DynamicMambaLayer, registry: ImportanceEstimatorRegistry
+) -> None:
+    """Register importance estimators for TransformerLayer and MambaLayer modules."""
+    module._register_temp_attribute("_scores", 0.0)
+
+    def _layer_imp_forward_hook(mod, module_inner, args, kwargs, output):
+        """Hook to collect cosine similarity between input and output to rank layers for depth pruning."""
+        hidden_states = kwargs["hidden_states"] if "hidden_states" in kwargs else args[0]
+
+        if isinstance(mod, _DynamicTransformerLayer):
+            output, _ = output  # [seq_len, batch_size, hidden_size]
+
+        # use full precision to avoid overflow
+        hidden_states = hidden_states.to(torch.float32)
+        output = output.to(torch.float32)
+
+        with torch.no_grad():
+            # Lower cosine_similarity means higher importance hence use 1 - cosine_similarity
+            score = 1 - F.cosine_similarity(hidden_states, output, dim=2).mean()
+            # TODO: Check if we need to reduce over TP regions (seems like all TP have same scores anyway)
+            global_score = reduce_from_tensor_model_parallel_region(score).item()
+            mod._scores += global_score  # aggregate sum instead of mean of scores for simplicity
+
+    registry.register_hook(
+        module,
+        partial(_layer_imp_forward_hook, module),
+        hook_type="forward",
+        with_kwargs=True,
+    )
+
+
+def _register_self_attention_importance(
+    module: _DynamicSelfAttention, registry: ImportanceEstimatorRegistry
+) -> None:
+    """Register importance estimators for SelfAttention modules."""
+    module._register_temp_attribute("_activations", None)
+
+    def _linear_proj_forward_hook(mod, module_inner, input, output):
+        """Hook to collect activations for importance estimation.
+
+        Activations are computed as mean over seq_len and then squared and summed over batch_size.
+        Later we take the square root of the sum to get the L2 norm.
+        """
+        # Gather input [seq_len, batch_size, query_projection_size] over all TP regions
+        # NOTE: This is not used at the moment since we restrict to TP=1
+        input = gather_from_tensor_model_parallel_region(input[0]).detach()
+
+        input = input.to(torch.float32)  # use full precision to avoid overflow
+        activations = input.abs().mean(dim=0)
+        activations = activations.pow(2).sum(dim=0)  # [query_projection_size]
+        if mod._activations is None:
+            mod._activations = activations
+        else:
+            mod._activations += activations
+
+    def _estimate_head_ranking(mod):
+        """Return the importance for num_attention_heads."""
+        assert mod._activations is not None, "No activations collected for importance estimation."
+        n_groups = mod.num_query_groups_per_partition
+        max_nheads = mod.get_hparam("num_attention_heads").max
+        max_heads_per_group = max_nheads // n_groups
+
+        # Convert squared sum to L2 norm
+        scores = mod._activations.pow(0.5).view(max_nheads, mod.config.kv_channels).cpu()
+        attn_head_importance = torch.linalg.vector_norm(scores, ord=2, dim=1)
+        # group_importance = torch.linalg.vector_norm(scores, ord=2, dim=(0, 2))
+
+        # Convert to global indices by adding offset
+        attn_head_ranking_per_group = attn_head_importance.view(
+            n_groups, max_heads_per_group
+        ).argsort(dim=1, descending=True)
+
+        attn_head_ranking_global = (
+            attn_head_ranking_per_group + torch.arange(0, max_nheads, max_heads_per_group)[:, None]
+        ).flatten()
+        assert torch.equal(attn_head_ranking_global.sort().values, torch.arange(max_nheads))
+        # Return group-aware ranking of all attention heads
+        # Actual group-aware trimming happens in NumAttentionHeadsHp
+        return attn_head_ranking_global
+
+    registry.register_hook(
+        module.linear_proj,
+        partial(_linear_proj_forward_hook, module),
+        hook_type="forward",
+    )
+    # [HACK] Return ranking (group-aware) instead of importance for sort_parameters()
+    # NOTE: Trimming should also happen within each group. This is handled in NumAttentionHeadsHp
+    registry.register_importance(
+        module,
+        "num_attention_heads",
+        lambda: _estimate_head_ranking(module),
+        importance_is_order=True,
+    )
+
+
+def _register_mlp_importance(module: _DynamicMLP, registry: ImportanceEstimatorRegistry) -> None:
+    """Register importance estimators for MLP modules."""
+    module._register_temp_attribute("_activations", None)
+
+    def _linear_fc2_forward_hook(mod, module_inner, input, output):
+        """Hook to collect activations for importance estimation.
+
+        Activations are computed as mean over seq_len and then squared and summed over batch_size.
+        Later we take the square root of the sum to get the L2 norm.
+        """
+        # Gather input [seq_len, batch_size, ffn_hidden_size] over all TP regions
+        # NOTE: This is not used at the moment since we restrict to TP=1
+        input = gather_from_tensor_model_parallel_region(input[0]).detach()
+        if input.dim() == 2:
+            # For sparse experts, there is no batch dimension.
+            input = input[:, None, :]
+
+        input = input.to(torch.float32)  # use full precision to avoid overflow
+        activations = input.abs().mean(dim=0)  # [batch_size, ffn_hidden_size]
+        activations = activations.pow(2).sum(dim=0)  # [ffn_hidden_size]
+        if mod._activations is None:
+            mod._activations = activations
+        else:
+            mod._activations += activations
+
+    def _estimate_importance(mod):
+        """Return the activation magnitude-based importance of the ffn_hidden_size."""
+        assert mod._activations is not None, "No activations collected for importance estimation."
+        # Convert squared sum to L2 norm
+        return mod._activations.pow(0.5)
+
+    registry.register_hook(
+        module.linear_fc2, partial(_linear_fc2_forward_hook, module), hook_type="forward"
+    )
+    registry.register_importance(module, module.hparam_name, lambda: _estimate_importance(module))
+
+
+def _register_sequential_mlp_importance(
+    module: _DynamicSequentialMLP, registry: ImportanceEstimatorRegistry
+) -> None:
+    """Register importance estimators for SequentialMLP (MoE experts) modules."""
+    module._register_temp_attribute(
+        "_activations",
+        {
+            "expert_l2_scores": torch.zeros(module.num_local_experts),
+            "expert_sample_counts": torch.zeros(module.num_local_experts),
+        },
+    )
+
+    def _expert_l2_imp_forward_hook(mod, module_inner, input, output):
+        """Track expert importance based on L2 norms of expert outputs."""
+        # Split output back to per-expert outputs using torch.split
+        tokens_per_expert_list = input[1].tolist()
+        # use full precision to avoid overflow
+        output_local = output[0].to(torch.float32).detach()
+        output_local_list = torch.split(output_local, tokens_per_expert_list)
+
+        # Compute L2 norm for each expert's output
+        for expert_idx, expert_output in enumerate(output_local_list):
+            # Guard: if expert_output is empty tensor, add zero score
+            if expert_output.numel() == 0:
+                l2_norm = 0.0
+            else:
+                # Compute L2 norm of expert output (router_prob * expert_output)
+                l2_norm = torch.linalg.vector_norm(expert_output, ord=2, dim=-1).sum().item()
+
+            # Accumulate L2 scores and sample counts
+            mod._activations["expert_l2_scores"][expert_idx] += l2_norm
+            mod._activations["expert_sample_counts"][expert_idx] += tokens_per_expert_list[
+                expert_idx
+            ]
+
+    def _estimate_expert_importance(mod):
+        """Estimate expert importance based on accumulated L2 norms."""
+        assert mod._activations["expert_sample_counts"].sum() > 0, (
+            "No activations collected for importance estimation."
+        )
+        # Average L2 scores across samples (avoid division by zero if some experts have no samples)
+        return mod._activations["expert_l2_scores"] / (
+            mod._activations["expert_sample_counts"] + 1e-8
+        )
+
+    registry.register_hook(
+        module,
+        partial(_expert_l2_imp_forward_hook, module),
+        hook_type="forward",
+    )
+    registry.register_importance(
+        module,
+        "num_local_experts",
+        lambda: _estimate_expert_importance(module),
+    )
+
+
+def _register_mamba_mixer_importance(
+    module: _DynamicMambaMixer, registry: ImportanceEstimatorRegistry
+) -> None:
+    """Register importance estimators for MambaMixer modules."""
+    module._register_temp_attribute("_activations", None)
+
+    def _mamba_in_proj_forward_hook(mod, module_inner, input, output):
+        """Hook to collect activations for importance estimation.
+
+        Activations are computed as mean over seq_len and then squared and summed over batch_size.
+        Later we take the square root of the sum to get the L2 norm.
+        """
+        # Gather output [seq_len, batch_size, d_inner] over all TP regions
+        # NOTE: This is not used at the moment since we restrict to TP=1
+        output = gather_from_tensor_model_parallel_region(output[0]).detach()
+
+        output = output.to(torch.float32)  # use full precision to avoid overflow
+        activations = output.abs().mean(dim=0)
+        activations = activations.pow(2).sum(dim=0)  # [d_inner]
+        if mod._activations is None:
+            mod._activations = activations
+        else:
+            mod._activations += activations
+
+    def _estimate_head_and_head_dim_rankings(mod):
+        """Get the rankings of Mamba heads and head dimensions."""
+        # Convert squared sum to L2 norm
+        scores = mod._activations.pow(0.5)
+        assert scores is not None, "No activations collected for importance estimation."
+
+        max_nheads = mod.get_hparam("mamba_num_heads").max
+        max_headdim = mod.get_hparam("mamba_head_dim").max
+        max_d_inner = mod.get_hparam("d_inner").max
+        target_headdim = mod.headdim
+        nheads_per_group = max_nheads // mod.ngroups
+
+        # While there can be many ways of computing the ranking out of z, x, and dt,
+        # based on ablations in the paper, using `x` is the best way to compute the ranking.
+        x_indices = torch.arange(max_d_inner, 2 * max_d_inner)
+        scores_x = scores[x_indices]  # shape = [max_d_inner] i.e. [max_nheads * max_headdim]
+
+        # Get ranking of all head and target head dimensions (same for each head)
+        all_head_dim_importance = torch.linalg.vector_norm(  # shape = [max_headdim]
+            scores_x.view(max_nheads, max_headdim), ord=2, dim=0
+        )
+        all_head_dim_ranking = all_head_dim_importance.argsort(descending=True).cpu()
+        target_head_dim_ranking = all_head_dim_ranking[:target_headdim]
+
+        # Get ranking of all heads with target head dimensions
+        target_head_dim_indices_per_head = torch.cat(  # shape = [max_nheads * target_headdim]
+            [i * max_headdim + target_head_dim_ranking for i in range(max_nheads)]
+        )
+
+        # Get ranking of heads (sorted within their group)
+        groupwise_head_importance = torch.linalg.vector_norm(  # shape = [ngroups, nheads_per_group]
+            scores_x[target_head_dim_indices_per_head].view(
+                mod.ngroups, nheads_per_group, target_headdim
+            ),
+            ord=2,
+            dim=2,
+        )
+        groupwise_head_ranking = groupwise_head_importance.argsort(dim=1, descending=True).cpu()
+        group_offsets = torch.arange(mod.ngroups).unsqueeze(1) * nheads_per_group
+        all_head_ranking = (groupwise_head_ranking + group_offsets).flatten()
+
+        return all_head_ranking, all_head_dim_ranking
+
+    registry.register_hook(
+        module.in_proj,
+        partial(_mamba_in_proj_forward_hook, module),
+        hook_type="forward",
+    )
+    # [HACK] Return ranking (group-aware) instead of importance for sort_parameters()
+    # NOTE: Trimming should also happen within each group. This is handled in MambaNumHeadsHp.
+    registry.register_importance(
+        module,
+        "mamba_num_heads",
+        lambda: _estimate_head_and_head_dim_rankings(module)[0],
+        importance_is_order=True,
+    )
+    registry.register_importance(
+        module,
+        "mamba_head_dim",
+        lambda: _estimate_head_and_head_dim_rankings(module)[1],
+        importance_is_order=True,
+    )

--- a/tests/gpu/torch/nas/plugins/test_megatron_gpt_dynamic_modules.py
+++ b/tests/gpu/torch/nas/plugins/test_megatron_gpt_dynamic_modules.py
@@ -18,29 +18,20 @@ from functools import partial
 import pytest
 import torch
 from _test_utils.import_helper import skip_if_no_megatron
-from _test_utils.torch.misc import compare_outputs
 
 skip_if_no_megatron(apex_or_te_required=True)
 
 from _test_utils.torch.distributed.utils import spawn_multiprocess_job
 from _test_utils.torch.megatron.models import get_mcore_gpt_model
-from _test_utils.torch.megatron.utils import (
-    run_mcore_inference,
-    run_mcore_inference_with_dummy_input,
-)
-from _test_utils.torch.misc import set_seed
+from _test_utils.torch.megatron.utils import run_mcore_inference
 from megatron.core.models.common.embeddings.language_model_embedding import LanguageModelEmbedding
-from megatron.core.parallel_state import destroy_model_parallel
 from megatron.core.transformer.attention import SelfAttention
-from megatron.core.transformer.identity_op import IdentityOp
 from megatron.core.transformer.mlp import MLP
 from megatron.core.transformer.transformer_layer import TransformerLayer
 
 import modelopt.torch.nas as mtn
-from modelopt.torch.nas.conversion import export_searchspace
 from modelopt.torch.nas.modules import DynamicModuleList
 from modelopt.torch.nas.plugins.megatron import (
-    NumAttentionHeadsHp,
     _DynamicColumnParallelLinear,
     _DynamicEmbedding,
     _DynamicLanguageModelEmbedding,
@@ -57,7 +48,6 @@ from modelopt.torch.nas.plugins.megatron import (
     expand_head_indices,
 )
 from modelopt.torch.opt.utils import named_dynamic_modules, search_space_size
-from modelopt.torch.prune.plugins.mcore_minitron import _convert_model_to_dynamic_space
 from modelopt.torch.utils.random import centroid
 
 SEED = 1234
@@ -156,145 +146,10 @@ def test_gpt_search_space(num_attention_heads, num_query_groups, activation_func
     )
 
 
-def _test_gpt_parameter_sorting(activation_func, rank, size):
-    num_layers = size
-    hidden_size = 128
-    num_attention_heads = 8
-    num_query_groups = 4
-    ffn_hidden_size = 64
-    max_sequence_length = 32
-    vocab_size = 128
-    batch_size = 2
-
-    model = get_mcore_gpt_model(
-        tensor_model_parallel_size=1,
-        pipeline_model_parallel_size=size,
-        initialize_megatron=True,
-        num_layers=num_layers,
-        hidden_size=hidden_size,
-        num_attention_heads=num_attention_heads,
-        num_query_groups=num_query_groups,
-        ffn_hidden_size=ffn_hidden_size,
-        max_sequence_length=max_sequence_length,
-        vocab_size=vocab_size,
-        activation_func=activation_func,
-        bf16=False,
-    ).cuda()
-
-    # Randomize layernorm weights instead of all zeros or ones
-    for n, m in model.named_modules():
-        if "layernorm" in n and not isinstance(m, IdentityOp):
-            m.weight.data = torch.randn_like(m.weight)
-
-    model.eval()
-    dynamic_space = _convert_model_to_dynamic_space(model)
-
-    # Compute activations for sorting
-    for _ in range(5):
-        run_mcore_inference_with_dummy_input(model, batch_size)
-
-    # Get the output of the original model
-    prompt_tokens = torch.randint(0, vocab_size, (batch_size, max_sequence_length)).cuda()
-    y1 = run_mcore_inference(model, prompt_tokens)
-
-    mtn.utils.sort_parameters(model)
-
-    # check if all ffn_hidden_size, num_attention_heads, hidden_size have been sorted
-    sortable_per_pp = [
-        n for n, hp in dynamic_space.named_hparams(configurable=True) if hp.importance is not None
-    ]
-    # 2 hps per layer (num_attention_heads, ffn_hidden_size) + 1 for hidden_size (num_layers is not sorted!)
-    assert len(sortable_per_pp) == 2 * num_layers // size + 1
-
-    # sanity check if the model functionality is preserved after sorting
-    y2 = run_mcore_inference(model, prompt_tokens)
-
-    # check if the inference results after sorting is the same
-    compare_outputs(y1, y2, rtol=1e-5, atol=1e-3)
-
-
-@pytest.mark.parametrize("activation_func", ["swiglu"])
-def test_gpt_parameter_sorting(activation_func, need_2_gpus):
-    set_seed(SEED)
-    spawn_multiprocess_job(
-        size=torch.cuda.device_count(),
-        job=partial(_test_gpt_parameter_sorting, activation_func),
-        backend="nccl",
-    )
-
-
 def test_expand_head_indices():
     heads = torch.LongTensor([1, 3, 2, 0])
     hidden_size_per_head = 2
     assert expand_head_indices(heads, hidden_size_per_head).tolist() == [2, 3, 6, 7, 4, 5, 0, 1]
-
-
-def test_self_attention_head_sorting(distributed_setup_size_1):
-    model = get_mcore_gpt_model(
-        tensor_model_parallel_size=1,
-        pipeline_model_parallel_size=1,
-        initialize_megatron=True,
-        num_layers=1,
-        hidden_size=16,
-        num_attention_heads=8,
-        num_query_groups=2,
-        ffn_hidden_size=16,
-        activation_func="squared_relu",
-    ).cuda()
-
-    model = mtn.convert(model, "mcore_minitron")
-
-    self_attn = model.decoder.layers[0].self_attention
-    assert isinstance(self_attn, _DynamicSelfAttention)
-    assert isinstance(self_attn.linear_qkv, _DynamicQKVColumnParallelLinear)
-    assert isinstance(self_attn.linear_proj, _DynamicProjRowParallelLinear)
-
-    hp_num_attention_heads = self_attn.get_hparam("num_attention_heads")
-    assert isinstance(hp_num_attention_heads, NumAttentionHeadsHp)
-
-    # Choices are multiples of num_query_groups (2): [2, 4, 6, 8]
-    assert hp_num_attention_heads.choices == [2, 4, 6, 8]
-    assert hp_num_attention_heads._num_query_groups == 2
-
-    # Set importance and slice order
-    # Importance per head (group-aware): [2.2, 0.1, 1.1, 2.1, 3.0, 2.0, 0.0, 1.0]
-    # Group 0 (heads 0-3): [2.2, 0.1, 1.1, 2.1] → sorted: [0, 3, 2, 1]
-    # Group 1 (heads 4-7): [3.0, 2.0, 0.0, 1.0] → sorted: [4, 5, 7, 6]
-    # Global ranking (group-aware, flattened): [0, 3, 2, 1, 4, 5, 7, 6]
-    hp_num_attention_heads._get_importance = lambda: torch.tensor(
-        [2.2, 0.1, 1.1, 2.1, 3.0, 2.0, 0.0, 1.0]
-    )
-    # _estimate_head_ranking returns ranking as 1D tensor
-    expected_ranking = torch.tensor([0, 3, 2, 1, 4, 5, 7, 6])
-    hp_num_attention_heads.enforce_order(expected_ranking)
-
-    assert hp_num_attention_heads.active_slice.tolist() == [0, 3, 2, 1, 4, 5, 7, 6]
-
-    # check if we get correct selection of sorted + pruned heads after setting active values
-    hp_num_attention_heads.active = 4  # top 2 heads per group (2 groups * 2 heads = 4 total)
-
-    # Expected: Top 2 heads from each group: [0, 3] from group 0, [4, 5] from group 1
-    expected_q_heads = [0, 3, 4, 5]
-    # In QKV layout (4 heads/group → 6 QKV heads/group):
-    # Group 0: Q=[0, 3], K=4, V=5 → QKV indices [0, 3, 4, 5]
-    # Group 1: Q=[4, 5], K=10, V=11 → QKV indices [6, 7, 10, 11]
-    expected_qkv_heads = [0, 3, 4, 5, 6, 7, 10, 11]
-
-    assert (
-        self_attn.linear_qkv._get_output_size_indices().tolist()
-        == expand_head_indices(
-            torch.LongTensor(expected_qkv_heads), model.config.kv_channels
-        ).tolist()
-    )
-    assert (
-        self_attn.linear_proj._get_input_size_indices().tolist()
-        == expand_head_indices(
-            torch.LongTensor(expected_q_heads), model.config.kv_channels
-        ).tolist()
-    )
-
-    # Clean up since this is not a spawned process
-    destroy_model_parallel()
 
 
 def _test_gpt_moe_search_space(rank, size):
@@ -373,77 +228,4 @@ def _test_gpt_moe_search_space(rank, size):
 def test_gpt_moe_search_space():
     spawn_multiprocess_job(
         size=torch.cuda.device_count(), job=_test_gpt_moe_search_space, backend="nccl"
-    )
-
-
-def _test_gpt_moe_parameter_sorting(rank, size):
-    num_layers = min(size * 2, 8)
-    hidden_size = 256
-    num_attention_heads = 8
-    num_query_groups = 4
-    moe_ffn_hidden_size = 128
-    num_moe_experts = 4
-    moe_shared_expert_intermediate_size = 256
-    max_sequence_length = 16
-    vocab_size = 64
-    batch_size = 2
-
-    model = get_mcore_gpt_model(
-        tensor_model_parallel_size=1,
-        pipeline_model_parallel_size=size,
-        initialize_megatron=True,
-        num_layers=num_layers,
-        hidden_size=hidden_size,
-        num_attention_heads=num_attention_heads,
-        num_query_groups=num_query_groups,
-        max_sequence_length=max_sequence_length,
-        vocab_size=vocab_size,
-        activation_func="squared_relu",
-        num_moe_experts=num_moe_experts,
-        moe_ffn_hidden_size=moe_ffn_hidden_size,
-        moe_shared_expert_intermediate_size=moe_shared_expert_intermediate_size,
-        bf16=False,
-    ).cuda()
-
-    # Randomize layernorm weights instead of all zeros or ones
-    for n, m in model.named_modules():
-        if "layernorm" in n and not isinstance(m, IdentityOp):
-            m.weight.data = torch.randn_like(m.weight)
-
-    model.eval()
-    dynamic_space = _convert_model_to_dynamic_space(model)
-
-    # Compute activations for sorting
-    for _ in range(10):
-        run_mcore_inference_with_dummy_input(model, batch_size)
-
-    # Get the output of the original model
-    prompt_tokens = torch.randint(0, vocab_size, (batch_size, max_sequence_length)).cuda()
-    y1 = run_mcore_inference(model, prompt_tokens)
-
-    mtn.utils.sort_parameters(model)
-
-    # check if all num_moe_experts, moe_ffn, moe_shared_ffn, num_attention_heads, hidden_size
-    # have been sorted
-    sortable_per_pp = [
-        n for n, hp in dynamic_space.named_hparams(configurable=True) if hp.importance is not None
-    ]
-    # (num_moe_experts + 3) hps per layer + 1 for hidden_size (num_layers is not sorted!)
-    # Per layer: num_attention_heads, num_moe_experts, moe_ffn (per expert), moe_shared_ffn
-    assert len(sortable_per_pp) == (num_moe_experts + 3) * num_layers // size + 1
-
-    # sanity check if the model functionality is preserved after sorting
-    export_searchspace(model, mtn.get_subnet_config(model))
-    y2 = run_mcore_inference(model, prompt_tokens)
-
-    # check if the inference results after sorting is the same
-    compare_outputs(y1, y2, rtol=1e-5, atol=1e-3)
-
-
-def test_gpt_moe_parameter_sorting(need_2_gpus):
-    set_seed(SEED)
-    spawn_multiprocess_job(
-        size=torch.cuda.device_count(),
-        job=_test_gpt_moe_parameter_sorting,
-        backend="nccl",
     )

--- a/tests/gpu/torch/nas/plugins/test_megatron_mamba_dynamic_modules.py
+++ b/tests/gpu/torch/nas/plugins/test_megatron_mamba_dynamic_modules.py
@@ -16,19 +16,13 @@
 
 import torch
 from _test_utils.import_helper import skip_if_no_megatron
-from _test_utils.torch.misc import compare_outputs
 
 skip_if_no_megatron(apex_or_te_required=True, mamba_required=True)
 
 from _test_utils.torch.distributed.utils import spawn_multiprocess_job
 from _test_utils.torch.megatron.models import get_mcore_mamba_hybrid_model
-from _test_utils.torch.megatron.utils import (
-    run_mcore_inference,
-    run_mcore_inference_with_dummy_input,
-)
-from _test_utils.torch.misc import set_seed
+from _test_utils.torch.megatron.utils import run_mcore_inference
 from megatron.core.parallel_state import is_pipeline_first_stage, is_pipeline_last_stage
-from megatron.core.transformer.identity_op import IdentityOp
 
 import modelopt.torch.nas as mtn
 from modelopt.torch.nas.modules.conv import _DynamicConvNd
@@ -46,7 +40,6 @@ from modelopt.torch.nas.plugins.megatron import (
 )
 from modelopt.torch.nas.traced_hp import TracedHp
 from modelopt.torch.opt.utils import named_dynamic_modules, search_space_size
-from modelopt.torch.prune.plugins.mcore_minitron import _convert_model_to_dynamic_space
 from modelopt.torch.utils.random import centroid
 
 SEED = 1234
@@ -128,73 +121,6 @@ def _test_mamba_search_space(rank, size):
 def test_mamba_search_space():
     spawn_multiprocess_job(
         size=torch.cuda.device_count(), job=_test_mamba_search_space, backend="nccl"
-    )
-
-
-def _test_mamba_parameter_sorting(rank, size):
-    num_layers = size
-    hybrid_override_pattern = "M" * size
-    hidden_size = 256
-    mamba_state_dim = 64
-    mamba_head_dim = 16
-    mamba_num_groups = 2
-    max_sequence_length = 32
-    vocab_size = 64
-    batch_size = 2
-
-    model = get_mcore_mamba_hybrid_model(
-        tensor_model_parallel_size=1,
-        pipeline_model_parallel_size=size,
-        initialize_megatron=True,
-        num_layers=num_layers,
-        hybrid_override_pattern=hybrid_override_pattern,
-        hidden_size=hidden_size,
-        mamba_state_dim=mamba_state_dim,
-        mamba_head_dim=mamba_head_dim,
-        mamba_num_groups=mamba_num_groups,
-        max_sequence_length=max_sequence_length,
-        vocab_size=vocab_size,
-        bf16=False,
-    ).cuda()
-
-    # Randomize norm weights instead of all zeros or ones
-    for n, m in model.named_modules():
-        if "norm" in n and not isinstance(m, IdentityOp):
-            m.weight.data = torch.randn_like(m.weight)
-
-    model.eval()
-    dynamic_space = _convert_model_to_dynamic_space(model)
-
-    # Compute activations for sorting
-    for _ in range(5):
-        run_mcore_inference_with_dummy_input(model, batch_size)
-
-    # Get the output of the original model
-    prompt_tokens = torch.randint(0, vocab_size, (batch_size, max_sequence_length)).cuda()
-    y1 = run_mcore_inference(model, prompt_tokens)
-
-    mtn.utils.sort_parameters(model)
-
-    # check if all mamba_num_heads, mamba_head_dim, hidden_size have been sorted
-    sortable_per_pp = [
-        n for n, hp in dynamic_space.named_hparams(configurable=True) if hp.importance is not None
-    ]
-    # 2 mamba hps per layer + 1 for hidden_size (num_layers is not sorted!)
-    assert len(sortable_per_pp) == 2 * num_layers // size + 1
-
-    # sanity check if the model functionality is preserved after sorting
-    y2 = run_mcore_inference(model, prompt_tokens)
-
-    # check if the inference results after sorting is the same
-    compare_outputs(y1, y2, rtol=1e-5, atol=1e-3)
-
-
-def test_mamba_parameter_sorting(need_2_gpus):
-    set_seed(SEED)
-    spawn_multiprocess_job(
-        size=torch.cuda.device_count(),
-        job=_test_mamba_parameter_sorting,
-        backend="nccl",
     )
 
 

--- a/tests/gpu/torch/prune/plugins/test_mcore_gpt_minitron_pruning.py
+++ b/tests/gpu/torch/prune/plugins/test_mcore_gpt_minitron_pruning.py
@@ -27,8 +27,163 @@ from _test_utils.torch.megatron.utils import (
     run_mcore_inference,
     run_mcore_inference_with_dummy_input,
 )
+from _test_utils.torch.misc import compare_outputs, set_seed
+from megatron.core.parallel_state import destroy_model_parallel
+from megatron.core.transformer.identity_op import IdentityOp
 
+import modelopt.torch.nas as mtn
 import modelopt.torch.prune as mtp
+from modelopt.torch.nas.conversion import export_searchspace
+from modelopt.torch.nas.plugins.megatron import (
+    NumAttentionHeadsHp,
+    _DynamicProjRowParallelLinear,
+    _DynamicQKVColumnParallelLinear,
+    _DynamicSelfAttention,
+    expand_head_indices,
+)
+from modelopt.torch.prune.plugins.mcore_minitron import (
+    ImportanceEstimatorRegistry,
+    _convert_model_to_dynamic_space,
+)
+
+SEED = 1234
+
+
+def _test_mcore_gpt_parameter_sorting(activation_func, rank, size):
+    num_layers = size
+    hidden_size = 128
+    num_attention_heads = 8
+    num_query_groups = 4
+    ffn_hidden_size = 64
+    max_sequence_length = 32
+    vocab_size = 128
+    batch_size = 2
+
+    model = get_mcore_gpt_model(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=size,
+        initialize_megatron=True,
+        num_layers=num_layers,
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+        num_query_groups=num_query_groups,
+        ffn_hidden_size=ffn_hidden_size,
+        max_sequence_length=max_sequence_length,
+        vocab_size=vocab_size,
+        activation_func=activation_func,
+        bf16=False,
+    ).cuda()
+
+    # Randomize layernorm weights instead of all zeros or ones
+    for n, m in model.named_modules():
+        if "layernorm" in n and not isinstance(m, IdentityOp):
+            m.weight.data = torch.randn_like(m.weight)
+
+    model.eval()
+    dynamic_space = _convert_model_to_dynamic_space(model)
+    registry = ImportanceEstimatorRegistry(model)  # register imp estimators and forward hooks
+
+    # Compute activations for sorting
+    for _ in range(5):
+        run_mcore_inference_with_dummy_input(model, batch_size)
+
+    # Get the output of the original model
+    prompt_tokens = torch.randint(0, vocab_size, (batch_size, max_sequence_length)).cuda()
+    y1 = run_mcore_inference(model, prompt_tokens)
+
+    mtn.utils.sort_parameters(model)
+    registry.cleanup()
+
+    # check if all ffn_hidden_size, num_attention_heads, hidden_size have been sorted
+    sortable_per_pp = [
+        n for n, hp in dynamic_space.named_hparams(configurable=True) if hp.importance is not None
+    ]
+    # 2 hps per layer (num_attention_heads, ffn_hidden_size) + 1 for hidden_size (num_layers is not sorted!)
+    assert len(sortable_per_pp) == 2 * num_layers // size + 1
+
+    # sanity check if the model functionality is preserved after sorting
+    y2 = run_mcore_inference(model, prompt_tokens)
+
+    # check if the inference results after sorting is the same
+    compare_outputs(y1, y2, rtol=1e-5, atol=1e-3)
+
+
+@pytest.mark.parametrize("activation_func", ["swiglu"])
+def test_mcore_gpt_parameter_sorting(activation_func, need_2_gpus):
+    set_seed(SEED)
+    spawn_multiprocess_job(
+        size=torch.cuda.device_count(),
+        job=partial(_test_mcore_gpt_parameter_sorting, activation_func),
+        backend="nccl",
+    )
+
+
+def test_mcore_gpt_self_attention_head_sorting(distributed_setup_size_1):
+    model = get_mcore_gpt_model(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        initialize_megatron=True,
+        num_layers=1,
+        hidden_size=16,
+        num_attention_heads=8,
+        num_query_groups=2,
+        ffn_hidden_size=16,
+        activation_func="squared_relu",
+    ).cuda()
+
+    model = mtn.convert(model, "mcore_minitron")
+
+    self_attn = model.decoder.layers[0].self_attention
+    assert isinstance(self_attn, _DynamicSelfAttention)
+    assert isinstance(self_attn.linear_qkv, _DynamicQKVColumnParallelLinear)
+    assert isinstance(self_attn.linear_proj, _DynamicProjRowParallelLinear)
+
+    hp_num_attention_heads = self_attn.get_hparam("num_attention_heads")
+    assert isinstance(hp_num_attention_heads, NumAttentionHeadsHp)
+
+    # Choices are multiples of num_query_groups (2): [2, 4, 6, 8]
+    assert hp_num_attention_heads.choices == [2, 4, 6, 8]
+    assert hp_num_attention_heads._num_query_groups == 2
+
+    # Set importance and slice order
+    # Importance per head (group-aware): [2.2, 0.1, 1.1, 2.1, 3.0, 2.0, 0.0, 1.0]
+    # Group 0 (heads 0-3): [2.2, 0.1, 1.1, 2.1] → sorted: [0, 3, 2, 1]
+    # Group 1 (heads 4-7): [3.0, 2.0, 0.0, 1.0] → sorted: [4, 5, 7, 6]
+    # Global ranking (group-aware, flattened): [0, 3, 2, 1, 4, 5, 7, 6]
+    hp_num_attention_heads._get_importance = lambda: torch.tensor(
+        [2.2, 0.1, 1.1, 2.1, 3.0, 2.0, 0.0, 1.0]
+    )
+    # _estimate_head_ranking returns ranking as 1D tensor
+    expected_ranking = torch.tensor([0, 3, 2, 1, 4, 5, 7, 6])
+    hp_num_attention_heads.enforce_order(expected_ranking)
+
+    assert hp_num_attention_heads.active_slice.tolist() == [0, 3, 2, 1, 4, 5, 7, 6]
+
+    # check if we get correct selection of sorted + pruned heads after setting active values
+    hp_num_attention_heads.active = 4  # top 2 heads per group (2 groups * 2 heads = 4 total)
+
+    # Expected: Top 2 heads from each group: [0, 3] from group 0, [4, 5] from group 1
+    expected_q_heads = [0, 3, 4, 5]
+    # In QKV layout (4 heads/group → 6 QKV heads/group):
+    # Group 0: Q=[0, 3], K=4, V=5 → QKV indices [0, 3, 4, 5]
+    # Group 1: Q=[4, 5], K=10, V=11 → QKV indices [6, 7, 10, 11]
+    expected_qkv_heads = [0, 3, 4, 5, 6, 7, 10, 11]
+
+    assert (
+        self_attn.linear_qkv._get_output_size_indices().tolist()
+        == expand_head_indices(
+            torch.LongTensor(expected_qkv_heads), model.config.kv_channels
+        ).tolist()
+    )
+    assert (
+        self_attn.linear_proj._get_input_size_indices().tolist()
+        == expand_head_indices(
+            torch.LongTensor(expected_q_heads), model.config.kv_channels
+        ).tolist()
+    )
+
+    # Clean up since this is not a spawned process
+    destroy_model_parallel()
 
 
 def _test_mcore_gpt_pruning(
@@ -234,6 +389,81 @@ def test_mcore_gpt_pruning(
             skip_sorting,
             tmp_path / "minitron_scores.pth" if test_ckpt else None,
         ),
+        backend="nccl",
+    )
+
+
+def _test_mcore_gpt_moe_parameter_sorting(rank, size):
+    num_layers = min(size * 2, 8)
+    hidden_size = 256
+    num_attention_heads = 8
+    num_query_groups = 4
+    moe_ffn_hidden_size = 128
+    num_moe_experts = 4
+    moe_shared_expert_intermediate_size = 256
+    max_sequence_length = 16
+    vocab_size = 64
+    batch_size = 2
+
+    model = get_mcore_gpt_model(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=size,
+        initialize_megatron=True,
+        num_layers=num_layers,
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+        num_query_groups=num_query_groups,
+        max_sequence_length=max_sequence_length,
+        vocab_size=vocab_size,
+        activation_func="squared_relu",
+        num_moe_experts=num_moe_experts,
+        moe_ffn_hidden_size=moe_ffn_hidden_size,
+        moe_shared_expert_intermediate_size=moe_shared_expert_intermediate_size,
+        bf16=False,
+    ).cuda()
+
+    # Randomize layernorm weights instead of all zeros or ones
+    for n, m in model.named_modules():
+        if "layernorm" in n and not isinstance(m, IdentityOp):
+            m.weight.data = torch.randn_like(m.weight)
+
+    model.eval()
+    dynamic_space = _convert_model_to_dynamic_space(model)
+    registry = ImportanceEstimatorRegistry(model)  # register imp estimators and forward hooks
+
+    # Compute activations for sorting
+    for _ in range(10):
+        run_mcore_inference_with_dummy_input(model, batch_size)
+
+    # Get the output of the original model
+    prompt_tokens = torch.randint(0, vocab_size, (batch_size, max_sequence_length)).cuda()
+    y1 = run_mcore_inference(model, prompt_tokens)
+
+    mtn.utils.sort_parameters(model)
+    registry.cleanup()
+
+    # check if all num_moe_experts, moe_ffn, moe_shared_ffn, num_attention_heads, hidden_size
+    # have been sorted
+    sortable_per_pp = [
+        n for n, hp in dynamic_space.named_hparams(configurable=True) if hp.importance is not None
+    ]
+    # (num_moe_experts + 3) hps per layer + 1 for hidden_size (num_layers is not sorted!)
+    # Per layer: num_attention_heads, num_moe_experts, moe_ffn (per expert), moe_shared_ffn
+    assert len(sortable_per_pp) == (num_moe_experts + 3) * num_layers // size + 1
+
+    # sanity check if the model functionality is preserved after sorting
+    export_searchspace(model, mtn.get_subnet_config(model))
+    y2 = run_mcore_inference(model, prompt_tokens)
+
+    # check if the inference results after sorting is the same
+    compare_outputs(y1, y2, rtol=1e-5, atol=1e-3)
+
+
+def test_mcore_gpt_moe_parameter_sorting(need_2_gpus):
+    set_seed(SEED)
+    spawn_multiprocess_job(
+        size=torch.cuda.device_count(),
+        job=_test_mcore_gpt_moe_parameter_sorting,
         backend="nccl",
     )
 

--- a/tests/gpu/torch/prune/plugins/test_mcore_mamba_minitron_pruning.py
+++ b/tests/gpu/torch/prune/plugins/test_mcore_mamba_minitron_pruning.py
@@ -23,10 +23,91 @@ skip_if_no_megatron(apex_or_te_required=True, mamba_required=True)
 
 from _test_utils.torch.distributed.utils import spawn_multiprocess_job
 from _test_utils.torch.megatron.models import get_mcore_mamba_hybrid_model
-from _test_utils.torch.megatron.utils import run_mcore_inference_with_dummy_input
+from _test_utils.torch.megatron.utils import (
+    run_mcore_inference,
+    run_mcore_inference_with_dummy_input,
+)
+from _test_utils.torch.misc import compare_outputs, set_seed
 from megatron.core.ssm.mamba_layer import MambaLayer
+from megatron.core.transformer.identity_op import IdentityOp
 
+import modelopt.torch.nas as mtn
 import modelopt.torch.prune as mtp
+from modelopt.torch.prune.plugins.mcore_minitron import (
+    ImportanceEstimatorRegistry,
+    _convert_model_to_dynamic_space,
+)
+
+SEED = 1234
+
+
+def _test_mcore_mamba_parameter_sorting(rank, size):
+    num_layers = size
+    hybrid_override_pattern = "M" * size
+    hidden_size = 256
+    mamba_state_dim = 64
+    mamba_head_dim = 16
+    mamba_num_groups = 2
+    max_sequence_length = 32
+    vocab_size = 64
+    batch_size = 2
+
+    model = get_mcore_mamba_hybrid_model(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=size,
+        initialize_megatron=True,
+        num_layers=num_layers,
+        hybrid_override_pattern=hybrid_override_pattern,
+        hidden_size=hidden_size,
+        mamba_state_dim=mamba_state_dim,
+        mamba_head_dim=mamba_head_dim,
+        mamba_num_groups=mamba_num_groups,
+        max_sequence_length=max_sequence_length,
+        vocab_size=vocab_size,
+        bf16=False,
+    ).cuda()
+
+    # Randomize norm weights instead of all zeros or ones
+    for n, m in model.named_modules():
+        if "norm" in n and not isinstance(m, IdentityOp):
+            m.weight.data = torch.randn_like(m.weight)
+
+    model.eval()
+    dynamic_space = _convert_model_to_dynamic_space(model)
+    registry = ImportanceEstimatorRegistry(model)  # register imp estimators and forward hooks
+
+    # Compute activations for sorting
+    for _ in range(5):
+        run_mcore_inference_with_dummy_input(model, batch_size)
+
+    # Get the output of the original model
+    prompt_tokens = torch.randint(0, vocab_size, (batch_size, max_sequence_length)).cuda()
+    y1 = run_mcore_inference(model, prompt_tokens)
+
+    mtn.utils.sort_parameters(model)
+    registry.cleanup()
+
+    # check if all mamba_num_heads, mamba_head_dim, hidden_size have been sorted
+    sortable_per_pp = [
+        n for n, hp in dynamic_space.named_hparams(configurable=True) if hp.importance is not None
+    ]
+    # 2 mamba hps per layer + 1 for hidden_size (num_layers is not sorted!)
+    assert len(sortable_per_pp) == 2 * num_layers // size + 1
+
+    # sanity check if the model functionality is preserved after sorting
+    y2 = run_mcore_inference(model, prompt_tokens)
+
+    # check if the inference results after sorting is the same
+    compare_outputs(y1, y2, rtol=1e-5, atol=1e-3)
+
+
+def test_mcore_mamba_parameter_sorting(need_2_gpus):
+    set_seed(SEED)
+    spawn_multiprocess_job(
+        size=torch.cuda.device_count(),
+        job=_test_mcore_mamba_parameter_sorting,
+        backend="nccl",
+    )
 
 
 def _test_mcore_mamba_hybrid_pruning(ckpt_path, rank, size):

--- a/tox.ini
+++ b/tox.ini
@@ -58,14 +58,11 @@ commands =
 # GPU test environments (Should be used with --current-env)
 ###########################################################
 [testenv:{py310,py311,py312}-cuda12-gpu]
-setenv =
-    MAMBA_FORCE_BUILD=TRUE
 commands_pre =
     # Install deps here so that it gets installed even in --current-env
     pip install -U megatron-core
     pip install git+https://github.com/Dao-AILab/fast-hadamard-transform.git
 
-    # Install Mamba model dependencies (takes 8-10mins!)
     # Skip triton because pytorch-triton is installed in the NGC PyTorch containers
     pip install pip-mark-installed
     pip-mark-installed triton


### PR DESCRIPTION
## What does this PR do?

- Code refactor, no logic change
- De-couple Minitron pruning importance estimator from Dynamic Module so its easy to configure different importance logic for pruning

## Testing
<!-- Mention how have you tested your change if applicable. -->

- [x] CI/CD tests passing
- [x] Compare mmlu on pruned Qwen3-8B with previous and current implementation
- [x] Compare mmlu on pruned Qwen3-30B-A3B with previous and current implementation (lot of variance in results, some pruning configs better some worse)
- [x] Compare mmlu on pruned Nemotron-Nano-v2-9B with previous and current implementation
