### PR TITLE
Fused QKV add node issue for GQA graph surgery 

### DIFF
--- a/modelopt/onnx/graph_surgery/gqa_replacement.py
+++ b/modelopt/onnx/graph_surgery/gqa_replacement.py
@@ -707,7 +707,7 @@ def _fuse_qkv_and_create_gqa(
                 outputs=[qkv_add_output],
                 name=qkv_add_name,
             )
-            graph.node.append(qkv_add_node)
+            qkv_matmul_nodes.append(qkv_add_node)
 
             # Add value_info
             qkv_add_info = helper.make_tensor_value_info(


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

There was a small issue where for models like qwen which have bias add nodes, while fusing the q,k,v matmul and q,k,v add nodes , the fused qkv bias add node was added to the graph before the fused qkv matmul node, causing the removal script to assume that the fused matmul and the add node were part of dead subgraph hence removing them. I just changed the order in which they are added. Now there are no issues. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized graph surgery operations for ONNX model processing by adjusting node insertion timing during the multi-head to grouped-query attention transformation, maintaining functional equivalence while improving internal processing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->