### PR TITLE
Set trust_remote_code default to False

### DIFF
--- a/modelopt/torch/export/plugins/megatron_importer.py
+++ b/modelopt/torch/export/plugins/megatron_importer.py
@@ -75,7 +75,7 @@ class GPTModelImporter:
         workspace_dir: str | None = None,
         dtype=torch.bfloat16,
         dequantize: bool = True,
-        trust_remote_code: bool = True,
+        trust_remote_code: bool = False,
         verbose: bool = False,
         moe_router_dtype: torch.dtype | None = None,
     ):


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

DeepSeek later has official `transformers` support and use `trust_remote_code=True` will encounter error. Set default to `False`.

**Overview:** ?

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->
