### PR TITLE
Fix test_transformers_tp for torch 2.10 env

### DIFF
--- a/modelopt/torch/quantization/model_calib.py
+++ b/modelopt/torch/quantization/model_calib.py
@@ -1038,6 +1038,8 @@ def awq_lite(
     def update_loss(self, out, out_actual, alpha):
         out_actual = out_actual[0] if isinstance(out_actual, tuple) else out_actual
         out = out[0] if isinstance(out, tuple) else out
+        out = out.to_local() if hasattr(out, "to_local") else out
+        out_actual = out_actual.to_local() if hasattr(out_actual, "to_local") else out_actual
         loss = (out - out_actual).float().pow(2).mean()
         self.awq_lite.loss[alpha] += loss.to(self.awq_lite.loss[alpha].device)
 


### PR DESCRIPTION
After bumping CICD dev containers to latest (with torch 2.10), `test_transformers_tp.py` is failing (was skpipped in PR-merge CICD as it requires 2-gpu)

Failing test: https://github.com/NVIDIA/Model-Optimizer/actions/runs/22258743173/job/64393623736#step:7:617

Passing test after this fix: https://github.com/NVIDIA/Model-Optimizer/actions/runs/22259791793/job/64396179609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quantization calibration by converting outputs to local tensor representations and adding a normalization step before loss computation, ensuring more reliable and accurate model calibration results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->