### PR TITLE
Fix Deepseek transformers model loading

### DIFF
--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -349,11 +349,12 @@ def get_model(
         else:
             architecture = hf_config.architectures[0]
 
-            if not hasattr(transformers, architecture):
-                warnings.warn(
-                    f"Architecture {architecture} not found in transformers: {transformers.__version__}. "
-                    "Falling back to AutoModelForCausalLM."
-                )
+            if not hasattr(transformers, architecture) or "Deepseek" in architecture:
+                if not hasattr(transformers, architecture):
+                    warnings.warn(
+                        f"Architecture {architecture} not found in transformers: {transformers.__version__}. "
+                        "Falling back to AutoModelForCausalLM."
+                    )
                 assert trust_remote_code, (
                     "Please set trust_remote_code to True if you want to use this architecture"
                 )


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ? Bug fix

**Overview:** ?
For Deepseek, let's force the user to apply trust_remote_code and use AutoModelForCausalLM for loading the model.

## Testing
python hf_ptq.py --pyt_ckpt_path <Kimi-K2-Thinking_path> --qformat nvfp4 --export_path <quantized_ckpt> --kv_cache_qformat none --calib_size 64 --trust_remote_code --dataset cnn_dailymail

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->
