### PR TITLE
Fix test assertions for 2-gpu

### DIFF
--- a/tests/gpu/torch/prune/plugins/test_mcore_gpt_minitron_pruning.py
+++ b/tests/gpu/torch/prune/plugins/test_mcore_gpt_minitron_pruning.py
@@ -297,40 +297,40 @@ def _test_mcore_gpt_pruning(
         # TODO: Simplify it: this unit test is too long,
         # hard to read (the same set of assertions across different test cases with if-else).
 
-        assert len(pruning_scores["activations_per_rank"]) == 1
-        rank_0_activations = pruning_scores["activations_per_rank"][0]
+        assert len(pruning_scores["activations_per_rank"]) == size
+        activations = pruning_scores["activations_per_rank"][rank]
 
         # Test case 1: MHA - pruned ffn/4 (num_attention_heads=8, num_query_groups=8, ffn_div=4)
-        if pruned_ffn_div == 4:
+        if size == 1 and pruned_ffn_div == 4:
             # Layer scores
             _assert_approx(pruning_scores["layer_scores"], {1: 0.028923, 2: 0.046508})
 
             # Validate decoder.layers.0.mlp activations
-            mlp_0_acts = rank_0_activations["decoder.layers.0.mlp"]
+            mlp_0_acts = activations["decoder.layers.0.mlp"]
             _assert_approx(mlp_0_acts.min().item(), 0.000026)
             _assert_approx(mlp_0_acts.max().item(), 0.000729)
             _assert_approx(mlp_0_acts.mean().item(), 0.000201)
 
             # Validate decoder.layers.1.mlp activations
-            mlp_1_acts = rank_0_activations["decoder.layers.1.mlp"]
+            mlp_1_acts = activations["decoder.layers.1.mlp"]
             _assert_approx(mlp_1_acts.min().item(), 0.000022)
             _assert_approx(mlp_1_acts.max().item(), 0.000762)
             _assert_approx(mlp_1_acts.mean().item(), 0.000162)
 
         # Test case 2: GQA - pruned attention/2 (num_attention_heads=8, num_query_groups=4, attention_div=2)
-        elif pruned_num_attention_heads_div == 2 and pruned_ffn_div == 1:
+        elif size == 1 and pruned_num_attention_heads_div == 2 and pruned_ffn_div == 1:
             # Layer scores
             _assert_approx(pruning_scores["layer_scores"], {1: 0.028056, 2: 0.038353})
 
             # Validate decoder.layers.0.self_attention activations
-            attn_0_acts = rank_0_activations["decoder.layers.0.self_attention"]
+            attn_0_acts = activations["decoder.layers.0.self_attention"]
             assert attn_0_acts.shape == torch.Size([hidden_size])
             _assert_approx(attn_0_acts.min().item(), 0.010091)
             _assert_approx(attn_0_acts.max().item(), 0.023826)
             _assert_approx(attn_0_acts.mean().item(), 0.014548)
 
             # Validate decoder.layers.1.self_attention activations
-            attn_1_acts = rank_0_activations["decoder.layers.1.self_attention"]
+            attn_1_acts = activations["decoder.layers.1.self_attention"]
             assert attn_1_acts.shape == torch.Size([hidden_size])
             _assert_approx(attn_1_acts.min().item(), 0.009982)
             _assert_approx(attn_1_acts.max().item(), 0.035644)


### PR DESCRIPTION
- Assertions should account for layers split across PP ranks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved GPU test handling by capping usage to at most 2 GPUs.
  * Enhanced validation logic for distributed training scenarios with dynamic assertion handling.
  * Refined pruning score assertion checks to properly handle multi-GPU distributed validation paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->