### PR TITLE
fix: Feature: Add validation for loaded modelopt state files (#1041)

### DIFF
--- a/modelopt/torch/opt/conversion.py
+++ b/modelopt/torch/opt/conversion.py
@@ -311,6 +311,79 @@ class ModeloptStateManager:
             last_mode.update_for_save(model, last_config, self._last_metadata)
             self._last_config = last_config
 
+    @staticmethod
+    def validate_modelopt_state(modelopt_state: Any) -> None:
+        """Validate that the loaded object is a valid modelopt state file.
+
+        Args:
+            modelopt_state: The loaded object to validate.
+
+        Raises:
+            TypeError: If the loaded object is not a dictionary or has invalid types for nested fields.
+            ValueError: If the loaded dictionary doesn't have the expected schema for a modelopt state file.
+        """
+        # Validate that the loaded object is a dictionary
+        if not isinstance(modelopt_state, dict):
+            raise TypeError(
+                f"Expected loaded modelopt state to be a dictionary, "
+                f"but got {type(modelopt_state).__name__}. "
+                f"The file may not be a valid modelopt state file."
+            )
+
+        # Validate that the dictionary has the expected keys
+        required_keys = {"modelopt_state_dict", "modelopt_version"}
+        missing_keys = required_keys - set(modelopt_state.keys())
+        if missing_keys:
+            raise ValueError(
+                f"The loaded modelopt state is missing required keys: {missing_keys}. "
+                f"Expected keys: {required_keys}. "
+                f"The file may not be a valid modelopt state file."
+            )
+
+        # Validate that modelopt_version is a string
+        version = modelopt_state["modelopt_version"]
+        if not isinstance(version, str):
+            raise TypeError(
+                f"Expected 'modelopt_version' to be a string, "
+                f"but got {type(version).__name__}. "
+                f"The file may not be a valid modelopt state file."
+            )
+
+        # Validate that modelopt_state_dict is a list
+        state_dict = modelopt_state["modelopt_state_dict"]
+        if not isinstance(state_dict, list):
+            raise TypeError(
+                f"Expected 'modelopt_state_dict' to be a list, "
+                f"but got {type(state_dict).__name__}. "
+                f"The file may not be a valid modelopt state file."
+            )
+
+        # Validate that each entry in the state_dict is a tuple with 2 elements
+        for i, entry in enumerate(state_dict):
+            if not isinstance(entry, tuple) or len(entry) != 2:
+                entry_type = type(entry).__name__
+                entry_len = len(entry) if isinstance(entry, (tuple, list)) else "N/A"
+                msg = (
+                    f"Expected each entry in 'modelopt_state_dict' to be "
+                    f"a tuple of length 2, but entry {i} is {entry_type} "
+                    f"with length {entry_len}. The file may not be a "
+                    f"valid modelopt state file."
+                )
+                raise ValueError(msg)
+            mode_name, mode_state = entry
+            if not isinstance(mode_name, str):
+                raise TypeError(
+                    f"Expected mode name (first element of tuple) to be a string, "
+                    f"but got {type(mode_name).__name__} at entry {i}. "
+                    f"The file may not be a valid modelopt state file."
+                )
+            if not isinstance(mode_state, dict):
+                raise TypeError(
+                    f"Expected mode state (second element of tuple) to be a dictionary, "
+                    f"but got {type(mode_state).__name__} at entry {i}. "
+                    f"The file may not be a valid modelopt state file."
+                )
+
 
 class ApplyModeError(RuntimeError):
     """Error raised when applying a mode to a model fails."""
@@ -522,12 +595,19 @@ def load_modelopt_state(modelopt_state_path: str | os.PathLike, **kwargs) -> dic
 
     Returns:
         A modelopt state dictionary describing the modifications to the model.
+
+    Raises:
+        TypeError: If the loaded object is not a dictionary.
+        ValueError: If the loaded dictionary doesn't have the expected schema for a modelopt state file.
     """
     # Security NOTE: weights_only=False is used here on ModelOpt-generated state_dict, not on untrusted user input
     kwargs.setdefault("weights_only", False)
     kwargs.setdefault("map_location", "cpu")
-    # TODO: Add some validation to ensure the file is a valid modelopt state file.
     modelopt_state = torch.load(modelopt_state_path, **kwargs)
+
+    # Validate the loaded modelopt state
+    ModeloptStateManager.validate_modelopt_state(modelopt_state)
+
     return modelopt_state
 
 

--- a/tests/unit/torch/opt/test_modelopt_state_validation.py
+++ b/tests/unit/torch/opt/test_modelopt_state_validation.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+
+import pytest
+import torch
+
+import modelopt.torch.opt as mto
+
+
+class TestModeloptStateValidation:
+    """Test suite for modelopt state validation."""
+
+    def test_validate_modelopt_state_valid(self):
+        """Test validation of a valid modelopt state."""
+        valid_state = {
+            "modelopt_state_dict": [],
+            "modelopt_version": "0.1.0",
+        }
+        # Should not raise any exception
+        mto.ModeloptStateManager.validate_modelopt_state(valid_state)
+
+    def test_validate_modelopt_state_not_dict(self):
+        """Test validation fails when state is not a dictionary."""
+        with pytest.raises(TypeError) as exc_info:
+            mto.ModeloptStateManager.validate_modelopt_state([1, 2, 3])
+        assert "Expected loaded modelopt state to be a dictionary" in str(exc_info.value)
+
+    def test_validate_modelopt_state_missing_keys(self):
+        """Test validation fails when required keys are missing."""
+        with pytest.raises(ValueError) as exc_info:
+            mto.ModeloptStateManager.validate_modelopt_state({"modelopt_state_dict": []})
+        assert "missing required keys" in str(exc_info.value)
+        assert "modelopt_version" in str(exc_info.value)
+
+    def test_validate_modelopt_state_invalid_version_type(self):
+        """Test validation fails when modelopt_version is not a string."""
+        with pytest.raises(TypeError) as exc_info:
+            mto.ModeloptStateManager.validate_modelopt_state(
+                {
+                    "modelopt_state_dict": [],
+                    "modelopt_version": 123,
+                }
+            )
+        assert "modelopt_version" in str(exc_info.value)
+        assert "string" in str(exc_info.value)
+
+    def test_validate_modelopt_state_invalid_state_dict_type(self):
+        """Test validation fails when modelopt_state_dict is not a list."""
+        with pytest.raises(TypeError) as exc_info:
+            mto.ModeloptStateManager.validate_modelopt_state(
+                {
+                    "modelopt_state_dict": "not a list",
+                    "modelopt_version": "0.1.0",
+                }
+            )
+        assert "modelopt_state_dict" in str(exc_info.value)
+
+    def test_validate_modelopt_state_invalid_entry_not_tuple(self):
+        """Test validation fails when state_dict entry is not a tuple."""
+        with pytest.raises(ValueError) as exc_info:
+            mto.ModeloptStateManager.validate_modelopt_state(
+                {
+                    "modelopt_state_dict": [{"mode": "quantize"}],
+                    "modelopt_version": "0.1.0",
+                }
+            )
+        assert "tuple of length 2" in str(exc_info.value)
+
+    def test_validate_modelopt_state_invalid_entry_wrong_length(self):
+        """Test validation fails when tuple has wrong length."""
+        with pytest.raises(ValueError) as exc_info:
+            mto.ModeloptStateManager.validate_modelopt_state(
+                {
+                    "modelopt_state_dict": [("quantize",)],
+                    "modelopt_version": "0.1.0",
+                }
+            )
+        assert "tuple of length 2" in str(exc_info.value)
+
+    def test_validate_modelopt_state_invalid_mode_name_type(self):
+        """Test validation fails when mode name is not a string."""
+        with pytest.raises(TypeError) as exc_info:
+            mto.ModeloptStateManager.validate_modelopt_state(
+                {
+                    "modelopt_state_dict": [(123, {})],
+                    "modelopt_version": "0.1.0",
+                }
+            )
+        assert "mode name" in str(exc_info.value)
+        assert "string" in str(exc_info.value)
+
+    def test_validate_modelopt_state_invalid_mode_state_type(self):
+        """Test validation fails when mode state is not a dictionary."""
+        with pytest.raises(TypeError) as exc_info:
+            mto.ModeloptStateManager.validate_modelopt_state(
+                {
+                    "modelopt_state_dict": [("quantize", "not a dict")],
+                    "modelopt_version": "0.1.0",
+                }
+            )
+        assert "mode state" in str(exc_info.value)
+        assert "dictionary" in str(exc_info.value)
+
+    def test_load_modelopt_state_valid_file(self):
+        """Test loading a valid modelopt state from file."""
+        valid_state = {
+            "modelopt_state_dict": [],
+            "modelopt_version": "0.1.0",
+        }
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            temp_file = f.name
+        try:
+            torch.save(valid_state, temp_file)
+            loaded_state = mto.load_modelopt_state(temp_file)
+            assert loaded_state == valid_state
+        finally:
+            os.remove(temp_file)
+
+    def test_load_modelopt_state_invalid_file(self):
+        """Test loading an invalid modelopt state from file."""
+        invalid_state = [1, 2, 3]
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            temp_file = f.name
+        try:
+            torch.save(invalid_state, temp_file)
+            with pytest.raises(TypeError) as exc_info:
+                mto.load_modelopt_state(temp_file)
+            assert "Expected loaded modelopt state to be a dictionary" in str(exc_info.value)
+        finally:
+            os.remove(temp_file)
+
+    def test_load_modelopt_state_with_valid_entries(self):
+        """Test loading modelopt state with valid mode entries."""
+        valid_state = {
+            "modelopt_state_dict": [
+                ("quantize", {"config": {}, "metadata": {}}),
+            ],
+            "modelopt_version": "0.1.0",
+        }
+        with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
+            temp_file = f.name
+        try:
+            torch.save(valid_state, temp_file)
+            loaded_state = mto.load_modelopt_state(temp_file)
+            assert loaded_state == valid_state
+        finally:
+            os.remove(temp_file)


### PR DESCRIPTION
Fixes #1041

## Summary
Add validation to the `load_modelopt_state()` function to ensure loaded files contain valid modelopt state objects with expected schema. Currently there is a TODO comment indicating this validation is needed, and missing validation can lead to unclear downstream errors when invalid files are loaded.

## Root Cause
The `load_modelopt_state()` function in `modelopt/torch/opt/conversion.py` performs `torch.load()` without any validation of the loaded object's structure. This allows invalid state files to be loaded, causing cryptic errors downstream instead of clear validation errors at load time.

## Agent Fix Summary
Successfully added validation for loaded modelopt state files in `modelopt/torch/opt/conversion.py`. The `load_modelopt_state()` function now validates:
1. Loaded object is a dictionary
2. Required keys 'modelopt_state_dict' and 'modelopt_version' are present
3. modelopt_state_dict is a list of 2-element tuples
4. Each tuple contains a string mode name and a dictionary mode state

All validation errors provide clear, informative messages. Validation was tested with:
- 6 specific validation test cases (all passed)
- 30 existing chaining tests (all passed)
- No backward compatibility issues detected

## Files Changed
- `modelopt/torch/opt/conversion.py`
## Reproduction

To reproduce the validation on a Slurm cluster, save these files in [nmm-sandbox](https://gitlab-master.nvidia.com/omniml/integration/nmm-sandbox) and run:

```bash
uv run slurm.py --yaml services/triage/test_validation_specific.yaml --yes
```

```bash
uv run slurm.py --yaml services/triage/test_load_modelopt_state_validation.yaml --yes
```

<details><summary><code>services/triage/test_validation_specific.yaml</code></summary>

```yaml
job_name: test_validation_specific
pipeline:
  task_0:
    script: services/triage/test_validation_specific.sh
    slurm_config:
      _factory_: "computelab_slurm_factory"
      nodes: 1

```
</details>

<details><summary><code>services/triage/test_validation_specific.sh</code></summary>

```sh
#!/bin/bash
SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
source ${SCRIPT_DIR}/../service_utils.sh
trap 'error_handler $0 $LINENO' ERR
trap 'exit_handler' EXIT

cd modules/Model-Optimizer

# Create a Python test script
cat > /tmp/test_validation.py << 'EOF'
import torch
import tempfile
import os
import sys
from pathlib import Path

# Add the modelopt module to the path
sys.path.insert(0, '/nemo_run/code/modules/Model-Optimizer')

import modelopt.torch.opt as mto

# Test 1: Invalid file - not a dictionary
print("Test 1: Testing with non-dictionary file...")
with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
    temp_file = f.name
    torch.save([1, 2, 3], temp_file)

try:
    mto.load_modelopt_state(temp_file)
    print("FAILED: Should have raised TypeError for non-dictionary file")
    sys.exit(1)
except TypeError as e:
    if "Expected loaded modelopt state to be a dictionary" in str(e):
        print(f"PASSED: Correctly raised TypeError: {e}")
    else:
        print(f"FAILED: Wrong error message: {e}")
        sys.exit(1)
finally:
    os.unlink(temp_file)

# Test 2: Invalid file - missing keys
print("\nTest 2: Testing with missing required keys...")
with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
    temp_file = f.name
    torch.save({"some_key": "value"}, temp_file)

try:
    mto.load_modelopt_state(temp_file)
    print("FAILED: Should have raised ValueError for missing keys")
    sys.exit(1)
except ValueError as e:
    if "missing required keys" in str(e):
        print(f"PASSED: Correctly raised ValueError: {e}")
    else:
        print(f"FAILED: Wrong error message: {e}")
        sys.exit(1)
finally:
    os.unlink(temp_file)

# Test 3: Invalid file - modelopt_state_dict is not a list
print("\nTest 3: Testing with invalid modelopt_state_dict type...")
with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
    temp_file = f.name
    torch.save({
        "modelopt_state_dict": "not_a_list",
        "modelopt_version": "0.1.0"
    }, temp_file)

try:
    mto.load_modelopt_state(temp_file)
    print("FAILED: Should have raised TypeError for non-list state_dict")
    sys.exit(1)
except TypeError as e:
    if "Expected 'modelopt_state_dict' to be a list" in str(e):
        print(f"PASSED: Correctly raised TypeError: {e}")
    else:
        print(f"FAILED: Wrong error message: {e}")
        sys.exit(1)
finally:
    os.unlink(temp_file)

# Test 4: Invalid file - state_dict entry is not a tuple
print("\nTest 4: Testing with invalid state_dict entry type...")
with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
    temp_file = f.name
    torch.save({
        "modelopt_state_dict": [["not", "a", "tuple"]],
        "modelopt_version": "0.1.0"
    }, temp_file)

try:
    mto.load_modelopt_state(temp_file)
    print("FAILED: Should have raised ValueError for non-tuple entry")
    sys.exit(1)
except ValueError as e:
    if "Expected each entry in 'modelopt_state_dict' to be a tuple of length 2" in str(e):
        print(f"PASSED: Correctly raised ValueError: {e}")
    else:
        print(f"FAILED: Wrong error message: {e}")
        sys.exit(1)
finally:
    os.unlink(temp_file)

# Test 5: Valid modelopt state file
print("\nTest 5: Testing with valid modelopt state file...")
with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
    temp_file = f.name
    torch.save({
        "modelopt_state_dict": [],
        "modelopt_version": "0.1.0"
    }, temp_file)

try:
    result = mto.load_modelopt_state(temp_file)
    if isinstance(result, dict) and "modelopt_state_dict" in result and "modelopt_version" in result:
        print(f"PASSED: Successfully loaded valid modelopt state file")
    else:
        print("FAILED: Loaded result doesn't have expected structure")
        sys.exit(1)
finally:
    os.unlink(temp_file)

# Test 6: Valid modelopt state file with actual mode data
print("\nTest 6: Testing with valid modelopt state file containing mode data...")
with tempfile.NamedTemporaryFile(suffix=".pt", delete=False) as f:
    temp_file = f.name
    torch.save({
        "modelopt_state_dict": [
            ("quantize", {"config": {}, "metadata": {}})
        ],
        "modelopt_version": "0.1.0"
    }, temp_file)

try:
    result = mto.load_modelopt_state(temp_file)
    if isinstance(result, dict) and "modelopt_state_dict" in result and len(result["modelopt_state_dict"]) == 1:
        print(f"PASSED: Successfully loaded valid modelopt state file with mode data")
    else:
        print("FAILED: Loaded result doesn't have expected structure")
        sys.exit(1)
finally:
    os.unlink(temp_file)

print("\n=== All validation tests passed! ===")
EOF

python /tmp/test_validation.py
report_result "PASS: validation tests"

```
</details>

<details><summary><code>services/triage/test_load_modelopt_state_validation.yaml</code></summary>

```yaml
job_name: test_load_modelopt_state_validation
pipeline:
  task_0:
    script: services/triage/test_load_modelopt_state_validation.sh
    slurm_config:
      _factory_: "computelab_slurm_factory"
      nodes: 1

```
</details>

<details><summary><code>services/triage/test_load_modelopt_state_validation.sh</code></summary>

```sh
#!/bin/bash
SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
source ${SCRIPT_DIR}/../service_utils.sh
trap 'error_handler $0 $LINENO' ERR
trap 'exit_handler' EXIT

cd modules/Model-Optimizer

# Run the test
python -m pytest tests/unit/torch/opt/test_chaining.py -v
report_result "PASS: test_chaining.py"

```
</details>


---
_Auto-generated by pensieve `/magic-triage` agentic fix — please review before merging._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Load of model state files now includes explicit runtime validation of the top-level structure and entries; malformed files are detected and reported with clear TypeError/ValueError messages for missing fields, wrong types, or malformed entries.

* **Tests**
  * Added unit tests validating successful loads and numerous invalid formats to ensure consistent error reporting and prevention of silent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->