### PR TITLE
[minor] Refactor TE fused-norm handling in GPTModelExporter

### DIFF
--- a/modelopt/torch/export/unified_export_megatron.py
+++ b/modelopt/torch/export/unified_export_megatron.py
@@ -479,11 +479,8 @@ class GPTModelExporter:
         elif (
             not isinstance(layer.mlp, IdentityOp)
             and "MoE" not in str(type(layer.mlp))
-            and (
-                norm_weight := self._get_fused_norm_weight(
-                    getattr(layer.mlp, "linear_fc1", None)
-                )
-            ) is not None
+            and (norm_weight := self._get_fused_norm_weight(getattr(layer.mlp, "linear_fc1", None)))
+            is not None
         ):
             self.rules["fused_norm"](norm_weight, layer_id)
 


### PR DESCRIPTION
### What does this PR do?

Type of change: Refactor (no behavior change)

Extract a `_get_fused_norm_weight` helper method in `GPTModelExporter` to consolidate the repeated
TE fused-norm detection logic that previously appeared as three separate multi-condition `elif` blocks
in `_get_transformer_layer_state_dict` (attention and MLP paths) and `_get_mamba_layer_state_dict`.

Changes:
- Add `_get_fused_norm_weight(module)` that checks `"fused_norm" in self.rules` and returns `getattr(module, "layer_norm_weight", None)`
- Replace double `hasattr` chains with `getattr(..., None)` chaining — `getattr` already returns `None` for missing attributes
- Remove redundant `isinstance(layer.norm, IdentityOp)` in the Mamba `elif` (guaranteed by being an `elif` branch)
- Use walrus operator (`:=`) to capture `norm_weight` without repeating the attribute traversal on the call line

### Before / After

Before (one of three nearly-identical blocks):
```python
elif (
    hasattr(layer.self_attention, "linear_qkv")
    and hasattr(layer.self_attention.linear_qkv, "layer_norm_weight")
    and layer.self_attention.linear_qkv.layer_norm_weight is not None
    and "fused_norm" in self.rules
):
    self.rules["fused_norm"](layer.self_attention.linear_qkv.layer_norm_weight, layer_id)
```

After:
```python
elif (
    norm_weight := self._get_fused_norm_weight(
        getattr(layer.self_attention, "linear_qkv", None)
    )
) is not None:
    self.rules["fused_norm"](norm_weight, layer_id)
```

### Testing

No behavior change — existing tests cover all paths.

- Is this change backward compatible?: ✅ Pure refactor, no API or logic change
- Did you write any new necessary tests?: N/A
- Did you update Changelog?: N/A (minor refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized fused-normalization detection during model export: replaced repeated attribute checks with a single helper to detect and emit fused-norm weights only when present, applied consistently across transformer, MLP, and mixer export paths.
  * Simplified control flow and reduced duplication to improve maintainability and ensure prior non-fused behavior is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->