### PR TITLE
[Do Not merge]Draft:Add NVFP4 four-over-six (4o6) adaptive activation quantization

### DIFF
--- a/examples/llm_ptq/hf_ptq.py
+++ b/examples/llm_ptq/hf_ptq.py
@@ -98,6 +98,7 @@ QUANT_CFG_CHOICES: dict[str, dict[str, Any]] = {
     "nvfp4": mtq.NVFP4_DEFAULT_CFG,
     "nvfp4_awq": mtq.NVFP4_AWQ_LITE_CFG,
     "nvfp4_mse": mtq.NVFP4_W4A4_WEIGHT_MSE_FP8_SWEEP_CFG,
+    "nvfp4_4o6": mtq.NVFP4_4O6_W4A4_CFG,
     "fp8_pb_wo": mtq.FP8_2D_BLOCKWISE_WEIGHT_ONLY_CFG,
     "fp8_pc_pt": mtq.FP8_PER_CHANNEL_PER_TOKEN_CFG,
     "w4a8_nvfp4_fp8": mtq.W4A8_NVFP4_FP8_CFG,
@@ -275,6 +276,7 @@ def auto_quantize(
             "w4a8_mxfp4_fp8",
             "nvfp4_mlp_only",
             "nvfp4_omlp_only",
+            "nvfp4_4o6",
             "mxfp8",
         ]
         for args.qformat in qformat_list
@@ -941,6 +943,7 @@ def quantize_main(
                 "w4a8_mxfp4_fp8",
                 "nvfp4_mlp_only",
                 "nvfp4_omlp_only",
+                "nvfp4_4o6",
                 "mxfp8",
             ]
             or args.kv_cache_qformat in KV_QUANT_CFG_CHOICES

--- a/modelopt/torch/quantization/calib/__init__.py
+++ b/modelopt/torch/quantization/calib/__init__.py
@@ -21,6 +21,7 @@ collect data statistics and determine modelopt.torch.quantization parameters.
 
 from .bias import *
 from .calibrator import *
+from .fouroversix import nvfp4_4o6_fake_quant
 from .histogram import *
 from .max import *
 from .mse import *

--- a/modelopt/torch/quantization/calib/fouroversix.py
+++ b/modelopt/torch/quantization/calib/fouroversix.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure-PyTorch reference implementation of NVFP4 "four over six" fake quantization.
+
+Each 16-element block independently chooses between a 4-bit or 6-bit FP8 scale
+encoding to minimize quantization error (MSE/MAE/abs_max), following the approach
+described in arxiv:2512.02010.
+"""
+
+from __future__ import annotations
+
+import torch
+
+__all__ = ["nvfp4_4o6_fake_quant"]
+
+_E2M1_MAX = 6
+_E2M1_MAX_FOUR = 4
+_E4M3_MAX_FOUROVERSIX = 256
+
+
+def _fake_quantize_to_e2m1(x: torch.Tensor) -> torch.Tensor:
+    """E2M1 round-trip fake quantization (nearest rounding)."""
+    step1 = torch.round(2 * x.abs()) / 2
+    step2 = torch.round(x.abs())
+    step3 = 2 * torch.round(x.abs() / 2)
+
+    mask1 = x.abs() < 2
+    mask2 = x.abs() < 4
+
+    return x.sign() * (step1 * mask1 + step2 * (~mask1) * mask2 + step3 * (~mask1) * (~mask2))
+
+
+def _quantize_to_nvfp4(
+    x_blocks: torch.Tensor,
+    x_amax: torch.Tensor,
+    *,
+    scale_expansion_factor: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute per-block FP8 scales and return block-scaled activations.
+
+    Args:
+        x_blocks: Tensor of shape (num_blocks, block_size), float32.
+        x_amax: Scalar float32 tensor — global amax of the full activation tensor.
+        scale_expansion_factor: If provided, multiply computed scales by this factor
+            (1.5 for the 4-bit path).
+
+    Returns:
+        (x_block_scaled, scales) where x_block_scaled has the same shape as x_blocks
+        and scales is float8_e4m3fn of shape (num_blocks,).
+    """
+    if x_amax == 0:
+        x_scales_hp = torch.zeros(
+            x_blocks.shape[0],
+            dtype=x_amax.dtype,
+            device=x_amax.device,
+        )
+    else:
+        encode_scale = (
+            torch.tensor(
+                _E2M1_MAX * _E4M3_MAX_FOUROVERSIX,
+                dtype=x_amax.dtype,
+                device=x_amax.device,
+            )
+            / x_amax
+        )
+        x_scales_hp = (
+            x_blocks.abs().max(dim=-1).values
+            / torch.tensor(_E2M1_MAX, dtype=x_amax.dtype, device=x_amax.device)
+            * encode_scale
+        )
+
+    if scale_expansion_factor is not None:
+        x_scales_hp = x_scales_hp * scale_expansion_factor
+
+    x_scales = x_scales_hp.to(torch.float8_e4m3fn)
+
+    decode_scale = (
+        torch.tensor(
+            _E2M1_MAX * _E4M3_MAX_FOUROVERSIX,
+            dtype=x_amax.dtype,
+            device=x_amax.device,
+        )
+        / x_amax
+    )
+    x_block_scaled = torch.where(
+        x_scales.unsqueeze(1) != 0,
+        x_blocks * (1 / (x_scales.to(x_amax.dtype).unsqueeze(1) / decode_scale)),
+        torch.zeros_like(x_blocks),
+    )
+
+    return x_block_scaled, x_scales
+
+
+def _select_fouroversix(
+    x_blocks: torch.Tensor,
+    x_scaled_6: torch.Tensor,
+    scales_6: torch.Tensor,
+    x_scaled_4: torch.Tensor,
+    scales_4: torch.Tensor,
+    x_amax: torch.Tensor,
+    *,
+    scale_rule: str = "mse",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per-block adaptive 4-or-6 bit scale selection with fake dequantization.
+
+    Args:
+        x_blocks: Original blocks, shape (num_blocks, block_size), float32.
+        x_scaled_6: Block-scaled activations from 6-bit path.
+        scales_6: FP8 scales from 6-bit path, shape (num_blocks,).
+        x_scaled_4: Block-scaled activations from 4-bit path.
+        scales_4: FP8 scales from 4-bit path, shape (num_blocks,).
+        x_amax: Scalar float32 global amax.
+        scale_rule: Error metric — "mse", "mae", or "abs_max".
+
+    Returns:
+        (x_fake_quantized, scales) where x_fake_quantized has shape
+        (num_blocks, block_size) and scales has shape (num_blocks, 1).
+    """
+    x_fq_6 = _fake_quantize_to_e2m1(x_scaled_6)
+    x_fq_4 = _fake_quantize_to_e2m1(x_scaled_4)
+
+    denom = torch.tensor(
+        _E2M1_MAX * _E4M3_MAX_FOUROVERSIX,
+        dtype=x_amax.dtype,
+        device=x_amax.device,
+    )
+    x_deq_6 = x_fq_6.to(x_amax.dtype) * scales_6.unsqueeze(1).to(x_amax.dtype) * x_amax / denom
+    x_deq_4 = x_fq_4.to(x_amax.dtype) * scales_4.unsqueeze(1).to(x_amax.dtype) * x_amax / denom
+
+    if scale_rule == "abs_max":
+        err_4 = (x_deq_4 - x_blocks).abs().max(dim=-1).values
+        err_6 = (x_deq_6 - x_blocks).abs().max(dim=-1).values
+    elif scale_rule == "mae":
+        err_4 = (x_deq_4 - x_blocks).abs().sum(dim=-1)
+        err_6 = (x_deq_6 - x_blocks).abs().sum(dim=-1)
+    elif scale_rule == "mse":
+        err_4 = ((x_deq_4 - x_blocks) ** 2).sum(dim=-1)
+        err_6 = ((x_deq_6 - x_blocks) ** 2).sum(dim=-1)
+    else:
+        raise ValueError(
+            f"Unknown scale_rule: {scale_rule!r}. Expected 'mse', 'mae', or 'abs_max'."
+        )
+
+    select_4 = (err_4 < err_6).unsqueeze(1)  # (num_blocks, 1)
+    x_fake_quantized = torch.where(
+        select_4,
+        x_fq_4.reshape(x_blocks.shape[0], -1),
+        x_fq_6.reshape(x_blocks.shape[0], -1),
+    )
+    scales = torch.where(
+        select_4,
+        scales_4.reshape(-1, 1).to(x_amax.dtype),
+        scales_6.reshape(-1, 1).to(x_amax.dtype),
+    )
+
+    return x_fake_quantized, scales
+
+
+def nvfp4_4o6_fake_quant(
+    x: torch.Tensor,
+    x_amax: torch.Tensor,
+    *,
+    scale_rule: str = "mse",
+    block_size: int = 16,
+) -> torch.Tensor:
+    """NVFP4 "four over six" fake quantization.
+
+    Each block of ``block_size`` elements independently chooses between a 4-bit
+    or 6-bit FP8 block scale to minimize the per-block quantization error, as
+    described in arxiv:2512.02010.
+
+    Args:
+        x: Input activation tensor of any shape. The last dimension (flattened)
+            must be divisible by ``block_size``.
+        x_amax: Scalar float32 tensor — global absolute maximum of ``x``.
+        scale_rule: Error metric used for scale selection. One of
+            ``"mse"`` (default), ``"mae"``, or ``"abs_max"``.
+        block_size: Number of elements per quantization block. Default: 16.
+
+    Returns:
+        Fake-quantized tensor with the same shape and dtype as ``x``.
+
+    Raises:
+        ValueError: If the total number of elements is not divisible by ``block_size``.
+    """
+    if x.numel() % block_size != 0:
+        raise ValueError(
+            f"Total number of elements ({x.numel()}) must be divisible by "
+            f"block_size ({block_size})."
+        )
+
+    orig_shape = x.shape
+    orig_dtype = x.dtype
+
+    x_blocks = x.reshape(-1, block_size).float()
+    x_amax = x_amax.float()
+
+    x_scaled_6, scales_6 = _quantize_to_nvfp4(x_blocks, x_amax)
+    x_scaled_4, scales_4 = _quantize_to_nvfp4(x_blocks, x_amax, scale_expansion_factor=1.5)
+
+    x_fake_q, scales = _select_fouroversix(
+        x_blocks, x_scaled_6, scales_6, x_scaled_4, scales_4, x_amax, scale_rule=scale_rule
+    )
+
+    # Dequantize: scales already float, shape (num_blocks, 1)
+    denom = _E2M1_MAX * _E4M3_MAX_FOUROVERSIX
+    x_out = x_fake_q * scales * x_amax / denom
+
+    return x_out.reshape(orig_shape).to(orig_dtype)

--- a/modelopt/torch/quantization/config.py
+++ b/modelopt/torch/quantization/config.py
@@ -418,10 +418,27 @@ _nvfp4_quantizer = {
     "enable": True,
 }
 
+_nvfp4_4o6_input_quantizer = {
+    "num_bits": (2, 1),
+    "block_sizes": {-1: 16, "type": "dynamic", "scale_bits": (4, 3)},
+    "enable": True,
+    "backend": "nvfp4_4o6",
+    "backend_extra_args": {"scale_rule": "mse"},
+}
+
 NVFP4_DEFAULT_CFG = {
     "quant_cfg": {
         "*weight_quantizer": _nvfp4_quantizer,
         "*input_quantizer": _nvfp4_quantizer,
+        **_default_disabled_quantizer_cfg,
+    },
+    "algorithm": "max",
+}
+
+NVFP4_4O6_W4A4_CFG = {
+    "quant_cfg": {
+        "*weight_quantizer": _nvfp4_quantizer,
+        "*input_quantizer": _nvfp4_4o6_input_quantizer,
         **_default_disabled_quantizer_cfg,
     },
     "algorithm": "max",
@@ -676,6 +693,7 @@ choices: set[str] = {
     "NVFP4_AWQ_CLIP_CFG",
     "NVFP4_AWQ_FULL_CFG",
     "NVFP4_AWQ_LITE_CFG",
+    "NVFP4_4O6_W4A4_CFG",
     "NVFP4_DEFAULT_CFG",
     "NVFP4_FP8_MHA_CONFIG",
     "NVFP4_KV_CFG",

--- a/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
+++ b/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
@@ -42,6 +42,7 @@ from modelopt.torch.utils.distributed import DistributedProcessGroup
 
 from ... import calib
 from ... import utils as quant_utils
+from ...calib.fouroversix import nvfp4_4o6_fake_quant
 from ...config import QuantizerAttributeConfig, RotateConfig
 from ...qtensor import (
     BaseQuantizedTensor,
@@ -117,6 +118,17 @@ def is_registered_quant_backend(name: str) -> bool:
         name: The name of the backend to check.
     """
     return name in _QUANT_FUNCTIONAL_BACKENDS
+
+
+def _nvfp4_4o6_backend(inputs: torch.Tensor, tq: "TensorQuantizer") -> torch.Tensor:
+    """NVFP4 four-over-six fake quantization backend."""
+    x_amax = inputs.abs().max().float()
+    scale_rule = (tq.backend_extra_args or {}).get("scale_rule", "mse")
+    block_size = (tq.block_sizes or {}).get(-1, 16)
+    return nvfp4_4o6_fake_quant(inputs, x_amax, scale_rule=scale_rule, block_size=block_size)
+
+
+register_quant_backend("nvfp4_4o6", _nvfp4_4o6_backend)
 
 
 class TensorQuantizerCache(Protocol):

--- a/tests/unit/torch/quantization/test_fouroversix_kernel.py
+++ b/tests/unit/torch/quantization/test_fouroversix_kernel.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the NVFP4 four-over-six fake quantization kernel."""
+
+import pytest
+import torch
+
+from modelopt.torch.quantization.calib.fouroversix import nvfp4_4o6_fake_quant
+
+
+def _amax(x: torch.Tensor) -> torch.Tensor:
+    return x.abs().max().float()
+
+
+class TestOutputShapeAndDtype:
+    def test_output_shape_and_dtype(self):
+        x = torch.randn(128, 64, dtype=torch.bfloat16)
+        out = nvfp4_4o6_fake_quant(x, _amax(x))
+        assert out.shape == x.shape
+        assert out.dtype == x.dtype
+
+
+class TestZeroTensor:
+    def test_zero_tensor(self):
+        x = torch.zeros(64, 32, dtype=torch.float32)
+        out = nvfp4_4o6_fake_quant(x, _amax(x))
+        assert out.shape == x.shape
+        assert torch.all(out == 0)
+
+
+class TestAllScaleRules:
+    @pytest.mark.parametrize("scale_rule", ["mse", "mae", "abs_max"])
+    def test_all_scale_rules(self, scale_rule):
+        x = torch.randn(64, 64, dtype=torch.float32)
+        out = nvfp4_4o6_fake_quant(x, _amax(x), scale_rule=scale_rule)
+        assert out.shape == x.shape
+        assert not torch.any(torch.isnan(out))
+
+
+class TestMseLowerErrorThanStatic6:
+    def test_mse_lower_error_than_static6(self):
+        """4o6-MSE error should be <= static-6 MSE on a tensor with outlier blocks."""
+        torch.manual_seed(0)
+        # Create a tensor where some blocks have large outliers
+        x = torch.randn(128, 64, dtype=torch.float32)
+        # Inject outliers into several blocks
+        x[0, :] *= 100
+        x[16, :] *= 50
+        x[64, :] *= 200
+
+        x_amax = _amax(x)
+
+        # 4o6 output
+        out_4o6 = nvfp4_4o6_fake_quant(x, x_amax, scale_rule="mse")
+
+        # Static-6 reference: use quantize_to_nvfp4 directly with no scale_expansion
+        from modelopt.torch.quantization.calib.fouroversix import (
+            _fake_quantize_to_e2m1,
+            _quantize_to_nvfp4,
+        )
+
+        x_blocks = x.reshape(-1, 16).float()
+        x_scaled_6, scales_6 = _quantize_to_nvfp4(x_blocks, x_amax)
+        x_fq_6 = _fake_quantize_to_e2m1(x_scaled_6)
+        denom = 6 * 256  # _E2M1_MAX * _E4M3_MAX_FOUROVERSIX
+        out_static6 = (
+            x_fq_6 * scales_6.unsqueeze(1).to(torch.float32) * x_amax / denom
+        ).reshape_as(x)
+
+        mse_4o6 = ((out_4o6 - x) ** 2).mean().item()
+        mse_static6 = ((out_static6 - x) ** 2).mean().item()
+
+        assert mse_4o6 <= mse_static6, (
+            f"4o6 MSE ({mse_4o6:.6f}) should be <= static-6 MSE ({mse_static6:.6f})"
+        )
+
+
+class TestRoundtripNearIdentity:
+    def test_roundtrip_near_identity(self):
+        """For a slowly-varying tensor, output should be finite and close in magnitude.
+
+        E2M1 4-bit float has only 8 positive representable levels (0, 0.5, 1, 1.5, 2, 3, 4, 6),
+        so per-element relative error can reach ~25% even for well-conditioned inputs.
+        We verify the mean relative error is reasonable (< 25%).
+        """
+        x = torch.linspace(0.1, 1.0, 128).reshape(8, 16).float()
+        out = nvfp4_4o6_fake_quant(x, _amax(x))
+        assert torch.all(torch.isfinite(out)), "Output contains non-finite values"
+        mean_rel_err = ((out - x).abs() / (x.abs() + 1e-8)).mean().item()
+        assert mean_rel_err < 0.25, f"Mean relative error {mean_rel_err:.4f} exceeds 25%"
+
+
+class TestNonDivisibleLength:
+    def test_non_divisible_length(self):
+        """Input whose numel is not divisible by block_size should raise ValueError."""
+        x = torch.randn(7, 5, dtype=torch.float32)  # 35 elements, not divisible by 16
+        with pytest.raises(ValueError, match="divisible"):
+            nvfp4_4o6_fake_quant(x, _amax(x))

--- a/tests/unit/torch/quantization/test_nvfp4_4o6_integration.py
+++ b/tests/unit/torch/quantization/test_nvfp4_4o6_integration.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end integration tests for NVFP4_4O6_W4A4_CFG."""
+
+import torch
+import torch.nn as nn
+
+import modelopt.torch.opt as mto
+import modelopt.torch.quantization as mtq
+from modelopt.torch.quantization import NVFP4_4O6_W4A4_CFG
+
+# CPU-compatible test config: INT8 weights + 4o6 input quantizer.
+# Dynamic NVFP4 block quantization for weights requires CUDA; using INT8 weights
+# lets the integration tests run on CPU while still exercising the 4o6 activation path.
+_4O6_INPUT_QUANTIZER = {
+    "num_bits": (2, 1),
+    "block_sizes": {-1: 16, "type": "dynamic", "scale_bits": (4, 3)},
+    "enable": True,
+    "backend": "nvfp4_4o6",
+    "backend_extra_args": {"scale_rule": "mse"},
+}
+
+_CPU_4O6_CFG = {
+    "quant_cfg": {
+        "*weight_quantizer": {"num_bits": 8, "axis": None, "enable": True},
+        "*input_quantizer": _4O6_INPUT_QUANTIZER,
+        "default": {"enable": False},
+    },
+    "algorithm": "max",
+}
+
+
+def _make_linear(in_f: int = 64, out_f: int = 64) -> nn.Linear:
+    torch.manual_seed(42)
+    return nn.Linear(in_f, out_f)
+
+
+class TestQuantizeLinearWith4o6Config:
+    def test_quantize_linear_with_4o6_config(self):
+        """Quantizing with NVFP4_4O6_W4A4_CFG sets input_quantizer.backend = 'nvfp4_4o6'."""
+        model = _make_linear()
+        # Only run calibration (no inference) to avoid CUDA requirement in weight quantizer
+        mtq.quantize(model, NVFP4_4O6_W4A4_CFG, lambda m: None)
+        assert model.input_quantizer.backend == "nvfp4_4o6"
+
+    def test_weight_quantizer_unaffected(self):
+        """Weight quantizer should not use a custom backend."""
+        model = _make_linear()
+        mtq.quantize(model, NVFP4_4O6_W4A4_CFG, lambda m: None)
+        assert model.weight_quantizer.backend is None
+
+
+class TestForwardPassRuns:
+    def test_forward_pass_runs(self):
+        """Forward pass on a CPU-friendly quantized model works correctly."""
+        model = _make_linear()
+        x = torch.randn(4, 64)
+        mtq.quantize(model, _CPU_4O6_CFG, lambda m: m(x))
+        out = model(x)
+        assert out.shape == (4, 64)
+        assert not torch.any(torch.isnan(out))
+
+
+class Test4o6LowerActError:
+    def test_4o6_lower_act_error(self):
+        """4o6 input quantizer gives lower or equal MSE than static-6 encoding on outlier inputs.
+
+        This test verifies the quality guarantee of the 4o6 algorithm by comparing the
+        input_quantizer output against the static-6 reference path from the 4o6 kernel directly,
+        avoiding the CUDA requirement of modelopt's dynamic block quantization.
+        """
+        torch.manual_seed(0)
+        x = torch.randn(4, 64)
+        x[0, :8] *= 100  # inject outliers
+
+        from modelopt.torch.quantization.calib.fouroversix import (
+            _fake_quantize_to_e2m1,
+            _quantize_to_nvfp4,
+            nvfp4_4o6_fake_quant,
+        )
+
+        x_amax = x.abs().max().float()
+
+        # 4o6 output
+        out_4o6 = nvfp4_4o6_fake_quant(x, x_amax, scale_rule="mse")
+
+        # Static-6 baseline (no adaptive scale selection)
+        x_blocks = x.reshape(-1, 16).float()
+        x_scaled_6, scales_6 = _quantize_to_nvfp4(x_blocks, x_amax)
+        x_fq_6 = _fake_quantize_to_e2m1(x_scaled_6)
+        denom = 6 * 256
+        out_static6 = (
+            x_fq_6 * scales_6.unsqueeze(1).to(torch.float32) * x_amax / denom
+        ).reshape_as(x)
+
+        mse_4o6 = ((out_4o6 - x) ** 2).mean().item()
+        mse_static6 = ((out_static6 - x) ** 2).mean().item()
+
+        assert mse_4o6 <= mse_static6, (
+            f"4o6 act MSE ({mse_4o6:.6f}) should be <= static-6 MSE ({mse_static6:.6f})"
+        )
+
+
+class TestScaleRuleMae:
+    def test_scale_rule_mae(self):
+        """MAE scale rule runs without error and produces valid output."""
+        cfg = {
+            "quant_cfg": {
+                "*weight_quantizer": {"num_bits": 8, "axis": None, "enable": True},
+                "*input_quantizer": {
+                    **_4O6_INPUT_QUANTIZER,
+                    "backend_extra_args": {"scale_rule": "mae"},
+                },
+                "default": {"enable": False},
+            },
+            "algorithm": "max",
+        }
+        model = _make_linear()
+        x = torch.randn(4, 64)
+        mtq.quantize(model, cfg, lambda m: m(x))
+        out = model(x)
+        assert out.shape == (4, 64)
+        assert not torch.any(torch.isnan(out))
+
+
+class TestModeloptStateRoundtrip:
+    def test_modelopt_state_roundtrip(self):
+        """modelopt_state save/restore preserves backend and backend_extra_args."""
+        model = _make_linear()
+        x = torch.randn(4, 64)
+        mtq.quantize(model, _CPU_4O6_CFG, lambda m: m(x))
+
+        assert model.input_quantizer.backend == "nvfp4_4o6"
+        assert model.input_quantizer.backend_extra_args.get("scale_rule") == "mse"
+
+        state = mto.modelopt_state(model)
+
+        model2 = _make_linear()
+        mto.restore_from_modelopt_state(model2, state)
+
+        assert model2.input_quantizer.backend == "nvfp4_4o6"
+        assert model2.input_quantizer.backend_extra_args.get("scale_rule") == "mse"
+
+        out = model2(x)
+        assert out.shape == (4, 64)


### PR DESCRIPTION
Implements the adaptive per-block scale selection strategy from arxiv:2512.02010. Each 16-element activation block independently chooses between a 4-bit or 6-bit FP8 block scale (MSE/MAE/abs_max criteria), reducing quantization error vs. uniform scale encoding without requiring Blackwell hardware.

New public API:
- `nvfp4_4o6_fake_quant` in `modelopt.torch.quantization.calib.fouroversix`
- `NVFP4_4O6_W4A4_CFG` config (standard NVFP4 weights + 4o6 activations)
- `"nvfp4_4o6"` qformat in `hf_ptq.py`

Integration uses the existing `TensorQuantizer` backend mechanism (`register_quant_backend("nvfp4_4o6", ...)`), with dynamic per-inference amax.

### What does this PR do?

Type of change: ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

<!-- Details about the change. -->

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->

### Additional Information
<!-- E.g. related issue. -->
