### PR TITLE
fix: cast aq score to float64 to avoid overflow

### DIFF
--- a/modelopt/torch/quantization/algorithms.py
+++ b/modelopt/torch/quantization/algorithms.py
@@ -763,7 +763,8 @@ class _AutoQuantizeBaseSearcher(BaseSearcher, ABC):
 
 
 def _get_auto_quantize_score(grad_output, output_diff):
-    return ((grad_output.float() ** 2) * (output_diff.float() ** 2)).sum()
+    x = grad_output.float() * output_diff.float()
+    return x.to(torch.float64).square().sum()
 
 
 def _add_auto_quantize_score(grad_output, output_diff, score_tensor):


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

Mamba mixer layers produce gradients with magnitudes up to ~1e22. Squaring these in float32  caused overflow to inf.
Fix: Multiply grad * diff first in float32, then cast to float64 only for the square + sum step to minimize performance overhead.

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->
```
python examples/llm_ptq/hf_ptq.py --pyt_ckpt_path nvidia/Nemotron-H-4B-Base-8K --qformat nvfp4_mse,fp8 --calib_size 64 --export_path ./output/nemotron-h-4b-fp8 --trust_remote_code --dataset cnn_dailymail --auto_quantize_bits 4.75
```

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->

### Additional Information
<!-- E.g. related issue. -->
