### PR TITLE
[Minor] fix:  do not requantize the scales in FP8 scale sweep calibration

### DIFF
--- a/modelopt/torch/quantization/model_calib.py
+++ b/modelopt/torch/quantization/model_calib.py
@@ -251,9 +251,7 @@ def mse_calibrate(
         fp8_scale_sweep: If True, sweep over all 126 valid FP8 E4M3 scale values
             for NVFP4 per-block quantization instead of using multipliers.
             This is specifically designed for optimizing the FP8-quantized
-            per-block scales in NVFP4 format. When enabled, sets
-            block_sizes["skip_fp8_scale_quant"] = True on NVFP4 quantizers
-            to skip dynamic FP8 scale quantization during inference (default: False).
+            per-block scales in NVFP4 format.
 
     See :class:`MseCalibConfig <modelopt.torch.quantization.config.MseCalibConfig>` for
     details on the remaining arguments.
@@ -283,12 +281,6 @@ def mse_calibrate(
                         f"fp8_scale_sweep is enabled but quantizer '{name}' is not NVFP4 static "
                         "block quantization. fp8_scale_sweep will be ignored for this quantizer."
                     )
-
-                # Skip dynamic FP8 scale quantization as scales are pre-optimized via FP8 sweep
-                if fp8_scale_sweep and is_nvfp4_static:
-                    if module._block_sizes is None:
-                        module._block_sizes = {}
-                    module._block_sizes["skip_fp8_scale_quant"] = True
 
                 # Create MSE calibrator with quant_func
                 module._calibrator = MseCalibrator(

--- a/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
+++ b/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
@@ -764,16 +764,11 @@ class TensorQuantizer(nn.Module):
                 self._pass_through_bwd,
             )
         elif self._num_bits == (2, 1) and self.is_static_block_quant:
-            skip_scale_quant = (
-                self._block_sizes.get("skip_fp8_scale_quant", False)
-                if self._block_sizes is not None
-                else False
-            )
             outputs = static_blockwise_fp4_fake_quant(
                 inputs,
                 None,  # scale
                 None,  # scale_fp8_quant_amax
-                skip_scale_quant,  # skip_scale_quant
+                True,  # skip_scale_quant
                 inputs.dtype,  # out_dtype
                 self._pass_through_bwd,  # pass_through_bwd
                 amax,  # amax


### PR DESCRIPTION
## What does this PR do?

**Type of change:** ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

**Overview:** ?

## Usage
<!-- You can potentially add a usage example below. -->

```python
# Add a code snippet demonstrating how to use this
```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conditional pre-quantization optimization for static block quantization when scale sweep is enabled.
  * Enhanced calibration flow with configurable scale quantization behavior based on optimization settings.

* **Improvements**
  * Updated quantization calibration documentation to clarify scale behavior and optimization interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->