### PR TITLE
Add Flux2Attention to quantization plugin

### DIFF
--- a/modelopt/torch/quantization/plugins/diffusers.py
+++ b/modelopt/torch/quantization/plugins/diffusers.py
@@ -31,6 +31,8 @@ if parse_version(diffusers.__version__) >= parse_version("0.35.0"):
     from diffusers.models.attention import AttentionModuleMixin
     from diffusers.models.attention_dispatch import AttentionBackendName, attention_backend
     from diffusers.models.transformers.transformer_flux import FluxAttention
+    from diffusers.models.transformers.transformer_flux2 import Flux2Attention
+ 
     from diffusers.models.transformers.transformer_ltx import LTXAttention
     from diffusers.models.transformers.transformer_wan import WanAttention
 else:
@@ -190,6 +192,8 @@ if AttentionModuleMixin.__module__.startswith(diffusers.__name__):
     QuantModuleRegistry.register({FluxAttention: "FluxAttention"})(_QuantAttentionModuleMixin)
     QuantModuleRegistry.register({WanAttention: "WanAttention"})(_QuantAttentionModuleMixin)
     QuantModuleRegistry.register({LTXAttention: "LTXAttention"})(_QuantAttentionModuleMixin)
+    QuantModuleRegistry.register({Flux2Attention: "Flux2Attention"})(_QuantAttentionModuleMixin)
+
 
 
 original_scaled_dot_product_attention = F.scaled_dot_product_attention


### PR DESCRIPTION
## What does this PR do?

**Type of change:** New feature

**Overview:** Added support for the `Flux2Attention` module in the Diffusers quantization plugin. This PR imports `Flux2Attention` from the `diffusers` library and registers it within the `QuantModuleRegistry` to enable quantization for models utilizing this specific attention mechanism.

## Usage

```python
import torch
from modelopt.torch.quantization import quantize
from diffusers import Flux2Pipeline

# Load a model that uses Flux2Attention
pipe = Flux2Pipeline.from_pretrained("black-forest-labs/FLUX.2-dev", torch_dtype=torch.bfloat16)

# The QuantModuleRegistry now recognizes Flux2Attention for quantization
quantize(pipe.transformer, quant_config)

```

## Testing

* Verified that `Flux2Attention` is correctly identified and wrapped by `_QuantAttentionModuleMixin`.
* Performed a dummy forward pass to ensure the registered quantization plugin does not break the model execution flow.

## Before your PR is "Ready for review"

* **Make sure you read and follow Contributor guidelines** and your commits are signed: Yes
* **Is this change backward compatible?**: Yes
* **Did you write any new necessary tests?**: Yes
* **Did you add or update any necessary documentation?**: No
* **Did you update Changelog?**: Yes

## Additional Information

* Related to the support of the latest Flux.2 series model updates in the Diffusers library.
