### PR TITLE
Fix Mcore test utils for M-LM main

### DIFF
--- a/examples/megatron_bridge/prune_minitron.py
+++ b/examples/megatron_bridge/prune_minitron.py
@@ -311,7 +311,12 @@ def main(args: argparse.Namespace):
     if mto.ModeloptStateManager.has_state_for_mode_type("prune", model=unwrapped_model):
         mto.ModeloptStateManager.remove_state(unwrapped_model)
     if isinstance(provider, MambaModelProvider):
-        provider.hybrid_override_pattern = unwrapped_model.hybrid_override_pattern
+        hybrid_key = (
+            "hybrid_override_pattern"
+            if hasattr(unwrapped_model, "hybrid_override_pattern")
+            else "hybrid_layer_pattern"
+        )
+        setattr(provider, hybrid_key, getattr(unwrapped_model, hybrid_key))
     print_rank_0(f"\nPruned {unwrapped_model=}")
     print_rank_0(
         f"Pruned model params: {num2hrb(mtp.mcore_minitron.get_mcore_param_count(unwrapped_model))}"
@@ -374,8 +379,8 @@ def main(args: argparse.Namespace):
             hf_cfg.layer_types = [
                 lt for i, lt in enumerate(hf_cfg.layer_types) if i + 1 in kept_layer_nums
             ]
-        if hasattr(hf_cfg, "hybrid_override_pattern"):
-            hf_cfg.hybrid_override_pattern = unwrapped_model.hybrid_override_pattern
+        if isinstance(provider, MambaModelProvider) and hasattr(hf_cfg, "hybrid_override_pattern"):
+            hf_cfg.hybrid_override_pattern = getattr(unwrapped_model, hybrid_key)
         hf_cfg.num_hidden_layers = mcore_cfg.num_layers
 
         # Save dummy pruned HF model to get the correct bridge for saving pruned weights

--- a/modelopt/torch/prune/plugins/mcore_minitron.py
+++ b/modelopt/torch/prune/plugins/mcore_minitron.py
@@ -317,19 +317,28 @@ class MCoreMinitronSearcher(BaseSearcher):
         # Prune homogeneously
         self._prune(export_config, prune_depth=True)
 
-        # TODO: Rename to hybrid_layer_pattern after https://github.com/NVIDIA/Megatron-LM/pull/3377
+        # TODO: Rename to hybrid_layer_pattern after MCore 0.17 and nemo:26.04 is released (for M-LM PR #3377)
         # Update hybrid_override_pattern if pruning is done on a hybrid model
         if isinstance(self.model, MambaModel):
-            print_rank_0(f"Original hybrid_override_pattern: {self.model.hybrid_override_pattern}")
+            hybrid_key = (
+                "hybrid_override_pattern"
+                if hasattr(self.model, "hybrid_override_pattern")
+                else "hybrid_layer_pattern"
+            )
+            print_rank_0(f"Original {hybrid_key}: {getattr(self.model, hybrid_key)}")
             new_num_layers = self.model.config.num_layers
             assert self.sorted_layers is not None
             kept_layers_numbers = self.sorted_layers[:new_num_layers]
-            self.model.hybrid_override_pattern = "".join(
-                c
-                for i, c in enumerate(self.model.hybrid_override_pattern)
-                if i + 1 in kept_layers_numbers
+            setattr(
+                self.model,
+                hybrid_key,
+                "".join(
+                    c
+                    for i, c in enumerate(getattr(self.model, hybrid_key))
+                    if i + 1 in kept_layers_numbers
+                ),
             )
-            print_rank_0(f"Pruned hybrid_override_pattern: {self.model.hybrid_override_pattern}")
+            print_rank_0(f"Pruned {hybrid_key}: {getattr(self.model, hybrid_key)}")
 
     def _prune(self, export_config: dict, prune_depth: bool = True) -> None:
         """Prune the model homogeneously based on the export_config by setting active choices for configurable hparams.

--- a/tests/_test_utils/torch/megatron/models.py
+++ b/tests/_test_utils/torch/megatron/models.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import textwrap
 from warnings import warn
 
 import torch
@@ -27,7 +26,6 @@ from megatron.core.models.gpt.gpt_layer_specs import (
 )
 from megatron.core.models.mamba import MambaModel
 from megatron.core.parallel_state import is_pipeline_first_stage, is_pipeline_last_stage
-from megatron.core.ssm.mamba_hybrid_layer_allocation import Symbols
 from megatron.core.tensor_parallel.layers import ColumnParallelLinear, RowParallelLinear
 from megatron.core.transformer.module import MegatronModule
 from megatron.core.transformer.transformer_config import TransformerConfig
@@ -356,10 +354,7 @@ def get_mcore_mamba_hybrid_model(
         **config_kwargs,
     )
 
-    if not (skip_moe or "E" in Symbols.VALID):  # Mcore 0.16+ has MoE support
-        warn("MoE blocks are not supported in current MambaModel. Skipping MoE blocks.")
-        skip_moe = True
-
+    # TODO: hybrid_override_pattern is deprecated in MCore 0.17+, use hybrid_layer_pattern instead
     if hybrid_override_pattern is None:
         # Generate pattern by repeating base_pattern and trimming to match num_layers
         #   E.g. for num_layers=3, return "MEM" (Mamba -> MoE -> Mamba)
@@ -367,23 +362,24 @@ def get_mcore_mamba_hybrid_model(
         base_pattern = "M*M-" if skip_moe else "MEM*M-"
         hybrid_override_pattern = (base_pattern * num_layers)[:num_layers]
 
-    # Add | symbols for Pipeline parallelism (required for MCore 0.16+)
+    # TODO: enable this when MCore 0.17+ is released (has fall-back so without this is still fine for sometime)
+    # Add | symbols for Pipeline parallelism (supported from MCore 0.17+, auto-added if not provided)
     # E.g. MEM* with PP2 becomes ME|M* and MEM*M-ME with PP2 becomes MEM*|M-ME
-    if pipeline_model_parallel_size > 1 and "|" in Symbols.VALID:
-        if "|" not in hybrid_override_pattern:
-            assert (
-                num_layers_in_first_pipeline_stage is None
-                and num_layers_in_last_pipeline_stage is None
-            ), "hybrid_override_pattern with `|` must be provided for uneven PP"
-            hybrid_override_pattern = "|".join(
-                textwrap.wrap(
-                    hybrid_override_pattern,
-                    width=num_layers // pipeline_model_parallel_size,
-                    break_long_words=True,
-                    break_on_hyphens=False,
-                )
-            )
-        assert hybrid_override_pattern.count("|") == pipeline_model_parallel_size - 1
+    # if pipeline_model_parallel_size > 1:
+    #     if "|" not in hybrid_override_pattern:
+    #         assert (
+    #             num_layers_in_first_pipeline_stage is None
+    #             and num_layers_in_last_pipeline_stage is None
+    #         ), "hybrid_override_pattern with `|` must be provided for uneven PP"
+    #         hybrid_override_pattern = "|".join(
+    #             textwrap.wrap(
+    #                 hybrid_override_pattern,
+    #                 width=num_layers // pipeline_model_parallel_size,
+    #                 break_long_words=True,
+    #                 break_on_hyphens=False,
+    #             )
+    #         )
+    #     assert hybrid_override_pattern.count("|") == pipeline_model_parallel_size - 1
     assert len(hybrid_override_pattern.replace("|", "")) == num_layers
     print(f"Using `{hybrid_override_pattern=}` for building MambaModel")
 

--- a/tests/_test_utils/torch/megatron/utils.py
+++ b/tests/_test_utils/torch/megatron/utils.py
@@ -15,17 +15,13 @@
 import copy
 import re
 from collections import defaultdict
-from warnings import warn
 
 import torch
 from megatron.core import dist_checkpointing
-from megatron.core.inference.communication_utils import broadcast_from_last_pipeline_stage
-from megatron.core.inference.contexts import StaticInferenceContext
-from megatron.core.inference.model_inference_wrappers.gpt.gpt_inference_wrapper import (
-    GPTInferenceWrapper,
-)
-from megatron.core.inference.model_inference_wrappers.inference_wrapper_config import (
-    InferenceWrapperConfig,
+from megatron.core.inference.communication_utils import (
+    broadcast_from_last_pipeline_stage,
+    recv_from_prev_pipeline_rank_,
+    send_to_next_pipeline_rank,
 )
 from megatron.core.models.gpt import GPTModel
 from megatron.core.models.mamba import MambaModel
@@ -34,10 +30,11 @@ from megatron.core.parallel_state import (
     get_expert_tensor_parallel_group,
     get_expert_tensor_parallel_rank,
     initialize_model_parallel,
+    is_pipeline_first_stage,
+    is_pipeline_last_stage,
 )
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
-from megatron.core.transformer.attention import SelfAttention
-from megatron.core.transformer.mlp import MLP
+from megatron.core.utils import get_attr_wrapped_model
 
 import modelopt.torch.quantization as mtq
 from modelopt.torch.opt.plugins.mcore_dist_checkpointing import (
@@ -46,73 +43,58 @@ from modelopt.torch.opt.plugins.mcore_dist_checkpointing import (
 )
 from modelopt.torch.utils import to_empty_if_meta_device
 
-try:
-    from megatron.core.ssm.mamba_layer import MambaLayer
-
-    HAS_MAMBA = True
-except ImportError as e:
-    warn(f"Mamba not installed: {e}")
-    HAS_MAMBA = False
-
 
 @torch.no_grad()
 def run_mcore_inference(
-    model: GPTModel | MambaModel,
-    prompt_tokens: torch.Tensor,
-    active_hidden_size: int | None = None,
+    model: GPTModel | MambaModel, prompt_tokens: torch.Tensor, active_hidden_size: int | None = None
 ) -> torch.Tensor:
-    """Run inference on a wrapped Megatron GPT or Mamba model.
+    """Run inference on a Megatron GPT or Mamba model with pipeline parallel support.
 
     Args:
         model: Megatron GPT or Mamba model.
         prompt_tokens: Input tokens for inference.
-        active_hidden_size: Hidden size to use for inference. If not provided, infer the hidden_size
-            NOTE: `model.config.hidden_size` may not be the same as the active hidden size
-                for the model since for a NAS search space-converted model, the hidden size
-                may be different until the model is exported.
-            NOTE: If depth pruned model and some PP have 0 layers, this would not work.
+        active_hidden_size: Hidden size for PP recv buffer allocation. Must match the actual
+            model output hidden dim — required for NAS models where it differs from
+            model.config.hidden_size. Defaults to model.config.hidden_size.
     """
-    batch_size = prompt_tokens.shape[0]
-    if active_hidden_size is None:
-        if HAS_MAMBA and isinstance(model.decoder.layers[0], MambaLayer):
-            active_hidden_size = model.decoder.layers[0].mixer.d_model
-        elif isinstance(model.decoder.layers[0].self_attention, SelfAttention):
-            if hasattr(model.decoder.layers[0].self_attention.linear_qkv, "in_features"):
-                active_hidden_size = model.decoder.layers[0].self_attention.linear_qkv.in_features
-            else:
-                active_hidden_size = model.decoder.layers[0].self_attention.linear_qkv.input_size
-        elif isinstance(model.decoder.layers[0].mlp, MLP):
-            active_hidden_size = model.decoder.layers[0].mlp.linear_fc1.input_size
-        else:
-            raise ValueError(f"Cannot infer hidden size from {type(model.decoder.layers[0])=}")
+    batch_size, seq_length = prompt_tokens.shape[0], model.max_sequence_length
+    hidden_size = active_hidden_size or model.config.hidden_size
 
-    inference_wrapper_config = InferenceWrapperConfig(
-        hidden_size=active_hidden_size,
-        inference_batch_times_seqlen_threshold=batch_size * model.max_sequence_length,
-        fp32_residual_connection=False,
-        params_dtype=torch.bfloat16 if model.config.bf16 else torch.float32,
-        padded_vocab_size=model.vocab_size,
-    )
-    # Get full sequence output instead of only last token logits
-    inference_context = StaticInferenceContext.from_config(inference_wrapper_config)
-    inference_context.materialize_only_last_token_logits = False
-
-    wrapped_model = GPTInferenceWrapper(model, inference_wrapper_config, inference_context)
-    wrapped_model.prep_model_for_inference()
-
-    inference_input = wrapped_model.prep_inference_input(prompt_tokens)
-    inference_input = wrapped_model.get_batch_for_context_window(
-        inference_input, 0, model.max_sequence_length
+    pp_first, pp_last = is_pipeline_first_stage(), is_pipeline_last_stage()
+    is_pp = not (pp_first and pp_last)
+    pp_dtype = model.config.pipeline_dtype or (
+        torch.bfloat16 if model.config.bf16 else torch.float32
     )
 
-    # Note: This is returned in all TP ranks or last PP stage in PP models
-    logits = wrapped_model.run_one_forward_step(inference_input)
-    logits = broadcast_from_last_pipeline_stage(
-        [batch_size, model.max_sequence_length, model.vocab_size],
-        dtype=torch.bfloat16 if model.config.bf16 else torch.float32,
-        tensor=logits,
+    is_training = model.training
+    model.eval()
+
+    if is_pp and not pp_first:
+        recv_buffer = torch.empty(
+            (seq_length, batch_size, hidden_size),
+            dtype=pp_dtype,
+            device=torch.cuda.current_device(),
+        )
+        recv_from_prev_pipeline_rank_(recv_buffer)
+        get_attr_wrapped_model(model, "set_input_tensor")(recv_buffer)
+
+    position_ids = (
+        torch.arange(seq_length, dtype=torch.long, device=prompt_tokens.device)
+        .unsqueeze(0)
+        .expand_as(prompt_tokens)
     )
-    return logits  # shape: (batch_size, max_sequence_length, vocab_size)
+    output = model(prompt_tokens, position_ids, None, runtime_gather_output=True)
+
+    model.train(is_training)
+
+    if is_pp and not pp_last:
+        send_to_next_pipeline_rank(output.to(dtype=pp_dtype))
+
+    return broadcast_from_last_pipeline_stage(
+        [batch_size, seq_length, model.vocab_size],
+        dtype=pp_dtype,
+        tensor=output if pp_last else None,
+    )
 
 
 def run_mcore_inference_with_dummy_input(

--- a/tests/gpu_megatron/torch/nas/plugins/test_megatron_gpt_dynamic_modules.py
+++ b/tests/gpu_megatron/torch/nas/plugins/test_megatron_gpt_dynamic_modules.py
@@ -125,7 +125,7 @@ def _test_gpt_search_space(
     prompt_tokens = torch.randint(0, vocab_size, (batch_size, max_sequence_length)).cuda()
     for sample_func in [min, max, centroid]:
         mtn.sample(model, sample_func)
-        output = run_mcore_inference(model, prompt_tokens)
+        output = run_mcore_inference(model, prompt_tokens, model.hidden_size)
         assert output.shape == (batch_size, max_sequence_length, vocab_size)
 
     # Make sure export and forward pass works on centroid model
@@ -306,7 +306,7 @@ def _test_gpt_moe_search_space(rank, size):
 
     # Make sure forward pass works on min and centroid subnets
     prompt_tokens = torch.randint(0, vocab_size, (batch_size, max_sequence_length)).cuda()
-    output = run_mcore_inference(model, prompt_tokens)
+    output = run_mcore_inference(model, prompt_tokens, model.hidden_size)
     assert output.shape == (batch_size, max_sequence_length, vocab_size)
 
     # Make sure export and forward pass works on centroid model

--- a/tests/gpu_megatron/torch/nas/plugins/test_megatron_mamba_dynamic_modules.py
+++ b/tests/gpu_megatron/torch/nas/plugins/test_megatron_mamba_dynamic_modules.py
@@ -121,7 +121,7 @@ def _test_mamba_search_space(rank, size):
     prompt_tokens = torch.randint(0, vocab_size, (batch_size, max_sequence_length)).cuda()
     for sample_func in [min, max, centroid]:
         mtn.sample(model, sample_func)
-        output = run_mcore_inference(model, prompt_tokens)
+        output = run_mcore_inference(model, prompt_tokens, model.hidden_size)
         assert output.shape == (batch_size, max_sequence_length, vocab_size)
 
     # Make sure export and forward pass works on centroid model


### PR DESCRIPTION
### What does this PR do?

- M-LM main removed some functions we were using for running mcore inference in unit tests - replace with alternative
- Future-proof `hybrid_override_pattern` -> `hybrid_layer_pattern` rename for Mamba models

### Testing

Ran megatron tests with M-LM main branch and previous 0.16 release version

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mamba model pruning to dynamically select the appropriate hybrid pattern configuration, ensuring correct handling across different model variants.
  * Simplified inference logic for pipeline-parallel models, improving robustness and reliability.

* **Tests**
  * Updated test infrastructure for Mamba and GPT model inference validation with explicit hidden size parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->