### PR TITLE
Nenotrom Nano PTQ fix where MoELayer forward has additional named arguments

### DIFF
--- a/modelopt/torch/quantization/plugins/megatron.py
+++ b/modelopt/torch/quantization/plugins/megatron.py
@@ -745,19 +745,25 @@ class _QuantMoELayer(QuantModule):
     However, even in calibration mode, the actual top_k routing is used to calculate the actual outputs this instance
     returns.
 
+    When group routing is used (e.g. DSR1 or V3), with group_topk set, topk can never be all experts (otherwise,
+    the total indices will be out of bound). Since DSR1 is the only model that uses group routing and all experts
+    can be calibrated normally, we disable this WAR when group_topk is used.
+
     If calibration is not enabled, this module behaves as a normal MoELayer.
+
+    Note:
+        There are new arguments (e.g. padding_mask) passed through the forward function. Since we always pass through
+        all the arguments, we use **args and **kwargs here.
     """
 
     def _setup(self):
         pass
 
-    def forward(self, hidden_states, padding_mask: torch.Tensor | None = None):
+    def forward(self, *args, **kwargs):
         if any(getattr(m, "_if_calib", False) for m in self.experts.modules()):
             if self.config.moe_router_num_groups is None:
                 original_top_k = self.router.topk
                 self.router.topk = self.router.num_experts
-                super().forward(hidden_states, padding_mask=padding_mask)
+                super().forward(*args, **kwargs)
                 self.router.topk = original_top_k
-            else:
-                super().forward(hidden_states, padding_mask=padding_mask)
-        return super().forward(hidden_states, padding_mask=padding_mask)
+        return super().forward(*args, **kwargs)


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

Bug fix

**Overview:** ?

Our `QuantMoELayer` dynamic module override the forward. In the latest version of `megatron.core` `MoELayer.forward` has additional argument ; hence resulting in failure. Since we are passing through all the arguments, here we change to use *args and **kwargs to avoid future issue.

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated argument propagation in the mixture-of-experts quantization layer to flexibly support additional calibration-related and padding parameters while maintaining backward compatibility.
  * Improved routing behavior with conditional top-k adjustments that activate when group routing configurations are in use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->