### PR TITLE
[5796745][ONNX][Autocast] Fix opset check for model with custom ops

### DIFF
--- a/modelopt/onnx/autocast/graphsanitizer.py
+++ b/modelopt/onnx/autocast/graphsanitizer.py
@@ -161,8 +161,8 @@ class GraphSanitizer:
             )
             self.min_opset = 19
 
-        # Convert if any default domain opset is below minimum
-        if any(op.version < self.min_opset for op in default_opsets):
+        # Convert if the default domain opset is below minimum
+        if onnx_utils.get_opset_version(self.model) < self.min_opset:
             invalid_opsets = [op.version for op in default_opsets if op.version < self.min_opset]
             try:
                 logger.info(


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:** This PR fixes the opset being incorrectly detected as being `1` in models with custom ops. That happens because the 'trt.plugins' domain version is detected rather than the actual model's opset version.

## Usage
<!-- You can potentially add a usage example below. -->

```python
$ python -m modelopt.onnx.autocast --onnx_path=${MODEL_NAME}.onnx
```

## Testing
See bug 5796745.

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: No
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the opset version detection logic for more efficient model conversion handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->