### PR TITLE
[5868890][ONNX][Autocast] Fix: failure when checking input shape with unknown dimension

### DIFF
--- a/modelopt/onnx/autocast/referencerunner.py
+++ b/modelopt/onnx/autocast/referencerunner.py
@@ -95,8 +95,8 @@ class ReferenceRunner:
                 # Compare input rank
                 raise_value_error = len(inp_shape_model) != len(inp_shape_data)
                 if not raise_value_error:
-                    # Compare input shape, skipping check for unknown dimensions (shape = -1)
-                    mask = inp_shape_model != -1
+                    # Compare input shape, skipping check for unknown dimensions
+                    mask = inp_shape_model > 0
                     raise_value_error = np.any(inp_shape_model[mask] != inp_shape_data[mask])
                 if raise_value_error:
                     raise ValueError(


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:** Skip unknown dimensions when comparing input shape in model vs calibration data.

## Usage

```python
$ python -m modelopt.onnx.autocast --onnx_path=$MODEL_NAME.onnx --calibration_data=calib_data_10.npz
```

## Testing
See bug 5868890.

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes
- **Did you write any new necessary tests?**: No
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced input shape validation to properly handle dynamic tensor dimensions, allowing more flexible dimension checking while maintaining validation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Aditional info
Regression introduced in https://github.com/NVIDIA/Model-Optimizer/pull/652.