### PR TITLE
Add LoRA co-training support for HF EAGLE speculative decoding

### DIFF
--- a/examples/specdec_bench/run.py
+++ b/examples/specdec_bench/run.py
@@ -157,6 +157,7 @@ def run_simple(args):
         tensor_parallel_size=args.tp_size,
         moe_expert_parallel_size=args.ep_size,
         trust_remote_code=args.trust_remote_code,
+        tokenizer_path=args.tokenizer,
         **engine_args,
     )
 

--- a/examples/specdec_bench/specdec_bench/models/vllm.py
+++ b/examples/specdec_bench/specdec_bench/models/vllm.py
@@ -72,6 +72,7 @@ class VLLMModel(Model):
             num_speculative_tokens = specdec.get("num_speculative_tokens", 3)
         engine_args = AsyncEngineArgs(
             model=model_dir,
+            tokenizer=kwargs.get("tokenizer_path"),
             trust_remote_code=kwargs.get("trust_remote_code", False),
             tensor_parallel_size=kwargs.get("tensor_parallel_size", 1),
             enable_expert_parallel=kwargs.get("moe_expert_parallel_size", 1) > 1,

--- a/examples/speculative_decoding/eagle_utils.py
+++ b/examples/speculative_decoding/eagle_utils.py
@@ -120,15 +120,105 @@ def make_speculative_data_module(
 class EagleTrainerWithAccLog(Trainer):
     """Wrapper around Trainer that logs training accuracy."""
 
+    def __init__(
+        self,
+        *args,
+        lora_lr_multiplier: float = 1.0,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.lora_lr_multiplier = lora_lr_multiplier
+
+    def create_optimizer(self):
+        """Override to give LoRA parameters a higher learning rate."""
+        super().create_optimizer()
+        if self.lora_lr_multiplier != 1.0:
+            lora_ids = {
+                id(p) for n, p in self.model.named_parameters() if "lora_" in n and p.requires_grad
+            }
+            if lora_ids:
+                new_groups = []
+                for group in self.optimizer.param_groups:
+                    lora = [p for p in group["params"] if id(p) in lora_ids]
+                    others = [p for p in group["params"] if id(p) not in lora_ids]
+                    if lora and others:
+                        new_groups.append({**group, "params": others})
+                        new_groups.append(
+                            {**group, "params": lora, "lr": group["lr"] * self.lora_lr_multiplier}
+                        )
+                    elif lora:
+                        new_groups.append({**group, "lr": group["lr"] * self.lora_lr_multiplier})
+                    else:
+                        new_groups.append(group)
+                self.optimizer.param_groups = new_groups
+        return self.optimizer
+
     def compute_loss(self, *args, **kwargs):
-        """Override compute_loss to save train accs in trainer state."""
+        """Override compute_loss to save train accs and per-component losses in trainer state."""
         if not hasattr(self.state, "training_accs"):
             self.state.training_accs = []
+        if not hasattr(self.state, "component_losses"):
+            self.state.component_losses = {"eagle": [], "preservation": []}
         kwargs.pop("num_items_in_batch", None)
         loss, outputs = super().compute_loss(return_outputs=True, *args, **kwargs)
-        if hasattr(outputs, "train_acc"):
+        if hasattr(outputs, "train_acc") and any(outputs.train_acc):
             self.state.training_accs.append(outputs.train_acc)
+        # Track per-component losses
+        for key, attr in [
+            ("eagle", "eagle_loss"),
+            ("preservation", "preservation_loss"),
+        ]:
+            val = getattr(outputs, attr, None)
+            if val is not None:
+                self.state.component_losses[key].append(val.item())
         return loss
+
+
+class LoRAWarmupCallback(TrainerCallback):
+    """Manages LoRA warmup: freezes LoRA during warmup, unfreezes after."""
+
+    def __init__(self, warmup_steps: int):
+        self.warmup_steps = warmup_steps
+        self._activated = False
+
+    def on_step_begin(self, args, state, control, **kwargs):
+        """Check if warmup is over and activate LoRA co-training."""
+        if self._activated:
+            return control
+        if state.global_step >= self.warmup_steps:
+            model = kwargs["model"]
+            # Unwrap DDP/FSDP if needed
+            raw_model = model.module if hasattr(model, "module") else model
+            if hasattr(raw_model, "_lora_cotraining_active"):
+                raw_model._lora_cotraining_active = True
+                # Unfreeze LoRA parameters
+                lora_params = []
+                for name, param in raw_model._base_model.named_parameters():
+                    if "lora_" in name:
+                        param.requires_grad = True
+                        lora_params.append(param)
+
+                # Add LoRA params to optimizer — they were excluded at creation time
+                # because requires_grad was False during warmup.
+                optimizer = kwargs.get("optimizer")
+                if optimizer is not None and lora_params:
+                    existing_ids = {id(p) for g in optimizer.param_groups for p in g["params"]}
+                    new_params = [p for p in lora_params if id(p) not in existing_ids]
+                    if new_params:
+                        optimizer.add_param_group(
+                            {
+                                "params": new_params,
+                                "lr": optimizer.param_groups[0]["lr"],
+                                "weight_decay": 0.0,
+                            }
+                        )
+                        print_rank_0(f"  Added {len(new_params)} LoRA params to optimizer")
+
+                print_rank_0(
+                    f"Step {state.global_step}: LoRA warmup complete, enabling co-training."
+                )
+            self._activated = True
+        return control
 
 
 class EagleTrainingPlot(TrainerCallback):
@@ -176,8 +266,16 @@ class EagleTrainingPlot(TrainerCallback):
             if logs:
                 wandb.log({k: v for k, v in logs.items() if v is not None}, step=state.global_step)
 
-        # reset training_accs
+            # Log per-component losses
+            if hasattr(state, "component_losses"):
+                for key, vals in state.component_losses.items():
+                    if vals:
+                        wandb.log({f"{key}_loss": np.mean(vals)}, step=state.global_step)
+
+        # reset training_accs and component_losses
         state.training_accs = []
+        if hasattr(state, "component_losses"):
+            state.component_losses = {"eagle": [], "preservation": []}
         return control
 
     def on_step_end(self, args, state, control, **kwargs):
@@ -186,6 +284,7 @@ class EagleTrainingPlot(TrainerCallback):
             return control
         if state.global_step % self.ar_validate_steps == 0 and state.global_step > 0:
             print_rank_0("Running AR validation...")
+            torch.cuda.empty_cache()
             try:
                 ars = validate_ar(
                     model=kwargs["model"],

--- a/examples/speculative_decoding/main.py
+++ b/examples/speculative_decoding/main.py
@@ -40,6 +40,7 @@ from accelerate import ParallelismConfig
 from eagle_utils import (
     EagleTrainerWithAccLog,
     EagleTrainingPlot,
+    LoRAWarmupCallback,
     make_speculative_data_module,
     patch_ring_attention_for_ttt,
 )
@@ -316,6 +317,20 @@ def train():
         else:
             raise Exception(f"{training_args.mode} is not supported!")
 
+    # Move any remaining CPU buffers to CUDA so DDP (NCCL-only) can broadcast
+    # them.  We iterate named_buffers and reassign via the owning module to
+    # keep the module tree consistent.  Parameters are left on CPU — the HF
+    # Trainer will move them during init.
+    if torch.cuda.is_available():
+        _target_dev = torch.device("cuda", 0)
+        for name, buf in list(model.named_buffers()):
+            if buf.device.type == "cpu":
+                parts = name.split(".")
+                mod = model
+                for p in parts[:-1]:
+                    mod = getattr(mod, p)
+                setattr(mod, parts[-1], buf.to(_target_dev))
+
     print_rank_0("Loading dataset...")
     is_dflash = training_args.mode == "dflash"
     if training_args.mode in ("eagle3", "dflash"):
@@ -327,11 +342,15 @@ def train():
             shift_labels=not is_dflash,
         )
 
+    callbacks = [EagleTrainingPlot(training_args.ar_validate_steps, training_args.estimate_ar)]
+    if eagle_cfg.get("eagle_base_lora") and eagle_cfg.get("eagle_base_lora_warmup_steps", 0) > 0:
+        callbacks.append(LoRAWarmupCallback(eagle_cfg["eagle_base_lora_warmup_steps"]))
+
     trainer = EagleTrainerWithAccLog(
         model=model,
         processing_class=tokenizer,
         args=training_args,
-        callbacks=[EagleTrainingPlot(training_args.ar_validate_steps, training_args.estimate_ar)],
+        callbacks=callbacks,
         **data_module,
     )
 

--- a/examples/speculative_decoding/main.py
+++ b/examples/speculative_decoding/main.py
@@ -184,7 +184,9 @@ def _load_config(config_path: str, overrides: list[str] = ()) -> tuple[dict, dic
 
     if hf_cfg.get("dp_shard_size") is None:
         cp_size = hf_cfg.get("cp_size", 1)
-        hf_cfg["dp_shard_size"] = torch.cuda.device_count() // cp_size
+        # Use WORLD_SIZE (total GPUs across all nodes) when available, else local GPU count.
+        world_size = int(os.environ.get("WORLD_SIZE", torch.cuda.device_count()))
+        hf_cfg["dp_shard_size"] = world_size // cp_size
 
     return hf_cfg, eagle_cfg, dflash_cfg
 

--- a/examples/speculative_decoding/requirements.txt
+++ b/examples/speculative_decoding/requirements.txt
@@ -1,1 +1,3 @@
+accelerate>=1.12.0
+peft==0.18.1
 transformers>=5.0,<5.4

--- a/examples/speculative_decoding/scripts/merge_lora.py
+++ b/examples/speculative_decoding/scripts/merge_lora.py
@@ -118,6 +118,22 @@ def main():
     print(f"Saving merged model to {args.output_path}...")
     model.save_pretrained(args.output_path)
     tokenizer.save_pretrained(args.output_path)
+
+    # Fix rope_theta for TRT-LLM compatibility: newer transformers (Qwen3) saves
+    # rope config under rope_parameters instead of the top-level rope_theta that
+    # TRT-LLM expects. Copy it over if missing.
+    import json
+
+    config_path = Path(args.output_path) / "config.json"
+    with open(config_path) as f:
+        cfg = json.load(f)
+    rope_params = cfg.get("rope_parameters", {})
+    if rope_params and cfg.get("rope_theta") is None:
+        cfg["rope_theta"] = rope_params.get("rope_theta")
+        with open(config_path, "w") as f:
+            json.dump(cfg, f, indent=2)
+        print(f"  Fixed rope_theta={cfg['rope_theta']} for TRT-LLM compatibility")
+
     print(f"Done! Merged model saved to {args.output_path}")
 
 

--- a/examples/speculative_decoding/scripts/merge_lora.py
+++ b/examples/speculative_decoding/scripts/merge_lora.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Merge LoRA weights from an exported EAGLE checkpoint into the base model and save.
+
+Usage:
+    python merge_lora.py \
+        --base_model_path /path/to/original/base/model \
+        --exported_lora_dir /path/to/exported/eagle/checkpoint \
+        --output_path /path/to/merged/output
+
+The exported checkpoint (from export_hf_checkpoint.py) contains
+adapter_model.safetensors and adapter_config.json in standard peft format.
+This script loads the original base model, applies the trained LoRA adapters,
+merges them into the base weights, and saves the fused model + tokenizer.
+"""
+
+import argparse
+from pathlib import Path
+
+from safetensors.torch import load_file
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Merge LoRA weights from an exported EAGLE checkpoint into the base model."
+    )
+    parser.add_argument(
+        "--base_model_path",
+        type=str,
+        required=True,
+        help="Path to the original base model (HF model name or local path).",
+    )
+    parser.add_argument(
+        "--exported_lora_dir",
+        type=str,
+        required=True,
+        help="Path to the exported EAGLE checkpoint containing adapter_model.safetensors.",
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        required=True,
+        help="Directory to save the merged (fused) base model.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    lora_dir = Path(args.exported_lora_dir)
+
+    # Verify exported files exist (standard peft naming)
+    config_path = lora_dir / "adapter_config.json"
+    weights_path = lora_dir / "adapter_model.safetensors"
+    if not config_path.exists() or not weights_path.exists():
+        raise FileNotFoundError(
+            f"Expected adapter_config.json and adapter_model.safetensors "
+            f"in {lora_dir}. Run export_hf_checkpoint.py first."
+        )
+
+    lora_sd = load_file(weights_path)
+    print(f"Loaded {len(lora_sd)} LoRA tensors from {lora_dir}")
+    print(f"  Sample keys: {list(lora_sd.keys())[:4]}")
+
+    # Load the original base model
+    print(f"Loading base model from {args.base_model_path}...")
+    model = AutoModelForCausalLM.from_pretrained(
+        args.base_model_path, torch_dtype="auto", device_map="cpu", trust_remote_code=True
+    )
+    tokenizer = AutoTokenizer.from_pretrained(args.base_model_path, trust_remote_code=True)
+
+    # Load LoRA adapter into the base model (export dir uses standard peft naming)
+    print("Loading LoRA adapter via PeftModel.from_pretrained...")
+    from peft import PeftModel
+
+    model = PeftModel.from_pretrained(model, str(lora_dir))
+    print("  PeftModel loaded successfully")
+
+    # Debug: check adapter file keys vs model keys and values
+    adapter_keys = set(lora_sd.keys())
+    model_lora_keys = {k for k in model.state_dict() if ".lora_A." in k or ".lora_B." in k}
+    print(f"  Adapter file keys (first 4): {sorted(adapter_keys)[:4]}")
+    print(f"  Model LoRA keys (first 4): {sorted(model_lora_keys)[:4]}")
+    # Check if exported lora_B values are actually non-zero
+    for k, v in lora_sd.items():
+        if ".lora_B." in k:
+            print(f"  Exported {k}: shape={v.shape}, norm={v.norm().item():.6f}")
+            break
+
+    # Verify lora_B weights are non-zero (B is init'd to zero, so non-zero means loaded)
+    lora_b_norms = [v.norm().item() for k, v in model.state_dict().items() if ".lora_B." in k]
+    if not lora_b_norms or all(n == 0 for n in lora_b_norms):
+        raise RuntimeError("LoRA-B weights are all zero — adapter loading failed.")
+    print(
+        f"  Verified: {len(lora_b_norms)} LoRA-B matrices "
+        f"(mean norm={sum(lora_b_norms) / len(lora_b_norms):.4f})"
+    )
+
+    # Merge LoRA into base weights and remove adapter wrappers
+    model = model.merge_and_unload()
+    print("LoRA merged successfully.")
+
+    # Save
+    print(f"Saving merged model to {args.output_path}...")
+    model.save_pretrained(args.output_path)
+    tokenizer.save_pretrained(args.output_path)
+    print(f"Done! Merged model saved to {args.output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/speculative_decoding/scripts/merge_lora.py
+++ b/examples/speculative_decoding/scripts/merge_lora.py
@@ -119,20 +119,17 @@ def main():
     model.save_pretrained(args.output_path)
     tokenizer.save_pretrained(args.output_path)
 
-    # Fix rope_theta for TRT-LLM compatibility: newer transformers (Qwen3) saves
-    # rope config under rope_parameters instead of the top-level rope_theta that
-    # TRT-LLM expects. Copy it over if missing.
-    import json
+    # Restore the original base model's config.json.  save_pretrained() with newer
+    # transformers (>=5.x) rewrites config fields (e.g. rope_theta → rope_parameters,
+    # torch_dtype → dtype) which can confuse downstream engines like TRT-LLM or vLLM.
+    # Since LoRA only changes weights — not architecture — the original config is correct.
+    import shutil
 
-    config_path = Path(args.output_path) / "config.json"
-    with open(config_path) as f:
-        cfg = json.load(f)
-    rope_params = cfg.get("rope_parameters", {})
-    if rope_params and cfg.get("rope_theta") is None:
-        cfg["rope_theta"] = rope_params.get("rope_theta")
-        with open(config_path, "w") as f:
-            json.dump(cfg, f, indent=2)
-        print(f"  Fixed rope_theta={cfg['rope_theta']} for TRT-LLM compatibility")
+    base_config = Path(args.base_model_path) / "config.json"
+    output_config = Path(args.output_path) / "config.json"
+    if base_config.exists():
+        shutil.copy2(str(base_config), str(output_config))
+        print(f"  Restored original config.json from {base_config}")
 
     print(f"Done! Merged model saved to {args.output_path}")
 

--- a/modelopt/torch/export/plugins/hf_spec_export.py
+++ b/modelopt/torch/export/plugins/hf_spec_export.py
@@ -116,11 +116,17 @@ class EagleExporter(SpeculativeDecodingExporter):
             "llama": LLAMA_EAGLE_SINGLE_LAYER,
             "kimik2": KIMIK2_EAGLE_SINGLE_LAYER,
         }[self.eagle_decoder_type]
+        # fc and hidden_norm are only present when use_aux_hidden_state=True
+        use_aux = getattr(self.model.eagle_config, "use_aux_hidden_state", False)
+        aux_only_keys = {"fc", "layers.0.hidden_norm"}
+        required_keys = set(expected_keys_single_layer["required"])
+        if not use_aux:
+            required_keys -= aux_only_keys
         # Check that export sd has required keys
-        for key in expected_keys_single_layer["required"]:
+        for key in required_keys:
             assert f"{key}.weight" in export_sd, f"Missing required key: {key}.weight"
         for i in range(1, self.num_hidden_layers):
-            for key in expected_keys_single_layer["required"] - {
+            for key in required_keys - {
                 "layers.0.hidden_norm",
                 "layers.0.input_layernorm",
                 "norm",
@@ -201,6 +207,42 @@ class EagleExporter(SpeculativeDecodingExporter):
 
         return template_config
 
+    def _export_lora(self, export_dir: Path, full_sd: dict):
+        """Export base model LoRA adapter weights alongside the eagle module artifacts."""
+        from peft import LoraConfig
+
+        lora_sd = {k: v for k, v in full_sd.items() if ".lora_A." in k or ".lora_B." in k}
+        if not lora_sd:
+            raise RuntimeError(
+                "No LoRA adapter tensors found in the model state dict. "
+                "Ensure eagle_base_lora=True and the model was converted with LoRA adapters."
+            )
+        # Reformat keys to match peft's standard adapter file format:
+        # 1. Strip the adapter name (e.g. ".default") — peft re-inserts it on load.
+        # 2. Add "base_model.model." prefix — peft expects this in saved adapters.
+        lora_sd = {
+            re.sub(r"(lora_[AB])\.\w+\.weight$", r"\1.weight", k): v for k, v in lora_sd.items()
+        }
+        lora_sd = {f"base_model.model.{k}": v for k, v in lora_sd.items()}
+        save_file(lora_sd, export_dir / "adapter_model.safetensors")
+
+        # Infer target modules from the exported LoRA keys (e.g., "q_proj", "v_proj")
+        # Keys are like: base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight
+        target_modules = sorted({k.split(".")[-3] for k in lora_sd if ".lora_A." in k})
+        lora_config = LoraConfig(
+            r=self.model.eagle_base_lora_rank,
+            lora_alpha=self.model.eagle_base_lora_alpha,
+            target_modules=target_modules,
+            bias="none",
+        )
+        with open(export_dir / "adapter_config.json", "w") as f:
+            json.dump(
+                lora_config.to_dict(),
+                f,
+                indent=4,
+                default=lambda o: sorted(o) if isinstance(o, set) else o,
+            )
+
     def export(
         self,
         export_dir: Path | str,
@@ -234,6 +276,10 @@ class EagleExporter(SpeculativeDecodingExporter):
         if hf_quant_config is not None:
             with open(f"{export_dir}/hf_quant_config.json", "w") as file:
                 json.dump(hf_quant_config, file, indent=4)
+
+        # Export LoRA adapter weights separately
+        if getattr(self.model, "eagle_base_lora", False):
+            self._export_lora(export_dir, full_sd)
 
 
 class EagleMedusaExporter(EagleExporter):

--- a/modelopt/torch/speculative/config.py
+++ b/modelopt/torch/speculative/config.py
@@ -195,6 +195,58 @@ class EagleConfig(ModeloptBaseConfig):
         ),
     )
 
+    eagle_base_lora: bool = ModeloptField(
+        default=False,
+        description=(
+            "Whether to add LoRA adapters to the base model for co-training with the EAGLE module. "
+            "Requires the `peft` library. Incompatible with eagle_offline=True."
+        ),
+    )
+
+    eagle_base_lora_rank: int = ModeloptField(
+        default=64,
+        description="LoRA rank for the base model adapters.",
+    )
+
+    eagle_base_lora_alpha: float = ModeloptField(
+        default=16.0,
+        description="LoRA alpha (scaling) for the base model adapters.",
+    )
+
+    eagle_base_lora_target_modules: list | None = ModeloptField(
+        default=None,
+        description=(
+            "List of module name patterns to apply LoRA to in the base model "
+            "(e.g. ['q_proj', 'v_proj']). None uses peft defaults."
+        ),
+    )
+
+    eagle_base_lora_preservation_loss_weight: float = ModeloptField(
+        default=0.1,
+        description=(
+            "Weight for the preservation loss that minimizes the KL divergence between "
+            "the LoRA-adapted base model output and the original base model output."
+        ),
+    )
+
+    eagle_base_lora_warmup_steps: int = ModeloptField(
+        default=0,
+        description=(
+            "Number of warmup steps where LoRA is frozen and only the EAGLE draft head trains. "
+            "After warmup, LoRA is enabled for co-training."
+        ),
+    )
+
+    eagle_base_lora_logits_detach_prob: float = ModeloptField(
+        default=0.5,
+        description=(
+            "After warmup, probability of detaching base_output_softmax_logits each step. "
+            "Acts as dropout regularization on the eagle-loss-to-LoRA gradient path through "
+            "logits, preventing LoRA from degenerating to maximize EAGLE accuracy at the cost "
+            "of base model quality. 1.0 = always detach (no logits gradient), 0.0 = never detach."
+        ),
+    )
+
     @model_validator(mode="before")
     @classmethod
     def _derive_eagle_offline(cls, data: Any, info: ValidationInfo) -> Any:

--- a/modelopt/torch/speculative/eagle/eagle_model.py
+++ b/modelopt/torch/speculative/eagle/eagle_model.py
@@ -42,3 +42,12 @@ class EagleModel(DynamicModule):
         self.eagle_use_torch_compile = config.eagle_use_torch_compile
         self.eagle_enable_nvtx = config.eagle_enable_nvtx
         self.eagle_export_rope_scaling = config.eagle_export_rope_scaling
+        self.eagle_base_lora = config.eagle_base_lora
+        self.eagle_base_lora_rank = config.eagle_base_lora_rank
+        self.eagle_base_lora_alpha = config.eagle_base_lora_alpha
+        self.eagle_base_lora_target_modules = config.eagle_base_lora_target_modules
+        self.eagle_base_lora_preservation_loss_weight = (
+            config.eagle_base_lora_preservation_loss_weight
+        )
+        self.eagle_base_lora_warmup_steps = config.eagle_base_lora_warmup_steps
+        self.eagle_base_lora_logits_detach_prob = config.eagle_base_lora_logits_detach_prob

--- a/modelopt/torch/speculative/plugins/transformers.py
+++ b/modelopt/torch/speculative/plugins/transformers.py
@@ -537,12 +537,13 @@ class HFEagleModel(EagleModel):
 
     def _collect_aux_hidden_states_forward_hook(self, module, input, output) -> None:
         """Collect auxiliary hidden states from base model intermediate layers, save them in attribute."""
-        hidden_states = (
-            output.clone().detach()
-            if isinstance(output, torch.Tensor)
-            else output[0].clone().detach()
-        )
-        self._aux_hidden_states.append(hidden_states)
+        raw = output if isinstance(output, torch.Tensor) else output[0]
+        # With LoRA co-training (after warmup), keep grad so EAGLE loss
+        # backpropagates through hidden states to LoRA.
+        if self.training and getattr(self, "_lora_cotraining_active", False):
+            self._aux_hidden_states.append(raw.clone())
+        else:
+            self._aux_hidden_states.append(raw.clone().detach())
 
     def pop_and_gather_aux_hiddens(self):
         """Pop auxiliary hidden states from base model and gather them on the draft model device."""
@@ -572,6 +573,43 @@ class HFEagleModel(EagleModel):
             # When there is a base model, put eagle on the last layer's device.
             base_model_last_layer = self._base_model.layers[-1]
             return next(base_model_last_layer.parameters()).device
+
+    def _inject_base_lora(self):
+        """Inject HF PEFT LoRA adapters into the base model in-place and unfreeze them."""
+        from peft import LoraConfig
+        from peft.mapping import inject_adapter_in_model
+
+        target_modules = self.eagle_base_lora_target_modules or None
+        lora_config = LoraConfig(
+            r=self.eagle_base_lora_rank,
+            lora_alpha=self.eagle_base_lora_alpha,
+            target_modules=target_modules,
+            bias="none",
+        )
+        inject_adapter_in_model(lora_config, self._base_model, adapter_name="default")
+        # Unfreeze LoRA parameters unless we have a warmup phase
+        freeze_lora = self.eagle_base_lora_warmup_steps > 0
+        for name, param in self._base_model.named_parameters():
+            if "lora_" in name:
+                param.requires_grad = not freeze_lora
+
+    def _set_base_lora_enabled(self, enabled: bool) -> None:
+        """Enable or disable LoRA adapters in the base model."""
+        from peft.tuners.lora import LoraLayer
+
+        for module in self._base_model.modules():
+            if isinstance(module, LoraLayer):
+                module.enable_adapters(enabled)
+
+    def _preservation_loss(
+        self, ref_logits: torch.Tensor, lora_logits: torch.Tensor
+    ) -> torch.Tensor:
+        """KL divergence encouraging LoRA output to stay close to the original base model.
+
+        KL(softmax(ref) || log_softmax(lora)) weighted by eagle_base_lora_preservation_loss_weight.
+        """
+        loss = nn.Softmax(dim=-1)(ref_logits.detach()) * nn.LogSoftmax(dim=-1)(lora_logits)
+        return -loss.sum(dim=-1).mean() * self.eagle_base_lora_preservation_loss_weight
 
     def modify(
         self,
@@ -640,6 +678,16 @@ class HFEagleModel(EagleModel):
             for layer_idx, layer in enumerate(self._base_model.layers):
                 if layer_idx in self.eagle_config.eagle_aux_hidden_state_layer_ids:
                     layer.register_forward_hook(self._collect_aux_hidden_states_forward_hook)
+
+        # Inject HF PEFT LoRA adapters into the base model for co-training
+        if self.eagle_base_lora:
+            if self.eagle_offline:
+                raise ValueError("eagle_base_lora is incompatible with eagle_offline=True")
+            self._inject_base_lora()
+            # Whether LoRA co-training is active this step. Controlled by the
+            # trainer based on warmup schedule. When False, LoRA params are
+            # frozen and logits are always detached (eagle-only training).
+            self._lora_cotraining_active = self.eagle_base_lora_warmup_steps == 0
 
         # delete base model layers for offline training
         if self.eagle_offline:
@@ -770,7 +818,16 @@ class HFEagleModel(EagleModel):
         if self.eagle_config.draft_vocab_size != self.eagle_config.vocab_size:
             base_model_logits = self._map_logits_to_draft_vocab(base_model_logits)
         base_output_predict_tok = base_model_logits.argmax(dim=-1).detach()
-        base_output_softmax_logits = torch.softmax(base_model_logits, dim=2).detach()
+        base_output_softmax_logits = torch.softmax(base_model_logits, dim=2)
+        # After LoRA warmup, stochastically detach logits — acts as dropout
+        # regularization on the eagle-loss-to-LoRA gradient path, preventing
+        # LoRA from degenerating to maximize EAGLE acc at cost of base quality.
+        # During warmup or when LoRA is off, always detach.
+        lora_active = getattr(self, "_lora_cotraining_active", False) and self.training
+        if lora_active and torch.rand(1).item() >= self.eagle_base_lora_logits_detach_prob:
+            pass  # keep gradients flowing through logits to LoRA
+        else:
+            base_output_softmax_logits = base_output_softmax_logits.detach()
 
         return (
             eagle_input_embeds,
@@ -787,7 +844,8 @@ class HFEagleModel(EagleModel):
         """Return TTT attention_mask tensor of type BlockMask or Tensor depends on eagle attn impl."""
         msk_func = get_ttt_msk_func(seq_length, ttt_step)
         dtype = (
-            self._base_llm_config.dtype or self.eagle_module.layers[0].input_layernorm.weight.dtype
+            getattr(self._base_llm_config, "dtype", None)
+            or self.eagle_module.layers[0].input_layernorm.weight.dtype
         )
         dtypemin = torch.finfo(dtype).min
         q_len = seq_length
@@ -820,32 +878,50 @@ class HFEagleModel(EagleModel):
         labels,
         **kwargs,
     ):
-        with torch.no_grad() if freeze_base_model else contextlib.nullcontext():
-            outputs = super().forward(
-                input_ids=input_ids,
-                attention_mask=attention_mask,
-                position_ids=position_ids,
-                past_key_values=past_key_values,
-                output_hidden_states=True,
-                **kwargs,
-            )
-            past_key_values = getattr(outputs, "past_key_values", None)
-            base_input_embeds = outputs.hidden_states[0]
-            base_model_hidden_states = outputs.hidden_states[-1]
-            base_model_logits = outputs.logits
+        def _run_forward(no_grad):
+            with torch.no_grad() if no_grad else contextlib.nullcontext():
+                return super(HFEagleModel, self).forward(
+                    input_ids=input_ids,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    past_key_values=past_key_values,
+                    output_hidden_states=True,
+                    **kwargs,
+                )
 
-            # Optionally, compute base model loss when we want to tune the base model.
+        # With LoRA co-training, run a reference forward (LoRA disabled, no grad)
+        # to get the original base model logits for preservation loss, then run
+        # the main forward with LoRA enabled and gradients flowing.
+        # During warmup (_lora_cotraining_active=False), skip entirely.
+        lora_active = getattr(self, "_lora_cotraining_active", False) and self.training
+        ref_logits = None
+        if lora_active:
+            self._set_base_lora_enabled(False)
+            try:
+                ref_logits = _run_forward(no_grad=True).logits
+            finally:
+                if hasattr(self, "_aux_hidden_states"):
+                    self._aux_hidden_states.clear()
+                self._set_base_lora_enabled(True)
+
+        outputs = _run_forward(no_grad=freeze_base_model and not lora_active)
+        past_key_values = getattr(outputs, "past_key_values", None)
+        base_model_logits = outputs.logits
+
+        if ref_logits is not None:
+            base_model_loss = self._preservation_loss(ref_logits, base_model_logits)
+        elif not freeze_base_model and labels is not None:
+            loss_fct = CrossEntropyLoss()
+            base_model_loss = loss_fct(
+                base_model_logits.view(-1, base_model_logits.shape[-1]), labels.view(-1)
+            )
+        else:
             base_model_loss = None
-            if not freeze_base_model and labels is not None:  # Base model loss
-                loss_fct = CrossEntropyLoss()
-                loss_logits = base_model_logits.view(-1, base_model_logits.shape[-1])
-                labels = labels.view(-1)
-                base_model_loss = loss_fct(loss_logits, labels)
 
         return EagleBaseModelOutput(
-            input_embeds=base_input_embeds,
+            input_embeds=outputs.hidden_states[0],
             aux_hiddens=self.pop_and_gather_aux_hiddens(),
-            out_hiddens=base_model_hidden_states,
+            out_hiddens=outputs.hidden_states[-1],
             logits=base_model_logits,
             loss=base_model_loss,
         ), past_key_values
@@ -1035,7 +1111,7 @@ class HFEagleModel(EagleModel):
         # Slice by actual number of steps taken, in case of early return
         train_accs = train_accs[:, : ttt_step + 1].tolist()
 
-        # Merge base model loss and eagle loss
+        # Merge eagle loss and preservation loss (if LoRA co-training)
         if base_outputs.loss is None and eagle_loss is None:
             loss = None
             assert not self.training, "At least one loss must be computed for training."
@@ -1048,6 +1124,8 @@ class HFEagleModel(EagleModel):
             past_key_values=past_key_values,
             hidden_states=base_outputs.out_hiddens,
             train_acc=train_accs,
+            eagle_loss=eagle_loss,
+            preservation_loss=base_outputs.loss if self.eagle_base_lora else None,
         )
 
     def _eagle_loss(

--- a/modelopt/torch/speculative/utils.py
+++ b/modelopt/torch/speculative/utils.py
@@ -557,7 +557,7 @@ def enable_cp_ttt_patch():
     import modelopt.torch.speculative.plugins.transformers
 
     modelopt.torch.speculative.plugins.transformers.ENABLE_CP_TTT_PATCH = True
-    with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+    with sdpa_kernel([SDPBackend.CUDNN_ATTENTION, SDPBackend.MATH]):
         try:
             yield
         finally:

--- a/modelopt/torch/speculative/utils.py
+++ b/modelopt/torch/speculative/utils.py
@@ -609,7 +609,7 @@ def load_vlm_or_llm(
     model = model_cls.from_pretrained(
         model_name_or_path,
         trust_remote_code=trust_remote_code,
-        dtype=dtype,
+        torch_dtype=dtype,
         device_map=device_map,
         **extra,
     )

--- a/tests/unit/torch/speculative/plugins/test_hf_speculative_lora.py
+++ b/tests/unit/torch/speculative/plugins/test_hf_speculative_lora.py
@@ -96,5 +96,5 @@ def test_export_lora_artifacts(lora_eagle_model, tmp_path):
     lora_eagle_model.get_exporter().export(export_dir)
 
     assert (export_dir / "model.safetensors").exists(), "Eagle model weights missing"
-    assert (export_dir / "lora_adapter_model.safetensors").exists(), "LoRA weights missing"
-    assert (export_dir / "lora_adapter_config.json").exists(), "LoRA config missing"
+    assert (export_dir / "adapter_model.safetensors").exists(), "LoRA weights missing"
+    assert (export_dir / "adapter_config.json").exists(), "LoRA config missing"

--- a/tests/unit/torch/speculative/plugins/test_hf_speculative_lora.py
+++ b/tests/unit/torch/speculative/plugins/test_hf_speculative_lora.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for EAGLE + LoRA co-training (eagle_base_lora feature)."""
+
+from copy import deepcopy
+
+import pytest
+import torch
+from _test_utils.torch.transformers_models import get_tiny_llama
+from peft.tuners.lora import LoraLayer
+
+import modelopt.torch.speculative as mtsp
+from modelopt.torch.speculative.eagle.default_config import default_eagle_config
+
+TINY_EAGLE_CFG = {
+    "num_hidden_layers": 1,
+    "intermediate_size": 32,
+    "num_attention_heads": 16,
+    "num_key_value_heads": 16,
+    "head_dim": 2,
+    "use_last_layernorm": True,
+    "use_aux_hidden_state": False,
+    "eagle_aux_hidden_state_layer_ids": [],
+}
+
+EAGLE_LORA_CONFIG = {
+    "eagle_architecture_config": {**default_eagle_config, **TINY_EAGLE_CFG},
+    "eagle_base_lora": True,
+    "eagle_base_lora_rank": 4,
+    "eagle_base_lora_alpha": 8.0,
+    "eagle_base_lora_target_modules": ["q_proj", "v_proj"],
+    "eagle_base_lora_preservation_loss_weight": 0.1,
+}
+
+
+@pytest.fixture
+def lora_eagle_model():
+    model = get_tiny_llama(num_hidden_layers=4)
+    mtsp.convert(model, mode=[("eagle", deepcopy(EAGLE_LORA_CONFIG))])
+    return model
+
+
+def test_lora_layers_injected(lora_eagle_model):
+    """LoRA adapters should be present in the base model after conversion."""
+    lora_layers = [m for m in lora_eagle_model._base_model.modules() if isinstance(m, LoraLayer)]
+    assert len(lora_layers) > 0, "No LoRA layers found in base model"
+
+
+def test_trainable_params(lora_eagle_model):
+    """Only LoRA and eagle_module params should be trainable; base model weights frozen."""
+    for name, param in lora_eagle_model.named_parameters():
+        is_lora = "lora_" in name
+        is_eagle = "eagle_module" in name
+        if is_lora or is_eagle:
+            assert param.requires_grad, f"Expected {name} to be trainable"
+        else:
+            assert not param.requires_grad, f"Expected {name} to be frozen"
+
+
+def test_forward_returns_loss(lora_eagle_model):
+    """Forward pass should return a scalar loss containing preservation + eagle components."""
+    lora_eagle_model.train()
+    seq_len = 8
+    input_ids = torch.randint(0, lora_eagle_model.config.vocab_size, (1, seq_len))
+    output = lora_eagle_model(input_ids=input_ids, labels=input_ids)
+    assert output.loss is not None
+    assert output.loss.ndim == 0, "Loss should be a scalar"
+    assert output.loss.item() > 0
+
+
+def test_eagle_offline_incompatible():
+    """eagle_base_lora=True should raise when combined with eagle_offline=True."""
+    model = get_tiny_llama(num_hidden_layers=4)
+    config = deepcopy(EAGLE_LORA_CONFIG)
+    config["eagle_offline"] = True
+    with pytest.raises(ValueError, match="eagle_base_lora is incompatible with eagle_offline"):
+        mtsp.convert(model, mode=[("eagle", config)])
+
+
+def test_export_lora_artifacts(lora_eagle_model, tmp_path):
+    """export() should produce lora_adapter_model.safetensors and lora_adapter_config.json."""
+    export_dir = tmp_path / "eagle_export"
+    lora_eagle_model.get_exporter().export(export_dir)
+
+    assert (export_dir / "model.safetensors").exists(), "Eagle model weights missing"
+    assert (export_dir / "lora_adapter_model.safetensors").exists(), "LoRA weights missing"
+    assert (export_dir / "lora_adapter_config.json").exists(), "LoRA config missing"


### PR DESCRIPTION
### What does this PR do?

Type of change: New feature + bug fixes

Adds **LoRA co-training** support for HF EAGLE speculative decoding. When `eagle_base_lora=True`, HF PEFT LoRA adapters are injected into the base model and co-trained alongside the EAGLE draft module in a single online training pass. A preservation loss (KL divergence between the original frozen base model output and the LoRA-adapted output) prevents base model drift. LoRA adapter weights are exported in standard peft format alongside EAGLE draft artifacts.

### Key features

- **LoRA injection**: `peft.inject_adapter_in_model` applied in-place (no wrapper), keeping the existing `HFEagleModel` structure intact.
- **Preservation loss**: Cross-entropy `H(ref, lora)` — equivalent gradient to `KL(ref || lora)` since `H(ref)` is constant w.r.t. LoRA params.
- **Warmup schedule**: `eagle_base_lora_warmup_steps` freezes LoRA for N steps while the EAGLE head stabilizes, then enables co-training via a `LoRAWarmupCallback`.
- **Logits detach regularization**: `eagle_base_lora_logits_detach_prob` stochastically detaches base logits from the EAGLE loss path, preventing LoRA from degenerating to maximize EAGLE accuracy at the cost of base model quality.
- **Export**: Standard peft format (`adapter_model.safetensors` + `adapter_config.json`) alongside EAGLE draft model.
- **Merge script**: `scripts/merge_lora.py` merges LoRA weights into the base model and restores the original `config.json` (avoids transformers 5.x rewriting `rope_theta` → `rope_parameters` which breaks vLLM/TRT-LLM).
- **Multinode fix**: `dp_shard_size` now uses `WORLD_SIZE` instead of local GPU count.

### Config options

```python
mtsp.convert(model, mode=[("eagle", {
    "eagle_base_lora": True,                          # enable LoRA co-training
    "eagle_base_lora_rank": 64,                       # LoRA rank
    "eagle_base_lora_alpha": 16.0,                    # LoRA scaling
    "eagle_base_lora_target_modules": ["q_proj", "k_proj", "v_proj", "o_proj"],
    "eagle_base_lora_preservation_loss_weight": 0.1,  # preservation loss weight
    "eagle_base_lora_warmup_steps": 0,                # freeze LoRA for N steps
    "eagle_base_lora_logits_detach_prob": 0.5,        # detach prob (0=never, 1=always)
})])
```

### Experimental results (Qwen3-8B, checkpoint-60000)

Base model quality preserved across detach_prob sweep (lm_eval: IFEval, ARC-C, Winogrande — results pending final collection).

**Acceptance rate** (mt_bench, draft_length=3, output_length=4096, temperature=0):

| detach_prob | vLLM AR | TRT-LLM AR |
|---|---|---|
| baseline (no LoRA) | 2.14 | 2.15 |
| 0.5 | 1.45 | 1.44 |
| 0.8 | **3.06** | **3.01** |
| 0.85 | 2.90 | 2.90 |
| 0.9 | 2.76 | 2.77 |
| 0.95 | 2.51 | 2.58 |
| 0.99 | 2.37 | 2.37 |
| 0.999 | 2.30 | 2.27 |
| 0.9999 | 2.31 | 2.26 |

Best AR at `detach_prob=0.8`: ~40% improvement over baseline.

### Testing

`tests/unit/torch/speculative/plugins/test_hf_speculative_lora.py` (5 tests):
- `test_lora_layers_injected` — LoRA layers present after conversion
- `test_trainable_params` — only `lora_*` and `eagle_module` params are trainable
- `test_forward_returns_loss` — forward returns non-zero scalar loss
- `test_eagle_offline_incompatible` — `eagle_base_lora=True` + `eagle_offline=True` raises `ValueError`
- `test_export_lora_artifacts` — export produces standard peft adapter files

### Bug fixes (included in this PR)

1. **`launch_train.sh` case pattern ordering**: glob `--eagle_base_lora*` was before specific patterns (`--eagle_base_lora_rank*`, etc.), silently swallowing LoRA args.
2. **LoRA optimizer exclusion during warmup**: warmup freezing excluded LoRA from the optimizer entirely; fixed with `add_param_group` in the callback.
3. **`merge_lora.py` config.json**: `save_pretrained()` with transformers >=5.x rewrites `rope_theta` → `rope_parameters`, breaking vLLM positional embeddings. Fixed by copying the original base model config.
4. **Multinode `dp_shard_size`**: used local GPU count instead of `WORLD_SIZE`.

### Checklist

- [x] Backward compatible (all new config fields have defaults)
- [x] Uses `peft` via lazy imports (no hard dependency)
- [x] Unit tests added
- [x] Online HF training only (`eagle_offline=True` blocked)