### PR TITLE
Fix TRT-LLM 2-gpu CI test shm issue

### DIFF
--- a/.github/workflows/_example_tests_runner.yml
+++ b/.github/workflows/_example_tests_runner.yml
@@ -34,6 +34,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_minutes }}
     container:
       image: ${{ inputs.docker_image }}
+      options: --shm-size=2gb # TRT-LLM tests on 2-GPU runner needs more shared memory
       env:
         PIP_CONSTRAINT: "" # Disable pip constraint for upgrading packages
         HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/example_tests.yml
+++ b/.github/workflows/example_tests.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        example: [llm_ptq]  # vlm_ptq temporarily disabled due to pipeline error
+        example: [llm_ptq] # vlm_ptq temporarily disabled due to pipeline error
     uses: ./.github/workflows/_example_tests_runner.yml
     secrets: inherit
     with:


### PR DESCRIPTION
- As suggested by NVGHA runners team to increase SHM size to avoid issue on 2-gpu nightly tests