### PR TITLE
vLLM fake quant with FP8 attention math

### DIFF
--- a/examples/vllm_serve/vllm_serve_fakequant.py
+++ b/examples/vllm_serve/vllm_serve_fakequant.py
@@ -76,6 +76,7 @@ additional_env_vars = {
     "QUANT_CFG",
     "AMAX_FILE_PATH",
     "KV_QUANT_CFG",
+    "KV_ATTN_MATH",
 }
 
 RayDistributedExecutor.ADDITIONAL_ENV_VARS.update(additional_env_vars)


### PR DESCRIPTION
## What does this PR do?

  **Type of change:** New feature                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                          
  **Overview:** Adds `KV_ATTN_MATH=fp8` support to the vLLM fake-quant serving example, enabling NVFP4 KV cache emulation with FP8 attention math (BMM).                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                          
  vLLM's FlashInfer backend has no native NVFP4 KV support. Previously, NVFP4 KV fake-quant ran with BF16 attention math, which does not match the hardware execution path on SM100 (Blackwell), where NVFP4 KV uses FP8 attention math. This PR closes that gap:                                                                                         

  1. `KV_QUANT_CFG=NVFP4_KV_CFG` applies NVFP4 fake-quant noise into the BF16 K/V tensors.
  2. With `KV_ATTN_MATH=fp8`, the FP8 KV cache scales are locked to 1.0, so those BF16 values are directly cast to FP8 when written to the cache (`--kv-cache-dtype fp8`).
  3. FlashInfer reads the FP8 KV cache and runs FP8 attention math, matching SM100 behavior.

  ## Usage

  ```bash
  # NVFP4 weight + KV quantization with FP8 attention math
  QUANT_CFG=NVFP4_DEFAULT_CFG \
  KV_QUANT_CFG=NVFP4_KV_CFG \
  KV_ATTN_MATH=fp8 \
  python examples/vllm_serve/vllm_serve_fakequant.py <model_path> \
      --kv-cache-dtype fp8 \
      -tp 8 --host 0.0.0.0 --port 8000
  ```

## Testing
<!-- Mention how have you tested your change if applicable. -->

## Before your PR is "*Ready for review*"
<!-- If you haven't finished some of the above items you can still open `Draft` PR. -->

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes/No <!--- If No, explain why. -->
- **Did you write any new necessary tests?**: Yes/No
- **Did you add or update any necessary documentation?**: Yes/No
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: Yes/No <!--- Only for new features, API changes, critical bug fixes or bw breaking changes. -->

## Additional Information
<!-- E.g. related issue. -->
