### PR TITLE
code clean up

### DIFF
--- a/modelopt/torch/puzzletron/subblock_stats/calc_subblock_params_and_memory.py
+++ b/modelopt/torch/puzzletron/subblock_stats/calc_subblock_params_and_memory.py
@@ -105,17 +105,7 @@ def calculate_subblock_params(
     layer_config: BlockConfig | FFNConfig | AttentionConfig,
     descriptor: Type[ModelDescriptor],
 ) -> int:
-    """Count parameters on one meta decoder layer (puzzletron ``calculate_subblock_params`` parity).
-
-    Unlike ``puzzletron_patcher`` during ``__init__``, we do **not** use ``deci_x_patcher`` here:
-    for models such as GPT-OSS, Transformers ``post_init`` validates ``_keep_in_fp32_modules``
-    against the module tree; replacing norms / attn / mlp with no-op placeholders **before**
-    ``post_init`` raises (e.g. ``post_attention_layernorm`` … not part of the modules).
-
-    With ``num_hidden_layers == 1`` we merge ``block_config_to_layer_overrides`` into the LM config
-    (what the patcher would pass into ``DecoderLayer.__init__``), build a stock layer, run
-    ``post_init``, then apply ``attn_no_op_post_init`` / ``mlp_no_op_post_init`` for param counting.
-    """
+    """Count parameters on one meta decoder layer."""
     if isinstance(layer_config, FFNConfig):
         block_config = layer_config.to_blockconfig()
     elif isinstance(layer_config, AttentionConfig):
@@ -147,12 +137,15 @@ def calculate_subblock_params(
     # Replaced earlier pattern:
     #   with EmptyInitOnDevice("meta"), deci_x_patcher(..., block_configs=block_configs):
     #       model = init_model_from_config(_config, ...)
+    #
     # That fails on GPT-OSS with recent Transformers: ``deci_x_patcher`` runs
     # ``attn_no_op_post_init`` / ``mlp_no_op_post_init`` inside ``DecoderLayer.__init__``, so norms
-    # / attn / mlp are swapped for placeholders before ``GptOssModel.post_init`` runs; ``post_init``
-    # then raises ``ValueError`` (e.g. ``post_attention_layernorm`` in ``_keep_in_fp32_modules`` no
-    # longer matches the tree). Below we merge per-layer fields manually, init without the patcher,
-    # then call the same descriptor no-op hooks on the built layer (equivalent param count for
+    # / attn / mlp are swapped for placeholders before ``GptOssModel.__init__`` finishes. At the end
+    # of ``GptOssModel.__init__`` the stack calls ``self.post_init()`` — inherited from
+    # ``PreTrainedModel`` — which then raises
+    # ``ValueError`` (e.g. ``post_attention_layernorm`` in ``_keep_in_fp32_modules`` no longer matches
+    # the tree). Below we merge per-layer fields manually, init without the patcher, then call the
+    # same descriptor no-op hooks on the built layer (equivalent param count for
     # ``num_hidden_layers == 1``).
 
     # ``block_config_to_layer_overrides`` may include keys with value ``None``; we omit those so

--- a/modelopt/torch/puzzletron/tools/checkpoint_utils_hf.py
+++ b/modelopt/torch/puzzletron/tools/checkpoint_utils_hf.py
@@ -138,10 +138,14 @@ def _get_model_class_from_config(config: PretrainedConfig) -> type:
 def init_model_from_config(
     config: PretrainedConfig,
     *,
-    trust_remote_code: bool = True,
+    trust_remote_code: bool = False,
     **kwargs,
 ) -> PreTrainedModel:
-    """Build a model from config on meta/uninitialized weights (used e.g. for subblock param counts)."""
+    """Build a model from config on meta/uninitialized weights (used e.g. for subblock param counts).
+
+    ``trust_remote_code`` defaults to False (only ``AutoModelForCausalLM.from_config`` uses it).
+    Pass True when loading configs that rely on custom modeling code from the checkpoint.
+    """
     model_class = _get_model_class_from_config(config)
     if model_class is AutoModelForCausalLM:
         return model_class.from_config(config, trust_remote_code=trust_remote_code, **kwargs)


### PR DESCRIPTION
### What does this PR do?

Remove hardcoded trust_remote_code=true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified documentation for parameter counting in model layer calculations.

* **Bug Fixes**
  * Remote code execution is now disabled by default in model configuration loading. Explicitly enable `trust_remote_code` when using custom modeling code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->