### PR TITLE
Remove --skip-softmax option from hf_sa (only allow calibration option)

### DIFF
--- a/examples/llm_sparsity/attention_sparsity/hf_sa.py
+++ b/examples/llm_sparsity/attention_sparsity/hf_sa.py
@@ -28,11 +28,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 import modelopt.torch.opt as mto
 import modelopt.torch.sparsity.attention_sparsity as mtsa
 from modelopt.torch.export import export_hf_checkpoint
-from modelopt.torch.sparsity.attention_sparsity.config import (
-    SKIP_SOFTMAX_CALIB,
-    SKIP_SOFTMAX_DEFAULT,
-    SPARSE_SOFTMAX_DEFAULT,
-)
+from modelopt.torch.sparsity.attention_sparsity.config import SKIP_SOFTMAX_CALIB
 from modelopt.torch.utils.memory_monitor import launch_memory_monitor
 
 RAND_SEED = 1234
@@ -42,9 +38,7 @@ mto.enable_huggingface_checkpointing()
 
 # Sparse attention configuration choices
 SPARSE_ATTN_CFG_CHOICES = {
-    "skip_softmax": SKIP_SOFTMAX_DEFAULT,
     "skip_softmax_calib": SKIP_SOFTMAX_CALIB,
-    "sparse_softmax": SPARSE_SOFTMAX_DEFAULT,
 }
 
 
@@ -236,7 +230,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--sparse_attn",
         type=str,
-        default="skip_softmax",
+        default="skip_softmax_calib",
         choices=list(SPARSE_ATTN_CFG_CHOICES.keys()),
         help="Sparse attention configuration to apply.",
     )

--- a/tests/examples/llm_sparsity/attention_sparsity/test_attention_sparsity.py
+++ b/tests/examples/llm_sparsity/attention_sparsity/test_attention_sparsity.py
@@ -19,7 +19,7 @@ import pytest
 from _test_utils.examples.run_command import extend_cmd_parts, run_example_command
 
 
-def run_attention_sparsity_command(*, model: str, method: str = "skip_softmax", **kwargs):
+def run_attention_sparsity_command(*, model: str, method: str = "skip_softmax_calib", **kwargs):
     """Run attention sparsity example script.
 
     Args:
@@ -40,7 +40,7 @@ def run_attention_sparsity_command(*, model: str, method: str = "skip_softmax", 
     run_example_command(cmd_parts, "llm_sparsity/attention_sparsity")
 
 
-@pytest.mark.parametrize("method", ["skip_softmax"])
+@pytest.mark.parametrize("method", ["skip_softmax_calib"])
 def test_attention_sparsity(tiny_llama_path, tmp_path, method):
     """Test sparse attention with TinyLlama (with and without calibration)."""
     run_attention_sparsity_command(


### PR DESCRIPTION
### What does this PR do?

The `hf_sa.py` script applies an attention sparsity method to a model and exports a "sparsified" checkpoint. The SKIP_SOFTMAX_DEFAULT sparse attention config doesn't run calibration or make any change to the checkpoint. If we use this method with `hf_sa.py` the exported checkpoint is identical to the original checkpoint. This could cause confusion so it's best to remove the option altogether. This PR removes the option and switches to SKIP_SOFTMAX_CALIB as the default config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the legacy "skip_softmax" sparse-attention option and set the default to "skip_softmax_calib", making the calibration-based configuration the new default.
* **Tests**
  * Updated test defaults and parametrization to match the new calibration-enabled sparse-attention default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->