### PR TITLE
Refactor: use get_expert_linear_names, remove _GATE_UP_PAIRS

### DIFF
--- a/modelopt/torch/export/layer_utils.py
+++ b/modelopt/torch/export/layer_utils.py
@@ -1171,55 +1171,6 @@ def set_expert_quantizer_amax(
     return uncalibrated_modules
 
 
-# Gate/up naming pairs for standard (unfused) MoE architectures.
-# Fused variants (gate_up_proj, linear_fc1) already share a single quantizer and need no sync.
-_GATE_UP_PAIRS = [("gate_proj", "up_proj"), ("w1", "w3")]
-
-
-def sync_moe_gate_up_amax(model: nn.Module) -> int:
-    """Take element-wise max of gate and up weight quantizer amaxes per expert.
-
-    Serving engines fuse gate_proj and up_proj into a single gate_up_proj and
-    require a single weight_scale_2. Since weight_scale_2 = amax / (6 * 448),
-    syncing amaxes before quantization ensures the per-block weight_scale values
-    are computed against a consistent global scale.
-
-    Only affects standard MoE models with separate gate/up linear layers
-    (e.g. Qwen MoE, DeepSeek). Models with already-fused gate_up_proj
-    (e.g. Llama4, GptOss) are unaffected.
-
-    Returns:
-        Number of expert gate/up pairs whose amaxes were synced.
-    """
-    synced = 0
-    for _, sub_module in model.named_modules():
-        if not (is_moe(sub_module) and hasattr(sub_module, "experts")):
-            continue
-        if not hasattr(sub_module.experts, "__iter__"):
-            continue
-        for expert in sub_module.experts:
-            for gate_name, up_name in _GATE_UP_PAIRS:
-                gate_linear = getattr(expert, gate_name, None)
-                up_linear = getattr(expert, up_name, None)
-                if gate_linear is None or up_linear is None:
-                    continue
-                gate_wq = getattr(gate_linear, "weight_quantizer", None)
-                up_wq = getattr(up_linear, "weight_quantizer", None)
-                if gate_wq is None or up_wq is None:
-                    break
-                gate_amax = getattr(gate_wq, "amax", None)
-                up_amax = getattr(up_wq, "amax", None)
-                if gate_amax is None or up_amax is None:
-                    break
-                if not torch.equal(gate_amax, up_amax):
-                    shared_amax = torch.max(gate_amax, up_amax)
-                    gate_wq.amax = shared_amax
-                    up_wq.amax = shared_amax.clone()
-                    synced += 1
-                break
-    return synced
-
-
 def build_stacked_experts(
     experts: nn.Module,
     linear_names: list[str],

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -73,7 +73,6 @@ from .layer_utils import (
     is_moe,
     is_quantlinear,
     set_expert_quantizer_amax,
-    sync_moe_gate_up_amax,
 )
 from .model_config import (
     QUANTIZATION_FP8,
@@ -778,14 +777,37 @@ def _export_transformers_checkpoint(
 
     # Safety net: sync any gate/up weight quantizer amaxes that
     # requantize_resmooth_fused_llm_layers did not reach (e.g. experts not
-    # activated during the dummy forward, or non-standard expert naming).
-    synced = sync_moe_gate_up_amax(model)
+    # activated during the dummy forward).
+    # Serving engines fuse gate+up into one projection and need a shared weight_scale_2.
+    synced = 0
+    for _, sub_module in model.named_modules():
+        if not (is_moe(sub_module) and hasattr(sub_module, "experts")):
+            continue
+        if not isinstance(sub_module.experts, collections.abc.Iterable):
+            continue
+        linear_names = get_expert_linear_names(sub_module)
+        # Only unfused 3-linear experts (e.g. gate_proj/down_proj/up_proj or w1/w2/w3)
+        if len(linear_names) != 3:
+            continue
+        gate_name, up_name = linear_names[0], linear_names[2]
+        for expert in sub_module.experts:
+            gate_wq = getattr(getattr(expert, gate_name, None), "weight_quantizer", None)
+            up_wq = getattr(getattr(expert, up_name, None), "weight_quantizer", None)
+            if gate_wq is None or up_wq is None:
+                continue
+            gate_amax = getattr(gate_wq, "amax", None)
+            up_amax = getattr(up_wq, "amax", None)
+            if gate_amax is None or up_amax is None:
+                continue
+            if not torch.equal(gate_amax, up_amax):
+                shared = torch.max(gate_amax, up_amax)
+                gate_wq.amax = shared
+                up_wq.amax = shared.clone()
+                synced += 1
     if synced:
         warnings.warn(
-            f"Found {synced} MoE expert gate/up projection pair(s) with mismatched "
-            f"weight_scale_2 after requantize_resmooth_fused_llm_layers. "
-            f"This typically means the dummy forward did not activate these experts. "
-            f"Taking element-wise max of amaxes for serving-engine fusion."
+            f"Synced {synced} MoE expert gate/up weight quantizer amax pair(s) "
+            f"by taking element-wise max for serving-engine fusion."
         )
 
     # Process all quantized modules and export weights


### PR DESCRIPTION
## Summary

Alternative to the `sync_moe_gate_up_amap` / `_GATE_UP_PAIRS` approach in #1033. Addresses the duplication concern while **preserving the correct placement** (after `requantize_resmooth_fused_llm_layers`).

Changes:
- Remove `sync_moe_gate_up_amax` function and `_GATE_UP_PAIRS` constant from `layer_utils.py`
- Inline the sync logic in `unified_export_hf.py` at the same location (after `requantize_resmooth_fused_llm_layers`, before `_process_quantized_modules`)
- Use `get_expert_linear_names(sub_module)` to derive gate/up names — single source of truth instead of a separate constant

Net result: -56 lines, +29 lines. Same behavior, no new public API surface in `layer_utils.py`.

## Test plan
- [ ] Existing MoE export tests should pass unchanged
- [ ] Verify with Qwen3.5 MoE and Kimi-K2.5 models that weight_scale_2 is unified

🤖 Generated with [Claude Code](https://claude.com/claude-code)