### PR TITLE
Fix DeepSpeed import crash on runtime-only CUDA and improve NVFP4 uncalibrated weight error

### DIFF
--- a/modelopt/torch/quantization/plugins/transformers.py
+++ b/modelopt/torch/quantization/plugins/transformers.py
@@ -26,7 +26,12 @@ def make_deepspeed_compatible(model: nn.Module):
     """Make the model compatible with DeepSpeed."""
     try:
         from deepspeed.runtime.zero.parameter_offload import ZeROOrderedDict
-    except ImportError:
+    except (ImportError, FileNotFoundError, RuntimeError):
+        # ImportError: deepspeed not installed
+        # FileNotFoundError: deepspeed installed but CUDA compiler (nvcc) not found.
+        #   DeepSpeed checks for nvcc at import time (via ops/op_builder), which
+        #   fails on runtime-only CUDA installations without the CUDA toolkit.
+        # RuntimeError: other deepspeed initialization failures
         return
     is_deepspeed_zero3_enabled = any(
         hasattr(module, "_parameters") and isinstance(module._parameters, ZeROOrderedDict)

--- a/modelopt/torch/quantization/qtensor/nvfp4_tensor.py
+++ b/modelopt/torch/quantization/qtensor/nvfp4_tensor.py
@@ -55,8 +55,14 @@ class NVFP4QTensor(BaseQuantizedTensor):
     @classmethod
     def get_weights_scaling_factor_2_from_quantizer(cls, weight_quantizer):
         """Returns per tensor weight scaling factor from the weight_quantizer amax."""
-        # Assert that weight_quantizer has attribute amax
-        assert hasattr(weight_quantizer, "_amax"), "Weight quantizer does not have attribute amax"
+        if not hasattr(weight_quantizer, "_amax") or weight_quantizer._amax is None:
+            raise ValueError(
+                "Weight quantizer does not have _amax attribute. "
+                "This usually means the layer was not calibrated during PTQ — for example, "
+                "if it was offloaded to disk via accelerate's device_map='auto'. "
+                "Call `_ensure_weight_quantizer_calibrated()` before export, "
+                "or increase --calib_size to ensure all experts are activated."
+            )
         return weight_quantizer._amax.float() / (6.0 * 448.0)
 
     @classmethod


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:** Fixes two crashes that block NVFP4 quantization of large models (>1TB) on production GPU infrastructure.

**Bug 1 — DeepSpeed import crashes on runtime-only CUDA systems:**

During `mtq.quantize()`, `make_deepspeed_compatible` imports DeepSpeed to check for ZeRO-3 compatibility. DeepSpeed's import chain calls `nvcc --version` to check CUDA compiler compatibility. On runtime-only CUDA installations (NGC containers, cloud GPU instances without the CUDA toolkit), this raises `FileNotFoundError`. The existing `except ImportError` doesn't catch it, so quantization crashes before calibration even starts — even though the user isn't using DeepSpeed at all.

**Fix:** Broaden the exception handler to also catch `FileNotFoundError` and `RuntimeError`.

**Bug 2 — Opaque assertion when weight quantizers lack `_amax`:**

`NVFP4QTensor.get_weights_scaling_factor_2_from_quantizer()` uses `assert hasattr(weight_quantizer, "_amax")` which produces an opaque `AssertionError` with no guidance on what went wrong. This is hit when `accelerate`'s `device_map="auto"` offloads layers to disk on large models — the quantizers are inserted but some may not accumulate `_amax` during calibration. The user loses hours of calibration time to an error that doesn't explain the cause or fix.

**Fix:** Replace bare assert with `ValueError` that explains why `_amax` is missing (disk offloading, insufficient `calib_size`) and points to `_ensure_weight_quantizer_calibrated()` as the resolution.

> **Note:** PR #785 added `_ensure_weight_quantizer_calibrated()` in `quant_utils.py` which handles this case at the call site. This PR improves the safety net in `nvfp4_tensor.py` itself — if `_ensure_weight_quantizer_calibrated` is bypassed or fails, the user gets a useful error instead of an opaque assert.

## Usage

```python
# Before this fix — crashes on systems without nvcc:
# FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/cuda/bin/nvcc'
import modelopt.torch.quantization as mtq
model = mtq.quantize(model, mtq.NVFP4_DEFAULT_CFG, forward_loop=calib_loop)

# After this fix — works correctly, DeepSpeed check is silently skipped
```

## Testing

Tested on:
- DeepSeek V3 671B BF16 model (1.3TB) on 8x NVIDIA B200 GPUs (SM100)
- Runtime-only CUDA 12.8 environment (no `nvcc` installed)
- PyTorch 2.9.1+cu128, ModelOpt 0.41.0
- Quantization with `NVFP4_DEFAULT_CFG`, `device_map="auto"`, 1024 calibration samples

**Before fix:** `FileNotFoundError` at `mtq.quantize()` (Bug 1), `AssertionError` at `export_hf_checkpoint()` (Bug 2)
**After fix:** Both operations complete successfully

## Before your PR is "*Ready for review*"

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes — only broadens exception handling and improves error messages. No API or behavior changes.
- **Did you write any new necessary tests?**: No — these are edge cases in exception handling. Could add a unit test that mocks a failed DeepSpeed import.
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: No — minor bug fix, not a feature or breaking change.

## Additional Information

Related: PR #785 (*Fix a nvfp4 weight amax attribute issue during export*) added `_ensure_weight_quantizer_calibrated()` which addresses the `_amax` issue at the `quant_utils.py` call site. This PR adds the safety net at the `nvfp4_tensor.py` level.

Encountered while quantizing fine-tuned DeepSeek V3 671B models on NVIDIA B200 Blackwell GPUs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for import failures with more specific exception catching and clearer diagnostic messages.
  * Enhanced validation with informative error messaging when required configuration attributes are missing, guiding users on calibration and export prerequisites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->