### PR TITLE
Revert onnxruntime-gpu version to 1.22.0 for Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,7 @@ optional_deps = {
         "onnx~=1.19.0",
         "onnxconverter-common~=1.16.0",
         "onnxruntime~=1.22.0 ; platform_machine == 'aarch64' or platform_system == 'Darwin'",
-        "onnxruntime-gpu~=1.22.0 ; platform_machine != 'aarch64' and platform_system != 'Darwin' and platform_system != 'Windows'",  # noqa: E501
-        "onnxruntime-gpu==1.23.2; platform_system == 'Windows'",
+        "onnxruntime-gpu~=1.22.0 ; platform_machine != 'aarch64' and platform_system != 'Darwin'",
         "onnxscript",  # For autocast opset conversion and test_onnx_dynamo_export unit test
         "onnxslim>=0.1.76",
         "polygraphy>=0.49.22",


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ? Bug fix

**Overview:** 
Reverted the windows ort version in setup.py to 1.22, since I later observed some regressions with vision models. 
Keeping ORT version as 1.23 in windows examples since i didn't face any issues with LLM's.

## Testing
Attaching results observed while testing these models.
[int8_trt_comparison.csv](https://github.com/user-attachments/files/24763088/int8_trt_comparison.csv)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GPU runtime dependencies for the optional ONNX package. Simplified platform-specific version constraints while maintaining compatibility across supported platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->