### PR TITLE
Use os.path.join for quant_summary path

### DIFF
--- a/modelopt/torch/quantization/model_quant.py
+++ b/modelopt/torch/quantization/model_quant.py
@@ -17,6 +17,7 @@
 
 import fnmatch
 import inspect
+import os
 import warnings
 from collections.abc import Callable, Iterable
 from typing import Any
@@ -519,11 +520,7 @@ def print_quant_summary(model: nn.Module, output_dir: str | None = None):
     lines.append(f"{len(lines)} TensorQuantizers found in model")
 
     if output_dir:
-        path = (
-            output_dir.joinpath(".quant_summary.txt")
-            if hasattr(output_dir, "joinpath")
-            else f"{output_dir}/.quant_summary.txt"
-        )
+        path = os.path.join(output_dir, ".quant_summary.txt")
         with open(path, "w", encoding="utf-8") as f:
             f.write("\n".join(lines) + "\n")
         print(f"\033[1mQuant summary saved to {path}\033[0m")


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

I'm seeing the error 
```
Error saving quant summary: [Errno 2] No such file or directory: '/home/chad/checkpoint//.quant_summary.txt'
```
when using a trailing slash in the `export_path` to `hf_ptq.py`.

### Testing

This fix will work for all cases of with and without trailing slash, and both `str` and `Path`.

```
cvoegele@nvdilw8aur4dw1a:~>> python
>>> os.path.join("/home/chad/output", "a.txt")
'/home/chad/output/a.txt'
>>> os.path.join("/home/chad/output/", "a.txt")
'/home/chad/output/a.txt'
>>> os.path.join(Path("/home/chad/output"), "a.txt")
'/home/chad/output/a.txt'
>>> os.path.join(Path("/home/chad/output/"), "a.txt")
'/home/chad/output/a.txt'
```

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅
- Did you write any new necessary tests?: ✅ 
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal path handling for quantization summary output to enhance cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->