### PR TITLE
[5991789][ONNX][Autotune] Add note about remote autotuning only being available in safety

### DIFF
--- a/examples/onnx_ptq/autotune/README.md
+++ b/examples/onnx_ptq/autotune/README.md
@@ -229,7 +229,7 @@ python3 -m modelopt.onnx.quantization.autotune \
 
 ## Remote Autotuning with TensorRT
 
-TensorRT 10.16+ supports remote autotuning, which allows TensorRT's optimization process to be offloaded to a remote hardware. This is useful when optimizing models for different target GPUs without having direct access to them.
+TensorRT 10.16+ supports remote autotuning in safety mode (`--safe`), which allows TensorRT's optimization process to be offloaded to a remote hardware. This is useful when optimizing models for different target GPUs without having direct access to them.
 
 To use remote autotuning during Q/DQ placement optimization, run with `trtexec` and pass extra args:
 
@@ -239,7 +239,7 @@ python3 -m modelopt.onnx.quantization.autotune \
     --output_dir ./resnet50_remote_autotuned \
     --schemes_per_region 50 \
     --use_trtexec \
-    --trtexec_benchmark_args "--remoteAutoTuningConfig=\"<remote autotuning config>\""
+    --trtexec_benchmark_args "--remoteAutoTuningConfig=\"<remote autotuning config>\" --safe"
 ```
 
 **Requirements:**
@@ -247,8 +247,10 @@ python3 -m modelopt.onnx.quantization.autotune \
 - TensorRT 10.16 or later
 - Valid remote autotuning configuration
 - `--use_trtexec` must be set (benchmarking uses `trtexec` instead of the TensorRT Python API)
+- `--safe` must be enabled via `--trtexec_benchmark_args`
 
-Replace `<remote autotuning config>` with user's actual remote autotuning configuration string. Other TensorRT benchmark options (e.g. `--timing_cache`, `--warmup_runs`, `--timing_runs`, `--plugin_libraries`) are also available; run `--help` for details.
+Replace `<remote autotuning config>` with an actual remote autotuning configuration string (see `trtexec --help` for more details).
+ Other TensorRT benchmark options (e.g. `--timing_cache`, `--warmup_runs`, `--timing_runs`, `--plugin_libraries`) are also available; run `--help` for details.
 
 ## Programmatic API Usage
 

--- a/modelopt/onnx/quantization/autotune/benchmark.py
+++ b/modelopt/onnx/quantization/autotune/benchmark.py
@@ -210,10 +210,15 @@ class TrtExecBenchmark(Benchmark):
             try:
                 _check_for_tensorrt(min_version="10.16")
                 self.logger.debug("TensorRT Python API version >= 10.16 detected")
+                if "--safe" not in trtexec_args:
+                    self.logger.warning(
+                        "Remote autotuning requires '--safe' to be set. Adding it to trtexec arguments."
+                    )
+                    self.trtexec_args.append("--safe")
                 return
             except ImportError:
                 self.logger.warning(
-                    "Remote autotuning is not supported with TensorRT version < 10.16"
+                    "Remote autotuning is not supported with TensorRT version < 10.16. "
                     "Removing --remoteAutoTuningConfig from trtexec arguments"
                 )
                 trtexec_args = [


### PR DESCRIPTION
Cherry-pick for 0.43

### What does this PR do?

**Type of change**: Bug fix

**Overview**: Remote autotuning via `--autotune` is only available with `--safe` enabled.

See `trtexec --help`:
```sh
  --remoteAutoTuningConfig           Set the remote auto tuning config. Must be specified with --safe.
                                     Format: protocol://username[:password]@hostname[:port]?param1=value1&param2=value2
                                     Example: ssh://user:pass@192.0.2.100:22?remote_exec_path=/opt/tensorrt/bin&remote_lib_path=/opt/tensorrt/lib
```

### Usage

```python
$ python -m modelopt.onnx.quantization.autotune \
    --onnx_path resnet50_Opset17_bs128.onnx \
    --use_trtexec \
    --trtexec_benchmark_args "--remoteAutoTuningConfig=\"<remote autotuning config>\" --safe"
```

### Testing
See `examples/onnx_ptq/autotune`.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote autotuning now automatically enforces safety mode by including the --safe flag if not already present, with informative warning messages when the flag is automatically added.

* **Documentation**
  * Updated remote autotuning guide to clarify that safety mode (--safe flag) must be enabled through the trtexec benchmark arguments for proper configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->