### PR TITLE
security(peft): enforce torch.nn.init prefix validation

### DIFF
--- a/modelopt/torch/peft/config.py
+++ b/modelopt/torch/peft/config.py
@@ -92,6 +92,10 @@ class PEFTAttributeConfig(ModeloptBaseConfig):
     @classmethod
     def _parse_init_callable(cls, v):
         if isinstance(v, str):
+            if not v.startswith("torch.nn.init."):
+                raise ValueError(
+                    f"Initializer must be from 'torch.nn.init', got '{v}'"
+                )
             try:
                 module_path, func_name = v.rsplit(".", 1)
                 mod = importlib.import_module(module_path)


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix (Security)

The current implementation of  allows importing arbitrary modules via configuration strings, which can lead to RCE if the config source is untrusted.

I added a strict prefix check to ensure only  modules are imported, matching the docstring's intent and preventing the loading of malicious packages.

### Usage



### Testing
Verified the logic by ensuring that valid  strings pass while arbitrary modules are rejected.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in : N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌ (Will update if required by maintainers)

### Additional Information
Related to security findings in automated scans.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for initializer configuration to ensure valid source references and reject invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->