### PR TITLE
Added fallback to preload cudnn dlls from nvidia cudnn venv package or torch venv package

### DIFF
--- a/modelopt/onnx/quantization/ort_utils.py
+++ b/modelopt/onnx/quantization/ort_utils.py
@@ -69,14 +69,29 @@ def _check_for_libcudnn():
             f"{lib_pattern} is accessible in {lib_path}! Please check that this is the correct version needed"
             f" for your ORT version at https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements."
         )
-    else:
-        logger.error(f"cuDNN library not found in {env_variable}")
-        raise FileNotFoundError(
-            f"{lib_pattern} is not accessible in {env_variable}! Please make sure that the path to that library"
-            f" is in the env var to use the CUDA or TensorRT EP and ensure that the correct version is available."
-            f" Versioning compatibility can be checked at https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements."
-        )
-    return found
+        return True
+
+    # Not found in system path — try preloading from Python site-packages
+    logger.warning(f"cuDNN not found in {env_variable}. Trying onnxruntime.preload_dlls()...")
+    if hasattr(ort, "preload_dlls"):
+        try:
+            ort.preload_dlls()
+            logger.info(
+                "onnxruntime.preload_dlls() succeeded; CUDA/cuDNN DLLs preloaded from site-packages."
+                " Please check that this is the correct version needed for your ORT version at"
+                " https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements."
+            )
+            return True
+        except Exception as e:
+            logger.warning(f"onnxruntime.preload_dlls() also failed: {e}")
+
+    logger.error(f"cuDNN library not found in {env_variable} or site-packages")
+    raise FileNotFoundError(
+        f"{lib_pattern} is not accessible in {env_variable} and onnxruntime.preload_dlls() could not locate it either."
+        f" Please make sure that the path to that library is in the env var, or install the cuDNN pip package"
+        f" (e.g. nvidia-cudnn-cu12) to use the CUDA or TensorRT EP."
+        f" Versioning compatibility can be checked at https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements."
+    )
 
 
 def _check_for_nv_tensorrt_rtx_libs():


### PR DESCRIPTION

### What does this PR do?

Type of change: Bug fix

There was a QA team that was testing the modelopt 0.43 release and pointed out that we could install nvidia-cudnn pypi packages and use ort.preload_dlls() to load the dlls from the python venv instead of trying to search in system path only .

Here is the info about onnxruntime.preload_dlls() function 
<img width="1478" height="414" alt="image" src="https://github.com/user-attachments/assets/e43ecbe3-ba52-4dd8-b2a2-e825d013205b" />

So added fallback to system path cudnn search to preload dlls and if that also fails then raise exception. 



### Testing
Tested quantization by installing nvidia-cudnn-cu12 package and removing cudnn dlls from system path. Working as expected.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cuDNN/CUDA discovery to attempt loading missing libraries from Python site-packages when not found on the system path.
  * Added clearer runtime messages: warnings before fallback attempts, info on successful loads, and warnings on fallback failures.
  * Updated failure message to include guidance on installing appropriate cuDNN packages and to only error after fallback attempts fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->