### PR TITLE
Only save modelopt_run_config if MBridge one not already saved

### DIFF
--- a/modelopt/torch/opt/plugins/mcore_dist_checkpointing.py
+++ b/modelopt/torch/opt/plugins/mcore_dist_checkpointing.py
@@ -152,10 +152,10 @@ def save_sharded_modelopt_state(
 
         return config
 
-    if dist.is_master():
+    # Save own version of run config, if not already saved by the framework.
+    if dist.is_master() and not os.path.exists(f"{checkpoint_name}/run_config.yaml"):
         run_config_name = f"{checkpoint_name}/modelopt_run_config.yaml"
-        # We avoid deepcopy here since some attributes in Megatron-Bridge config cannot be
-        # deepcopy.
+        # We avoid deepcopy since some attributes in Megatron-Bridge config cannot be deepcopied.
         config_dict = _parse_transformer_config(model[0].config.__dict__)
         config_dict["nvidia_modelopt_version"] = modelopt.__version__
         with open(run_config_name, "w") as f:


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ? Bug fix

**Overview:** ModelOpt's copy of run_config is duplicate in MBridge and has serialization issues sometimes

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->
