### PR TITLE
chore(onnx): Remove dead code in find_scales and add test coverage

### DIFF
--- a/modelopt/onnx/quantization/quant_utils.py
+++ b/modelopt/onnx/quantization/quant_utils.py
@@ -331,7 +331,6 @@ def find_scales(
         max_int = (2**num_bits) - 1
         min_int = 0
         s = (max_val - min_val).clip(min=CLIP_MIN) / max_int
-        # z = -np.round(temp).clip(min=min_int, max=max_int)    # gives 0 - need to check
         temp = min_val / s
         temp = np.round(temp)
         temp = -temp


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Dead code cleanup, new tests

**Overview:** Remove confusing dead code in [find_scales](file:///c:/Users/USER/DEVELOPMENT_SPACE/ImportantProjects/Model-Optimizer/modelopt/onnx/quantization/quant_utils.py#306-353) function and add test coverage.

The commented-out line `# z = -np.round(temp).clip(...)` in [quant_utils.py](https://github.com/NVIDIA/Model-Optimizer/blob/main/modelopt/onnx/quantization/quant_utils.py) represented a buggy implementation due to operator precedence. Python interprets `-np.round(temp).clip(...)` as `-(np.round(temp).clip(...))`, which incorrectly produces 0 for negative input ranges. The active code correctly performs negation before clipping.

This PR:
1. Removes the confusing commented-out dead code
2. Adds a parametrized test to verify the zero-point calculation works correctly for various input ranges

## Testing

Added `test_find_scales_zero_point` which tests:
- Negative-only range
- Mixed range (negative to positive)
- Positive-only range
- Symmetric around zero

## Before your PR is "*Ready for review*"

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed. ✅
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: Yes
- **Did you add or update any necessary documentation?**: No (code cleanup, no API changes)
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: No (minor cleanup, not a feature/bug fix)

## Additional Information

Files changed:
- [modelopt/onnx/quantization/quant_utils.py](https://github.com/NVIDIA/Model-Optimizer/blob/main/modelopt/onnx/quantization/quant_utils.py): Removed 1 line of dead code
- [tests/unit/onnx/test_quant_utils.py](https://github.com/NVIDIA/Model-Optimizer/blob/main/tests/unit/onnx/test_quant_utils.py): Added test for `find_scales`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete comment from quantization utilities code.

* **Tests**
  * Added test coverage for asymmetric quantization zero-point calculations to validate scale values, shape consistency, and zero-point bounds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->