### PR TITLE
Update ModelOpt with Olive documentation to mention CUDA EP commands

### DIFF
--- a/docs/source/getting_started/windows/_installation_with_olive.rst
+++ b/docs/source/getting_started/windows/_installation_with_olive.rst
@@ -24,7 +24,9 @@ Setup Steps for Olive with ModelOpt-Windows
             $ pip install onnxruntime-genai-cuda
             $ pip install onnxruntime-gpu
 
-   - Above onnxruntime and onnxruntime-genai packages enable Olive workflow with CUDA Execution-Provider (EP). To use other EPs, install corresponding packages; refer to the ONNX Runtime's `EP documentation <https://onnxruntime.ai/docs/execution-providers/>`_ for details about differfent EPs and thier requirements and installation instructions.
+   - Above onnxruntime and onnxruntime-genai packages enable Olive workflow with CUDA Execution-Provider (EP). To use other EPs, install corresponding packages.
+
+   - Refer to the ONNX Runtime's `EP documentation <https://onnxruntime.ai/docs/execution-providers/>`_ for details about different EPs, their requirements, and installation instructions.
 
    - Additionally, ensure that dependencies for Model Optimizer - Windows are met as mentioned in the :ref:`Install-Page-Standalone-Windows`.
 

--- a/examples/windows/README.md
+++ b/examples/windows/README.md
@@ -51,7 +51,14 @@ pip install nvidia-modelopt[onnx]
 
 ### Installation with Olive
 
-The ModelOpt-Windows is integrated in Microsoft's [Olive](https://microsoft.github.io/Olive/) framework. To install ModelOpt with Olive, please refer to the [detailed installation instructions](https://nvidia.github.io/Model-Optimizer/getting_started/windows/_installation_for_Windows.html).
+The ModelOpt-Windows is integrated into Microsoft's [Olive](https://microsoft.github.io/Olive/) framework. Run the following commands to install ModelOpt through Olive.
+
+```bash
+pip install olive-ai[nvmo]
+pip install onnxruntime-genai-cuda
+```
+
+For more details, or to use different [ONNX Runtime Execution Providers](https://onnxruntime.ai/docs/execution-providers/), refer to the [detailed installation instructions](https://nvidia.github.io/Model-Optimizer/getting_started/windows/_installation_for_Windows.html).
 
 ## Techniques
 


### PR DESCRIPTION
### What does this PR do?

Type of change: Minor documentation update

- Update documentation (olive installation instructions) to mention install commands for CUDA EP packages for ORT / ORT-genai.

### Testing

- Locally checked the readme, doc.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Windows Olive installation guidance to recommend CUDA-based ONNX Runtime packages instead of DirectML and added a link to ONNX Runtime’s Execution-Provider docs for alternative EPs and requirements.
  * Simplified Windows examples by removing explicit package install commands and pointing users to the consolidated Olive setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->