### PR TITLE
[CI] Cleanup ubuntu-runner disk storage before installing deps

### DIFF
--- a/.github/actions/ubuntu-setup/action.yml
+++ b/.github/actions/ubuntu-setup/action.yml
@@ -1,0 +1,20 @@
+name: Ubuntu runner setup
+description: Standard setup for ubuntu-latest runners (setup Python, cleanup disk space)
+
+inputs:
+  python-version:
+    description: Python version to setup
+    required: false
+    default: "3.12"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Clean up disk space
+      shell: bash
+      run: |
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /usr/share/dotnet || true

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -18,9 +18,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
+      - uses: ./.github/actions/ubuntu-setup
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@v3.90.5
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,9 +26,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
+      - uses: ./.github/actions/ubuntu-setup
       - name: Build docs
         run: pip install tox && tox -e build-docs
       - name: Upload docs artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
+      - uses: ./.github/actions/ubuntu-setup
       - name: Install dependencies
         run: pip install tox
-      # - name: Run basic unit tests
-      #   run: tox -e py312-torch29-tf_latest-unit
+      - name: Run basic unit tests
+        run: tox -e py312-torch29-tf_latest-unit
       - name: Build Wheel
         run: |
           tox -e build-wheel

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,9 +35,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
+      - uses: ./.github/actions/ubuntu-setup
       - name: Run unit tests
         run: pip install tox && COV_ARGS="--cov" tox -e py312-torch29-tf_latest-unit
       - name: Upload coverage reports to Codecov
@@ -68,7 +66,7 @@ jobs:
         py: [10, 11]
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: ./.github/actions/ubuntu-setup
         with:
           python-version: "3.${{ matrix.py }}"
       - name: Run unit tests
@@ -83,9 +81,7 @@ jobs:
         torch: [26, 27, 28]
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
+      - uses: ./.github/actions/ubuntu-setup
       - name: Run unit tests
         run: pip install tox && tox -e py312-torch${{ matrix.torch }}-tf_latest-unit
   multi-transformers:
@@ -98,9 +94,7 @@ jobs:
         tf: [min]
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
+      - uses: ./.github/actions/ubuntu-setup
       - name: Run unit tests
         run: pip install tox && tox -e py312-torch29-tf_${{ matrix.tf }}-unit
   partial-install:
@@ -113,9 +107,7 @@ jobs:
         test-env: [onnx, torch]
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
+      - uses: ./.github/actions/ubuntu-setup
       - name: Run unit tests
         run: pip install tox && tox -e py312-partial-unit-${{ matrix.test-env }}
   unit-pr-required-check:


### PR DESCRIPTION
We started seeing this issue in GitHub's free ubuntu-latest runners: `ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device`.

Suggested by other GH runners users to remove unnecessary android / dotnet files to avoid the storage issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated GitHub Actions workflow setup into a reusable custom action for improved maintainability and consistency across CI/CD pipelines.
  * Enhanced release workflow with automated unit testing and artifact upload capabilities.
  * Streamlined runner initialization by reducing redundant configuration steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->