### PR TITLE
Remove quantization_config in config.json from original deepseek models

### DIFF
--- a/examples/deepseek/quantize_to_nvfp4.py
+++ b/examples/deepseek/quantize_to_nvfp4.py
@@ -83,36 +83,17 @@ def _remap_key(key_dict: dict[str, Any]):
 
 
 def remove_quantization_config_from_original_config(export_dir: str) -> None:
-    """Remove `quantization_config` from exported HF `config.json` if present.
+    """Remove `quantization_config` from exported HF `config.json`.
 
-    DeepSeek original checkpoints may include a `quantization_config` field in `config.json`
-    (describing the source checkpoint's quantization). When we export ModelOpt quantization
-    configs to `hf_quant_config.json`, leaving the original `quantization_config` in place can
-    be confusing. This function performs an in-place, best-effort cleanup in the exported
-    checkpoint directory.
+    Assumes the exported checkpoint directory has a `config.json` containing `quantization_config`.
     """
     config_path = os.path.join(export_dir, "config.json")
-    if not os.path.exists(config_path):
-        return
-
-    try:
-        with open(config_path) as f:
-            cfg = json.load(f)
-    except Exception as e:
-        print(f"Warning: Failed to read {config_path}: {e}")
-        return
-
-    if not isinstance(cfg, dict) or "quantization_config" not in cfg:
-        return
-
-    cfg.pop("quantization_config", None)
-    try:
-        with open(config_path, "w") as f:
-            json.dump(cfg, f, indent=2, sort_keys=True)
-            f.write("\n")
-    except Exception as e:
-        print(f"Warning: Failed to write {config_path}: {e}")
-        return
+    with open(config_path) as f:
+        cfg = json.load(f)
+    del cfg["quantization_config"]
+    with open(config_path, "w") as f:
+        json.dump(cfg, f, indent=2, sort_keys=True)
+        f.write("\n")
 
 
 def load_and_preprocess_state_dict(modelopt_state_root, world_size=8):


### PR DESCRIPTION
## What does this PR do?

**Type of change:**  Bug fix

**Overview:**     DeepSeek original checkpoints may include a `quantization_config` field in `config.json`
    (describing the source checkpoint's quantization). When we export ModelOpt quantization
    configs to `hf_quant_config.json`, leaving the original `quantization_config` in place can
    be confusing. Add a function to remove it.

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
Resolve nvbug https://nvbugspro.nvidia.com/bug/5736665 
