### PR TITLE
[5763424][ONNX][Autocast] Fix ConstantOfShape layer output precision

### DIFF
--- a/modelopt/onnx/autocast/precisionconverter.py
+++ b/modelopt/onnx/autocast/precisionconverter.py
@@ -347,6 +347,8 @@ class PrecisionConverter:
                 return node.inputs[1].dtype  # scale type
             elif node.op == "QuantizeLinear":
                 return node.inputs[2].dtype  # zero_point type
+            elif node.op == "ConstantOfShape":
+                return node.attrs["value"].dtype
             elif not inp.dtype or inp.dtype == onnx.TensorProto.UNDEFINED:
                 return None
             elif node.op not in self.custom_ops:


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:** Fixed the output precision of ConstantOfShape layers in models with custom ops.

## Usage
<!-- You can potentially add a usage example below. -->

```python
$ python -m modelopt.onnx.quantization --onnx_path=$MODEL_NAME.onnx
```

## Testing
See bug 5763424.

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: No
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
This issue only affects models with custom ops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type propagation handling for ConstantOfShape operations in ONNX autocast, ensuring correct precision type conversion across related operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->