### PR TITLE
[OMNIML-3495] Fix megatron_generate to pass position_ids for MTP model support

### DIFF
--- a/modelopt/torch/utils/plugins/megatron_generate.py
+++ b/modelopt/torch/utils/plugins/megatron_generate.py
@@ -78,8 +78,11 @@ def megatron_prefill(
             .view(batch_size, 1, seq_len, seq_len)
         )
 
-        # NOTE: we don't support traditional positional embedding. Only RoPE or YaRN are supported.
-        position_ids = None
+        position_ids = (
+            torch.arange(seq_len, dtype=torch.long, device=device)
+            .unsqueeze(0)
+            .expand(batch_size, -1)
+        )
 
         output_tensor = model(
             data["tokens"],
@@ -209,8 +212,11 @@ def megatron_generate(
         else:
             attention_mask = None
 
-        # NOTE: we don't support traditional positional embedding. Only RoPE or YaRN are supported.
-        position_ids = None
+        position_ids = (
+            torch.arange(seq_len, dtype=torch.long, device=device)
+            .unsqueeze(0)
+            .expand(batch_size, -1)
+        )
 
         # Check if this is a VLM model (has vision inputs)
         _has_pixel_values = data.get("pixel_values") is not None


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

`megatron_generate` and `megatron_prefill` set `position_ids = None` for text-only LLM models. This crashes models with Multi-Token Prediction (MTP) layers (e.g., Nemotron Super with `mtp_num_layers=2`) because MTP's `roll_tensor` calls `torch.roll(position_ids, ...)` which requires a Tensor, not None.

```
File "megatron/core/transformer/multi_token_prediction.py", line 161, in roll_tensor
    rolled_tensor = torch.roll(tensor, shifts=shifts, dims=dims)
TypeError: roll(): argument 'input' (position 1) must be Tensor, not NoneType
```

This fix generates sequential `position_ids = [0, 1, 2, ..., seq_len-1]` per batch element.

### Usage

No API change. Models with MTP now work with `megatron_generate` without any caller-side changes:

```python
from modelopt.torch.utils.plugins.megatron_generate import megatron_generate

# This now works for MTP models (previously crashed with TypeError)
megatron_generate(model, tokens.input_ids.cuda(), osl=1)
```

### Testing

- Verified Nemotron Super (88-layer hybrid Mamba/Attention/MoE model with `mtp_num_layers=2`) quantization + generation works end-to-end with `megatron_generate` on 16 GPUs (2 nodes, TP=16, EP=16).
```
torchrun --nproc_per_node 8 examples/quantization/quantize.py \
  --hf-model-id /models/nemotron-super-rl-021126/ \
  --calib-size 1 \
  --export-quant-cfg fp8 \
  --megatron-save-path /models/nemotron-super-rl-021126-FP8-MLM \
  --pp 1 \
  --tp 8 \
  --ep 8 \
  --trust-remote-code
```

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, using `torch.load(..., weights_only=True)`, avoiding `pickle`, etc.).

- Is this change backward compatible?: ✅ All modern models (RoPE, YaRN, Mamba) have `add_position_embedding = False`, so `position_ids` is ignored by the embedding layer. RoPE generates identical sequential positions internally whether `position_ids` is provided or `None`.
- If you copied code from any other source, did you follow IP policy in [CONTRIBUTING.md](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md#-copying-code-from-other-sources)?: N/A
- Did you write any new necessary tests?: ❌ Existing quantization tests cover the code path. The fix is a one-line behavioral change (None → Tensor) with no new branches.
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌ Bug fix for a previously unsupported model type.

### Additional Information

The VLM code path in `_forward_step_func` already generates `position_ids` correctly (lines 223-227). This fix applies the same pattern to the text-only LLM code path for consistency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed positional ID handling in the text generation pipeline so token positions are tracked consistently across batches during both initial and subsequent generation steps, improving generation stability and alignment with attention behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->