### PR TITLE
[5951713] Fix benchmark allocation failure

### DIFF
--- a/modelopt/onnx/quantization/autotune/benchmark.py
+++ b/modelopt/onnx/quantization/autotune/benchmark.py
@@ -543,12 +543,15 @@ class TensorRTPyBenchmark(Benchmark):
         try:
             ctype = np.ctypeslib.as_ctypes_type(dtype)
             arr = np.ctypeslib.as_array((ctype * size).from_address(addr))
-        except NotImplementedError:
+        except NotImplementedError as e:
             # float16/bfloat16 have no ctypes equivalent; use same-size type and view
             if dtype.itemsize == 2:
                 ctype = ctypes.c_uint16
             else:
-                raise
+                raise TypeError(
+                    f"Pinned host allocation for dtype {dtype} is not supported: "
+                    "no ctypes mapping and no fallback for this itemsize"
+                ) from e
             arr = np.ctypeslib.as_array((ctype * size).from_address(addr)).view(dtype)
         return (host_ptr, arr, cudart.cudaError_t.cudaSuccess)
 


### PR DESCRIPTION
### What does this PR do?

```
[modelopt][onnx] - ERROR - Benchmark failed: Converting dtype('float16') to a ctypes type
Traceback (most recent call last):
...
    raise NotImplementedError(
NotImplementedError: Converting dtype('float16') to a ctypes type
```

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, using `torch.load(..., weights_only=True)`, avoiding `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other source, did you follow IP policy in [CONTRIBUTING.md](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md#-copying-code-from-other-sources)?: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved dtype handling robustness in host memory allocation to avoid failures for uncommon numeric types.
  * Added fallback support for 2-byte floating-point formats (float16, bfloat16); clearer errors now raised when a dtype is unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->