### PR TITLE
Drop '_pg_collection' in MBridge model config when checkpointing

### DIFF
--- a/modelopt/torch/opt/plugins/mcore_dist_checkpointing.py
+++ b/modelopt/torch/opt/plugins/mcore_dist_checkpointing.py
@@ -39,7 +39,6 @@ SUPPORTED_WRAPPERS[Float16Module] = "module"
 DROP_SUBSTRINGS = [
     "fp4",
     "fp8",
-    "tp_",
     "parallel",
     "cuda_graph",
     "init_",
@@ -49,6 +48,10 @@ DROP_SUBSTRINGS = [
     "pipeline",
     "comm",
     "batch",
+    "pg_collection",
+]
+DROP_STARTSWITH = [
+    "tp_",  # would drop 'mtp_*' otherwise
 ]
 
 
@@ -144,6 +147,8 @@ def save_sharded_modelopt_state(
 
         for k, v in transformer_config.items():
             if any(substring in k for substring in DROP_SUBSTRINGS):
+                continue
+            if any(k.startswith(prefix) for prefix in DROP_STARTSWITH):
                 continue
             if isinstance(v, (bool, int, str)):
                 config[k] = v


### PR DESCRIPTION
## What does this PR do?

**Type of change:**  Bug Fix

**Overview:** Bug report appeared where this was an issue, since we save our own `modelopt_run_config.yaml` which has repr() issues. The main fix is happening in MCore's `ProcessGroupCollection.__repr__`, but this is a backup measure since we don't want to save it anyway, regardless. Megatron-LM does not have this issue since only M-Bridge's Model Provider classes extend `TransformerConfig` and store an extra `_pg_collection` attribute.

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration key filtering in distributed training checkpoints to better preserve relevant configuration entries while maintaining necessary prefix-based filtering rules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->