### PR TITLE
[4/n] Add vLLM integration for modelopt sparse attention

### DIFF
--- a/examples/diffusers/sparsity/README.md
+++ b/examples/diffusers/sparsity/README.md
@@ -18,8 +18,8 @@ tiles whose attention scores are negligible during the FlashAttention computatio
 reducing FLOPs without retraining.
 
 Two modes are supported:
-- **Fixed raw threshold** — pass a log2-space threshold directly to the Triton
-  kernel. No calibration needed. Good for quick testing and sweeps.
+- **Fixed threshold** — pass a BLASST lambda threshold directly. No calibration
+  needed. Good for quick testing and sweeps.
 - **Calibrated threshold** — an exponential model
   (`scale_factor = a * exp(b * target_sparsity)`) is calibrated once via the
   Triton calibration kernel, then the target sparsity can be adjusted at runtime
@@ -37,10 +37,10 @@ Two modes are supported:
 ## Quick Start
 
 ```bash
-# Fixed raw threshold (no calibration, fast)
+# Fixed threshold (no calibration, fast)
 python wan22_skip_softmax.py \
     --model-path /path/to/Wan2.2-T2V-A14B-Diffusers \
-    --raw-threshold -0.7 \
+    --skip-softmax-threshold 0.61557 \
     --prompt "A cat playing piano" --output out.mp4
 
 # With calibration
@@ -58,7 +58,7 @@ python wan22_skip_softmax.py \
 # Report runtime sparsity (per-layer tile skip ratios)
 python wan22_skip_softmax.py \
     --model-path /path/to/Wan2.2-T2V-A14B-Diffusers \
-    --raw-threshold -0.7 --report-avg-sparsity \
+    --skip-softmax-threshold 0.61557 --report-avg-sparsity \
     --prompt "A cat playing piano" --output out.mp4
 ```
 
@@ -66,9 +66,9 @@ python wan22_skip_softmax.py \
 
 | Mode | How threshold reaches the kernel | Use case |
 |------|----------------------------------|----------|
-| **Raw threshold** (`--raw-threshold -0.7`) | Passed directly as `skip_threshold_log2` — no conversion | Quick testing, sweeps |
-| **Calibrated** (`--calibrate --target-sparsity 0.5`) | `scale_factor = a * exp(b * target)`, then backend computes `threshold = scale_factor / seq_k`, then kernel converts `log2(threshold) * sm_scale` | Production use with automatic seqlen adaptation |
-| **Static lambda** (default `skip_softmax_threshold=0.1`) | `log2(lambda) * sm_scale` | Fallback when neither raw nor calibrated |
+| **Fixed threshold** (`--skip-softmax-threshold 0.61557`) | Kernel converts the lambda threshold with `log2(lambda)` | Quick testing, sweeps |
+| **Calibrated** (`--calibrate --target-sparsity 0.5`) | `scale_factor = a * exp(b * target)`, then backend computes `threshold = scale_factor / seq_k`, then kernel converts `log2(threshold)` | Production use with automatic seqlen adaptation |
+| **Static lambda** (default `skip_softmax_threshold=0.1`) | Kernel converts `log2(lambda)` | Fallback when neither fixed nor calibrated |
 
 ## Known Issues
 

--- a/examples/diffusers/sparsity/wan22_skip_softmax.py
+++ b/examples/diffusers/sparsity/wan22_skip_softmax.py
@@ -21,8 +21,8 @@ generation model (text-to-video). Four modes are supported:
 1. **Baseline** — pass ``--baseline`` for dense inference (default diffusers backend).
 2. **Triton baseline** — pass ``--triton-baseline`` for dense Triton FA kernel
    (no skip-softmax, same kernel as sparse runs for apples-to-apples comparison).
-3. **Fixed raw threshold** — pass ``--raw-threshold`` to supply a log2-space
-   threshold directly to the Triton kernel. No calibration data is needed.
+3. **Fixed skip-softmax threshold** — pass ``--skip-softmax-threshold`` to
+   supply the BLASST lambda threshold. No calibration data is needed.
 4. **Calibrated threshold** — pass ``--calibrate`` to run exponential-model
    calibration (``scale_factor = a * exp(b * target_sparsity)``).
 
@@ -40,8 +40,8 @@ Usage::
     python wan22_skip_softmax.py --baseline --prompt "A cat playing piano" \\
         --output baseline.mp4
 
-    # Fixed raw threshold (no calibration needed)
-    python wan22_skip_softmax.py --raw-threshold -5.0 --report-avg-sparsity \\
+    # Fixed skip-softmax threshold (no calibration needed)
+    python wan22_skip_softmax.py --skip-softmax-threshold 0.03125 --report-avg-sparsity \\
         --prompt "A cat playing piano" --output out.mp4
 
     # With calibration
@@ -150,12 +150,12 @@ def parse_args() -> argparse.Namespace:
         "apples-to-apples comparison with sparse runs)",
     )
     parser.add_argument(
-        "--raw-threshold",
+        "--skip-softmax-threshold",
         type=float,
         default=None,
-        help="Raw skip_threshold_log2 value passed directly to the Triton kernel. "
-        "Negative values (e.g., -5.0 means tile must be within 5 units of running max). "
-        "Bypasses calibration and lambda conversion. Typical range: -1 to -30.",
+        help="Fixed BLASST lambda threshold passed as skip_softmax_threshold. "
+        "Example: 0.03125 keeps tiles within 5 log2-score units of the running max. "
+        "Bypasses calibration. Typical range: 1e-6 to 0.5.",
     )
     parser.add_argument(
         "--skip-first-last",
@@ -214,8 +214,8 @@ def build_sparse_config(args: argparse.Namespace, num_blocks: int) -> dict:
     """Build sparse attention config from CLI args.
 
     Two modes:
-    - **Raw threshold**: ``--raw-threshold`` sets ``skip_softmax_raw_threshold``
-      directly on the Triton kernel — no calibration needed.
+    - **Fixed threshold**: ``--skip-softmax-threshold`` sets
+      ``skip_softmax_threshold`` directly — no calibration needed.
     - **Calibrated**: ``--calibrate`` collects multi-threshold sparsity statistics
       via the Triton calibration kernel, then fits an exponential model:
       ``scale_factor = a * exp(b * sparsity)``.
@@ -229,9 +229,9 @@ def build_sparse_config(args: argparse.Namespace, num_blocks: int) -> dict:
         "enable": True,
     }
 
-    # Raw threshold bypasses calibration and lambda conversion
-    if args.raw_threshold is not None:
-        attn_cfg["skip_softmax_raw_threshold"] = args.raw_threshold
+    # Fixed threshold bypasses calibration.
+    if args.skip_softmax_threshold is not None:
+        attn_cfg["skip_softmax_threshold"] = args.skip_softmax_threshold
 
     sparse_cfg: dict = {
         "*.attn1*": attn_cfg,  # Self-attention only
@@ -246,8 +246,8 @@ def build_sparse_config(args: argparse.Namespace, num_blocks: int) -> dict:
 
     config: dict = {"sparse_cfg": sparse_cfg}
 
-    # Add calibration config only when calibrating (not with raw threshold)
-    if args.calibrate and args.raw_threshold is None:
+    # Add calibration config only when calibrating (not with a fixed threshold)
+    if args.calibrate and args.skip_softmax_threshold is None:
         sparse_cfg["calibration"] = {
             "target_sparse_ratio": {"prefill": args.target_sparsity},
             "threshold_trials": DEFAULT_THRESHOLD_TRIALS,
@@ -407,10 +407,13 @@ def main() -> None:
     else:
         # Build calibration forward loop if needed
         forward_loop = None
-        if args.raw_threshold is not None:
-            print(f"Using fixed raw threshold: {args.raw_threshold} (skipping calibration)")
+        if args.skip_softmax_threshold is not None:
+            print(
+                f"Using fixed skip-softmax threshold: {args.skip_softmax_threshold} "
+                "(skipping calibration)"
+            )
             if args.calibrate:
-                print("Warning: --calibrate is ignored when --raw-threshold is set")
+                print("Warning: --calibrate is ignored when --skip-softmax-threshold is set")
         elif args.calibrate:
             forward_loop = build_calibration_forward_loop(
                 pipe,
@@ -426,7 +429,7 @@ def main() -> None:
             )
         else:
             print(
-                "Warning: neither --baseline, --raw-threshold, nor --calibrate specified; "
+                "Warning: neither --baseline, --skip-softmax-threshold, nor --calibrate specified; "
                 "using default static threshold"
             )
 

--- a/examples/llm_sparsity/attention_sparsity/README.md
+++ b/examples/llm_sparsity/attention_sparsity/README.md
@@ -58,7 +58,7 @@ model = mtsa.sparsify(model, config=SKIP_SOFTMAX_CALIB)
 
 ### N:M Sparse Softmax (SPARSE_SOFTMAX_DEFAULT)
 
-Applies N:M structured sparsity to attention scores using the Triton backend. For every M consecutive key positions, keeps only the top-N scores and sets the rest to -inf. Supports M=4 (N=1,2,3) and M=8 (N=1..7). Attention sinks and a local dense window can be configured to preserve important positions.
+Applies N:M structured sparsity to attention scores using the Triton backend. For every M consecutive key positions, keeps only the top-N scores and sets the rest to -inf. Supports M=4 (N=1,2,3) and M=8 (N=1..7). Attention sinks and a local recent-token window can be configured to preserve important positions.
 
 ```python
 from modelopt.torch.sparsity.attention_sparsity.config import SPARSE_SOFTMAX_DEFAULT
@@ -81,8 +81,8 @@ sparse_cfg = {
             "method": "triton_sparse_softmax",
             "sparsity_n": 2,            # Keep top-2 of every 4
             "sparsity_m": 4,            # Group size
-            "num_sink_tokens": 4,       # Keep first 4 tokens dense (attention sinks)
-            "dense_window_size": 128,   # Keep tokens within distance 128 dense
+            "dense_sink_tokens": 4,       # Exclude first 4 tokens from N:M and keep dense
+            "dense_recent_tokens": 128,   # Exclude recent 128 tokens from N:M and keep dense
             "backend": "triton",
             "enable": True,
         },
@@ -125,7 +125,7 @@ Apply sparse attention with a fixed threshold:
 ```bash
 python hf_sa.py \
     --pyt_ckpt_path Qwen/Qwen3-8B \
-    --sparse_attn skip_softmax
+    --sparse_attn sparse_softmax
 ```
 
 ### With RULER Calibration
@@ -144,15 +144,19 @@ The calibration process:
 2. Collects attention statistics during forward passes
 3. Determines optimal threshold scale factor for target sparsity ratio
 
+Set the target sparsity ratio in the selected sparse attention config, or override
+both prefill and decode targets from the example script with `--target_sparse_ratio`.
+
 ### Command Line Arguments
 
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `--pyt_ckpt_path` | Required | HuggingFace model path or name |
-| `--sparse_attn` | `skip_softmax` | Configuration: `skip_softmax`, `skip_softmax_calib`, or `sparse_softmax` |
-| `--backend` | `pytorch` | Backend: `pytorch` (skip-softmax) or `triton` (N:M sparse softmax) |
+| `--sparse_attn` | `skip_softmax_calib` | Configuration: `skip_softmax_calib`, `sparse_softmax`, or `skip_softmax_calib_sparse24` |
+| `--backend` | selected config | Backend: `pytorch` (skip-softmax) or `triton` (N:M sparse softmax) |
 | `--seq_len` | `2048` | Maximum sequence length for input prompts |
 | `--export_dir` | `None` | Directory to export the sparsified model |
+| `--target_sparse_ratio` | selected config | Target sparsity ratio for skip-softmax calibration |
 
 ## Output Comparison
 
@@ -175,7 +179,27 @@ python hf_sa.py \
     --export_dir ./exported_sparse_model
 ```
 
-The exported model can be loaded and used with standard HuggingFace APIs.
+Export a 2:4 sparse-softmax checkpoint for vLLM restore:
+
+```bash
+python hf_sa.py \
+    --pyt_ckpt_path Qwen/Qwen3-8B \
+    --sparse_attn sparse_softmax \
+    --export_dir ./exported_sparse24_model
+```
+
+Export calibrated skip-softmax plus 2:4 sparse-softmax metadata for combined vLLM restore:
+
+```bash
+python hf_sa.py \
+    --pyt_ckpt_path Qwen/Qwen3-8B \
+    --sparse_attn skip_softmax_calib_sparse24 \
+    --export_dir ./exported_skip_sparse24_model
+```
+
+The exported checkpoint writes `sparse_attention_config` into `config.json`. For combined
+export, the skip-softmax calibration and 2:4 sparse-softmax metadata are defined in the
+selected config rather than CLI overrides.
 
 ## Custom Configuration
 
@@ -198,6 +222,11 @@ custom_config = {
             "bc": 128,          # Flash Attention block columns
             "backend": "pytorch",
             "collect_stats": True,
+            "sparsity_n": 2,              # Export top-2 of every 4 for vLLM restore
+            "sparsity_m": 4,
+            "dense_sink_tokens": 0,
+            "dense_recent_tokens": 64,
+            "export_sparse_softmax": True,
             "enable": True,
         },
         "default": {"enable": False},

--- a/examples/llm_sparsity/attention_sparsity/hf_sa.py
+++ b/examples/llm_sparsity/attention_sparsity/hf_sa.py
@@ -28,7 +28,11 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 import modelopt.torch.opt as mto
 import modelopt.torch.sparsity.attention_sparsity as mtsa
 from modelopt.torch.export import export_hf_checkpoint
-from modelopt.torch.sparsity.attention_sparsity.config import SKIP_SOFTMAX_CALIB
+from modelopt.torch.sparsity.attention_sparsity.config import (
+    SKIP_SOFTMAX_CALIB,
+    SKIP_SOFTMAX_CALIB_SPARSE24,
+    SPARSE_SOFTMAX_DEFAULT,
+)
 from modelopt.torch.utils.memory_monitor import launch_memory_monitor
 
 RAND_SEED = 1234
@@ -39,6 +43,8 @@ mto.enable_huggingface_checkpointing()
 # Sparse attention configuration choices
 SPARSE_ATTN_CFG_CHOICES = {
     "skip_softmax_calib": SKIP_SOFTMAX_CALIB,
+    "skip_softmax_calib_sparse24": SKIP_SOFTMAX_CALIB_SPARSE24,
+    "sparse_softmax": SPARSE_SOFTMAX_DEFAULT,
 }
 
 
@@ -172,6 +178,14 @@ def main(args):
             "prefill": args.target_sparse_ratio,
             "decode": args.target_sparse_ratio,
         }
+    calib = sparse_cfg.get("calibration")
+    if isinstance(calib, dict):
+        if args.calib_samples is not None:
+            calib["samples"] = args.calib_samples
+        if args.calib_max_seqlen is not None:
+            calib["max_seqlen"] = args.calib_max_seqlen
+        if args.calib_chunk_size is not None:
+            calib["chunk_size"] = args.calib_chunk_size
 
     model = mtsa.sparsify(model, config=sparse_config)
     print("Sparse attention applied successfully!")
@@ -269,6 +283,24 @@ if __name__ == "__main__":
         type=float,
         default=None,
         help="Target sparsity ratio for calibration (0.0 to 1.0). Overrides config value.",
+    )
+    parser.add_argument(
+        "--calib_samples",
+        type=int,
+        default=None,
+        help="Number of RULER samples for calibration. Overrides config value.",
+    )
+    parser.add_argument(
+        "--calib_max_seqlen",
+        type=int,
+        default=None,
+        help="Maximum sequence length for calibration. Overrides config value.",
+    )
+    parser.add_argument(
+        "--calib_chunk_size",
+        type=int,
+        default=None,
+        help="Chunk size for calibration prefill. Overrides config value.",
     )
 
     args = parser.parse_args()

--- a/examples/vllm_serve/README.md
+++ b/examples/vllm_serve/README.md
@@ -99,7 +99,7 @@ QUANT_CFG=<quant_cfg> QUANT_FILE_PATH=<quantizer_state.pth> python vllm_serve_fa
 
 Apply ModelOpt sparse attention at serve time. The launcher replaces vLLM's `FlashAttentionImpl` with `ModelOptSparseAttentionImpl` (Triton kernel with paged KV cache support) on every attention layer right after model load.
 
-The configuration is read from the checkpoint's `config.json` `sparse_attention_config` block, written by ModelOpt's HF export during calibration. Today the launcher recognizes `sparse_algo: softmax_skip` and maps it to `SKIP_SOFTMAX_TRITON_DEFAULT`. Per-layer / per-seqlen threshold mapping and N:M sparsity (sparsity_n / sparsity_m / sink / dense-window) require extending `export_sparse_attention_config` to serialize per-layer `method_config`; both are on the roadmap.
+The configuration is read from the checkpoint's `config.json` `sparse_attention_config` block, written by ModelOpt's HF export. The launcher restores calibrated skip-softmax metadata and N:M sparse-softmax metadata (`sparsity_n`, `sparsity_m`, `dense_sink_tokens`, `dense_recent_tokens`). Checkpoints exported with both metadata entries run both sparse modes in the ModelOpt Triton attention kernel.
 
 Workflow:
 
@@ -114,7 +114,7 @@ If the checkpoint has no `sparse_attention_config`, the worker logs a message an
 
 Limitations:
 
-- Chunked prefill is not supported (`max-num-batched-tokens` must be `>= max_model_len`); the worker raises `NotImplementedError` if a chunked-prefill batch reaches the kernel.
+- vLLM V1 chunked prefill and prefix-cache suffix attention are supported by offsetting query positions into the longer KV span.
 - CUDA graph capture is not validated yet — use `--enforce-eager`.
 
 ## Known Problems

--- a/examples/vllm_serve/README.md
+++ b/examples/vllm_serve/README.md
@@ -95,6 +95,28 @@ MODELOPT_STATE_PATH=<vllm_fq_modelopt_state.pth> python vllm_serve_fakequant.py 
 QUANT_CFG=<quant_cfg> QUANT_FILE_PATH=<quantizer_state.pth> python vllm_serve_fakequant.py <model_path> -tp 8 --host 0.0.0.0 --port 8000
 ```
 
+## Serve a model with sparse attention in vLLM
+
+Apply ModelOpt sparse attention at serve time. The launcher replaces vLLM's `FlashAttentionImpl` with `ModelOptSparseAttentionImpl` (Triton kernel with paged KV cache support) on every attention layer right after model load.
+
+The configuration is read from the checkpoint's `config.json` `sparse_attention_config` block, written by ModelOpt's HF export during calibration. Today the launcher recognizes `sparse_algo: softmax_skip` and maps it to `SKIP_SOFTMAX_TRITON_DEFAULT`. Per-layer / per-seqlen threshold mapping and N:M sparsity (sparsity_n / sparsity_m / sink / dense-window) require extending `export_sparse_attention_config` to serialize per-layer `method_config`; both are on the roadmap.
+
+Workflow:
+
+1. Calibrate and export the model with `examples/llm_sparsity/attention_sparsity/hf_sa.py`. This writes `sparse_attention_config` into the exported checkpoint's `config.json`.
+2. Serve the exported checkpoint with `--enforce-eager` (CUDA graph capture is not yet validated with the sparse attention kernel — see Known Problems):
+
+   ```bash
+   python vllm_serve_sparse_attn.py <EXPORT_DIR> --enforce-eager -tp 8 --host 0.0.0.0 --port 8000
+   ```
+
+If the checkpoint has no `sparse_attention_config`, the worker logs a message and passes through — vLLM runs unchanged. Quant-only flows are handled by `vllm_serve_fakequant.py`; combined sparse + quant will land in a follow-up PR.
+
+Limitations:
+
+- Chunked prefill is not supported (`max-num-batched-tokens` must be `>= max_model_len`); the worker raises `NotImplementedError` if a chunked-prefill batch reaches the kernel.
+- CUDA graph capture is not validated yet — use `--enforce-eager`.
+
 ## Known Problems
 
 1. **MCore reload does not use `MODELOPT_STATE_PATH`**; use `QUANT_FILE_PATH` and make sure `QUANT_CFG` matches the quantization recipe used for the original MCore model (otherwise quantizer keys/config won’t align).

--- a/examples/vllm_serve/README.md
+++ b/examples/vllm_serve/README.md
@@ -99,7 +99,7 @@ QUANT_CFG=<quant_cfg> QUANT_FILE_PATH=<quantizer_state.pth> python vllm_serve_fa
 
 Apply ModelOpt sparse attention at serve time. The launcher replaces vLLM's `FlashAttentionImpl` with `ModelOptSparseAttentionImpl` (Triton kernel with paged KV cache support) on every attention layer right after model load.
 
-The configuration is read from the checkpoint's `config.json` `sparse_attention_config` block, written by ModelOpt's HF export. The launcher restores calibrated skip-softmax metadata and N:M sparse-softmax metadata (`sparsity_n`, `sparsity_m`, `dense_sink_tokens`, `dense_recent_tokens`). Checkpoints exported with both metadata entries run both sparse modes in the ModelOpt Triton attention kernel.
+The configuration is read from the checkpoint's `config.json` `sparse_attention_config` block, written by ModelOpt's HF export. The launcher restores calibrated skip-softmax metadata and N:M sparse-softmax metadata (`sparsity_n`, `sparsity_m`, `dense_sink_tokens`, `dense_recent_tokens`). Checkpoints exported with both metadata entries use ModelOpt Triton for sparse prefill launches; decode-only launches and launches without active sparse work delegate back to vLLM FlashAttention.
 
 Workflow:
 

--- a/examples/vllm_serve/sparse_attn_worker.py
+++ b/examples/vllm_serve/sparse_attn_worker.py
@@ -17,8 +17,7 @@
 
 ``SparseAttnWorker``: Replaces ``FlashAttentionImpl`` with
 ``ModelOptSparseAttentionImpl`` on each Attention module after model loading.
-The sparse impl uses the ModelOpt Triton kernel for prefill and falls back to
-FlashAttention for decode.
+The sparse impl uses the ModelOpt Triton kernel for both prefill and decode.
 
 ``SparseQuantWorker``: Applies quantization first, then sparse attention via
 direct module walk (registry stacking does not work due to ``_DMRegistryCls``
@@ -37,10 +36,10 @@ from typing import Any
 
 import torch
 from fakequant_worker import disable_compilation
+from vllm.v1.worker.gpu_worker import Worker as BaseWorker
 
 import modelopt.torch.sparsity.attention_sparsity as mtsa
 from modelopt.torch.kernels.triton_fa import attention as triton_attention
-from vllm.v1.worker.gpu_worker import Worker as BaseWorker
 
 # ---------------------------------------------------------------------------
 # Configuration from environment variables

--- a/examples/vllm_serve/sparse_attn_worker.py
+++ b/examples/vllm_serve/sparse_attn_worker.py
@@ -38,10 +38,7 @@ from vllm.attention.layer import Attention as VLLMAttention
 from vllm.v1.worker.gpu_worker import Worker as BaseWorker
 
 import modelopt.torch.sparsity.attention_sparsity as mtsa
-from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
-    ModelOptSparseAttentionImpl,
-    set_sparse_config,
-)
+from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import ModelOptSparseAttentionImpl
 
 # ---------------------------------------------------------------------------
 # Configuration from environment variables
@@ -132,29 +129,53 @@ def _replace_attention_impl(worker, config: dict):
     if cfg is None:
         return
 
-    set_sparse_config(cfg)
-
     model = worker.model_runner.model
     if hasattr(model, "unwrap"):
         model = model.unwrap()
 
     patched = 0
     for name, module in model.named_modules():
-        if isinstance(module, VLLMAttention):
-            old_impl = module.impl
-            module.impl = ModelOptSparseAttentionImpl(
-                num_heads=old_impl.num_heads,
-                head_size=old_impl.head_size,
-                scale=old_impl.scale,
-                num_kv_heads=old_impl.num_kv_heads,
-                alibi_slopes=old_impl.alibi_slopes,
-                sliding_window=None,
-                kv_cache_dtype=old_impl.kv_cache_dtype,
-                logits_soft_cap=old_impl.logits_soft_cap,
-                attn_type=old_impl.attn_type,
-                kv_sharing_target_layer_name=old_impl.kv_sharing_target_layer_name,
-            )
-            patched += 1
+        if not isinstance(module, VLLMAttention):
+            continue
+
+        # Match per-layer sparse config using name-based patterns
+        layer_cfg = _match_sparse_config(name, cfg)
+        if layer_cfg is None or not layer_cfg.get("enable", True):
+            continue
+
+        # Build per-layer sparse kwargs
+        sparse_kw = {}
+        sparsity_n = layer_cfg.get("sparsity_n", 0)
+        if sparsity_n > 0:
+            sparse_kw["sparsity_n"] = sparsity_n
+            sparse_kw["sparsity_m"] = layer_cfg.get("sparsity_m", 4)
+            sparse_kw["num_sink_tokens"] = layer_cfg.get("num_sink_tokens", 0)
+            sparse_kw["dense_window_size"] = layer_cfg.get("dense_window_size", 1)
+        threshold = layer_cfg.get("skip_softmax_threshold")
+        if threshold:
+            sparse_kw["skip_softmax_threshold"] = threshold
+
+        # Replace impl and store per-layer config
+        old_impl = module.impl
+        new_impl = ModelOptSparseAttentionImpl(
+            num_heads=old_impl.num_heads,
+            head_size=old_impl.head_size,
+            scale=old_impl.scale,
+            num_kv_heads=old_impl.num_kv_heads,
+            alibi_slopes=old_impl.alibi_slopes,
+            sliding_window=None,  # overwritten below
+            kv_cache_dtype=old_impl.kv_cache_dtype,
+            logits_soft_cap=old_impl.logits_soft_cap,
+            attn_type=old_impl.attn_type,
+            kv_sharing_target_layer_name=old_impl.kv_sharing_target_layer_name,
+        )
+        # Copy the already-transformed sliding_window tuple directly,
+        # since __init__ transforms int -> (sw-1, 0) and we can't reverse it.
+        new_impl.sliding_window = old_impl.sliding_window
+        # Store per-layer sparse kwargs on the impl for forward() to read
+        new_impl.sparse_kw = sparse_kw
+        module.impl = new_impl
+        patched += 1
     print(f"[ModelOpt] Sparse attention: replaced impl on {patched} attention layers")
 
 

--- a/examples/vllm_serve/sparse_attn_worker.py
+++ b/examples/vllm_serve/sparse_attn_worker.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom vLLM workers for sparse attention.
+
+``SparseAttnWorker``: Replaces ``FlashAttentionImpl`` with
+``ModelOptSparseAttentionImpl`` on each Attention module after model loading.
+The sparse impl uses the ModelOpt Triton kernel for prefill and falls back to
+FlashAttention for decode.
+
+``SparseQuantWorker``: Applies quantization first, then sparse attention via
+direct module walk (registry stacking does not work due to ``_DMRegistryCls``
+forward identity check).
+
+Usage:
+    SPARSE_ATTN_CFG=SPARSE_SOFTMAX_DEFAULT python vllm_serve_sparse_attn.py \\
+        meta-llama/Llama-3.1-8B --enforce-eager
+"""
+
+import fnmatch
+import functools
+import json
+import os
+from typing import Any
+
+import torch
+from fakequant_worker import disable_compilation
+
+import modelopt.torch.sparsity.attention_sparsity as mtsa
+from modelopt.torch.kernels.triton_fa import attention as triton_attention
+from vllm.v1.worker.gpu_worker import Worker as BaseWorker
+
+# ---------------------------------------------------------------------------
+# Configuration from environment variables
+# ---------------------------------------------------------------------------
+
+sparse_config: dict[str, Any] = {
+    "sparse_cfg": os.environ.get("SPARSE_ATTN_CFG", None),
+    "calib_config_path": os.environ.get("SPARSE_CALIB_CONFIG_PATH", None),
+}
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_SPARSE_CFG = {
+    "sparse_cfg": {
+        "*attn*": {
+            "sparsity_n": 2,
+            "sparsity_m": 4,
+            "num_sink_tokens": 0,
+            "dense_window_size": 1,
+            "enable": True,
+        },
+        "default": {"enable": False},
+    },
+}
+
+
+def _build_sparse_config(env_config: dict[str, Any]) -> dict | None:
+    """Build sparse_cfg dict from env vars."""
+    cfg_name = env_config["sparse_cfg"]
+    if cfg_name is None:
+        return None
+    # Try looking up preset from mtsa, fall back to default
+    cfg = getattr(mtsa, cfg_name, None)
+    if cfg is not None:
+        return cfg
+    # Use built-in default if name matches
+    if cfg_name in ("SPARSE_SOFTMAX_DEFAULT", "default"):
+        return _DEFAULT_SPARSE_CFG
+    raise ValueError(
+        f"Unknown sparse config: {cfg_name}. Set SPARSE_ATTN_CFG to 'default' or a valid preset name."
+    )
+
+
+def _load_sparse_config(path: str) -> dict:
+    """Load offline calibration config JSON."""
+    with open(path) as f:
+        calib_cfg = json.load(f)
+
+    sparse_cfg = {}
+    for pattern, layer_cfg in calib_cfg.items():
+        if pattern == "calibration":
+            sparse_cfg[pattern] = layer_cfg
+            continue
+        layer_cfg.setdefault("method", "triton_sparse_softmax")
+        layer_cfg.setdefault("backend", "triton")
+        layer_cfg.setdefault("enable", True)
+        sparse_cfg[pattern] = layer_cfg
+    sparse_cfg["default"] = {"enable": False}
+
+    return {"sparse_cfg": sparse_cfg}
+
+
+def _match_sparse_config(module_name: str, sparse_cfg: dict) -> dict | None:
+    """Match a module name against sparse_cfg patterns."""
+    cfg = sparse_cfg.get("sparse_cfg", sparse_cfg)
+    for pattern, layer_cfg in cfg.items():
+        if pattern in ("default", "calibration"):
+            continue
+        if fnmatch.fnmatch(module_name, pattern):
+            return layer_cfg
+    return None
+
+
+def _sparse_attention_forward(module, query, key, value, kv_cache, attn_metadata, **kwargs):
+    """Sparse attention forward — used by SparseQuantWorker for direct module patching."""
+    if not getattr(module, "_sparse_enabled", False):
+        return module._original_forward(query, key, value, kv_cache, attn_metadata, **kwargs)
+
+    from vllm._custom_ops import reshape_and_cache_flash
+
+    reshape_and_cache_flash(
+        key,
+        value,
+        kv_cache,
+        attn_metadata.slot_mapping,
+        module.impl.kv_cache_dtype,
+        getattr(module.impl, "k_scale", 1.0),
+        getattr(module.impl, "v_scale", 1.0),
+    )
+
+    # Unpack paged KV cache
+    k_cache = kv_cache[:, 0]  # [num_blocks, page_size, num_kv_heads, head_dim]
+    v_cache = kv_cache[:, 1]
+    page_size = k_cache.shape[1]
+
+    output = torch.empty_like(query)
+    sm_scale = module.impl.scale
+    sparse_kw = module._sparse_kw
+
+    # Paged KV kwargs
+    paged_kw = {
+        "k_cache": k_cache,
+        "v_cache": v_cache,
+        "page_size": page_size,
+    }
+
+    if attn_metadata.num_prefill_tokens > 0:
+        pm = attn_metadata.prefill
+        n = attn_metadata.num_prefill_tokens
+        output[:n] = triton_attention(
+            q=query[:n],
+            k=query[:0],  # dummy, not used in paged mode
+            v=query[:0],
+            b_start_loc=pm.query_start_loc,
+            b_seq_len=pm.seq_lens_q,
+            max_input_len=int(pm.seq_lens_q.max().item()),
+            is_causal=True,
+            softmax_scale=sm_scale,
+            b_seq_len_k=pm.seq_lens,
+            max_input_len_k=int(pm.seq_lens.max().item()),
+            block_table=pm.block_tables,
+            **paged_kw,
+            **sparse_kw,
+        )
+
+    if attn_metadata.num_decode_tokens > 0:
+        dm = attn_metadata.decode
+        offset = attn_metadata.num_prefill_tokens
+        nd = attn_metadata.num_decode_tokens
+        output[offset : offset + nd] = triton_attention(
+            q=query[offset : offset + nd],
+            k=query[:0],  # dummy, not used in paged mode
+            v=query[:0],
+            b_start_loc=dm.query_start_loc,
+            b_seq_len=torch.ones(nd, dtype=torch.int32, device=query.device),
+            max_input_len=1,
+            is_causal=True,
+            softmax_scale=sm_scale,
+            b_seq_len_k=dm.seq_lens,
+            max_input_len_k=int(dm.seq_lens.max().item()),
+            block_table=dm.block_tables,
+            **paged_kw,
+            **sparse_kw,
+        )
+
+    return output
+
+
+def _apply_sparse_to_attention_modules(model, sparse_cfg: dict):
+    """Walk model modules, patch attention layers with sparse forward.
+
+    Used by SparseQuantWorker where registry-based mtsa.sparsify() cannot
+    find already-quantized attention modules (forward identity check fails).
+    """
+    from vllm.attention.layer import Attention as VLLMAttention
+
+    for name, module in model.named_modules():
+        if not isinstance(module, VLLMAttention):
+            continue
+
+        layer_cfg = _match_sparse_config(name, sparse_cfg)
+        if layer_cfg is None or not layer_cfg.get("enable", True):
+            continue
+
+        # Build kernel kwargs from layer config
+        sparse_kw = {}
+        sparsity_n = layer_cfg.get("sparsity_n", 0)
+        if sparsity_n > 0:
+            sparse_kw["sparsity_n"] = sparsity_n
+            sparse_kw["sparsity_m"] = layer_cfg.get("sparsity_m", 4)
+            sparse_kw["num_sink_tokens"] = layer_cfg.get("num_sink_tokens", 0)
+            sparse_kw["dense_window_size"] = layer_cfg.get("dense_window_size", 1)
+        threshold = layer_cfg.get("skip_softmax_threshold", None)
+        if threshold:
+            sparse_kw["skip_softmax_threshold"] = threshold
+
+        module._sparse_enabled = True
+        module._sparse_kw = sparse_kw
+
+        original_forward = module.forward
+        module._original_forward = original_forward
+        module.forward = functools.partial(_sparse_attention_forward, module)
+
+
+# ---------------------------------------------------------------------------
+# Workers
+# ---------------------------------------------------------------------------
+
+
+class SparseAttnWorker(BaseWorker):
+    """vLLM worker that uses the ModelOpt sparse attention backend.
+
+    Replaces FlashAttentionImpl with ModelOptSparseAttentionImpl on each
+    Attention module right after model loading — before any forward pass
+    (including determine_available_memory profiling).
+    """
+
+    def load_model(self, *args, **kwargs) -> None:
+        """Load model, then replace attention impl with sparse variant."""
+        super().load_model(*args, **kwargs)
+
+        if sparse_config["calib_config_path"]:
+            cfg = _load_sparse_config(sparse_config["calib_config_path"])
+        else:
+            cfg = _build_sparse_config(sparse_config)
+
+        if cfg is None:
+            return
+
+        from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
+            ModelOptSparseAttentionImpl,
+            set_sparse_config,
+        )
+
+        set_sparse_config(cfg)
+
+        from vllm.attention.layer import Attention as VLLMAttention
+
+        model = self.model_runner.model
+        if hasattr(model, "unwrap"):
+            model = model.unwrap()
+
+        patched = 0
+        for name, module in model.named_modules():
+            if isinstance(module, VLLMAttention):
+                old_impl = module.impl
+                module.impl = ModelOptSparseAttentionImpl(
+                    num_heads=old_impl.num_heads,
+                    head_size=old_impl.head_size,
+                    scale=old_impl.scale,
+                    num_kv_heads=old_impl.num_kv_heads,
+                    alibi_slopes=old_impl.alibi_slopes,
+                    sliding_window=None,
+                    kv_cache_dtype=old_impl.kv_cache_dtype,
+                    logits_soft_cap=old_impl.logits_soft_cap,
+                    attn_type=old_impl.attn_type,
+                    kv_sharing_target_layer_name=old_impl.kv_sharing_target_layer_name,
+                )
+                patched += 1
+        print(f"[ModelOpt] Sparse attention: replaced impl on {patched} attention layers")
+
+
+class SparseQuantWorker(BaseWorker):
+    """vLLM worker that applies quantization + sparse attention.
+
+    Quantization uses the standard registry-based ``mtq.quantize()``.
+    Sparse attention uses direct module walk because the registry cannot
+    match already-quantized attention modules (forward identity check).
+    """
+
+    def compile_or_warm_up_model(self) -> None:
+        """Apply quantization then sparse attention before warm-up."""
+        from .fakequant_worker import _fakequant_run_prolog_worker, quant_config
+
+        model = self.model_runner.model
+        if hasattr(model, "unwrap"):
+            model = model.unwrap()
+
+        with disable_compilation(model):
+            # Step 1: Quantize
+            if quant_config["quant_cfg"] or quant_config["kv_quant_cfg"]:
+                _fakequant_run_prolog_worker(self)
+
+            # Step 2: Apply sparse attention via direct module walk
+            if sparse_config["calib_config_path"]:
+                cfg = _load_sparse_config(sparse_config["calib_config_path"])
+            elif sparse_config["sparse_cfg"]:
+                cfg = _build_sparse_config(sparse_config)
+            else:
+                cfg = None
+
+            if cfg is not None:
+                _apply_sparse_to_attention_modules(model, cfg)
+
+        super().compile_or_warm_up_model()

--- a/examples/vllm_serve/sparse_attn_worker.py
+++ b/examples/vllm_serve/sparse_attn_worker.py
@@ -29,17 +29,19 @@ Usage:
 """
 
 import fnmatch
-import functools
 import json
 import os
 from typing import Any
 
-import torch
 from fakequant_worker import disable_compilation
+from vllm.attention.layer import Attention as VLLMAttention
 from vllm.v1.worker.gpu_worker import Worker as BaseWorker
 
 import modelopt.torch.sparsity.attention_sparsity as mtsa
-from modelopt.torch.kernels.triton_fa import attention as triton_attention
+from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
+    ModelOptSparseAttentionImpl,
+    set_sparse_config,
+)
 
 # ---------------------------------------------------------------------------
 # Configuration from environment variables
@@ -117,115 +119,43 @@ def _match_sparse_config(module_name: str, sparse_cfg: dict) -> dict | None:
     return None
 
 
-def _sparse_attention_forward(module, query, key, value, kv_cache, attn_metadata, **kwargs):
-    """Sparse attention forward — used by SparseQuantWorker for direct module patching."""
-    if not getattr(module, "_sparse_enabled", False):
-        return module._original_forward(query, key, value, kv_cache, attn_metadata, **kwargs)
+def _replace_attention_impl(worker, config: dict):
+    """Replace FlashAttentionImpl with ModelOptSparseAttentionImpl on all Attention layers.
 
-    from vllm._custom_ops import reshape_and_cache_flash
-
-    reshape_and_cache_flash(
-        key,
-        value,
-        kv_cache,
-        attn_metadata.slot_mapping,
-        module.impl.kv_cache_dtype,
-        getattr(module.impl, "k_scale", 1.0),
-        getattr(module.impl, "v_scale", 1.0),
-    )
-
-    # Unpack paged KV cache
-    k_cache = kv_cache[:, 0]  # [num_blocks, page_size, num_kv_heads, head_dim]
-    v_cache = kv_cache[:, 1]
-    page_size = k_cache.shape[1]
-
-    output = torch.empty_like(query)
-    sm_scale = module.impl.scale
-    sparse_kw = module._sparse_kw
-
-    # Paged KV kwargs
-    paged_kw = {
-        "k_cache": k_cache,
-        "v_cache": v_cache,
-        "page_size": page_size,
-    }
-
-    if attn_metadata.num_prefill_tokens > 0:
-        pm = attn_metadata.prefill
-        n = attn_metadata.num_prefill_tokens
-        output[:n] = triton_attention(
-            q=query[:n],
-            k=query[:0],  # dummy, not used in paged mode
-            v=query[:0],
-            b_start_loc=pm.query_start_loc,
-            b_seq_len=pm.seq_lens_q,
-            max_input_len=int(pm.seq_lens_q.max().item()),
-            is_causal=True,
-            softmax_scale=sm_scale,
-            b_seq_len_k=pm.seq_lens,
-            max_input_len_k=int(pm.seq_lens.max().item()),
-            block_table=pm.block_tables,
-            **paged_kw,
-            **sparse_kw,
-        )
-
-    if attn_metadata.num_decode_tokens > 0:
-        dm = attn_metadata.decode
-        offset = attn_metadata.num_prefill_tokens
-        nd = attn_metadata.num_decode_tokens
-        output[offset : offset + nd] = triton_attention(
-            q=query[offset : offset + nd],
-            k=query[:0],  # dummy, not used in paged mode
-            v=query[:0],
-            b_start_loc=dm.query_start_loc,
-            b_seq_len=torch.ones(nd, dtype=torch.int32, device=query.device),
-            max_input_len=1,
-            is_causal=True,
-            softmax_scale=sm_scale,
-            b_seq_len_k=dm.seq_lens,
-            max_input_len_k=int(dm.seq_lens.max().item()),
-            block_table=dm.block_tables,
-            **paged_kw,
-            **sparse_kw,
-        )
-
-    return output
-
-
-def _apply_sparse_to_attention_modules(model, sparse_cfg: dict):
-    """Walk model modules, patch attention layers with sparse forward.
-
-    Used by SparseQuantWorker where registry-based mtsa.sparsify() cannot
-    find already-quantized attention modules (forward identity check fails).
+    Shared by SparseAttnWorker and SparseQuantWorker.
     """
-    from vllm.attention.layer import Attention as VLLMAttention
+    if config["calib_config_path"]:
+        cfg = _load_sparse_config(config["calib_config_path"])
+    else:
+        cfg = _build_sparse_config(config)
 
+    if cfg is None:
+        return
+
+    set_sparse_config(cfg)
+
+    model = worker.model_runner.model
+    if hasattr(model, "unwrap"):
+        model = model.unwrap()
+
+    patched = 0
     for name, module in model.named_modules():
-        if not isinstance(module, VLLMAttention):
-            continue
-
-        layer_cfg = _match_sparse_config(name, sparse_cfg)
-        if layer_cfg is None or not layer_cfg.get("enable", True):
-            continue
-
-        # Build kernel kwargs from layer config
-        sparse_kw = {}
-        sparsity_n = layer_cfg.get("sparsity_n", 0)
-        if sparsity_n > 0:
-            sparse_kw["sparsity_n"] = sparsity_n
-            sparse_kw["sparsity_m"] = layer_cfg.get("sparsity_m", 4)
-            sparse_kw["num_sink_tokens"] = layer_cfg.get("num_sink_tokens", 0)
-            sparse_kw["dense_window_size"] = layer_cfg.get("dense_window_size", 1)
-        threshold = layer_cfg.get("skip_softmax_threshold", None)
-        if threshold:
-            sparse_kw["skip_softmax_threshold"] = threshold
-
-        module._sparse_enabled = True
-        module._sparse_kw = sparse_kw
-
-        original_forward = module.forward
-        module._original_forward = original_forward
-        module.forward = functools.partial(_sparse_attention_forward, module)
+        if isinstance(module, VLLMAttention):
+            old_impl = module.impl
+            module.impl = ModelOptSparseAttentionImpl(
+                num_heads=old_impl.num_heads,
+                head_size=old_impl.head_size,
+                scale=old_impl.scale,
+                num_kv_heads=old_impl.num_kv_heads,
+                alibi_slopes=old_impl.alibi_slopes,
+                sliding_window=None,
+                kv_cache_dtype=old_impl.kv_cache_dtype,
+                logits_soft_cap=old_impl.logits_soft_cap,
+                attn_type=old_impl.attn_type,
+                kv_sharing_target_layer_name=old_impl.kv_sharing_target_layer_name,
+            )
+            patched += 1
+    print(f"[ModelOpt] Sparse attention: replaced impl on {patched} attention layers")
 
 
 # ---------------------------------------------------------------------------
@@ -244,78 +174,32 @@ class SparseAttnWorker(BaseWorker):
     def load_model(self, *args, **kwargs) -> None:
         """Load model, then replace attention impl with sparse variant."""
         super().load_model(*args, **kwargs)
-
-        if sparse_config["calib_config_path"]:
-            cfg = _load_sparse_config(sparse_config["calib_config_path"])
-        else:
-            cfg = _build_sparse_config(sparse_config)
-
-        if cfg is None:
-            return
-
-        from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
-            ModelOptSparseAttentionImpl,
-            set_sparse_config,
-        )
-
-        set_sparse_config(cfg)
-
-        from vllm.attention.layer import Attention as VLLMAttention
-
-        model = self.model_runner.model
-        if hasattr(model, "unwrap"):
-            model = model.unwrap()
-
-        patched = 0
-        for name, module in model.named_modules():
-            if isinstance(module, VLLMAttention):
-                old_impl = module.impl
-                module.impl = ModelOptSparseAttentionImpl(
-                    num_heads=old_impl.num_heads,
-                    head_size=old_impl.head_size,
-                    scale=old_impl.scale,
-                    num_kv_heads=old_impl.num_kv_heads,
-                    alibi_slopes=old_impl.alibi_slopes,
-                    sliding_window=None,
-                    kv_cache_dtype=old_impl.kv_cache_dtype,
-                    logits_soft_cap=old_impl.logits_soft_cap,
-                    attn_type=old_impl.attn_type,
-                    kv_sharing_target_layer_name=old_impl.kv_sharing_target_layer_name,
-                )
-                patched += 1
-        print(f"[ModelOpt] Sparse attention: replaced impl on {patched} attention layers")
+        _replace_attention_impl(self, sparse_config)
 
 
 class SparseQuantWorker(BaseWorker):
     """vLLM worker that applies quantization + sparse attention.
 
     Quantization uses the standard registry-based ``mtq.quantize()``.
-    Sparse attention uses direct module walk because the registry cannot
-    match already-quantized attention modules (forward identity check).
+    Sparse attention replaces FlashAttentionImpl with ModelOptSparseAttentionImpl
+    (same approach as SparseAttnWorker).
     """
 
+    def load_model(self, *args, **kwargs) -> None:
+        """Load model, then replace attention impl with sparse variant."""
+        super().load_model(*args, **kwargs)
+        _replace_attention_impl(self, sparse_config)
+
     def compile_or_warm_up_model(self) -> None:
-        """Apply quantization then sparse attention before warm-up."""
-        from .fakequant_worker import _fakequant_run_prolog_worker, quant_config
+        """Apply quantization before warm-up."""
+        from fakequant_worker import _fakequant_run_prolog_worker, quant_config
 
         model = self.model_runner.model
         if hasattr(model, "unwrap"):
             model = model.unwrap()
 
         with disable_compilation(model):
-            # Step 1: Quantize
             if quant_config["quant_cfg"] or quant_config["kv_quant_cfg"]:
                 _fakequant_run_prolog_worker(self)
-
-            # Step 2: Apply sparse attention via direct module walk
-            if sparse_config["calib_config_path"]:
-                cfg = _load_sparse_config(sparse_config["calib_config_path"])
-            elif sparse_config["sparse_cfg"]:
-                cfg = _build_sparse_config(sparse_config)
-            else:
-                cfg = None
-
-            if cfg is not None:
-                _apply_sparse_to_attention_modules(model, cfg)
 
         super().compile_or_warm_up_model()

--- a/examples/vllm_serve/sparse_attn_worker.py
+++ b/examples/vllm_serve/sparse_attn_worker.py
@@ -92,8 +92,15 @@ def _replace_attention_impl(worker):
             sparse_kw["num_sink_tokens"] = layer_cfg.get("num_sink_tokens", 0)
             sparse_kw["dense_window_size"] = layer_cfg.get("dense_window_size", 64)
         threshold = layer_cfg.get("skip_softmax_threshold")
-        if threshold:
+        if threshold is not None:
             sparse_kw["skip_softmax_threshold"] = threshold
+        raw_threshold = layer_cfg.get("skip_softmax_raw_threshold")
+        if raw_threshold is not None:
+            sparse_kw["skip_softmax_raw_threshold"] = raw_threshold
+        threshold_scale_factor = layer_cfg.get("threshold_scale_factor")
+        if threshold_scale_factor is not None:
+            sparse_kw["threshold_scale_factor"] = threshold_scale_factor
+            sparse_kw["target_sparse_ratio"] = layer_cfg.get("target_sparse_ratio")
 
         new_impl = _clone_sparse_impl(module.impl)
         new_impl.sparse_kw = sparse_kw

--- a/examples/vllm_serve/sparse_attn_worker.py
+++ b/examples/vllm_serve/sparse_attn_worker.py
@@ -13,121 +13,63 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Custom vLLM workers for sparse attention.
+"""Custom vLLM worker for sparse attention.
 
 ``SparseAttnWorker``: Replaces ``FlashAttentionImpl`` with
 ``ModelOptSparseAttentionImpl`` on each Attention module after model loading.
 The sparse impl uses the ModelOpt Triton kernel for both prefill and decode.
 
-``SparseQuantWorker``: Applies quantization first, then sparse attention via
-direct module walk (registry stacking does not work due to ``_DMRegistryCls``
-forward identity check).
+Configuration flows exclusively through the loaded checkpoint's
+``sparse_attention_config`` block (written by ModelOpt's HF export). If the
+checkpoint has no such block, the worker logs a message and passes through
+unchanged.
+
+Quantization combined with sparse attention is not handled by this worker
+and will land in a follow-up PR once the combined path is tested.
 
 Usage:
-    SPARSE_ATTN_CFG=SPARSE_SOFTMAX_DEFAULT python vllm_serve_sparse_attn.py \\
-        meta-llama/Llama-3.1-8B --enforce-eager
+    python vllm_serve_sparse_attn.py <path/to/modelopt-exported-ckpt>
 """
 
-import fnmatch
-import json
-import os
-from typing import Any
+import importlib
 
-from fakequant_worker import disable_compilation
-from vllm.attention.layer import Attention as VLLMAttention
+try:
+    _has_legacy_attention_layer = importlib.util.find_spec("vllm.attention.layer") is not None
+except (ModuleNotFoundError, ValueError):
+    _has_legacy_attention_layer = False
+
+if _has_legacy_attention_layer:
+    from vllm.attention.layer import Attention as VLLMAttention
+else:
+    from vllm.model_executor.layers.attention import Attention as VLLMAttention
+
 from vllm.v1.worker.gpu_worker import Worker as BaseWorker
 
-import modelopt.torch.sparsity.attention_sparsity as mtsa
-from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import ModelOptSparseAttentionImpl
-
-# ---------------------------------------------------------------------------
-# Configuration from environment variables
-# ---------------------------------------------------------------------------
-
-sparse_config: dict[str, Any] = {
-    "sparse_cfg": os.environ.get("SPARSE_ATTN_CFG", None),
-    "calib_config_path": os.environ.get("SPARSE_CALIB_CONFIG_PATH", None),
-}
+from modelopt.torch.sparsity.attention_sparsity.plugins.sparse_attn_config import (
+    load_from_checkpoint_metadata,
+    match_sparse_config,
+)
+from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import _clone_sparse_impl
 
 
-# ---------------------------------------------------------------------------
-# Helper functions
-# ---------------------------------------------------------------------------
-
-
-_DEFAULT_SPARSE_CFG = {
-    "sparse_cfg": {
-        "*attn*": {
-            "sparsity_n": 2,
-            "sparsity_m": 4,
-            "num_sink_tokens": 0,
-            "dense_window_size": 1,
-            "enable": True,
-        },
-        "default": {"enable": False},
-    },
-}
-
-
-def _build_sparse_config(env_config: dict[str, Any]) -> dict | None:
-    """Build sparse_cfg dict from env vars."""
-    cfg_name = env_config["sparse_cfg"]
-    if cfg_name is None:
-        return None
-    # Try looking up preset from mtsa, fall back to default
-    cfg = getattr(mtsa, cfg_name, None)
-    if cfg is not None:
-        return cfg
-    # Use built-in default if name matches
-    if cfg_name in ("SPARSE_SOFTMAX_DEFAULT", "default"):
-        return _DEFAULT_SPARSE_CFG
-    raise ValueError(
-        f"Unknown sparse config: {cfg_name}. Set SPARSE_ATTN_CFG to 'default' or a valid preset name."
-    )
-
-
-def _load_sparse_config(path: str) -> dict:
-    """Load offline calibration config JSON."""
-    with open(path) as f:
-        calib_cfg = json.load(f)
-
-    sparse_cfg = {}
-    for pattern, layer_cfg in calib_cfg.items():
-        if pattern == "calibration":
-            sparse_cfg[pattern] = layer_cfg
-            continue
-        layer_cfg.setdefault("method", "triton_sparse_softmax")
-        layer_cfg.setdefault("backend", "triton")
-        layer_cfg.setdefault("enable", True)
-        sparse_cfg[pattern] = layer_cfg
-    sparse_cfg["default"] = {"enable": False}
-
-    return {"sparse_cfg": sparse_cfg}
-
-
-def _match_sparse_config(module_name: str, sparse_cfg: dict) -> dict | None:
-    """Match a module name against sparse_cfg patterns."""
-    cfg = sparse_cfg.get("sparse_cfg", sparse_cfg)
-    for pattern, layer_cfg in cfg.items():
-        if pattern in ("default", "calibration"):
-            continue
-        if fnmatch.fnmatch(module_name, pattern):
-            return layer_cfg
-    return None
-
-
-def _replace_attention_impl(worker, config: dict):
+def _replace_attention_impl(worker):
     """Replace FlashAttentionImpl with ModelOptSparseAttentionImpl on all Attention layers.
 
-    Shared by SparseAttnWorker and SparseQuantWorker.
+    The sole configuration source is the checkpoint's ``sparse_attention_config``
+    metadata. No-op if the checkpoint has no such block.
     """
-    if config["calib_config_path"]:
-        cfg = _load_sparse_config(config["calib_config_path"])
-    else:
-        cfg = _build_sparse_config(config)
-
-    if cfg is None:
+    hf_config = getattr(worker.model_runner.model_config, "hf_config", None)
+    detected = load_from_checkpoint_metadata(hf_config)
+    if detected is None:
+        print(
+            "[ModelOpt] No sparse_attention_config found in the checkpoint; "
+            "skipping sparse attention. Run examples/llm_sparsity/"
+            "attention_sparsity/hf_sa.py to calibrate and export a checkpoint "
+            "with the config embedded."
+        )
         return
+    cfg, preset_name = detected
+    print(f"[ModelOpt] Sparse attention config: algo -> {preset_name}")
 
     model = worker.model_runner.model
     if hasattr(model, "unwrap"):
@@ -138,41 +80,22 @@ def _replace_attention_impl(worker, config: dict):
         if not isinstance(module, VLLMAttention):
             continue
 
-        # Match per-layer sparse config using name-based patterns
-        layer_cfg = _match_sparse_config(name, cfg)
+        layer_cfg = match_sparse_config(name, cfg)
         if layer_cfg is None or not layer_cfg.get("enable", True):
             continue
 
-        # Build per-layer sparse kwargs
         sparse_kw = {}
         sparsity_n = layer_cfg.get("sparsity_n", 0)
         if sparsity_n > 0:
             sparse_kw["sparsity_n"] = sparsity_n
             sparse_kw["sparsity_m"] = layer_cfg.get("sparsity_m", 4)
             sparse_kw["num_sink_tokens"] = layer_cfg.get("num_sink_tokens", 0)
-            sparse_kw["dense_window_size"] = layer_cfg.get("dense_window_size", 1)
+            sparse_kw["dense_window_size"] = layer_cfg.get("dense_window_size", 64)
         threshold = layer_cfg.get("skip_softmax_threshold")
         if threshold:
             sparse_kw["skip_softmax_threshold"] = threshold
 
-        # Replace impl and store per-layer config
-        old_impl = module.impl
-        new_impl = ModelOptSparseAttentionImpl(
-            num_heads=old_impl.num_heads,
-            head_size=old_impl.head_size,
-            scale=old_impl.scale,
-            num_kv_heads=old_impl.num_kv_heads,
-            alibi_slopes=old_impl.alibi_slopes,
-            sliding_window=None,  # overwritten below
-            kv_cache_dtype=old_impl.kv_cache_dtype,
-            logits_soft_cap=old_impl.logits_soft_cap,
-            attn_type=old_impl.attn_type,
-            kv_sharing_target_layer_name=old_impl.kv_sharing_target_layer_name,
-        )
-        # Copy the already-transformed sliding_window tuple directly,
-        # since __init__ transforms int -> (sw-1, 0) and we can't reverse it.
-        new_impl.sliding_window = old_impl.sliding_window
-        # Store per-layer sparse kwargs on the impl for forward() to read
+        new_impl = _clone_sparse_impl(module.impl)
         new_impl.sparse_kw = sparse_kw
         module.impl = new_impl
         patched += 1
@@ -195,32 +118,4 @@ class SparseAttnWorker(BaseWorker):
     def load_model(self, *args, **kwargs) -> None:
         """Load model, then replace attention impl with sparse variant."""
         super().load_model(*args, **kwargs)
-        _replace_attention_impl(self, sparse_config)
-
-
-class SparseQuantWorker(BaseWorker):
-    """vLLM worker that applies quantization + sparse attention.
-
-    Quantization uses the standard registry-based ``mtq.quantize()``.
-    Sparse attention replaces FlashAttentionImpl with ModelOptSparseAttentionImpl
-    (same approach as SparseAttnWorker).
-    """
-
-    def load_model(self, *args, **kwargs) -> None:
-        """Load model, then replace attention impl with sparse variant."""
-        super().load_model(*args, **kwargs)
-        _replace_attention_impl(self, sparse_config)
-
-    def compile_or_warm_up_model(self) -> None:
-        """Apply quantization before warm-up."""
-        from fakequant_worker import _fakequant_run_prolog_worker, quant_config
-
-        model = self.model_runner.model
-        if hasattr(model, "unwrap"):
-            model = model.unwrap()
-
-        with disable_compilation(model):
-            if quant_config["quant_cfg"] or quant_config["kv_quant_cfg"]:
-                _fakequant_run_prolog_worker(self)
-
-        super().compile_or_warm_up_model()
+        _replace_attention_impl(self)

--- a/examples/vllm_serve/sparse_attn_worker.py
+++ b/examples/vllm_serve/sparse_attn_worker.py
@@ -89,14 +89,11 @@ def _replace_attention_impl(worker):
         if sparsity_n > 0:
             sparse_kw["sparsity_n"] = sparsity_n
             sparse_kw["sparsity_m"] = layer_cfg.get("sparsity_m", 4)
-            sparse_kw["num_sink_tokens"] = layer_cfg.get("num_sink_tokens", 0)
-            sparse_kw["dense_window_size"] = layer_cfg.get("dense_window_size", 64)
+            sparse_kw["dense_sink_tokens"] = layer_cfg.get("dense_sink_tokens", 0)
+            sparse_kw["dense_recent_tokens"] = layer_cfg.get("dense_recent_tokens", 64)
         threshold = layer_cfg.get("skip_softmax_threshold")
         if threshold is not None:
             sparse_kw["skip_softmax_threshold"] = threshold
-        raw_threshold = layer_cfg.get("skip_softmax_raw_threshold")
-        if raw_threshold is not None:
-            sparse_kw["skip_softmax_raw_threshold"] = raw_threshold
         threshold_scale_factor = layer_cfg.get("threshold_scale_factor")
         if threshold_scale_factor is not None:
             sparse_kw["threshold_scale_factor"] = threshold_scale_factor

--- a/examples/vllm_serve/sparse_attn_worker.py
+++ b/examples/vllm_serve/sparse_attn_worker.py
@@ -17,7 +17,9 @@
 
 ``SparseAttnWorker``: Replaces ``FlashAttentionImpl`` with
 ``ModelOptSparseAttentionImpl`` on each Attention module after model loading.
-The sparse impl uses the ModelOpt Triton kernel for both prefill and decode.
+The sparse impl uses the ModelOpt Triton kernel for sparse prefill launches.
+Decode-only launches and launches without active sparse work delegate back to
+vLLM FlashAttention.
 
 Configuration flows exclusively through the loaded checkpoint's
 ``sparse_attention_config`` block (written by ModelOpt's HF export). If the
@@ -49,7 +51,10 @@ from modelopt.torch.sparsity.attention_sparsity.plugins.sparse_attn_config impor
     load_from_checkpoint_metadata,
     match_sparse_config,
 )
-from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import _clone_sparse_impl
+from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
+    _build_sparse_kw,
+    _clone_sparse_impl,
+)
 
 
 def _replace_attention_impl(worker):
@@ -84,21 +89,11 @@ def _replace_attention_impl(worker):
         if layer_cfg is None or not layer_cfg.get("enable", True):
             continue
 
-        sparse_kw = {}
-        sparsity_n = layer_cfg.get("sparsity_n", 0)
-        if sparsity_n > 0:
-            sparse_kw["sparsity_n"] = sparsity_n
-            sparse_kw["sparsity_m"] = layer_cfg.get("sparsity_m", 4)
-            sparse_kw["dense_sink_tokens"] = layer_cfg.get("dense_sink_tokens", 0)
-            sparse_kw["dense_recent_tokens"] = layer_cfg.get("dense_recent_tokens", 64)
-        threshold = layer_cfg.get("skip_softmax_threshold")
-        if threshold is not None:
-            sparse_kw["skip_softmax_threshold"] = threshold
-        threshold_scale_factor = layer_cfg.get("threshold_scale_factor")
-        if threshold_scale_factor is not None:
-            sparse_kw["threshold_scale_factor"] = threshold_scale_factor
-            sparse_kw["target_sparse_ratio"] = layer_cfg.get("target_sparse_ratio")
-
+        sparse_kw = _build_sparse_kw(layer_cfg)
+        if not sparse_kw:
+            # Keep vLLM's original impl when the exported layer config does not
+            # enable any sparse feature.
+            continue
         new_impl = _clone_sparse_impl(module.impl)
         new_impl.sparse_kw = sparse_kw
         module.impl = new_impl

--- a/examples/vllm_serve/vllm_serve_sparse_attn.py
+++ b/examples/vllm_serve/vllm_serve_sparse_attn.py
@@ -29,9 +29,8 @@ import sys
 from pathlib import Path
 
 import uvloop
-from packaging import version
-
 import vllm
+from packaging import version
 from vllm.entrypoints.openai.api_server import run_server
 from vllm.entrypoints.openai.cli_args import make_arg_parser
 

--- a/examples/vllm_serve/vllm_serve_sparse_attn.py
+++ b/examples/vllm_serve/vllm_serve_sparse_attn.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch vLLM with sparse attention.
+
+Usage:
+    SPARSE_ATTN_CFG=SPARSE_SOFTMAX_DEFAULT python vllm_serve_sparse_attn.py \\
+        meta-llama/Llama-3.1-8B --max-model-len 8192
+
+Combined with quantization:
+    QUANT_CFG=INT8_SMOOTHQUANT_CFG SPARSE_ATTN_CFG=SPARSE_SOFTMAX_DEFAULT \\
+        python vllm_serve_sparse_attn.py meta-llama/Llama-3.1-8B
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import uvloop
+from packaging import version
+
+import vllm
+from vllm.entrypoints.openai.api_server import run_server
+from vllm.entrypoints.openai.cli_args import make_arg_parser
+
+vllm_version = version.parse(vllm.__version__)
+if vllm_version <= version.parse("0.11.0"):
+    from vllm.utils import FlexibleArgumentParser
+else:
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+# Pass sparse attention env vars to ray workers (if supported by this vLLM version)
+additional_env_vars = {
+    "SPARSE_ATTN_CFG",
+    "SPARSE_CALIB_CONFIG_PATH",
+    "QUANT_DATASET",
+    "QUANT_CALIB_SIZE",
+    "QUANT_CFG",
+    "AMAX_FILE_PATH",
+    "KV_QUANT_CFG",
+}
+
+try:
+    if vllm_version <= version.parse("0.11.0"):
+        from vllm.executor.ray_distributed_executor import RayDistributedExecutor
+    else:
+        from vllm.v1.executor.ray_executor import RayDistributedExecutor
+    if hasattr(RayDistributedExecutor, "ADDITIONAL_ENV_VARS"):
+        RayDistributedExecutor.ADDITIONAL_ENV_VARS.update(additional_env_vars)
+except ImportError:
+    pass  # Ray not installed, single-node only
+
+
+def main():
+    """Launch vLLM with sparse attention worker."""
+    parser = FlexibleArgumentParser(description="vLLM model server with sparse attention")
+    parser.add_argument("model", type=str, help="The path or name of the model to serve")
+    parser = make_arg_parser(parser)
+
+    # Ensure workers can import our custom worker module
+    repo_root = str(Path(__file__).resolve().parent)
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+    os.environ["PYTHONPATH"] = os.environ.get("PYTHONPATH", "") + ":" + f"{repo_root}"
+
+    # Select worker based on env vars
+    has_quant = os.environ.get("QUANT_CFG") or os.environ.get("KV_QUANT_CFG")
+    has_sparse = os.environ.get("SPARSE_ATTN_CFG") or os.environ.get("SPARSE_CALIB_CONFIG_PATH")
+
+    if has_quant and has_sparse:
+        worker_cls = "sparse_attn_worker.SparseQuantWorker"
+    elif has_sparse:
+        worker_cls = "sparse_attn_worker.SparseAttnWorker"
+    else:
+        print("Warning: No SPARSE_ATTN_CFG or QUANT_CFG set. Running standard vLLM.")
+        worker_cls = None
+
+    if worker_cls:
+        parser.set_defaults(worker_cls=worker_cls)
+
+    args = parser.parse_args()
+    uvloop.run(run_server(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/vllm_serve/vllm_serve_sparse_attn.py
+++ b/examples/vllm_serve/vllm_serve_sparse_attn.py
@@ -15,13 +15,17 @@
 
 """Launch vLLM with sparse attention.
 
-Usage:
-    SPARSE_ATTN_CFG=SPARSE_SOFTMAX_DEFAULT python vllm_serve_sparse_attn.py \\
-        meta-llama/Llama-3.1-8B --max-model-len 8192
+Configuration is read exclusively from ``<ckpt>/config.json``'s
+``sparse_attention_config`` block, written during calibration by
+``examples/llm_sparsity/attention_sparsity/hf_sa.py``. If the checkpoint has
+no such block, the worker logs a message and the server runs as standard
+vLLM.
 
-Combined with quantization:
-    QUANT_CFG=INT8_SMOOTHQUANT_CFG SPARSE_ATTN_CFG=SPARSE_SOFTMAX_DEFAULT \\
-        python vllm_serve_sparse_attn.py meta-llama/Llama-3.1-8B
+Combined sparse attention + quantization is not handled by this launcher; it
+will be added in a follow-up PR once the combined path is tested.
+
+Usage:
+    python vllm_serve_sparse_attn.py <path/to/modelopt-exported-ckpt>
 """
 
 import os
@@ -40,27 +44,6 @@ if vllm_version <= version.parse("0.11.0"):
 else:
     from vllm.utils.argparse_utils import FlexibleArgumentParser
 
-# Pass sparse attention env vars to ray workers (if supported by this vLLM version)
-additional_env_vars = {
-    "SPARSE_ATTN_CFG",
-    "SPARSE_CALIB_CONFIG_PATH",
-    "QUANT_DATASET",
-    "QUANT_CALIB_SIZE",
-    "QUANT_CFG",
-    "AMAX_FILE_PATH",
-    "KV_QUANT_CFG",
-}
-
-try:
-    if vllm_version <= version.parse("0.11.0"):
-        from vllm.executor.ray_distributed_executor import RayDistributedExecutor
-    else:
-        from vllm.v1.executor.ray_executor import RayDistributedExecutor
-    if hasattr(RayDistributedExecutor, "ADDITIONAL_ENV_VARS"):
-        RayDistributedExecutor.ADDITIONAL_ENV_VARS.update(additional_env_vars)
-except ImportError:
-    pass  # Ray not installed, single-node only
-
 
 def main():
     """Launch vLLM with sparse attention worker."""
@@ -72,22 +55,10 @@ def main():
     repo_root = str(Path(__file__).resolve().parent)
     if repo_root not in sys.path:
         sys.path.insert(0, repo_root)
-    os.environ["PYTHONPATH"] = os.environ.get("PYTHONPATH", "") + ":" + f"{repo_root}"
+    current = os.environ.get("PYTHONPATH")
+    os.environ["PYTHONPATH"] = os.pathsep.join([current, repo_root]) if current else repo_root
 
-    # Select worker based on env vars
-    has_quant = os.environ.get("QUANT_CFG") or os.environ.get("KV_QUANT_CFG")
-    has_sparse = os.environ.get("SPARSE_ATTN_CFG") or os.environ.get("SPARSE_CALIB_CONFIG_PATH")
-
-    if has_quant and has_sparse:
-        worker_cls = "sparse_attn_worker.SparseQuantWorker"
-    elif has_sparse:
-        worker_cls = "sparse_attn_worker.SparseAttnWorker"
-    else:
-        print("Warning: No SPARSE_ATTN_CFG or QUANT_CFG set. Running standard vLLM.")
-        worker_cls = None
-
-    if worker_cls:
-        parser.set_defaults(worker_cls=worker_cls)
+    parser.set_defaults(worker_cls="sparse_attn_worker.SparseAttnWorker")
 
     args = parser.parse_args()
     uvloop.run(run_server(args))

--- a/modelopt/torch/kernels/common/attention/hf_triton_attention.py
+++ b/modelopt/torch/kernels/common/attention/hf_triton_attention.py
@@ -112,8 +112,8 @@ def triton_attention_forward(
     if method is not None and not is_decode and getattr(module, "_apply_sparse_nm", False):
         kw["sparsity_n"] = method.sparsity_n
         kw["sparsity_m"] = method.sparsity_m
-        kw["num_sink_tokens"] = method.num_sink_tokens
-        kw["dense_window_size"] = method.dense_window_size
+        kw["dense_sink_tokens"] = method.dense_sink_tokens
+        kw["dense_recent_tokens"] = method.dense_recent_tokens
 
     # Skip-softmax: applies to both prefill and decode
     if method is not None and getattr(module, "_apply_skip_softmax", False):

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -79,6 +79,11 @@ _FWD_CONFIGS = [
 if "PYTEST_VERSION" in __import__("os").environ:
     _FWD_CONFIGS = [triton.Config({"BLOCK_M": 128, "BLOCK_N": 64}, num_stages=1, num_warps=4)]
 
+_MEASURE_BLOCK_M = 128
+_MEASURE_BLOCK_N = 64
+_MEASURE_NUM_STAGES = 1
+_MEASURE_NUM_WARPS = 4
+
 
 # ---------------------------------------------------------------------------
 # Paged KV cache helpers
@@ -852,11 +857,7 @@ class _Attention(torch.autograd.Function):
             sparsity_total = None
             sparsity_skipped = None
 
-        # Grid: (batch, q_heads, q_tiles). Uses a function because BLOCK_M is autotuned.
-        def grid(META):
-            return (batch, num_q_heads, triton.cdiv(max_input_len, META["BLOCK_M"]))
-
-        _attn_fwd[grid](
+        fwd_args = (
             q,
             k,
             v,
@@ -877,35 +878,58 @@ class _Attention(torch.autograd.Function):
             o.stride(1),
             lse.stride(0),
             lse.stride(1),
-            N_CTX=max_input_len,
-            kv_group_num=kv_group_num,
-            BLOCK_D=BLOCK_D,
-            IS_CAUSAL=is_causal,
-            HEAD_DIM=HEAD_DIM,
-            STORE_LSE=True,
-            SPARSITY_N=sparsity_n,
-            SPARSITY_M=sparsity_m,
-            NUM_SINK_TOKENS=num_sink_tokens,
-            DENSE_WINDOW_SIZE=dense_window_size,
-            APPLY_SKIP_SOFTMAX=apply_skip,
-            SKIP_THRESHOLD_LOG2=skip_threshold_log2,
-            Sparsity_total=sparsity_total,
-            Sparsity_skipped=sparsity_skipped,
-            MEASURE_SPARSITY=do_measure,
-            IS_PAGED=is_paged,
-            K_cache=k_cache,
-            V_cache=v_cache,
-            Block_table=block_table,
-            stride_kc_block=k_cache.stride(0) if is_paged else 0,
-            stride_kc_pos=k_cache.stride(1) if is_paged else 0,
-            stride_kc_head=k_cache.stride(2) if is_paged else 0,
-            stride_vc_block=v_cache.stride(0) if is_paged else 0,
-            stride_vc_pos=v_cache.stride(1) if is_paged else 0,
-            stride_vc_head=v_cache.stride(2) if is_paged else 0,
-            PAGE_SIZE=page_size,
-            max_blocks_per_seq=block_table.shape[1] if is_paged else 0,
-            # BLOCK_M, BLOCK_N, num_warps, num_stages chosen by autotune
         )
+        fwd_meta = {
+            "N_CTX": max_input_len,
+            "kv_group_num": kv_group_num,
+            "BLOCK_D": BLOCK_D,
+            "IS_CAUSAL": is_causal,
+            "HEAD_DIM": HEAD_DIM,
+            "STORE_LSE": True,
+            "SPARSITY_N": sparsity_n,
+            "SPARSITY_M": sparsity_m,
+            "NUM_SINK_TOKENS": num_sink_tokens,
+            "DENSE_WINDOW_SIZE": dense_window_size,
+            "APPLY_SKIP_SOFTMAX": apply_skip,
+            "SKIP_THRESHOLD_LOG2": skip_threshold_log2,
+            "Sparsity_total": sparsity_total,
+            "Sparsity_skipped": sparsity_skipped,
+            "MEASURE_SPARSITY": do_measure,
+            "IS_PAGED": is_paged,
+            "K_cache": k_cache,
+            "V_cache": v_cache,
+            "Block_table": block_table,
+            "stride_kc_block": k_cache.stride(0) if is_paged else 0,
+            "stride_kc_pos": k_cache.stride(1) if is_paged else 0,
+            "stride_kc_head": k_cache.stride(2) if is_paged else 0,
+            "stride_vc_block": v_cache.stride(0) if is_paged else 0,
+            "stride_vc_pos": v_cache.stride(1) if is_paged else 0,
+            "stride_vc_head": v_cache.stride(2) if is_paged else 0,
+            "PAGE_SIZE": page_size,
+            "max_blocks_per_seq": block_table.shape[1] if is_paged else 0,
+        }
+
+        # Grid: (batch, q_heads, q_tiles). Uses a function because BLOCK_M is autotuned.
+        def grid(META):
+            return (batch, num_q_heads, triton.cdiv(max_input_len, META["BLOCK_M"]))
+
+        if do_measure:
+            # Runtime counters mutate global tensors, so do not run them through
+            # autotune candidate trials. Use one stable config for measurement.
+            _attn_fwd.fn[grid](
+                *fwd_args,
+                **fwd_meta,
+                BLOCK_M=_MEASURE_BLOCK_M,
+                BLOCK_N=_MEASURE_BLOCK_N,
+                num_warps=_MEASURE_NUM_WARPS,
+                num_stages=_MEASURE_NUM_STAGES,
+            )
+        else:
+            _attn_fwd[grid](
+                *fwd_args,
+                **fwd_meta,
+                # BLOCK_M, BLOCK_N, num_warps, num_stages chosen by autotune
+            )
 
         # Store sparsity counters on the output tensor for retrieval by callers
         if do_measure:

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -81,6 +81,95 @@ if "PYTEST_VERSION" in __import__("os").environ:
 
 
 # ---------------------------------------------------------------------------
+# Paged KV cache helpers
+# ---------------------------------------------------------------------------
+@triton.jit
+def _load_paged_k_tile(
+    K_cache,  # [num_blocks, page_size, num_kv_heads, head_dim]
+    Block_table,  # [batch, max_blocks_per_seq]
+    batch_idx,
+    kv_head_idx,
+    kv_start,
+    kv_pos,  # [BLOCK_N] relative positions
+    dim_pos,  # [BLOCK_D]
+    seq_len_kv,
+    stride_kc_block,
+    stride_kc_pos,
+    stride_kc_head,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    max_blocks_per_seq,
+):
+    """Load K^T tile [BLOCK_D, BLOCK_N] from paged KV cache."""
+    d_mask = dim_pos < HEAD_DIM
+    kv_abs = kv_start + kv_pos  # absolute token positions
+    kv_valid = kv_abs < seq_len_kv
+
+    # Translate token positions -> (page_id, offset_in_page)
+    page_local = kv_abs // PAGE_SIZE
+    offset_in_page = kv_abs % PAGE_SIZE
+    page_global = tl.load(
+        Block_table + batch_idx * max_blocks_per_seq + page_local,
+        mask=kv_valid,
+        other=0,
+    )
+
+    # Load K values: K_cache[page_global, offset_in_page, kv_head_idx, dim]
+    # K^T layout [BLOCK_D, BLOCK_N] for Q @ K^T matmul
+    k_ptrs = (
+        page_global[None, :] * stride_kc_block
+        + offset_in_page[None, :] * stride_kc_pos
+        + kv_head_idx * stride_kc_head
+        + dim_pos[:, None]
+    )
+    return tl.load(K_cache + k_ptrs, mask=kv_valid[None, :] & d_mask[:, None], other=0.0)
+
+
+@triton.jit
+def _load_paged_v_tile(
+    V_cache,  # [num_blocks, page_size, num_kv_heads, head_dim]
+    Block_table,  # [batch, max_blocks_per_seq]
+    batch_idx,
+    kv_head_idx,
+    kv_start,
+    kv_pos,  # [BLOCK_N] relative positions
+    dim_pos,  # [BLOCK_D]
+    seq_len_kv,
+    stride_vc_block,
+    stride_vc_pos,
+    stride_vc_head,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    max_blocks_per_seq,
+):
+    """Load V tile [BLOCK_N, BLOCK_D] from paged KV cache."""
+    d_mask = dim_pos < HEAD_DIM
+    kv_abs = kv_start + kv_pos
+    kv_valid = kv_abs < seq_len_kv
+
+    page_local = kv_abs // PAGE_SIZE
+    offset_in_page = kv_abs % PAGE_SIZE
+    page_global = tl.load(
+        Block_table + batch_idx * max_blocks_per_seq + page_local,
+        mask=kv_valid,
+        other=0,
+    )
+
+    # V layout [BLOCK_N, BLOCK_D]
+    v_ptrs = (
+        page_global[:, None] * stride_vc_block
+        + offset_in_page[:, None] * stride_vc_pos
+        + kv_head_idx * stride_vc_head
+        + dim_pos[None, :]
+    )
+    return tl.load(V_cache + v_ptrs, mask=kv_valid[:, None] & d_mask[None, :], other=0.0)
+
+
+# ---------------------------------------------------------------------------
 # Masking helper
 # ---------------------------------------------------------------------------
 @triton.jit
@@ -149,6 +238,18 @@ def _attn_fwd(
     Sparsity_total=None,  # Optional int64 scalar for counting total tiles (atomic)
     Sparsity_skipped=None,  # Optional int64 scalar for counting skipped tiles (atomic)
     MEASURE_SPARSITY: tl.constexpr = False,  # When True, count total/skipped tiles via atomic adds
+    IS_PAGED: tl.constexpr = False,  # Whether K/V are in paged cache
+    K_cache=None,  # [num_blocks, page_size, num_kv_heads, head_dim] paged K
+    V_cache=None,  # [num_blocks, page_size, num_kv_heads, head_dim] paged V
+    Block_table=None,  # [batch, max_blocks_per_seq] page table
+    stride_kc_block=0,
+    stride_kc_pos=0,
+    stride_kc_head=0,
+    stride_vc_block=0,
+    stride_vc_pos=0,
+    stride_vc_head=0,
+    PAGE_SIZE: tl.constexpr = 16,
+    max_blocks_per_seq=0,
 ):
     # --- Grid: (batch, num_q_heads, num_q_tiles) ---
     # Example: batch=2, num_q_heads=32, seq_len=256, BLOCK_M=128
@@ -195,12 +296,32 @@ def _attn_fwd(
         kv_start = tl.multiple_of(kv_start, BLOCK_N)  # Compiler hint for alignment
 
         # Load K^T [BLOCK_D, BLOCK_N] (transposed layout for Q @ K^T matmul)
-        k_offs = (kv_offset + kv_start + kv_pos[None, :]) * stride_kbs + dim_pos[:, None]
-        k = tl.load(
-            k_base + k_offs,
-            mask=((kv_start + kv_pos[None, :]) < seq_len_kv) & d_mask[:, None],
-            other=0.0,
-        )
+        if IS_PAGED:
+            k = _load_paged_k_tile(
+                K_cache,
+                Block_table,
+                batch_idx,
+                kv_head_idx,
+                kv_start,
+                kv_pos,
+                dim_pos,
+                seq_len_kv,
+                stride_kc_block,
+                stride_kc_pos,
+                stride_kc_head,
+                PAGE_SIZE,
+                BLOCK_N,
+                BLOCK_D,
+                HEAD_DIM,
+                max_blocks_per_seq,
+            )
+        else:
+            k_offs = (kv_offset + kv_start + kv_pos[None, :]) * stride_kbs + dim_pos[:, None]
+            k = tl.load(
+                k_base + k_offs,
+                mask=((kv_start + kv_pos[None, :]) < seq_len_kv) & d_mask[:, None],
+                other=0.0,
+            )
 
         # scores = Q @ K^T * scale  [BLOCK_M, BLOCK_N]
         scores = tl.dot(q, k) * qk_scale
@@ -245,12 +366,32 @@ def _attn_fwd(
             acc = acc * correction[:, None]
 
             # Load V and accumulate
-            v_offs = (kv_offset + kv_start + kv_pos[:, None]) * stride_vbs + dim_pos[None, :]
-            v = tl.load(
-                v_base + v_offs,
-                mask=((kv_start + kv_pos[:, None]) < seq_len_kv) & d_mask[None, :],
-                other=0.0,
-            )
+            if IS_PAGED:
+                v = _load_paged_v_tile(
+                    V_cache,
+                    Block_table,
+                    batch_idx,
+                    kv_head_idx,
+                    kv_start,
+                    kv_pos,
+                    dim_pos,
+                    seq_len_kv,
+                    stride_vc_block,
+                    stride_vc_pos,
+                    stride_vc_head,
+                    PAGE_SIZE,
+                    BLOCK_N,
+                    BLOCK_D,
+                    HEAD_DIM,
+                    max_blocks_per_seq,
+                )
+            else:
+                v_offs = (kv_offset + kv_start + kv_pos[:, None]) * stride_vbs + dim_pos[None, :]
+                v = tl.load(
+                    v_base + v_offs,
+                    mask=((kv_start + kv_pos[:, None]) < seq_len_kv) & d_mask[None, :],
+                    other=0.0,
+                )
             acc = tl.dot(p.to(v.dtype), v, acc)
             row_max = m_new
         # else: tile skipped — no softmax, no V load, no BMM2 for this tile
@@ -643,6 +784,10 @@ class _Attention(torch.autograd.Function):
         skip_softmax_threshold,
         skip_softmax_raw_threshold,
         measure_sparsity,
+        k_cache,
+        v_cache,
+        block_table,
+        page_size,
     ):
         HEAD_DIM = q.shape[2]
         num_q_heads = q.shape[1]
@@ -650,12 +795,19 @@ class _Attention(torch.autograd.Function):
         kv_group_num = num_q_heads // num_kv_heads
         batch = b_seq_len.shape[0]
 
+        is_paged = k_cache is not None
+
         # Prefill: Q/K/V are the same packed tensor, reuse Q offsets for K/V.
         # Decode: K/V is a separate KV cache tensor, caller must pass explicit metadata.
         if b_seq_len_k is None:
             b_seq_len_k = b_seq_len
             b_start_loc_k = b_start_loc
             max_input_len_k = max_input_len
+
+        # Paged mode: b_start_loc_k may be None (KV is in paged cache, not contiguous).
+        # Provide a dummy tensor so Triton can compile the tl.load (it won't be used).
+        if b_start_loc_k is None:
+            b_start_loc_k = torch.zeros_like(b_start_loc)
 
         # Pre-multiply scale by log2(e) so the kernel can use exp2()
         # exp(score * sm_scale) = exp2(score * sm_scale * log2(e))
@@ -733,6 +885,18 @@ class _Attention(torch.autograd.Function):
             Sparsity_total=sparsity_total,
             Sparsity_skipped=sparsity_skipped,
             MEASURE_SPARSITY=do_measure,
+            IS_PAGED=is_paged,
+            K_cache=k_cache,
+            V_cache=v_cache,
+            Block_table=block_table,
+            stride_kc_block=k_cache.stride(0) if is_paged else 0,
+            stride_kc_pos=k_cache.stride(1) if is_paged else 0,
+            stride_kc_head=k_cache.stride(2) if is_paged else 0,
+            stride_vc_block=v_cache.stride(0) if is_paged else 0,
+            stride_vc_pos=v_cache.stride(1) if is_paged else 0,
+            stride_vc_head=v_cache.stride(2) if is_paged else 0,
+            PAGE_SIZE=page_size,
+            max_blocks_per_seq=block_table.shape[1] if is_paged else 0,
             # BLOCK_M, BLOCK_N, num_warps, num_stages chosen by autotune
         )
 
@@ -871,21 +1035,25 @@ class _Attention(torch.autograd.Function):
             dq,
             dk,
             dv,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
+            None,  # b_start_loc
+            None,  # b_seq_len
+            None,  # max_input_len
+            None,  # is_causal
+            None,  # sm_scale
+            None,  # b_start_loc_k
+            None,  # b_seq_len_k
+            None,  # max_input_len_k
+            None,  # sparsity_n
+            None,  # sparsity_m
+            None,  # num_sink_tokens
+            None,  # dense_window_size
+            None,  # skip_softmax_threshold
+            None,  # skip_softmax_raw_threshold
+            None,  # measure_sparsity
+            None,  # k_cache
+            None,  # v_cache
+            None,  # block_table
+            None,  # page_size
         )
 
 
@@ -909,8 +1077,12 @@ def attention(
     skip_softmax_threshold: float | None = None,
     skip_softmax_raw_threshold: float | None = None,
     measure_sparsity: bool = False,
+    k_cache: torch.Tensor | None = None,
+    v_cache: torch.Tensor | None = None,
+    block_table: torch.Tensor | None = None,
+    page_size: int = 16,
 ) -> torch.Tensor:
-    """Variable-length flash attention with GQA, autograd, and optional N:M sparse softmax and skip-softmax.
+    """Variable-length flash attention with GQA, autograd, optional sparsity, and paged KV.
 
     Args:
         q: [total_q_tokens, num_q_heads, head_dim]
@@ -933,7 +1105,7 @@ def attention(
             (attention sinks). Absolute token count, BLOCK_N-independent.
         dense_window_size: Tokens near the query diagonal kept dense (local
             attention window). Absolute token count, BLOCK_N-independent.
-            Default 64 (one reference block).
+            Default 64 tokens.
         skip_softmax_threshold: BLASST threshold lambda
             (https://arxiv.org/pdf/2512.12087). Skip KV tiles where
             ``exp(tile_max - running_max) < lambda``, meaning the tile's
@@ -950,6 +1122,13 @@ def attention(
             and skipped tiles via atomic counters. The counts are stored as
             ``_sparsity_total`` and ``_sparsity_skipped`` attributes on the
             returned output tensor.
+        k_cache: Paged K cache [num_blocks, page_size, num_kv_heads, head_dim].
+            When provided, K/V are read from paged cache via block_table
+            instead of from contiguous k/v tensors.
+        v_cache: Paged V cache [num_blocks, page_size, num_kv_heads, head_dim].
+        block_table: Page table [batch, max_blocks_per_seq] mapping sequence
+            block indices to global page IDs.
+        page_size: Number of tokens per page in the KV cache.
 
     Returns:
         Output tensor [total_q_tokens, num_q_heads, head_dim].
@@ -975,6 +1154,10 @@ def attention(
         skip_softmax_threshold,
         skip_softmax_raw_threshold,
         measure_sparsity,
+        k_cache,
+        v_cache,
+        block_table,
+        page_size,
     )
 
 

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -797,6 +797,15 @@ class _Attention(torch.autograd.Function):
 
         is_paged = k_cache is not None
 
+        # Backward indexes contiguous K/V via b_start_loc_k. In paged mode, callers
+        # pass dummy k/v (e.g. torch.empty(0, ...)) and KV lives in k_cache/v_cache,
+        # so dK/dV would be computed against the dummies — silently incorrect. Fail
+        # fast instead of allowing autograd to produce wrong gradients.
+        if is_paged and (q.requires_grad or k.requires_grad or v.requires_grad):
+            raise NotImplementedError(
+                "Paged KV cache path is forward-only; backward is not implemented."
+            )
+
         # Prefill: Q/K/V are the same packed tensor, reuse Q offsets for K/V.
         # Decode: K/V is a separate KV cache tensor, caller must pass explicit metadata.
         if b_seq_len_k is None:
@@ -1132,6 +1141,12 @@ def attention(
 
     Returns:
         Output tensor [total_q_tokens, num_q_heads, head_dim].
+
+    Note:
+        The paged KV path (``k_cache``/``v_cache`` not None) is forward-only —
+        ``backward`` raises ``NotImplementedError`` if any of ``q``/``k``/``v``
+        require grad, because the saved ``k``/``v`` are dummy tensors in paged
+        mode and dK/dV would be silently incorrect.
     """
     _load_sparsity_helpers()
     sm_scale = 1.0 / (q.shape[2] ** 0.5) if softmax_scale is None else softmax_scale

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -189,9 +189,12 @@ def _apply_mask(
 ):
     """Apply causal mask and padding mask to a score tile."""
     if IS_CAUSAL:
+        # In chunked prefill or prefix-cache hits, Q is the latest suffix of KV
+        # rather than starting at KV position 0.
+        q_to_k_offset = seq_len_kv - seq_len_q
         scores += tl.where(
             (kv_start + kv_pos[None, :] < seq_len_kv)
-            & (q_pos[:, None] >= (kv_start + kv_pos[None, :])),
+            & (q_pos[:, None] + q_to_k_offset >= (kv_start + kv_pos[None, :])),
             0,
             float("-inf"),
         )
@@ -236,8 +239,8 @@ def _attn_fwd(
     STORE_LSE: tl.constexpr,  # Whether to save LSE for backward pass
     SPARSITY_N: tl.constexpr = 0,  # N:M sparsity — keep top-N of every M elements (0 = disabled)
     SPARSITY_M: tl.constexpr = 4,  # N:M sparsity — group size (4 or 8)
-    NUM_SINK_TOKENS: tl.constexpr = 0,  # KV positions before this are kept dense (attention sinks)
-    DENSE_WINDOW_SIZE: tl.constexpr = 64,  # Tokens near diagonal kept dense (absolute, BLOCK_N-independent)
+    DENSE_SINK_TOKENS: tl.constexpr = 0,  # Leading KV tokens kept dense (attention sinks)
+    DENSE_RECENT_TOKENS: tl.constexpr = 64,  # Recent KV tokens kept dense (BLOCK_N-independent)
     APPLY_SKIP_SOFTMAX: tl.constexpr = False,  # Skip KV tiles with negligible scores
     SKIP_THRESHOLD_LOG2: tl.constexpr = 0.0,  # log2(lambda) in the kernel's scaled log2 score space
     Sparsity_total=None,  # Optional int64 scalar for counting total tiles (atomic)
@@ -293,8 +296,13 @@ def _attn_fwd(
     row_sum = tl.zeros([BLOCK_M], dtype=tl.float32)  # Running sum of exp(scores)
     acc = tl.zeros([BLOCK_M, BLOCK_D], dtype=tl.float32)  # Running weighted sum of V
 
-    # Causal bound: Q position i only attends to KV positions 0..i
-    kv_bound = seq_len_kv if not IS_CAUSAL else tl.minimum((tile_q + 1) * BLOCK_M, seq_len_kv)
+    # Causal bound: chunked/prefix prefill Q tiles are suffixes of the KV span.
+    causal_offset = seq_len_kv - seq_len_q
+    kv_bound = (
+        seq_len_kv
+        if not IS_CAUSAL
+        else tl.minimum(causal_offset + (tile_q + 1) * BLOCK_M, seq_len_kv)
+    )
 
     # --- Main loop: iterate over KV tiles ---
     for kv_start in range(0, kv_bound, BLOCK_N):
@@ -340,8 +348,8 @@ def _attn_fwd(
                 seq_len_q,
                 seq_len_kv,
                 BLOCK_M,
-                NUM_SINK_TOKENS,
-                DENSE_WINDOW_SIZE,
+                DENSE_SINK_TOKENS,
+                DENSE_RECENT_TOKENS,
             ):
                 scores = _apply_sparse_nm_to_qk_tile(
                     scores, BLOCK_M, BLOCK_N, SPARSITY_N, SPARSITY_M
@@ -500,8 +508,8 @@ def _attn_bwd_dq(
     HEAD_DIM: tl.constexpr,
     SPARSITY_N: tl.constexpr = 0,
     SPARSITY_M: tl.constexpr = 4,
-    NUM_SINK_TOKENS: tl.constexpr = 0,
-    DENSE_WINDOW_SIZE: tl.constexpr = 64,
+    DENSE_SINK_TOKENS: tl.constexpr = 0,
+    DENSE_RECENT_TOKENS: tl.constexpr = 64,
     APPLY_SKIP_SOFTMAX: tl.constexpr = False,
     SKIP_THRESHOLD_LOG2: tl.constexpr = 0.0,
 ):
@@ -546,7 +554,12 @@ def _attn_bwd_dq(
     row_delta = tl.load(Delta + row_ptrs, mask=q_mask, other=0.0)
 
     dq = tl.zeros([BLOCK_M, BLOCK_D], dtype=tl.float32)
-    kv_bound = seq_len_kv if not IS_CAUSAL else tl.minimum((tile_q + 1) * BLOCK_M, seq_len_kv)
+    causal_offset = seq_len_kv - seq_len_q
+    kv_bound = (
+        seq_len_kv
+        if not IS_CAUSAL
+        else tl.minimum(causal_offset + (tile_q + 1) * BLOCK_M, seq_len_kv)
+    )
 
     # --- Loop over KV tiles: recompute S, then compute dQ contribution ---
     for kv_start in range(0, kv_bound, BLOCK_N):
@@ -578,8 +591,8 @@ def _attn_bwd_dq(
                 seq_len_q,
                 seq_len_kv,
                 BLOCK_M,
-                NUM_SINK_TOKENS,
-                DENSE_WINDOW_SIZE,
+                DENSE_SINK_TOKENS,
+                DENSE_RECENT_TOKENS,
             ):
                 scores = _apply_sparse_nm_to_qk_tile(
                     scores, BLOCK_M, BLOCK_N, SPARSITY_N, SPARSITY_M
@@ -646,8 +659,8 @@ def _attn_bwd_dkdv(
     HEAD_DIM: tl.constexpr,
     SPARSITY_N: tl.constexpr = 0,
     SPARSITY_M: tl.constexpr = 4,
-    NUM_SINK_TOKENS: tl.constexpr = 0,
-    DENSE_WINDOW_SIZE: tl.constexpr = 64,
+    DENSE_SINK_TOKENS: tl.constexpr = 0,
+    DENSE_RECENT_TOKENS: tl.constexpr = 64,
     APPLY_SKIP_SOFTMAX: tl.constexpr = False,
     SKIP_THRESHOLD_LOG2: tl.constexpr = 0.0,
 ):
@@ -694,9 +707,9 @@ def _attn_bwd_dkdv(
     dv = tl.zeros([BLOCK_N, BLOCK_D], dtype=tl.float32)
 
     n_q_tiles = (seq_len_q + BLOCK_M - 1) // BLOCK_M
-    # Causal: Q position i attends to KV 0..i, so this KV tile (at kv_start)
-    # only receives gradients from Q tiles where q_pos >= kv_start. Skip earlier ones.
-    first_q_tile = kv_start // BLOCK_M if IS_CAUSAL else 0
+    # Causal with chunked/prefix prefill: Q positions are offset into KV space.
+    causal_offset = seq_len_kv - seq_len_q
+    first_q_tile = tl.maximum((kv_start - causal_offset) // BLOCK_M, 0) if IS_CAUSAL else 0
     q_pos_base = tl.arange(0, BLOCK_M)
 
     for qi in range(first_q_tile, n_q_tiles):
@@ -732,8 +745,8 @@ def _attn_bwd_dkdv(
                     seq_len_q,
                     seq_len_kv,
                     BLOCK_M,
-                    NUM_SINK_TOKENS,
-                    DENSE_WINDOW_SIZE,
+                    DENSE_SINK_TOKENS,
+                    DENSE_RECENT_TOKENS,
                 ):
                     scores = _apply_sparse_nm_to_qk_tile(
                         scores, BLOCK_M, BLOCK_N, SPARSITY_N, SPARSITY_M
@@ -784,10 +797,9 @@ class _Attention(torch.autograd.Function):
         max_input_len_k,
         sparsity_n,
         sparsity_m,
-        num_sink_tokens,
-        dense_window_size,
+        dense_sink_tokens,
+        dense_recent_tokens,
         skip_softmax_threshold,
-        skip_softmax_raw_threshold,
         measure_sparsity,
         k_cache,
         v_cache,
@@ -829,14 +841,8 @@ class _Attention(torch.autograd.Function):
         # Triton tiles must be powers of 2; pad head dim
         BLOCK_D = triton.next_power_of_2(HEAD_DIM)
 
-        # Skip-softmax threshold in the kernel's scaled log2 score space.
-        # Two modes:
-        #   1. raw_threshold: passed directly as skip_threshold_log2 (for testing)
-        #   2. lambda threshold: converted via log2(lambda)
-        if skip_softmax_raw_threshold is not None:
-            apply_skip = True
-            skip_threshold_log2 = skip_softmax_raw_threshold
-        elif skip_softmax_threshold is not None and skip_softmax_threshold > 0.0:
+        # Convert the public lambda threshold to the kernel's log2 score space.
+        if skip_softmax_threshold is not None and skip_softmax_threshold > 0.0:
             apply_skip = True
             # scores already include sm_scale and LOG2E, so the lambda cutoff is
             # just converted from natural-log probability space to log2 space.
@@ -879,7 +885,7 @@ class _Attention(torch.autograd.Function):
             lse.stride(0),
             lse.stride(1),
         )
-        fwd_meta = {
+        fwd_kwargs = {
             "N_CTX": max_input_len,
             "kv_group_num": kv_group_num,
             "BLOCK_D": BLOCK_D,
@@ -888,8 +894,8 @@ class _Attention(torch.autograd.Function):
             "STORE_LSE": True,
             "SPARSITY_N": sparsity_n,
             "SPARSITY_M": sparsity_m,
-            "NUM_SINK_TOKENS": num_sink_tokens,
-            "DENSE_WINDOW_SIZE": dense_window_size,
+            "DENSE_SINK_TOKENS": dense_sink_tokens,
+            "DENSE_RECENT_TOKENS": dense_recent_tokens,
             "APPLY_SKIP_SOFTMAX": apply_skip,
             "SKIP_THRESHOLD_LOG2": skip_threshold_log2,
             "Sparsity_total": sparsity_total,
@@ -918,7 +924,7 @@ class _Attention(torch.autograd.Function):
             # autotune candidate trials. Use one stable config for measurement.
             _attn_fwd.fn[grid](
                 *fwd_args,
-                **fwd_meta,
+                **fwd_kwargs,
                 BLOCK_M=_MEASURE_BLOCK_M,
                 BLOCK_N=_MEASURE_BLOCK_N,
                 num_warps=_MEASURE_NUM_WARPS,
@@ -927,7 +933,7 @@ class _Attention(torch.autograd.Function):
         else:
             _attn_fwd[grid](
                 *fwd_args,
-                **fwd_meta,
+                **fwd_kwargs,
                 # BLOCK_M, BLOCK_N, num_warps, num_stages chosen by autotune
             )
 
@@ -949,8 +955,8 @@ class _Attention(torch.autograd.Function):
         ctx.batch = batch
         ctx.sparsity_n = sparsity_n
         ctx.sparsity_m = sparsity_m
-        ctx.num_sink_tokens = num_sink_tokens
-        ctx.dense_window_size = dense_window_size
+        ctx.dense_sink_tokens = dense_sink_tokens
+        ctx.dense_recent_tokens = dense_recent_tokens
         ctx.apply_skip = apply_skip
         ctx.skip_threshold_log2 = skip_threshold_log2
         return o
@@ -1029,8 +1035,8 @@ class _Attention(torch.autograd.Function):
             HEAD_DIM=HEAD_DIM,
             SPARSITY_N=ctx.sparsity_n,
             SPARSITY_M=ctx.sparsity_m,
-            NUM_SINK_TOKENS=ctx.num_sink_tokens,
-            DENSE_WINDOW_SIZE=ctx.dense_window_size,
+            DENSE_SINK_TOKENS=ctx.dense_sink_tokens,
+            DENSE_RECENT_TOKENS=ctx.dense_recent_tokens,
             APPLY_SKIP_SOFTMAX=ctx.apply_skip,
             SKIP_THRESHOLD_LOG2=ctx.skip_threshold_log2,
             num_warps=num_warps,
@@ -1054,8 +1060,8 @@ class _Attention(torch.autograd.Function):
             HEAD_DIM=HEAD_DIM,
             SPARSITY_N=ctx.sparsity_n,
             SPARSITY_M=ctx.sparsity_m,
-            NUM_SINK_TOKENS=ctx.num_sink_tokens,
-            DENSE_WINDOW_SIZE=ctx.dense_window_size,
+            DENSE_SINK_TOKENS=ctx.dense_sink_tokens,
+            DENSE_RECENT_TOKENS=ctx.dense_recent_tokens,
             APPLY_SKIP_SOFTMAX=ctx.apply_skip,
             SKIP_THRESHOLD_LOG2=ctx.skip_threshold_log2,
             num_warps=num_warps,
@@ -1076,10 +1082,9 @@ class _Attention(torch.autograd.Function):
             None,  # max_input_len_k
             None,  # sparsity_n
             None,  # sparsity_m
-            None,  # num_sink_tokens
-            None,  # dense_window_size
+            None,  # dense_sink_tokens
+            None,  # dense_recent_tokens
             None,  # skip_softmax_threshold
-            None,  # skip_softmax_raw_threshold
             None,  # measure_sparsity
             None,  # k_cache
             None,  # v_cache
@@ -1103,10 +1108,9 @@ def attention(
     *,
     sparsity_n: int = 0,
     sparsity_m: int = 4,
-    num_sink_tokens: int = 0,
-    dense_window_size: int = 64,
+    dense_sink_tokens: int = 0,
+    dense_recent_tokens: int = 64,
     skip_softmax_threshold: float | None = None,
-    skip_softmax_raw_threshold: float | None = None,
     measure_sparsity: bool = False,
     k_cache: torch.Tensor | None = None,
     v_cache: torch.Tensor | None = None,
@@ -1132,22 +1136,15 @@ def attention(
             ``sparsity_n=2, sparsity_m=4`` for 2:4 sparsity;
             ``sparsity_n=4, sparsity_m=8`` for 4:8 sparsity.
         sparsity_m: N:M sparsity — group size (4 or 8).
-        num_sink_tokens: KV positions before this token index are kept dense
-            (attention sinks). Absolute token count, BLOCK_N-independent.
-        dense_window_size: Tokens near the query diagonal kept dense (local
-            attention window). Absolute token count, BLOCK_N-independent.
-            Default 64 tokens.
+        dense_sink_tokens: Leading KV tokens excluded from N:M sparsity and kept dense.
+            Absolute token count, BLOCK_N-independent.
+        dense_recent_tokens: Recent KV tokens excluded from N:M sparsity and kept dense.
+            Absolute token count, BLOCK_N-independent. Default 64 tokens.
         skip_softmax_threshold: BLASST threshold lambda
             (https://arxiv.org/pdf/2512.12087). Skip KV tiles where
             ``exp(tile_max - running_max) < lambda``, meaning the tile's
             softmax contribution is negligible. Tiles are skipped entirely
             (no softmax, V load, or BMM2). Set to ``None`` or ``0`` to disable.
-        skip_softmax_raw_threshold: Raw ``skip_threshold_log2`` value passed
-            directly to the kernel without conversion. The kernel skips tiles
-            where ``tile_row_max < row_max + raw_threshold``. Typical values
-            are negative (e.g., ``-5.0`` means tiles must be within 5 units of
-            the running max in the kernel's scaled score space). Takes
-            precedence over ``skip_softmax_threshold`` when both are set.
         measure_sparsity: When True and skip-softmax is active, count total
             and skipped tiles via atomic counters. The counts are stored as
             ``_sparsity_total`` and ``_sparsity_skipped`` attributes on the
@@ -1185,10 +1182,9 @@ def attention(
         max_input_len_k,
         sparsity_n,
         sparsity_m,
-        num_sink_tokens,
-        dense_window_size,
+        dense_sink_tokens,
+        dense_recent_tokens,
         skip_softmax_threshold,
-        skip_softmax_raw_threshold,
         measure_sparsity,
         k_cache,
         v_cache,

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -234,7 +234,7 @@ def _attn_fwd(
     NUM_SINK_TOKENS: tl.constexpr = 0,  # KV positions before this are kept dense (attention sinks)
     DENSE_WINDOW_SIZE: tl.constexpr = 64,  # Tokens near diagonal kept dense (absolute, BLOCK_N-independent)
     APPLY_SKIP_SOFTMAX: tl.constexpr = False,  # Skip KV tiles with negligible scores
-    SKIP_THRESHOLD_LOG2: tl.constexpr = 0.0,  # log2(lambda) * sm_scale, pre-scaled for comparison on scaled scores
+    SKIP_THRESHOLD_LOG2: tl.constexpr = 0.0,  # log2(lambda) in the kernel's scaled log2 score space
     Sparsity_total=None,  # Optional int64 scalar for counting total tiles (atomic)
     Sparsity_skipped=None,  # Optional int64 scalar for counting skipped tiles (atomic)
     MEASURE_SPARSITY: tl.constexpr = False,  # When True, count total/skipped tiles via atomic adds
@@ -824,20 +824,18 @@ class _Attention(torch.autograd.Function):
         # Triton tiles must be powers of 2; pad head dim
         BLOCK_D = triton.next_power_of_2(HEAD_DIM)
 
-        # Skip-softmax threshold in scaled log2 space for the kernel.
+        # Skip-softmax threshold in the kernel's scaled log2 score space.
         # Two modes:
         #   1. raw_threshold: passed directly as skip_threshold_log2 (for testing)
-        #   2. lambda threshold: converted via log2(lambda) * sm_scale
+        #   2. lambda threshold: converted via log2(lambda)
         if skip_softmax_raw_threshold is not None:
             apply_skip = True
             skip_threshold_log2 = skip_softmax_raw_threshold
         elif skip_softmax_threshold is not None and skip_softmax_threshold > 0.0:
             apply_skip = True
-            # The BLASST reference (https://arxiv.org/pdf/2512.12087) checks
-            # ln(lambda) on unscaled scores. Our kernel works in log2-scaled space
-            # (scores pre-multiplied by qk_scale = sm_scale * LOG2E), so we
-            # pre-scale: threshold_scaled = log2(lambda) * sm_scale.
-            skip_threshold_log2 = math.log2(skip_softmax_threshold) * sm_scale
+            # scores already include sm_scale and LOG2E, so the lambda cutoff is
+            # just converted from natural-log probability space to log2 space.
+            skip_threshold_log2 = math.log2(skip_softmax_threshold)
         else:
             apply_skip = False
             skip_threshold_log2 = 0.0
@@ -1119,8 +1117,7 @@ def attention(
             (https://arxiv.org/pdf/2512.12087). Skip KV tiles where
             ``exp(tile_max - running_max) < lambda``, meaning the tile's
             softmax contribution is negligible. Tiles are skipped entirely
-            (no softmax, V load, or BMM2). The threshold is applied on
-            unscaled scores. Set to ``None`` or ``0`` to disable.
+            (no softmax, V load, or BMM2). Set to ``None`` or ``0`` to disable.
         skip_softmax_raw_threshold: Raw ``skip_threshold_log2`` value passed
             directly to the kernel without conversion. The kernel skips tiles
             where ``tile_row_max < row_max + raw_threshold``. Typical values

--- a/modelopt/torch/kernels/sparsity/attention/calibrate.py
+++ b/modelopt/torch/kernels/sparsity/attention/calibrate.py
@@ -261,9 +261,9 @@ def attention_calibrate(
 
     num_thresholds = len(threshold_trials)
 
-    # Convert thresholds to log2-scaled space: log2(lambda) * sm_scale
+    # Scores already include sm_scale and LOG2E; convert lambda to log2 space only.
     threshold_tensor = torch.tensor(
-        [math.log2(t) * sm_scale for t in threshold_trials],
+        [math.log2(t) for t in threshold_trials],
         dtype=torch.float32,
         device=q.device,
     )

--- a/modelopt/torch/kernels/sparsity/attention/diffusers_triton_attention.py
+++ b/modelopt/torch/kernels/sparsity/attention/diffusers_triton_attention.py
@@ -53,7 +53,6 @@ def set_triton_skip_softmax_config(
     calibration_mode: bool = False,
     threshold_trials: list[float] | None = None,
     scale_factor: float | None = None,
-    raw_threshold: float | None = None,
     measure_sparsity: bool = False,
 ) -> None:
     """Set thread-local skip-softmax config for the next Triton attention call.
@@ -67,8 +66,6 @@ def set_triton_skip_softmax_config(
         scale_factor: Calibrated scale factor for dynamic threshold computation.
             When set, the actual threshold is computed as ``scale_factor / seq_k``
             at attention call time, adapting to the actual sequence length.
-        raw_threshold: Raw ``skip_threshold_log2`` value passed directly to the
-            kernel without conversion. Takes precedence over other thresholds.
         measure_sparsity: If True, count total and skipped tiles during
             inference via atomic counters in the forward kernel.
     """
@@ -76,7 +73,6 @@ def set_triton_skip_softmax_config(
     _thread_local.calibration_mode = calibration_mode
     _thread_local.threshold_trials = threshold_trials
     _thread_local.scale_factor = scale_factor
-    _thread_local.raw_threshold = raw_threshold
     _thread_local.measure_sparsity = measure_sparsity
     # Accumulated counters across all attention calls in one forward pass
     _thread_local.calibration_counters = None
@@ -92,7 +88,6 @@ def clear_triton_skip_softmax_config() -> None:
     _thread_local.calibration_mode = False
     _thread_local.threshold_trials = None
     _thread_local.scale_factor = None
-    _thread_local.raw_threshold = None
     _thread_local.measure_sparsity = False
     _thread_local.calibration_counters = None
     _thread_local.calibration_seq_k = None
@@ -186,20 +181,15 @@ def _diffusers_triton_attention(
 
             return o.view(batch, seq_q, num_heads_q, head_dim)
 
-    # --- Inference mode: skip-softmax with raw, dynamic, or static threshold ---
-    raw_thresh = getattr(_thread_local, "raw_threshold", None)
-    if raw_thresh is not None:
-        # Raw threshold: passed directly to kernel as skip_threshold_log2
-        kw["skip_softmax_raw_threshold"] = raw_thresh
+    # --- Inference mode: skip-softmax with dynamic or static threshold ---
+    scale_factor = getattr(_thread_local, "scale_factor", None)
+    if scale_factor is not None and scale_factor > 0.0:
+        # Dynamic threshold: adapt to actual sequence length.
+        kw["skip_softmax_threshold"] = scale_factor / seq_k
     else:
-        scale_factor = getattr(_thread_local, "scale_factor", None)
-        if scale_factor is not None and scale_factor > 0.0:
-            # Dynamic threshold: adapt to actual sequence length
-            kw["skip_softmax_threshold"] = scale_factor / seq_k
-        else:
-            threshold = getattr(_thread_local, "skip_threshold", None)
-            if threshold is not None and threshold > 0.0:
-                kw["skip_softmax_threshold"] = threshold
+        threshold = getattr(_thread_local, "skip_threshold", None)
+        if threshold is not None and threshold > 0.0:
+            kw["skip_softmax_threshold"] = threshold
 
     from modelopt.torch.kernels.common.attention import attention
 

--- a/modelopt/torch/kernels/sparsity/attention/ltx_triton_attention.py
+++ b/modelopt/torch/kernels/sparsity/attention/ltx_triton_attention.py
@@ -41,7 +41,6 @@ def set_ltx_triton_context(
     calibration_mode: bool = False,
     threshold_trials: list[float] | None = None,
     scale_factor: float | None = None,
-    raw_threshold: float | None = None,
     **kwargs,
 ) -> None:
     """Set thread-local Triton config for LTX-2 attention."""
@@ -50,7 +49,6 @@ def set_ltx_triton_context(
     _thread_local.calibration_mode = calibration_mode
     _thread_local.threshold_trials = threshold_trials
     _thread_local.scale_factor = scale_factor
-    _thread_local.raw_threshold = raw_threshold
     if not calibration_mode:
         _thread_local.calibration_counters = None
     _thread_local.calibration_seq_k = None
@@ -63,7 +61,6 @@ def clear_ltx_triton_context() -> None:
     _thread_local.calibration_mode = False
     _thread_local.threshold_trials = None
     _thread_local.scale_factor = None
-    _thread_local.raw_threshold = None
     _thread_local.calibration_counters = None
     _thread_local.calibration_seq_k = None
 
@@ -145,12 +142,9 @@ def _ltx_triton_attention(
 
             return o.view(b, seq_q, heads * dim_head)
 
-    # --- Inference mode: raw, dynamic, or static threshold ---
-    raw_thresh = getattr(_thread_local, "raw_threshold", None)
+    # --- Inference mode: dynamic or static threshold ---
     scale_factor = getattr(_thread_local, "scale_factor", None)
-    if raw_thresh is not None:
-        kw["skip_softmax_raw_threshold"] = raw_thresh
-    elif scale_factor is not None and scale_factor > 0.0:
+    if scale_factor is not None and scale_factor > 0.0:
         kw["skip_softmax_threshold"] = scale_factor / seq_k
     elif threshold is not None and threshold > 0.0:
         kw["skip_softmax_threshold"] = threshold

--- a/modelopt/torch/kernels/sparsity/attention/skip_softmax_helpers.py
+++ b/modelopt/torch/kernels/sparsity/attention/skip_softmax_helpers.py
@@ -189,8 +189,8 @@ def _is_dense_region(
     seq_len_q,
     seq_len_kv,
     BLOCK_M: tl.constexpr,
-    NUM_SINK_TOKENS: tl.constexpr,
-    DENSE_WINDOW_SIZE: tl.constexpr,
+    DENSE_SINK_TOKENS: tl.constexpr,
+    DENSE_RECENT_TOKENS: tl.constexpr,
 ):
     """Check if a KV tile falls in a dense region (sink tokens or local window).
 
@@ -200,9 +200,9 @@ def _is_dense_region(
     Returns:
         True if the tile should be kept dense (skip N:M sparsification).
     """
-    is_sink = kv_start < NUM_SINK_TOKENS
+    is_sink = kv_start < DENSE_SINK_TOKENS
     causal_offset = seq_len_kv - seq_len_q
     q_abs_pos = tile_q * BLOCK_M + causal_offset
     token_distance = q_abs_pos - kv_start
-    is_local = (token_distance >= 0) and (token_distance < DENSE_WINDOW_SIZE)
+    is_local = (token_distance >= 0) and (token_distance < DENSE_RECENT_TOKENS)
     return is_sink or is_local

--- a/modelopt/torch/kernels/sparsity/attention/skip_softmax_helpers.py
+++ b/modelopt/torch/kernels/sparsity/attention/skip_softmax_helpers.py
@@ -200,9 +200,12 @@ def _is_dense_region(
     Returns:
         True if the tile should be kept dense (skip N:M sparsification).
     """
+    # N:M sparse softmax is a prefill optimization. Keep decode rows dense,
+    # including decode rows that are scheduled in a mixed prefill/decode launch.
+    is_decode = seq_len_q <= 1
     is_sink = kv_start < DENSE_SINK_TOKENS
     causal_offset = seq_len_kv - seq_len_q
     q_abs_pos = tile_q * BLOCK_M + causal_offset
     token_distance = q_abs_pos - kv_start
     is_local = (token_distance >= 0) and (token_distance < DENSE_RECENT_TOKENS)
-    return is_sink or is_local
+    return is_decode or is_sink or is_local

--- a/modelopt/torch/kernels/sparsity/attention/skip_softmax_helpers.py
+++ b/modelopt/torch/kernels/sparsity/attention/skip_softmax_helpers.py
@@ -156,8 +156,8 @@ def _skip_softmax_decision(
     < lambda ~= 0`` and the block's contribution to the output is negligible.
     The caller may then skip the softmax computation, V load, and BMM2.
 
-    The threshold is pre-scaled to log2 space by the Python wrapper so it can
-    be compared directly against the already-scaled scores.
+    The threshold is converted to the kernel's scaled log2 score space by the
+    Python wrapper so it can be compared directly against ``scores``.
 
     Returns:
         True when *all* Q rows in the tile satisfy the skip criterion.

--- a/modelopt/torch/sparsity/attention_sparsity/config.py
+++ b/modelopt/torch/sparsity/attention_sparsity/config.py
@@ -100,32 +100,48 @@ class SparseAttentionAttributeConfig(ModeloptBaseConfig):
         default=2,
         title="N in N:M sparsity.",
         description=(
-            "Keep top-N of every M attention scores. Only used by triton_sparse_softmax. "
-            "Set to 0 to disable sparsity."
+            "Keep top-N of every M attention scores. Used by triton_sparse_softmax, "
+            "or exported for vLLM restore when export_sparse_softmax is True. Set to 0 "
+            "to disable sparsity."
         ),
     )
 
     sparsity_m: int = ModeloptField(
         default=4,
         title="M in N:M sparsity.",
-        description="Group size for N:M sparsity (4 or 8). Only used by triton_sparse_softmax.",
-    )
-
-    num_sink_tokens: int = ModeloptField(
-        default=0,
-        title="Number of sink tokens.",
         description=(
-            "KV positions before this index are kept dense (attention sinks). "
-            "Absolute token count. Only used by triton_sparse_softmax."
+            "Group size for N:M sparsity (4 or 8). Used by triton_sparse_softmax, "
+            "or exported for vLLM restore when export_sparse_softmax is True."
         ),
     )
 
-    dense_window_size: int = ModeloptField(
-        default=64,
-        title="Dense window size in tokens.",
+    dense_sink_tokens: int = ModeloptField(
+        default=0,
+        title="Dense sink tokens.",
         description=(
-            "Tokens near the query diagonal kept dense (local attention window). "
-            "Absolute token count. Default 64. Only used by triton_sparse_softmax."
+            "Number of leading KV tokens excluded from N:M sparsity and kept dense "
+            "(attention sinks). Used by triton_sparse_softmax, or exported for vLLM "
+            "restore when export_sparse_softmax is True."
+        ),
+    )
+
+    dense_recent_tokens: int = ModeloptField(
+        default=64,
+        title="Dense recent tokens.",
+        description=(
+            "Number of recent KV tokens excluded from N:M sparsity and kept dense. "
+            "Default 64. Used by triton_sparse_softmax, or exported for vLLM restore "
+            "when export_sparse_softmax is True."
+        ),
+    )
+
+    export_sparse_softmax: bool = ModeloptField(
+        default=False,
+        title="Export N:M sparse-softmax metadata.",
+        description=(
+            "If True, HF export records sparsity_n/sparsity_m metadata even when "
+            "the active sparse attention method is skip-softmax. This is used by "
+            "vLLM to restore combined skip-softmax plus N:M sparse softmax."
         ),
     )
 
@@ -136,17 +152,6 @@ class SparseAttentionAttributeConfig(ModeloptBaseConfig):
             "Tiles contributing less than this fraction are skipped entirely. "
             "Only used by triton_skip_softmax. Typical values: 1e-3 to 1e-1. "
             "Set to 0 to disable."
-        ),
-    )
-
-    skip_softmax_raw_threshold: float | None = ModeloptField(
-        default=None,
-        title="Raw skip-softmax threshold (skip_threshold_log2).",
-        description=(
-            "Raw value passed directly to the Triton kernel as skip_threshold_log2. "
-            "The kernel skips tiles where tile_row_max < row_max + raw_threshold. "
-            "Typical values are negative (e.g., -5.0). Takes precedence over "
-            "skip_softmax_threshold and calibration when set."
         ),
     )
 
@@ -186,20 +191,20 @@ class SparseAttentionAttributeConfig(ModeloptBaseConfig):
             raise ValueError(f"sparsity_n must be >= 0, got {v}")
         return v
 
-    @field_validator("num_sink_tokens")
+    @field_validator("dense_sink_tokens")
     @classmethod
-    def validate_num_sink_tokens(cls, v):
-        """Validate num_sink_tokens is non-negative."""
+    def validate_dense_sink_tokens(cls, v):
+        """Validate dense_sink_tokens is non-negative."""
         if v < 0:
-            raise ValueError(f"num_sink_tokens must be >= 0, got {v}")
+            raise ValueError(f"dense_sink_tokens must be >= 0, got {v}")
         return v
 
-    @field_validator("dense_window_size")
+    @field_validator("dense_recent_tokens")
     @classmethod
-    def validate_dense_window_size(cls, v):
-        """Validate dense_window_size is non-negative."""
+    def validate_dense_recent_tokens(cls, v):
+        """Validate dense_recent_tokens is non-negative."""
         if v < 0:
-            raise ValueError(f"dense_window_size must be >= 0, got {v}")
+            raise ValueError(f"dense_recent_tokens must be >= 0, got {v}")
         return v
 
     @field_validator("br", "bc")
@@ -678,9 +683,36 @@ SPARSE_SOFTMAX_DEFAULT = {
             "method": "triton_sparse_softmax",
             "sparsity_n": 2,
             "sparsity_m": 4,
-            "num_sink_tokens": 0,
-            "dense_window_size": 64,
+            "dense_sink_tokens": 0,
+            "dense_recent_tokens": 64,
             "backend": "triton",
+            "enable": True,
+        },
+        "default": {"enable": False},
+    },
+}
+
+
+# Calibrated skip-softmax with 2:4 sparse-softmax metadata for vLLM restore.
+SKIP_SOFTMAX_CALIB_SPARSE24 = {
+    "sparse_cfg": {
+        "calibration": {
+            "target_sparse_ratio": {"prefill": 0.5, "decode": 0.5},
+            "samples": 64,
+            "max_seqlen": 16384,
+            "chunk_size": 4096,
+        },
+        "*attn*": {
+            "method": "flash_skip_softmax",
+            "br": 128,
+            "bc": 128,
+            "backend": "pytorch",
+            "collect_stats": True,
+            "sparsity_n": 2,
+            "sparsity_m": 4,
+            "dense_sink_tokens": 0,
+            "dense_recent_tokens": 64,
+            "export_sparse_softmax": True,
             "enable": True,
         },
         "default": {"enable": False},
@@ -704,6 +736,7 @@ SKIP_SOFTMAX_TRITON_DEFAULT = {
 
 __all__ = [
     "SKIP_SOFTMAX_CALIB",
+    "SKIP_SOFTMAX_CALIB_SPARSE24",
     "SKIP_SOFTMAX_DEFAULT",
     "SKIP_SOFTMAX_TRITON_DEFAULT",
     "SPARSE_SOFTMAX_DEFAULT",

--- a/modelopt/torch/sparsity/attention_sparsity/conversion.py
+++ b/modelopt/torch/sparsity/attention_sparsity/conversion.py
@@ -379,6 +379,7 @@ def export_sparse_attention_config(model: nn.Module) -> dict[str, Any] | None:
     """
     # Collect sparse attention module info
     calibration_params = None
+    target_sparse_ratio = None
     target_classes: set[str] = set()
 
     for module in get_sparse_attention_modules(model):
@@ -391,6 +392,10 @@ def export_sparse_attention_config(model: nn.Module) -> dict[str, Any] | None:
         # Get calibration params from first module that has them
         if calibration_params is None:
             calibration_params = getattr(module._sparse_method_instance, "calibration_params", None)
+        if target_sparse_ratio is None:
+            target_sparse_ratio = getattr(
+                module._sparse_method_instance, "target_sparse_ratio", None
+            )
 
     # Return None if no calibration params found
     if calibration_params is None:
@@ -421,6 +426,8 @@ def export_sparse_attention_config(model: nn.Module) -> dict[str, Any] | None:
             "version": mo_version,
         },
     }
+    if target_sparse_ratio is not None:
+        export_config["target_sparse_ratio"] = target_sparse_ratio
 
     return export_config
 

--- a/modelopt/torch/sparsity/attention_sparsity/conversion.py
+++ b/modelopt/torch/sparsity/attention_sparsity/conversion.py
@@ -31,6 +31,13 @@ from .plugins import register_custom_model_plugins_on_the_fly
 from .sparse_attention import SparseAttentionModule, SparseAttentionRegistry
 from .utils import get_named_sparse_attention_modules, get_sparse_attention_modules
 
+SPARSE_SOFTMAX_METADATA_KEYS = (
+    "sparsity_n",
+    "sparsity_m",
+    "dense_sink_tokens",
+    "dense_recent_tokens",
+)
+
 
 def _set_attn_implementation(model: nn.Module, config: SparseAttentionConfig) -> None:
     """Set the correct attn_implementation based on the sparse attention method/backend.
@@ -346,11 +353,29 @@ def update_sparse_attention_metadata(
     )
 
 
+def _get_sparse_softmax_export_config(module: SparseAttentionModule) -> dict[str, Any] | None:
+    """Return N:M sparse-softmax export metadata for one sparse attention module."""
+    method_config = getattr(module, "_method_config", {})
+    method_name = module._sparse_method_instance.name
+    should_export = method_name == "triton_sparse_softmax" or method_config.get(
+        "export_sparse_softmax", False
+    )
+    if not should_export:
+        return None
+
+    sparse_softmax_config = {
+        key: method_config[key] for key in SPARSE_SOFTMAX_METADATA_KEYS if key in method_config
+    }
+    if sparse_softmax_config.get("sparsity_n", 0) <= 0:
+        return None
+    return sparse_softmax_config
+
+
 def export_sparse_attention_config(model: nn.Module) -> dict[str, Any] | None:
     """Extract sparse attention config for export to config.json.
 
-    Extracts the calibration parameters (a, b) for the exponential threshold model
-    from the first sparse attention module that has calibrated thresholds.
+    Extracts calibrated skip-softmax parameters and N:M sparse-softmax metadata
+    from sparse attention modules.
 
     The exported config allows computing threshold at runtime:
         scale_factor = a * exp(b * target_sparsity)
@@ -361,7 +386,7 @@ def export_sparse_attention_config(model: nn.Module) -> dict[str, Any] | None:
 
     Returns:
         Dictionary with sparse attention config for HuggingFace config.json export.
-        Returns None if no calibrated sparse attention modules found.
+        Returns None if no exportable sparse attention metadata is found.
 
     Example output::
 
@@ -374,12 +399,19 @@ def export_sparse_attention_config(model: nn.Module) -> dict[str, Any] | None:
                 "prefill": {"a": 7.93, "b": 8.61},
                 "decode": {"a": 0.12, "b": 9.85},
             },
+            "sparse_softmax": {
+                "sparsity_n": 2,
+                "sparsity_m": 4,
+                "dense_sink_tokens": 0,
+                "dense_recent_tokens": 64,
+            },
             "producer": {"name": "modelopt", "version": "0.37.0"},
         }
     """
     # Collect sparse attention module info
     calibration_params = None
     target_sparse_ratio = None
+    sparse_softmax_config = None
     target_classes: set[str] = set()
 
     for module in get_sparse_attention_modules(model):
@@ -396,38 +428,53 @@ def export_sparse_attention_config(model: nn.Module) -> dict[str, Any] | None:
             target_sparse_ratio = getattr(
                 module._sparse_method_instance, "target_sparse_ratio", None
             )
+        if sparse_softmax_config is None:
+            sparse_softmax_config = _get_sparse_softmax_export_config(module)
 
-    # Return None if no calibration params found
-    if calibration_params is None:
+    if calibration_params is None and sparse_softmax_config is None:
         return None
 
-    # Build threshold_scale_factor with model parameters
-    threshold_scale_factor: dict[str, Any] = {
-        "formula": "a * exp(b * target_sparsity)",
-    }
-    for phase in ["prefill", "decode"]:
-        if phase in calibration_params:
-            threshold_scale_factor[phase] = {
-                "a": calibration_params[phase]["a"],
-                "b": calibration_params[phase]["b"],
-            }
+    targets = sorted(target_classes) if target_classes else ["Attention"]
+    config_groups = {}
+    group_idx = 0
+    if calibration_params is not None:
+        config_groups[f"group_{group_idx}"] = {
+            "sparse_algo": "softmax_skip",
+            "targets": targets,
+        }
+        group_idx += 1
+    if sparse_softmax_config is not None:
+        config_groups[f"group_{group_idx}"] = {
+            "sparse_algo": "sparse_softmax",
+            "targets": targets,
+        }
 
     # Build the export config
     export_config: dict[str, Any] = {
-        "config_groups": {
-            "group_0": {
-                "sparse_algo": "softmax_skip",
-                "targets": sorted(target_classes) if target_classes else ["Attention"],
-            }
-        },
-        "threshold_scale_factor": threshold_scale_factor,
+        "config_groups": config_groups,
         "producer": {
             "name": "modelopt",
             "version": mo_version,
         },
     }
-    if target_sparse_ratio is not None:
+
+    if calibration_params is not None:
+        # Build threshold_scale_factor with model parameters
+        threshold_scale_factor: dict[str, Any] = {
+            "formula": "a * exp(b * target_sparsity)",
+        }
+        for phase in ["prefill", "decode"]:
+            if phase in calibration_params:
+                threshold_scale_factor[phase] = {
+                    "a": calibration_params[phase]["a"],
+                    "b": calibration_params[phase]["b"],
+                }
+        export_config["threshold_scale_factor"] = threshold_scale_factor
+
+    if calibration_params is not None and target_sparse_ratio is not None:
         export_config["target_sparse_ratio"] = target_sparse_ratio
+    if sparse_softmax_config is not None:
+        export_config["sparse_softmax"] = sparse_softmax_config
 
     return export_config
 

--- a/modelopt/torch/sparsity/attention_sparsity/methods/triton_skip_softmax.py
+++ b/modelopt/torch/sparsity/attention_sparsity/methods/triton_skip_softmax.py
@@ -47,9 +47,6 @@ class TritonSkipSoftmaxMethod(SparseAttentionMethod):
         super().__init__()
         method_config = method_config or {}
         self.skip_softmax_threshold = method_config.get("skip_softmax_threshold", 0.1)
-        self.skip_softmax_raw_threshold: float | None = method_config.get(
-            "skip_softmax_raw_threshold", None
-        )
         # Calibration state
         self._threshold_trials: list[float] | None = None
         # Runtime sparsity measurement
@@ -94,17 +91,12 @@ class TritonSkipSoftmaxMethod(SparseAttentionMethod):
         if self._measure_sparsity:
             backend_kwargs["measure_sparsity"] = True
 
-        # Priority: raw_threshold > scale_factor (calibrated) > static threshold
-        if self.skip_softmax_raw_threshold is not None:
-            self._set_triton_backends(
-                raw_threshold=self.skip_softmax_raw_threshold, **backend_kwargs
-            )
+        # Priority: calibrated dynamic threshold > static threshold.
+        scale_factor = self._get_scale_factor()
+        if scale_factor is not None:
+            self._set_triton_backends(scale_factor=scale_factor, **backend_kwargs)
         else:
-            scale_factor = self._get_scale_factor()
-            if scale_factor is not None:
-                self._set_triton_backends(scale_factor=scale_factor, **backend_kwargs)
-            else:
-                self._set_triton_backends(threshold=self.skip_softmax_threshold, **backend_kwargs)
+            self._set_triton_backends(threshold=self.skip_softmax_threshold, **backend_kwargs)
         with self._get_diffusers_backend_context():
             try:
                 yield

--- a/modelopt/torch/sparsity/attention_sparsity/methods/triton_sparse_softmax.py
+++ b/modelopt/torch/sparsity/attention_sparsity/methods/triton_sparse_softmax.py
@@ -32,8 +32,8 @@ class TritonSparseSoftmaxMethod(SparseAttentionMethod):
     Config params:
         sparsity_n: Keep top-N of every M attention scores (0 to disable).
         sparsity_m: Group size (4 or 8).
-        num_sink_tokens: KV positions before this index kept dense (attention sinks).
-        dense_window_size: Tokens near diagonal kept dense (absolute token count).
+        dense_sink_tokens: Leading KV tokens excluded from N:M sparsity and kept dense.
+        dense_recent_tokens: Recent KV tokens excluded from N:M sparsity and kept dense.
     """
 
     def __init__(self, method_config=None):
@@ -42,8 +42,8 @@ class TritonSparseSoftmaxMethod(SparseAttentionMethod):
         method_config = method_config or {}
         self.sparsity_n = method_config.get("sparsity_n", 2)
         self.sparsity_m = method_config.get("sparsity_m", 4)
-        self.num_sink_tokens = method_config.get("num_sink_tokens", 0)
-        self.dense_window_size = method_config.get("dense_window_size", 64)
+        self.dense_sink_tokens = method_config.get("dense_sink_tokens", 0)
+        self.dense_recent_tokens = method_config.get("dense_recent_tokens", 64)
 
     @property
     def name(self) -> str:

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/__init__.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/__init__.py
@@ -15,6 +15,8 @@
 
 """Plugins for sparse attention integration with various frameworks."""
 
+from modelopt.torch.utils import import_plugin
+
 # List of model plugins that are called during conversion
 # Each plugin is a callable that takes (model) and performs validation/setup
 CUSTOM_MODEL_PLUGINS: list = []

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/__init__.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/__init__.py
@@ -15,8 +15,6 @@
 
 """Plugins for sparse attention integration with various frameworks."""
 
-from modelopt.torch.utils import import_plugin
-
 # List of model plugins that are called during conversion
 # Each plugin is a callable that takes (model) and performs validation/setup
 CUSTOM_MODEL_PLUGINS: list = []

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/sparse_attn_config.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/sparse_attn_config.py
@@ -34,6 +34,13 @@ ALGO_TO_PRESET = {
 }
 
 DEFAULT_TARGET_SPARSE_RATIO = {"prefill": 0.5, "decode": 0.5}
+SPARSE_SOFTMAX_ALGOS = {"sparse_softmax", "triton_sparse_softmax"}
+SPARSE_SOFTMAX_DEFAULTS = {
+    "sparsity_n": 2,
+    "sparsity_m": 4,
+    "dense_sink_tokens": 0,
+    "dense_recent_tokens": 64,
+}
 
 
 def _normalize_target_sparse_ratio(value) -> dict[str, float]:
@@ -60,6 +67,34 @@ def _has_calibrated_threshold_scale_factor(value) -> bool:
     return False
 
 
+def _has_sparse_softmax_algo(algos: set[str | None]) -> bool:
+    """Return True if checkpoint metadata requests N:M sparse softmax."""
+    return bool(algos & SPARSE_SOFTMAX_ALGOS)
+
+
+def _sparse_softmax_params(sparse_meta: dict, config_groups: dict) -> dict:
+    """Resolve N:M sparse-softmax params from checkpoint metadata."""
+    params = SPARSE_SOFTMAX_DEFAULTS.copy()
+    exported_params = sparse_meta.get("sparse_softmax")
+    if isinstance(exported_params, dict):
+        params.update(
+            {key: exported_params[key] for key in SPARSE_SOFTMAX_DEFAULTS if key in exported_params}
+        )
+        return params
+
+    for group in config_groups.values():
+        if not isinstance(group, dict) or group.get("sparse_algo") not in SPARSE_SOFTMAX_ALGOS:
+            continue
+        params.update({key: group[key] for key in SPARSE_SOFTMAX_DEFAULTS if key in group})
+        return params
+    return params
+
+
+def _add_sparse_softmax_params(layer_cfg: dict, sparse_meta: dict, config_groups: dict) -> None:
+    """Add N:M sparse-softmax params to a vLLM layer config."""
+    layer_cfg.update(_sparse_softmax_params(sparse_meta, config_groups))
+
+
 def _build_calibrated_softmax_skip_config(sparse_meta: dict) -> dict:
     """Build a vLLM Triton sparse config from exported calibration metadata."""
     return {
@@ -73,6 +108,22 @@ def _build_calibrated_softmax_skip_config(sparse_meta: dict) -> dict:
                 "backend": "triton",
                 "enable": True,
             },
+            "default": {"enable": False},
+        },
+    }
+
+
+def _build_sparse_softmax_config(sparse_meta: dict, config_groups: dict) -> dict:
+    """Build a vLLM Triton N:M sparse-softmax config from exported metadata."""
+    layer_cfg = {
+        "method": "triton_sparse_softmax",
+        "backend": "triton",
+        "enable": True,
+    }
+    _add_sparse_softmax_params(layer_cfg, sparse_meta, config_groups)
+    return {
+        "sparse_cfg": {
+            "*attn*": layer_cfg,
             "default": {"enable": False},
         },
     }
@@ -123,9 +174,14 @@ def load_from_checkpoint_metadata(hf_config) -> tuple[dict, str] | None:
     if "softmax_skip" in algos and _has_calibrated_threshold_scale_factor(
         sparse_meta.get("threshold_scale_factor")
     ):
-        return _build_calibrated_softmax_skip_config(
-            sparse_meta
-        ), "CHECKPOINT_CALIBRATED_SOFTMAX_SKIP"
+        cfg = _build_calibrated_softmax_skip_config(sparse_meta)
+        if _has_sparse_softmax_algo(algos):
+            layer_cfg = cfg["sparse_cfg"]["*attn*"]
+            _add_sparse_softmax_params(layer_cfg, sparse_meta, config_groups)
+            return cfg, "CHECKPOINT_CALIBRATED_SOFTMAX_SKIP_SPARSE_SOFTMAX"
+        return cfg, "CHECKPOINT_CALIBRATED_SOFTMAX_SKIP"
+    if _has_sparse_softmax_algo(algos):
+        return _build_sparse_softmax_config(sparse_meta, config_groups), "CHECKPOINT_SPARSE_SOFTMAX"
     for algo, preset_name in ALGO_TO_PRESET.items():
         if algo in algos:
             preset = getattr(mtsa, preset_name, None)

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/sparse_attn_config.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/sparse_attn_config.py
@@ -21,21 +21,61 @@ it installed.
 
 - ``match_sparse_config`` — fnmatch a module name against a sparse_cfg dict.
 - ``load_from_checkpoint_metadata`` — read ``sparse_attention_config`` from a
-  HF config and map ``sparse_algo`` to an mtsa preset.
+  HF config and resolve it to a serving sparse_cfg.
 """
 
 import fnmatch
 
 import modelopt.torch.sparsity.attention_sparsity as mtsa
 
-# Maps ``sparse_algo`` values written by ``export_sparse_attention_config`` into
-# the checkpoint config.json to mtsa presets. Per-layer / per-seqlen calibration
-# mapping (using the (a, b) polynomial under ``threshold_scale_factor``) and N:M
-# sparsity require extending ``export_sparse_attention_config`` to serialize
-# per-layer method_config; deferred to a follow-up.
+# Maps ``sparse_algo`` values without calibration metadata into mtsa presets.
 ALGO_TO_PRESET = {
     "softmax_skip": "SKIP_SOFTMAX_TRITON_DEFAULT",
 }
+
+DEFAULT_TARGET_SPARSE_RATIO = {"prefill": 0.5, "decode": 0.5}
+
+
+def _normalize_target_sparse_ratio(value) -> dict[str, float]:
+    """Normalize exported target sparsity metadata, defaulting old checkpoints."""
+    if isinstance(value, (float, int)):
+        ratio = float(value)
+        return {"prefill": ratio, "decode": ratio}
+    if isinstance(value, dict):
+        return {
+            "prefill": float(value.get("prefill", DEFAULT_TARGET_SPARSE_RATIO["prefill"])),
+            "decode": float(value.get("decode", DEFAULT_TARGET_SPARSE_RATIO["decode"])),
+        }
+    return DEFAULT_TARGET_SPARSE_RATIO.copy()
+
+
+def _has_calibrated_threshold_scale_factor(value) -> bool:
+    """Return True when checkpoint metadata has usable phase calibration params."""
+    if not isinstance(value, dict):
+        return False
+    for phase in ("prefill", "decode"):
+        params = value.get(phase)
+        if isinstance(params, dict) and "a" in params and "b" in params:
+            return True
+    return False
+
+
+def _build_calibrated_softmax_skip_config(sparse_meta: dict) -> dict:
+    """Build a vLLM Triton sparse config from exported calibration metadata."""
+    return {
+        "sparse_cfg": {
+            "*attn*": {
+                "method": "triton_skip_softmax",
+                "threshold_scale_factor": sparse_meta["threshold_scale_factor"],
+                "target_sparse_ratio": _normalize_target_sparse_ratio(
+                    sparse_meta.get("target_sparse_ratio")
+                ),
+                "backend": "triton",
+                "enable": True,
+            },
+            "default": {"enable": False},
+        },
+    }
 
 
 def match_sparse_config(module_name: str, sparse_cfg: dict) -> dict | None:
@@ -58,8 +98,9 @@ def load_from_checkpoint_metadata(hf_config) -> tuple[dict, str] | None:
     """Resolve sparse_cfg from a HF model config object.
 
     Reads ``sparse_attention_config`` written by ModelOpt's HF export
-    (``unified_export_hf.export_sparse_attention_config``) and maps the
-    declared ``sparse_algo`` to an mtsa preset via :data:`ALGO_TO_PRESET`.
+    (``unified_export_hf.export_sparse_attention_config``). Calibrated
+    ``softmax_skip`` metadata is converted into a dynamic Triton config;
+    uncalibrated algorithms fall back to mtsa presets via :data:`ALGO_TO_PRESET`.
 
     Args:
         hf_config: A ``transformers.PretrainedConfig``-like object (or any
@@ -79,6 +120,12 @@ def load_from_checkpoint_metadata(hf_config) -> tuple[dict, str] | None:
     if not isinstance(config_groups, dict):
         return None
     algos = {grp.get("sparse_algo") for grp in config_groups.values() if isinstance(grp, dict)}
+    if "softmax_skip" in algos and _has_calibrated_threshold_scale_factor(
+        sparse_meta.get("threshold_scale_factor")
+    ):
+        return _build_calibrated_softmax_skip_config(
+            sparse_meta
+        ), "CHECKPOINT_CALIBRATED_SOFTMAX_SKIP"
     for algo, preset_name in ALGO_TO_PRESET.items():
         if algo in algos:
             preset = getattr(mtsa, preset_name, None)

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/sparse_attn_config.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/sparse_attn_config.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for resolving sparse attention config in a serving context.
+
+These helpers operate on plain dicts and ``transformers.PretrainedConfig``-like
+objects — they do not depend on vLLM and can be used (and unit-tested) without
+it installed.
+
+- ``match_sparse_config`` — fnmatch a module name against a sparse_cfg dict.
+- ``load_from_checkpoint_metadata`` — read ``sparse_attention_config`` from a
+  HF config and map ``sparse_algo`` to an mtsa preset.
+"""
+
+import fnmatch
+
+import modelopt.torch.sparsity.attention_sparsity as mtsa
+
+# Maps ``sparse_algo`` values written by ``export_sparse_attention_config`` into
+# the checkpoint config.json to mtsa presets. Per-layer / per-seqlen calibration
+# mapping (using the (a, b) polynomial under ``threshold_scale_factor``) and N:M
+# sparsity require extending ``export_sparse_attention_config`` to serialize
+# per-layer method_config; deferred to a follow-up.
+ALGO_TO_PRESET = {
+    "softmax_skip": "SKIP_SOFTMAX_TRITON_DEFAULT",
+}
+
+
+def match_sparse_config(module_name: str, sparse_cfg: dict) -> dict | None:
+    """Match a module name against ``sparse_cfg`` patterns (first hit wins).
+
+    ``sparse_cfg`` is either ``{"sparse_cfg": {...}}`` (as exported by mtsa
+    presets) or the bare inner dict. ``default`` and ``calibration`` keys are
+    metadata and never matched as patterns.
+    """
+    cfg = sparse_cfg.get("sparse_cfg", sparse_cfg)
+    for pattern, layer_cfg in cfg.items():
+        if pattern in ("default", "calibration"):
+            continue
+        if fnmatch.fnmatch(module_name, pattern):
+            return layer_cfg
+    return None
+
+
+def load_from_checkpoint_metadata(hf_config) -> tuple[dict, str] | None:
+    """Resolve sparse_cfg from a HF model config object.
+
+    Reads ``sparse_attention_config`` written by ModelOpt's HF export
+    (``unified_export_hf.export_sparse_attention_config``) and maps the
+    declared ``sparse_algo`` to an mtsa preset via :data:`ALGO_TO_PRESET`.
+
+    Args:
+        hf_config: A ``transformers.PretrainedConfig``-like object (or any
+            namespace) whose ``sparse_attention_config`` attribute holds the
+            exported metadata dict.
+
+    Returns:
+        ``(sparse_cfg, preset_name)`` on hit; ``None`` if the config has no
+        recognized sparse attention metadata.
+    """
+    if hf_config is None:
+        return None
+    sparse_meta = getattr(hf_config, "sparse_attention_config", None)
+    if not isinstance(sparse_meta, dict):
+        return None
+    config_groups = sparse_meta.get("config_groups", {})
+    if not isinstance(config_groups, dict):
+        return None
+    algos = {grp.get("sparse_algo") for grp in config_groups.values() if isinstance(grp, dict)}
+    for algo, preset_name in ALGO_TO_PRESET.items():
+        if algo in algos:
+            preset = getattr(mtsa, preset_name, None)
+            if isinstance(preset, dict):
+                return preset, preset_name
+    return None

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -21,18 +21,17 @@ with paged KV cache support. Integration approach:
 - No module replacement — the Attention module stays intact with all its state
 - Only ``impl`` is swapped from FlashAttentionImpl to ModelOptSparseAttentionImpl
 - KV cache update is handled by vLLM (inherited ``do_kv_cache_update``)
-- Only ``forward()`` is overridden to call our Triton kernel for prefill
-- Decode falls back to FlashAttention (sparse attention has no benefit for single-token queries)
+- Only ``forward()`` is overridden to call our Triton kernel for both prefill and decode
 """
 
 import torch
-
-from modelopt.torch.kernels.triton_fa import attention as triton_attention
 from vllm.v1.attention.backends.flash_attn import (
     FlashAttentionBackend,
     FlashAttentionImpl,
     FlashAttentionMetadata,
 )
+
+from modelopt.torch.kernels.triton_fa import attention as triton_attention
 
 # Sparse config is set by the worker before model loading
 _sparse_config: dict = {}
@@ -50,7 +49,7 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
     Inherits from FlashAttentionImpl to reuse:
     - __init__ (all configuration)
     - do_kv_cache_update (KV cache writing)
-    Only overrides forward() to replace the attention computation for prefill.
+    Only overrides forward() to replace the attention computation.
     """
 
     def forward(
@@ -72,21 +71,8 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             # Profiling run
             return output.fill_(0)
 
-        # Decode: fall back to FlashAttention (no benefit from sparse attention)
-        if attn_metadata.max_query_len <= 1:
-            return super().forward(
-                layer,
-                query,
-                key,
-                value,
-                kv_cache,
-                attn_metadata,
-                output=output,
-                output_scale=output_scale,
-                output_block_scale=output_block_scale,
-            )
-
         num_actual_tokens = attn_metadata.num_actual_tokens
+        is_prefill = attn_metadata.max_query_len > 1
 
         # Unpack paged KV cache: [2, num_blocks, page_size, num_kv_heads, head_dim]
         key_cache, value_cache = kv_cache.unbind(0)
@@ -120,29 +106,35 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
 
         b_start_loc = cu_seqlens_q[:batch]
         b_seq_len = cu_seqlens_q[1 : batch + 1] - cu_seqlens_q[:batch]
-        max_query_len = attn_metadata.max_query_len
 
-        # Dummy K/V for paged mode — must have correct num_kv_heads for GQA ratio
+        # Dummy K/V for paged mode: not used by the kernel (KV are read from
+        # k_cache/v_cache via block_table), but shape[1] must be num_kv_heads
+        # so the kernel computes the correct GQA ratio (num_q_heads // num_kv_heads).
         k_dummy = torch.empty(0, self.num_kv_heads, self.head_size, device=q.device, dtype=q.dtype)
-        v_dummy = k_dummy
 
-        # Call ModelOpt Triton kernel with paged KV
+        # Call ModelOpt Triton kernel with paged KV.
+        # b_seq_len is the query length (e.g., 6 for prefill, 1 for decode).
+        # b_seq_len_k is the total KV length including cache (e.g., 6 for first
+        # prefill, 7/8/... for subsequent decode steps).
         triton_out = triton_attention(
             q,
             k=k_dummy,
-            v=v_dummy,
+            v=k_dummy,
+            # Query metadata
             b_start_loc=b_start_loc,
             b_seq_len=b_seq_len,
-            max_input_len=max_query_len,
-            is_causal=True,
+            max_input_len=attn_metadata.max_query_len,
+            is_causal=is_prefill,  # causal for prefill, non-causal for decode
             softmax_scale=self.scale,
-            b_start_loc_k=None,
-            b_seq_len_k=seq_lens,
+            # KV metadata
+            b_start_loc_k=None,  # paged mode: KV offsets not needed
+            b_seq_len_k=seq_lens,  # total KV length per sequence
             max_input_len_k=attn_metadata.max_seq_len,
-            k_cache=key_cache,
-            v_cache=value_cache,
-            block_table=attn_metadata.block_table,
-            page_size=page_size,
+            # Paged KV cache
+            k_cache=key_cache,  # [num_blocks, page_size, num_kv_heads, head_dim]
+            v_cache=value_cache,  # [num_blocks, page_size, num_kv_heads, head_dim]
+            block_table=attn_metadata.block_table,  # [batch, max_blocks]
+            page_size=page_size,  # tokens per page in the KV cache
             **sparse_kw,
         )
 

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ModelOpt sparse attention backend for vLLM.
+
+Registers a custom vLLM attention backend that uses the ModelOpt Triton kernel
+with paged KV cache support. Integration approach:
+
+- No module replacement — the Attention module stays intact with all its state
+- Only ``impl`` is swapped from FlashAttentionImpl to ModelOptSparseAttentionImpl
+- KV cache update is handled by vLLM (inherited ``do_kv_cache_update``)
+- Only ``forward()`` is overridden to call our Triton kernel for prefill
+- Decode falls back to FlashAttention (sparse attention has no benefit for single-token queries)
+"""
+
+import torch
+
+from modelopt.torch.kernels.triton_fa import attention as triton_attention
+from vllm.v1.attention.backends.flash_attn import (
+    FlashAttentionBackend,
+    FlashAttentionImpl,
+    FlashAttentionMetadata,
+)
+
+# Sparse config is set by the worker before model loading
+_sparse_config: dict = {}
+
+
+def set_sparse_config(config: dict):
+    """Set the sparse attention config (called by the worker)."""
+    global _sparse_config
+    _sparse_config = config
+
+
+class ModelOptSparseAttentionImpl(FlashAttentionImpl):
+    """Attention implementation that uses the ModelOpt Triton kernel.
+
+    Inherits from FlashAttentionImpl to reuse:
+    - __init__ (all configuration)
+    - do_kv_cache_update (KV cache writing)
+    Only overrides forward() to replace the attention computation for prefill.
+    """
+
+    def forward(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: FlashAttentionMetadata,
+        output: torch.Tensor | None = None,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Forward with ModelOpt Triton sparse attention kernel."""
+        assert output is not None, "Output tensor must be provided."
+
+        if attn_metadata is None:
+            # Profiling run
+            return output.fill_(0)
+
+        # Decode: fall back to FlashAttention (no benefit from sparse attention)
+        if attn_metadata.max_query_len <= 1:
+            return super().forward(
+                layer,
+                query,
+                key,
+                value,
+                kv_cache,
+                attn_metadata,
+                output=output,
+                output_scale=output_scale,
+                output_block_scale=output_block_scale,
+            )
+
+        num_actual_tokens = attn_metadata.num_actual_tokens
+
+        # Unpack paged KV cache: [2, num_blocks, page_size, num_kv_heads, head_dim]
+        key_cache, value_cache = kv_cache.unbind(0)
+        page_size = key_cache.shape[1]
+
+        # Build sparse kwargs from global config
+        sparse_kw = {}
+        sparse_cfg = _sparse_config.get("sparse_cfg", {})
+        if isinstance(sparse_cfg, str):
+            sparse_cfg = {}
+        for pattern, layer_cfg in sparse_cfg.items():
+            if pattern in ("default", "calibration"):
+                continue
+            if isinstance(layer_cfg, dict) and layer_cfg.get("enable", True):
+                sparsity_n = layer_cfg.get("sparsity_n", 0)
+                if sparsity_n > 0:
+                    sparse_kw["sparsity_n"] = sparsity_n
+                    sparse_kw["sparsity_m"] = layer_cfg.get("sparsity_m", 4)
+                    sparse_kw["num_sink_tokens"] = layer_cfg.get("num_sink_tokens", 0)
+                    sparse_kw["dense_window_size"] = layer_cfg.get("dense_window_size", 1)
+                threshold = layer_cfg.get("skip_softmax_threshold")
+                if threshold:
+                    sparse_kw["skip_softmax_threshold"] = threshold
+                break
+
+        # Prepare metadata for our kernel
+        q = query[:num_actual_tokens].contiguous()
+        cu_seqlens_q = attn_metadata.query_start_loc
+        seq_lens = attn_metadata.seq_lens
+        batch = seq_lens.shape[0]
+
+        b_start_loc = cu_seqlens_q[:batch]
+        b_seq_len = cu_seqlens_q[1 : batch + 1] - cu_seqlens_q[:batch]
+        max_query_len = attn_metadata.max_query_len
+
+        # Dummy K/V for paged mode — must have correct num_kv_heads for GQA ratio
+        k_dummy = torch.empty(0, self.num_kv_heads, self.head_size, device=q.device, dtype=q.dtype)
+        v_dummy = k_dummy
+
+        # Call ModelOpt Triton kernel with paged KV
+        triton_out = triton_attention(
+            q,
+            k=k_dummy,
+            v=v_dummy,
+            b_start_loc=b_start_loc,
+            b_seq_len=b_seq_len,
+            max_input_len=max_query_len,
+            is_causal=True,
+            softmax_scale=self.scale,
+            b_start_loc_k=None,
+            b_seq_len_k=seq_lens,
+            max_input_len_k=attn_metadata.max_seq_len,
+            k_cache=key_cache,
+            v_cache=value_cache,
+            block_table=attn_metadata.block_table,
+            page_size=page_size,
+            **sparse_kw,
+        )
+
+        output[:num_actual_tokens] = triton_out
+        return output
+
+
+class ModelOptSparseAttentionBackend(FlashAttentionBackend):
+    """Attention backend that uses ModelOpt's sparse Triton kernel.
+
+    Inherits everything from FlashAttentionBackend except get_impl_cls and get_name.
+    """
+
+    @staticmethod
+    def get_name() -> str:
+        """Return backend name."""
+        return "MODELOPT_SPARSE"
+
+    @staticmethod
+    def get_impl_cls() -> type:
+        """Return the attention implementation class."""
+        return ModelOptSparseAttentionImpl

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -28,6 +28,7 @@ live in ``plugins/sparse_attn_config.py`` and are unit-testable without vLLM.
 """
 
 import math
+import warnings
 
 import torch
 from vllm.v1.attention.backends.flash_attn import (
@@ -57,7 +58,7 @@ def _resolve_skip_softmax_calibration(
     """Convert exported calibration params into the scalar threshold kernel API."""
     threshold_scale_factor = sparse_kw.pop("threshold_scale_factor", None)
     sparse_target_ratio = sparse_kw.pop("target_sparse_ratio", None)
-    if threshold_scale_factor is None or sparse_kw.get("skip_softmax_raw_threshold") is not None:
+    if threshold_scale_factor is None:
         return
 
     phase = "prefill" if is_prefill else "decode"
@@ -78,7 +79,17 @@ def _resolve_skip_softmax_calibration(
     scale_factor = a * math.exp(b * target)
     # The current Triton kernel accepts one scalar threshold per launch. Use
     # the max KV length in the scheduled batch; shorter sequences are denser.
-    sparse_kw["skip_softmax_threshold"] = scale_factor / seq_len
+    threshold = scale_factor / seq_len
+    if threshold >= 1.0:
+        warnings.warn(
+            "Disabling calibrated skip-softmax for this vLLM launch because "
+            f"the derived threshold is outside the valid lambda range: "
+            f"phase={phase}, seq_len={seq_len}, scale_factor={scale_factor:.6g}, "
+            f"target_sparse_ratio={target:.6g}, threshold={threshold:.6g}.",
+            stacklevel=2,
+        )
+        return
+    sparse_kw["skip_softmax_threshold"] = threshold
 
 
 class ModelOptSparseAttentionImpl(FlashAttentionImpl):
@@ -117,24 +128,6 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         b_seq_len = cu_seqlens_q[1 : batch + 1] - cu_seqlens_q[:batch]
 
         is_prefill = attn_metadata.max_query_len > 1
-        if is_prefill:
-            # The kernel takes one global causal-mode flag. In prefill mode that
-            # is only correct when every sequence is pure self-attention, i.e.
-            # per-sequence query length equals total KV length.
-            mismatched_lengths = b_seq_len != seq_lens
-            if torch.any(mismatched_lengths).item():
-                has_full_prefill = torch.any(~mismatched_lengths).item()
-                has_decode_like = torch.any((b_seq_len == 1) & (seq_lens > 1)).item()
-                if has_full_prefill and has_decode_like:
-                    raise NotImplementedError(
-                        "Mixed prefill/decode batches are not supported by "
-                        "ModelOptSparseAttentionImpl."
-                    )
-                raise NotImplementedError(
-                    "Chunked prefill is not supported by ModelOptSparseAttentionImpl. "
-                    "Run vLLM without chunked prefill "
-                    "(e.g. --max-num-batched-tokens >= max_model_len)."
-                )
 
         # Unpack paged KV cache: [2, num_blocks, page_size, num_kv_heads, head_dim]
         key_cache, value_cache = kv_cache.unbind(0)

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -31,16 +31,7 @@ from vllm.v1.attention.backends.flash_attn import (
     FlashAttentionMetadata,
 )
 
-from modelopt.torch.kernels.triton_fa import attention as triton_attention
-
-# Sparse config is set by the worker before model loading
-_sparse_config: dict = {}
-
-
-def set_sparse_config(config: dict):
-    """Set the sparse attention config (called by the worker)."""
-    global _sparse_config
-    _sparse_config = config
+from modelopt.torch.kernels.common.attention.triton_fa import attention as triton_attention
 
 
 class ModelOptSparseAttentionImpl(FlashAttentionImpl):
@@ -78,25 +69,8 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         key_cache, value_cache = kv_cache.unbind(0)
         page_size = key_cache.shape[1]
 
-        # Build sparse kwargs from global config
-        sparse_kw = {}
-        sparse_cfg = _sparse_config.get("sparse_cfg", {})
-        if isinstance(sparse_cfg, str):
-            sparse_cfg = {}
-        for pattern, layer_cfg in sparse_cfg.items():
-            if pattern in ("default", "calibration"):
-                continue
-            if isinstance(layer_cfg, dict) and layer_cfg.get("enable", True):
-                sparsity_n = layer_cfg.get("sparsity_n", 0)
-                if sparsity_n > 0:
-                    sparse_kw["sparsity_n"] = sparsity_n
-                    sparse_kw["sparsity_m"] = layer_cfg.get("sparsity_m", 4)
-                    sparse_kw["num_sink_tokens"] = layer_cfg.get("num_sink_tokens", 0)
-                    sparse_kw["dense_window_size"] = layer_cfg.get("dense_window_size", 1)
-                threshold = layer_cfg.get("skip_softmax_threshold")
-                if threshold:
-                    sparse_kw["skip_softmax_threshold"] = threshold
-                break
+        # Per-layer sparse kwargs (set by _replace_attention_impl in the worker)
+        sparse_kw = getattr(self, "sparse_kw", {})
 
         # Prepare metadata for our kernel
         q = query[:num_actual_tokens].contiguous()

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -27,6 +27,8 @@ Vllm-free config helpers (``match_sparse_config`` / ``load_from_checkpoint_metad
 live in ``plugins/sparse_attn_config.py`` and are unit-testable without vLLM.
 """
 
+import math
+
 import torch
 from vllm.v1.attention.backends.flash_attn import (
     FlashAttentionBackend,
@@ -35,6 +37,48 @@ from vllm.v1.attention.backends.flash_attn import (
 )
 
 from modelopt.torch.kernels.common.attention.triton_fa import attention as triton_attention
+
+
+def _target_sparse_ratio_for_phase(target_sparse_ratio, phase: str) -> float:
+    """Return target sparsity for a phase, defaulting old checkpoint metadata."""
+    if isinstance(target_sparse_ratio, (float, int)):
+        return float(target_sparse_ratio)
+    if isinstance(target_sparse_ratio, dict):
+        return float(target_sparse_ratio.get(phase, 0.5))
+    return 0.5
+
+
+def _resolve_skip_softmax_calibration(
+    sparse_kw: dict,
+    *,
+    is_prefill: bool,
+    max_seq_len: int,
+) -> None:
+    """Convert exported calibration params into the scalar threshold kernel API."""
+    threshold_scale_factor = sparse_kw.pop("threshold_scale_factor", None)
+    sparse_target_ratio = sparse_kw.pop("target_sparse_ratio", None)
+    if threshold_scale_factor is None or sparse_kw.get("skip_softmax_raw_threshold") is not None:
+        return
+
+    phase = "prefill" if is_prefill else "decode"
+    params = threshold_scale_factor.get(phase) if isinstance(threshold_scale_factor, dict) else None
+    if not isinstance(params, dict):
+        return
+
+    try:
+        a = float(params["a"])
+        b = float(params["b"])
+        seq_len = int(max_seq_len)
+    except (KeyError, TypeError, ValueError):
+        return
+    if a <= 0.0 or seq_len <= 0:
+        return
+
+    target = _target_sparse_ratio_for_phase(sparse_target_ratio, phase)
+    scale_factor = a * math.exp(b * target)
+    # The current Triton kernel accepts one scalar threshold per launch. Use
+    # the max KV length in the scheduled batch; shorter sequences are denser.
+    sparse_kw["skip_softmax_threshold"] = scale_factor / seq_len
 
 
 class ModelOptSparseAttentionImpl(FlashAttentionImpl):
@@ -97,7 +141,12 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         page_size = key_cache.shape[1]
 
         # Per-layer sparse kwargs (set by _replace_attention_impl in the worker)
-        sparse_kw = getattr(self, "sparse_kw", {})
+        sparse_kw = dict(getattr(self, "sparse_kw", {}))
+        _resolve_skip_softmax_calibration(
+            sparse_kw,
+            is_prefill=is_prefill,
+            max_seq_len=attn_metadata.max_seq_len,
+        )
 
         # Prepare metadata for our kernel
         q = query[:num_actual_tokens].contiguous()

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -21,7 +21,7 @@ with paged KV cache support. Integration approach:
 - No module replacement — the Attention module stays intact with all its state
 - Only ``impl`` is swapped from FlashAttentionImpl to ModelOptSparseAttentionImpl
 - KV cache update is handled by vLLM (inherited ``do_kv_cache_update``)
-- Only ``forward()`` is overridden to call our Triton kernel for both prefill and decode
+- ``forward()`` calls ModelOpt Triton only when a validated sparse path is active
 
 Vllm-free config helpers (``match_sparse_config`` / ``load_from_checkpoint_metadata``)
 live in ``plugins/sparse_attn_config.py`` and are unit-testable without vLLM.
@@ -92,14 +92,60 @@ def _resolve_skip_softmax_calibration(
     sparse_kw["skip_softmax_threshold"] = threshold
 
 
+def _build_sparse_kw(layer_cfg: dict) -> dict:
+    """Convert one checkpoint layer config into kernel kwargs."""
+    sparse_kw = {}
+    sparsity_n = layer_cfg.get("sparsity_n", 0)
+    if sparsity_n > 0:
+        sparse_kw["sparsity_n"] = sparsity_n
+        sparse_kw["sparsity_m"] = layer_cfg.get("sparsity_m", 4)
+        sparse_kw["dense_sink_tokens"] = layer_cfg.get("dense_sink_tokens", 0)
+        sparse_kw["dense_recent_tokens"] = layer_cfg.get("dense_recent_tokens", 64)
+
+    threshold = layer_cfg.get("skip_softmax_threshold")
+    if threshold is not None:
+        sparse_kw["skip_softmax_threshold"] = threshold
+    threshold_scale_factor = layer_cfg.get("threshold_scale_factor")
+    if threshold_scale_factor is not None:
+        sparse_kw["threshold_scale_factor"] = threshold_scale_factor
+        sparse_kw["target_sparse_ratio"] = layer_cfg.get("target_sparse_ratio")
+
+    return sparse_kw
+
+
 class ModelOptSparseAttentionImpl(FlashAttentionImpl):
     """Attention implementation that uses the ModelOpt Triton kernel.
 
     Inherits from FlashAttentionImpl to reuse:
     - __init__ (all configuration)
     - do_kv_cache_update (KV cache writing)
-    Only overrides forward() to replace the attention computation.
+    Only overrides forward() to replace sparse prefill attention computation.
     """
+
+    def _forward_vllm_flash_attn(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: FlashAttentionMetadata,
+        output: torch.Tensor | None,
+        output_scale: torch.Tensor | None,
+        output_block_scale: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Delegate a launch back to vLLM's native FlashAttention impl."""
+        return super().forward(
+            layer,
+            query,
+            key,
+            value,
+            kv_cache,
+            attn_metadata,
+            output,
+            output_scale,
+            output_block_scale,
+        )
 
     def forward(
         self,
@@ -120,6 +166,22 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             # Profiling run
             return output.fill_(0)
 
+        if getattr(attn_metadata, "use_cascade", False):
+            # vLLM cascade metadata splits the request into shared-prefix and
+            # suffix pieces. The ModelOpt paged kernel consumes plain per-request
+            # KV lengths, so delegate cascade launches back to vLLM's impl.
+            return self._forward_vllm_flash_attn(
+                layer,
+                query,
+                key,
+                value,
+                kv_cache,
+                attn_metadata,
+                output,
+                output_scale,
+                output_block_scale,
+            )
+
         num_actual_tokens = attn_metadata.num_actual_tokens
         cu_seqlens_q = attn_metadata.query_start_loc
         seq_lens = attn_metadata.seq_lens
@@ -127,7 +189,10 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         b_start_loc = cu_seqlens_q[:batch]
         b_seq_len = cu_seqlens_q[1 : batch + 1] - cu_seqlens_q[:batch]
 
-        is_prefill = attn_metadata.max_query_len > 1
+        # Standard decode schedules one query token per request. Chunked
+        # prefill and mixed prefill/decode launches use the prefill path.
+        is_decode_only = attn_metadata.max_query_len <= 1
+        is_causal = getattr(attn_metadata, "causal", not is_decode_only)
 
         # Unpack paged KV cache: [2, num_blocks, page_size, num_kv_heads, head_dim]
         key_cache, value_cache = kv_cache.unbind(0)
@@ -137,9 +202,44 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         sparse_kw = dict(getattr(self, "sparse_kw", {}))
         _resolve_skip_softmax_calibration(
             sparse_kw,
-            is_prefill=is_prefill,
+            is_prefill=not is_decode_only,
             max_seq_len=attn_metadata.max_seq_len,
         )
+        if is_decode_only:
+            # N:M sparse softmax is prefill-only.
+            for name in ("sparsity_n", "sparsity_m", "dense_sink_tokens", "dense_recent_tokens"):
+                sparse_kw.pop(name, None)
+            if set(sparse_kw) <= {"skip_softmax_threshold"}:
+                # The current ModelOpt paged kernel is only validated for
+                # sparse prefill in vLLM. Decode-only skip-softmax would route
+                # through the dense Triton path for every non-skipped tile, so
+                # keep decode on vLLM FlashAttention until that path is covered.
+                return self._forward_vllm_flash_attn(
+                    layer,
+                    query,
+                    key,
+                    value,
+                    kv_cache,
+                    attn_metadata,
+                    output,
+                    output_scale,
+                    output_block_scale,
+                )
+        if not sparse_kw:
+            # Dynamic calibration can disable sparse work for a launch, e.g.
+            # short-prefill thresholds outside the valid lambda range. Avoid
+            # swapping in the ModelOpt dense kernel when no sparse feature is active.
+            return self._forward_vllm_flash_attn(
+                layer,
+                query,
+                key,
+                value,
+                kv_cache,
+                attn_metadata,
+                output,
+                output_scale,
+                output_block_scale,
+            )
 
         # Prepare metadata for our kernel
         q = query[:num_actual_tokens].contiguous()
@@ -160,7 +260,7 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             b_start_loc=b_start_loc,
             b_seq_len=b_seq_len,
             max_input_len=attn_metadata.max_query_len,
-            is_causal=is_prefill,  # causal for prefill, non-causal for decode
+            is_causal=is_causal,
             softmax_scale=self.scale,
             # KV metadata
             b_start_loc_k=None,  # paged mode: KV offsets not needed
@@ -198,7 +298,7 @@ class ModelOptSparseAttentionBackend(FlashAttentionBackend):
 def _clone_sparse_impl(old_impl):
     """Create a sparse impl while preserving vLLM's initialized runtime state."""
     if getattr(old_impl, "sinks", None) is not None:
-        # vLLM passes sinks to FlashAttention as s_aux; our Triton path does support sinks yet.
+        # vLLM passes sinks to FlashAttention as s_aux; our Triton path does not support sinks yet.
         raise NotImplementedError(
             "ModelOptSparseAttentionImpl does not support vLLM FlashAttention sinks yet."
         )

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -22,6 +22,9 @@ with paged KV cache support. Integration approach:
 - Only ``impl`` is swapped from FlashAttentionImpl to ModelOptSparseAttentionImpl
 - KV cache update is handled by vLLM (inherited ``do_kv_cache_update``)
 - Only ``forward()`` is overridden to call our Triton kernel for both prefill and decode
+
+Vllm-free config helpers (``match_sparse_config`` / ``load_from_checkpoint_metadata``)
+live in ``plugins/sparse_attn_config.py`` and are unit-testable without vLLM.
 """
 
 import torch
@@ -63,7 +66,31 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             return output.fill_(0)
 
         num_actual_tokens = attn_metadata.num_actual_tokens
+        cu_seqlens_q = attn_metadata.query_start_loc
+        seq_lens = attn_metadata.seq_lens
+        batch = seq_lens.shape[0]
+        b_start_loc = cu_seqlens_q[:batch]
+        b_seq_len = cu_seqlens_q[1 : batch + 1] - cu_seqlens_q[:batch]
+
         is_prefill = attn_metadata.max_query_len > 1
+        if is_prefill:
+            # The kernel takes one global causal-mode flag. In prefill mode that
+            # is only correct when every sequence is pure self-attention, i.e.
+            # per-sequence query length equals total KV length.
+            mismatched_lengths = b_seq_len != seq_lens
+            if torch.any(mismatched_lengths).item():
+                has_full_prefill = torch.any(~mismatched_lengths).item()
+                has_decode_like = torch.any((b_seq_len == 1) & (seq_lens > 1)).item()
+                if has_full_prefill and has_decode_like:
+                    raise NotImplementedError(
+                        "Mixed prefill/decode batches are not supported by "
+                        "ModelOptSparseAttentionImpl."
+                    )
+                raise NotImplementedError(
+                    "Chunked prefill is not supported by ModelOptSparseAttentionImpl. "
+                    "Run vLLM without chunked prefill "
+                    "(e.g. --max-num-batched-tokens >= max_model_len)."
+                )
 
         # Unpack paged KV cache: [2, num_blocks, page_size, num_kv_heads, head_dim]
         key_cache, value_cache = kv_cache.unbind(0)
@@ -74,13 +101,6 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
 
         # Prepare metadata for our kernel
         q = query[:num_actual_tokens].contiguous()
-        cu_seqlens_q = attn_metadata.query_start_loc
-        seq_lens = attn_metadata.seq_lens
-        batch = seq_lens.shape[0]
-
-        b_start_loc = cu_seqlens_q[:batch]
-        b_seq_len = cu_seqlens_q[1 : batch + 1] - cu_seqlens_q[:batch]
-
         # Dummy K/V for paged mode: not used by the kernel (KV are read from
         # k_cache/v_cache via block_table), but shape[1] must be num_kv_heads
         # so the kernel computes the correct GQA ratio (num_q_heads // num_kv_heads).
@@ -131,3 +151,23 @@ class ModelOptSparseAttentionBackend(FlashAttentionBackend):
     def get_impl_cls() -> type:
         """Return the attention implementation class."""
         return ModelOptSparseAttentionImpl
+
+
+def _clone_sparse_impl(old_impl):
+    """Create a sparse impl while preserving vLLM's initialized runtime state."""
+    if getattr(old_impl, "sinks", None) is not None:
+        # vLLM passes sinks to FlashAttention as s_aux; our Triton path does support sinks yet.
+        raise NotImplementedError(
+            "ModelOptSparseAttentionImpl does not support vLLM FlashAttention sinks yet."
+        )
+
+    try:
+        old_state = vars(old_impl)
+    except TypeError as err:
+        raise TypeError(
+            "Cannot clone vLLM attention impl state: old impl does not expose __dict__."
+        ) from err
+
+    new_impl = ModelOptSparseAttentionImpl.__new__(ModelOptSparseAttentionImpl)
+    new_impl.__dict__.update(old_state)
+    return new_impl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,7 @@ convention = "google"
 
 [tool.ruff.lint.isort]
 known-first-party = ["modelopt"]
+known-third-party = ["vllm"]
 split-on-trailing-comma = false
 
 

--- a/tests/examples/diffusers_sparsity/test_sparsity.py
+++ b/tests/examples/diffusers_sparsity/test_sparsity.py
@@ -17,7 +17,7 @@
 
 Uses a tiny Wan 2.2 model (dual transformer, 2 layers, hidden_dim=24) created
 from scratch. Tests run the wan22_skip_softmax.py example script in baseline,
-triton-baseline, and raw-threshold modes.
+triton-baseline, and fixed-threshold modes.
 """
 
 import pytest
@@ -85,20 +85,20 @@ def test_wan22_triton_baseline(tiny_wan22_path, tmp_path):
     run_example_command(cmd, EXAMPLE_PATH)
 
 
-def test_wan22_raw_threshold(tiny_wan22_path, tmp_path):
-    """Skip-softmax with a fixed raw threshold — no calibration needed."""
+def test_wan22_skip_softmax_threshold(tiny_wan22_path, tmp_path):
+    """Skip-softmax with a fixed lambda threshold — no calibration needed."""
     cmd = [
         "python",
         "wan22_skip_softmax.py",
         "--model-path",
         tiny_wan22_path,
-        "--raw-threshold",
-        "-5.0",
+        "--skip-softmax-threshold",
+        "0.03125",
         "--report-avg-sparsity",
         "--prompt",
         "test",
         "--output",
-        str(tmp_path / "raw_threshold.mp4"),
+        str(tmp_path / "skip_softmax_threshold.mp4"),
         *_TINY_ARGS,
     ]
     run_example_command(cmd, EXAMPLE_PATH)

--- a/tests/gpu/torch/kernels/common/attention/test_triton_fa_paged.py
+++ b/tests/gpu/torch/kernels/common/attention/test_triton_fa_paged.py
@@ -359,6 +359,109 @@ class TestPagedKV:
         assert out.shape == q_flat.shape
         assert not torch.isnan(out).any(), "NaN in paged decode output"
 
+    def test_paged_decode_ignores_sparse_nm(self):
+        """N:M sparse softmax is prefill-only; paged decode remains dense."""
+        batch = 2
+        seq_lens_k = [64, 128]
+        num_heads, num_kv_heads, head_dim = 4, 2, 64
+        page_size = 16
+        scale = 1.0 / (head_dim**0.5)
+        total_kv = sum(seq_lens_k)
+
+        torch.manual_seed(34)
+        q_flat = torch.randn(batch, num_heads, head_dim, device="cuda", dtype=torch.float16)
+        k_flat = torch.randn(total_kv, num_kv_heads, head_dim, device="cuda", dtype=torch.float16)
+        v_flat = torch.randn(total_kv, num_kv_heads, head_dim, device="cuda", dtype=torch.float16)
+
+        b_start_loc_q = torch.arange(batch, device="cuda", dtype=torch.int32)
+        b_seq_len_q = torch.ones(batch, device="cuda", dtype=torch.int32)
+        cumsum = [0]
+        for sl in seq_lens_k:
+            cumsum.append(cumsum[-1] + sl)
+        b_start_loc_k = torch.tensor(cumsum[:-1], device="cuda", dtype=torch.int32)
+        b_seq_len_k = torch.tensor(seq_lens_k, device="cuda", dtype=torch.int32)
+        k_cache, v_cache, block_table = _scatter_to_paged_cache(
+            k_flat, v_flat, b_start_loc_k, b_seq_len_k, num_kv_heads, head_dim, page_size
+        )
+
+        common_kwargs = {
+            "is_causal": False,
+            "softmax_scale": scale,
+            "b_start_loc_k": b_start_loc_k,
+            "b_seq_len_k": b_seq_len_k,
+            "max_input_len_k": max(seq_lens_k),
+            "k_cache": k_cache,
+            "v_cache": v_cache,
+            "block_table": block_table,
+            "page_size": page_size,
+        }
+        out_dense = attention(
+            q_flat, k_flat, v_flat, b_start_loc_q, b_seq_len_q, 1, **common_kwargs
+        )
+        out_sparse = attention(
+            q_flat,
+            k_flat,
+            v_flat,
+            b_start_loc_q,
+            b_seq_len_q,
+            1,
+            **common_kwargs,
+            sparsity_n=2,
+            sparsity_m=4,
+            dense_recent_tokens=64,
+        )
+
+        torch.testing.assert_close(out_sparse, out_dense, rtol=1e-2, atol=1e-2)
+
+    def test_paged_mixed_prefill_decode_sparse_nm_keeps_decode_dense(self):
+        """Decode rows stay dense even when batched with sparse prefill rows."""
+        q_lens = [64, 1]
+        kv_lens = [64, 128]
+        num_heads, num_kv_heads, head_dim = 4, 2, 64
+        page_size = 16
+        scale = 1.0 / (head_dim**0.5)
+
+        torch.manual_seed(35)
+        q = torch.randn(sum(q_lens), num_heads, head_dim, device="cuda", dtype=torch.float16)
+        k = torch.randn(sum(kv_lens), num_kv_heads, head_dim, device="cuda", dtype=torch.float16)
+        v = torch.randn(sum(kv_lens), num_kv_heads, head_dim, device="cuda", dtype=torch.float16)
+
+        locs_q, lens_q = make_varlen_meta(q_lens)
+        locs_k, lens_k = make_varlen_meta(kv_lens)
+        k_cache, v_cache, block_table = _scatter_to_paged_cache(
+            k, v, locs_k, lens_k, num_kv_heads, head_dim, page_size
+        )
+
+        common_kwargs = {
+            "is_causal": True,
+            "softmax_scale": scale,
+            "b_start_loc_k": locs_k,
+            "b_seq_len_k": lens_k,
+            "max_input_len_k": max(kv_lens),
+            "k_cache": k_cache,
+            "v_cache": v_cache,
+            "block_table": block_table,
+            "page_size": page_size,
+        }
+        out_dense = attention(q, k, v, locs_q, lens_q, max(q_lens), **common_kwargs)
+        out_sparse = attention(
+            q,
+            k,
+            v,
+            locs_q,
+            lens_q,
+            max(q_lens),
+            **common_kwargs,
+            sparsity_n=2,
+            sparsity_m=4,
+            dense_recent_tokens=64,
+        )
+
+        decode_start = q_lens[0]
+        torch.testing.assert_close(
+            out_sparse[decode_start:], out_dense[decode_start:], rtol=1e-2, atol=1e-2
+        )
+
     def test_paged_chunked_prefill_matches_suffix_causal_reference(self):
         """Paged causal mode offsets suffix Q positions into the longer KV span."""
         q_lens = [7, 13]

--- a/tests/gpu/torch/kernels/common/attention/test_triton_fa_paged.py
+++ b/tests/gpu/torch/kernels/common/attention/test_triton_fa_paged.py
@@ -86,6 +86,30 @@ def _scatter_to_paged_cache(k, v, b_start_loc, b_seq_len, num_kv_heads, head_dim
     return k_cache, v_cache, block_table
 
 
+def _suffix_causal_reference(q, k, v, q_lens, kv_lens, num_heads, num_kv_heads, scale):
+    """Reference for chunked prefill where Q is the latest suffix of KV."""
+    out = torch.empty_like(q)
+    q_start = 0
+    kv_start = 0
+    head_repeat = num_heads // num_kv_heads
+    for q_len, kv_len in zip(q_lens, kv_lens):
+        q_b = q[q_start : q_start + q_len].float()
+        k_b = k[kv_start : kv_start + kv_len].float().repeat_interleave(head_repeat, dim=1)
+        v_b = v[kv_start : kv_start + kv_len].float().repeat_interleave(head_repeat, dim=1)
+
+        scores = torch.einsum("qhd,khd->hqk", q_b, k_b) * scale
+        prefix_len = kv_len - q_len
+        q_pos = torch.arange(q_len, device=q.device) + prefix_len
+        kv_pos = torch.arange(kv_len, device=q.device)
+        scores = scores.masked_fill(kv_pos[None, :] > q_pos[:, None], float("-inf"))
+        probs = torch.softmax(scores, dim=-1)
+        ref = torch.einsum("hqk,khd->qhd", probs, v_b)
+        out[q_start : q_start + q_len] = ref.to(q.dtype)
+        q_start += q_len
+        kv_start += kv_len
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Paged KV cache tests
 # ---------------------------------------------------------------------------
@@ -334,3 +358,43 @@ class TestPagedKV:
 
         assert out.shape == q_flat.shape
         assert not torch.isnan(out).any(), "NaN in paged decode output"
+
+    def test_paged_chunked_prefill_matches_suffix_causal_reference(self):
+        """Paged causal mode offsets suffix Q positions into the longer KV span."""
+        q_lens = [7, 13]
+        kv_lens = [31, 48]
+        num_heads, num_kv_heads, head_dim = 4, 2, 64
+        page_size = 16
+        scale = 1.0 / (head_dim**0.5)
+
+        torch.manual_seed(44)
+        q = torch.randn(sum(q_lens), num_heads, head_dim, device="cuda", dtype=torch.float16)
+        k = torch.randn(sum(kv_lens), num_kv_heads, head_dim, device="cuda", dtype=torch.float16)
+        v = torch.randn(sum(kv_lens), num_kv_heads, head_dim, device="cuda", dtype=torch.float16)
+
+        locs_q, lens_q = make_varlen_meta(q_lens)
+        locs_k, lens_k = make_varlen_meta(kv_lens)
+        k_cache, v_cache, block_table = _scatter_to_paged_cache(
+            k, v, locs_k, lens_k, num_kv_heads, head_dim, page_size
+        )
+
+        out = attention(
+            q,
+            k,
+            v,
+            locs_q,
+            lens_q,
+            max(q_lens),
+            is_causal=True,
+            softmax_scale=scale,
+            b_start_loc_k=locs_k,
+            b_seq_len_k=lens_k,
+            max_input_len_k=max(kv_lens),
+            k_cache=k_cache,
+            v_cache=v_cache,
+            block_table=block_table,
+            page_size=page_size,
+        )
+        ref = _suffix_causal_reference(q, k, v, q_lens, kv_lens, num_heads, num_kv_heads, scale)
+
+        torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-2)

--- a/tests/gpu/torch/kernels/common/attention/test_triton_fa_paged.py
+++ b/tests/gpu/torch/kernels/common/attention/test_triton_fa_paged.py
@@ -25,10 +25,10 @@ pytestmark = [
     pytest.mark.filterwarnings("ignore::DeprecationWarning"),
 ]
 
-from modelopt.torch.kernels import IS_AVAILABLE as TRITON_KERNEL_AVAILABLE
+from modelopt.torch.kernels.common.attention import IS_AVAILABLE as TRITON_KERNEL_AVAILABLE
 
 if TRITON_KERNEL_AVAILABLE:
-    from modelopt.torch.kernels import attention
+    from modelopt.torch.kernels.common.attention import attention
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gpu/torch/kernels/sparsity/attention/test_diffusers_triton_attention.py
+++ b/tests/gpu/torch/kernels/sparsity/attention/test_diffusers_triton_attention.py
@@ -59,8 +59,8 @@ class TestDiffusersTritonAttention:
         out = diffusers_mod._diffusers_triton_attention(q, k, v)
         assert out.shape == q.shape
 
-    def test_raw_threshold_path(self):
-        diffusers_mod.set_triton_skip_softmax_config(raw_threshold=-10.0)
+    def test_small_threshold_path(self):
+        diffusers_mod.set_triton_skip_softmax_config(threshold=0.0009765625)
         q, k, v = self._make_qkv()
         out = diffusers_mod._diffusers_triton_attention(q, k, v)
         assert out.shape == q.shape
@@ -120,8 +120,8 @@ class TestLTXTritonAttention:
         assert out.shape == q.shape
         assert not torch.isnan(out).any()
 
-    def test_inference_with_raw_threshold(self):
-        ltx_mod.set_ltx_triton_context(active=True, raw_threshold=-10.0)
+    def test_inference_with_small_threshold(self):
+        ltx_mod.set_ltx_triton_context(active=True, threshold=0.0009765625)
         q, k, v = self._make_qkv()
         out = ltx_mod._ltx_triton_attention(q, k, v, heads=4)
         assert out.shape == q.shape

--- a/tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_calibrate.py
+++ b/tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_calibrate.py
@@ -19,6 +19,10 @@ Exercises ``attention_calibrate`` which computes full attention while counting
 how many KV tiles would be skipped at each threshold in ``threshold_trials``.
 """
 
+import os
+import subprocess
+import sys
+
 import pytest
 import torch
 from conftest import make_qkv, make_varlen_meta
@@ -159,6 +163,50 @@ class TestAttentionCalibrate:
         assert c1[0, 1].item() == c2[1, 1].item()
         assert c1[1, 1].item() == c2[0, 1].item()
 
+    def test_threshold_semantics_match_runtime_counts(self):
+        """Calibration threshold trials use the same lambda semantics as runtime."""
+        batch, seq_len, num_heads, head_dim = 1, 256, 1, 64
+        total = batch * seq_len
+        scale = 1.0 / (head_dim**0.5)
+        qk_scale = scale * 1.44269504088896
+        threshold = 0.1
+
+        q = torch.zeros(total, num_heads, head_dim, device="cuda", dtype=torch.float16)
+        k = torch.zeros_like(q)
+        v = torch.zeros_like(q)
+        q[:, :, 0] = 1.0
+        k[128:, :, 0] = -1.0 / qk_scale
+        v[128:] = 1.0
+        locs = torch.zeros(batch, device="cuda", dtype=torch.int32)
+        lens = torch.full((batch,), seq_len, device="cuda", dtype=torch.int32)
+
+        out = attention(
+            q,
+            k,
+            v,
+            locs,
+            lens,
+            seq_len,
+            softmax_scale=scale,
+            is_causal=False,
+            skip_softmax_threshold=threshold,
+            measure_sparsity=True,
+        )
+        _, counters = attention_calibrate(
+            q,
+            k,
+            v,
+            locs,
+            lens,
+            seq_len,
+            softmax_scale=scale,
+            is_causal=False,
+            threshold_trials=[threshold],
+        )
+
+        assert counters[0, 0].item() == out._sparsity_total
+        assert counters[0, 1].item() == out._sparsity_skipped
+
 
 @pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
 class TestMeasureSparsity:
@@ -191,6 +239,50 @@ class TestMeasureSparsity:
         assert hasattr(out, "_sparsity_skipped")
         assert out._sparsity_total > 0
         assert out._sparsity_skipped <= out._sparsity_total
+
+    def test_first_measured_call_has_real_tile_count_with_autotune(self):
+        """Counters from the first measured call should not include autotune trials."""
+        script = r"""
+import torch
+from modelopt.torch.kernels.common.attention import attention
+
+batch, seq_len, num_heads, head_dim = 1, 256, 1, 64
+total = batch * seq_len
+scale = 1.0 / (head_dim**0.5)
+q = torch.zeros(total, num_heads, head_dim, device="cuda", dtype=torch.float16)
+k = torch.zeros_like(q)
+v = torch.zeros_like(q)
+locs = torch.zeros(batch, device="cuda", dtype=torch.int32)
+lens = torch.full((batch,), seq_len, device="cuda", dtype=torch.int32)
+out = attention(
+    q,
+    k,
+    v,
+    locs,
+    lens,
+    seq_len,
+    softmax_scale=scale,
+    is_causal=False,
+    skip_softmax_threshold=0.5,
+    measure_sparsity=True,
+)
+torch.cuda.synchronize()
+print(f"TOTAL={out._sparsity_total}")
+"""
+        env = os.environ.copy()
+        env.pop("PYTEST_VERSION", None)
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=os.getcwd(),
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        totals = [line for line in result.stdout.splitlines() if line.startswith("TOTAL=")]
+        assert totals, result.stdout
+        assert int(totals[-1].split("=", maxsplit=1)[1]) == 8
 
     def test_measure_sparsity_without_skip_is_noop(self):
         """Without skip-softmax, measure_sparsity doesn't attach counters."""

--- a/tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_calibrate.py
+++ b/tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_calibrate.py
@@ -296,12 +296,12 @@ print(f"TOTAL={out._sparsity_total}")
         # No skip-softmax active => counters should not be attached
         assert not hasattr(out, "_sparsity_total")
 
-    def test_raw_threshold_path(self):
-        """Raw threshold is passed directly to the kernel without conversion."""
+    def test_tiny_threshold_path(self):
+        """A tiny lambda threshold keeps output close to dense."""
         q, k, v = make_qkv(256, 4, 4, 64, dtype=torch.float16)
         locs, lens = make_varlen_meta([256])
         scale = 1.0 / (64**0.5)
-        out_raw = attention(
+        out_skip = attention(
             q,
             k,
             v,
@@ -310,12 +310,11 @@ print(f"TOTAL={out._sparsity_total}")
             256,
             softmax_scale=scale,
             is_causal=False,
-            skip_softmax_raw_threshold=-20.0,
+            skip_softmax_threshold=2**-20,
         )
-        # With a very negative raw threshold, almost no tiles are skipped
-        # Output should be close to dense
+        # A near-zero threshold skips very few tiles, so output stays close to dense.
         out_dense = attention(q, k, v, locs, lens, 256, softmax_scale=scale, is_causal=False)
-        torch.testing.assert_close(out_raw, out_dense, rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(out_skip, out_dense, rtol=1e-2, atol=1e-2)
 
 
 @pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")

--- a/tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_skip_softmax.py
+++ b/tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_skip_softmax.py
@@ -15,6 +15,8 @@
 
 """GPU tests for skip-softmax (BLASST) on the Triton flash attention kernel."""
 
+import math
+
 import pytest
 import torch
 from conftest import make_varlen_meta
@@ -57,6 +59,48 @@ class TestSkipSoftmax:
         )
         assert torch.equal(out_none, out_zero)
 
+    def test_lambda_threshold_matches_raw_log2_threshold(self):
+        """Public lambda threshold should convert directly to raw log2 kernel space."""
+        batch, seq_len, num_heads, head_dim = 1, 256, 1, 64
+        total = batch * seq_len
+        scale = 1.0 / math.sqrt(head_dim)
+        qk_scale = scale * math.log2(math.e)
+        threshold = 0.1
+
+        q = torch.zeros(total, num_heads, head_dim, device="cuda", dtype=torch.float16)
+        k = torch.zeros_like(q)
+        v = torch.zeros_like(q)
+        q[:, :, 0] = 1.0
+        k[128:, :, 0] = -1.0 / qk_scale
+        v[128:] = 1.0
+        locs = torch.zeros(batch, device="cuda", dtype=torch.int32)
+        lens = torch.full((batch,), seq_len, device="cuda", dtype=torch.int32)
+
+        out_lambda = attention(
+            q,
+            k,
+            v,
+            locs,
+            lens,
+            seq_len,
+            is_causal=False,
+            softmax_scale=scale,
+            skip_softmax_threshold=threshold,
+        )
+        out_raw = attention(
+            q,
+            k,
+            v,
+            locs,
+            lens,
+            seq_len,
+            is_causal=False,
+            softmax_scale=scale,
+            skip_softmax_raw_threshold=math.log2(threshold),
+        )
+
+        assert torch.equal(out_lambda, out_raw)
+
     def test_small_threshold_close_to_dense(self):
         """A small threshold (1e-3) should produce output very close to dense."""
         q, k, v, locs, lens = self._make_inputs()
@@ -90,7 +134,7 @@ class TestSkipSoftmax:
         scale = 1.0 / (head_dim**0.5)
         out_dense = attention(q, k, v, locs, lens, seq_len, softmax_scale=scale)
         out_skip = attention(
-            q, k, v, locs, lens, seq_len, softmax_scale=scale, skip_softmax_threshold=0.5
+            q, k, v, locs, lens, seq_len, softmax_scale=scale, skip_softmax_threshold=0.99
         )
         assert not torch.allclose(out_skip, out_dense, atol=1e-3)
 

--- a/tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_skip_softmax.py
+++ b/tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_skip_softmax.py
@@ -15,8 +15,6 @@
 
 """GPU tests for skip-softmax (BLASST) on the Triton flash attention kernel."""
 
-import math
-
 import pytest
 import torch
 from conftest import make_varlen_meta
@@ -58,48 +56,6 @@ class TestSkipSoftmax:
             q, k, v, locs, lens, 256, softmax_scale=scale, skip_softmax_threshold=0.0
         )
         assert torch.equal(out_none, out_zero)
-
-    def test_lambda_threshold_matches_raw_log2_threshold(self):
-        """Public lambda threshold should convert directly to raw log2 kernel space."""
-        batch, seq_len, num_heads, head_dim = 1, 256, 1, 64
-        total = batch * seq_len
-        scale = 1.0 / math.sqrt(head_dim)
-        qk_scale = scale * math.log2(math.e)
-        threshold = 0.1
-
-        q = torch.zeros(total, num_heads, head_dim, device="cuda", dtype=torch.float16)
-        k = torch.zeros_like(q)
-        v = torch.zeros_like(q)
-        q[:, :, 0] = 1.0
-        k[128:, :, 0] = -1.0 / qk_scale
-        v[128:] = 1.0
-        locs = torch.zeros(batch, device="cuda", dtype=torch.int32)
-        lens = torch.full((batch,), seq_len, device="cuda", dtype=torch.int32)
-
-        out_lambda = attention(
-            q,
-            k,
-            v,
-            locs,
-            lens,
-            seq_len,
-            is_causal=False,
-            softmax_scale=scale,
-            skip_softmax_threshold=threshold,
-        )
-        out_raw = attention(
-            q,
-            k,
-            v,
-            locs,
-            lens,
-            seq_len,
-            is_causal=False,
-            softmax_scale=scale,
-            skip_softmax_raw_threshold=math.log2(threshold),
-        )
-
-        assert torch.equal(out_lambda, out_raw)
 
     def test_small_threshold_close_to_dense(self):
         """A small threshold (1e-3) should produce output very close to dense."""

--- a/tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_sparse_nm.py
+++ b/tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_sparse_nm.py
@@ -141,8 +141,8 @@ class TestSparseNM:
         [(2, 4), (4, 8)],
         ids=["2:4", "4:8"],
     )
-    def test_dense_window_preserves_local(self, n, m):
-        """Large dense_window_size makes sparse output closer to dense."""
+    def test_dense_recent_tokens_preserves_local(self, n, m):
+        """Large dense_recent_tokens makes sparse output closer to dense."""
         q, k, v, locs, lens = self._make_inputs(seq_len=256)
         scale = 1.0 / (64**0.5)
         out_dense = attention(q, k, v, locs, lens, 256, softmax_scale=scale)
@@ -156,7 +156,7 @@ class TestSparseNM:
             softmax_scale=scale,
             sparsity_n=n,
             sparsity_m=m,
-            dense_window_size=64,
+            dense_recent_tokens=64,
         )
         out_large = attention(
             q,
@@ -168,7 +168,7 @@ class TestSparseNM:
             softmax_scale=scale,
             sparsity_n=n,
             sparsity_m=m,
-            dense_window_size=100000,
+            dense_recent_tokens=100000,
         )
         err_small = (out_small - out_dense).abs().mean().item()
         err_large = (out_large - out_dense).abs().mean().item()
@@ -179,8 +179,8 @@ class TestSparseNM:
         [(2, 4), (4, 8)],
         ids=["2:4", "4:8"],
     )
-    def test_sink_tokens_preserve_early_kv(self, n, m):
-        """num_sink_tokens keeps early KV positions dense, reducing error vs fully sparse."""
+    def test_dense_sink_tokens_preserve_early_kv(self, n, m):
+        """dense_sink_tokens keeps early KV positions dense, reducing error vs fully sparse."""
         q, k, v, locs, lens = self._make_inputs(seq_len=512)
         scale = 1.0 / (64**0.5)
         out_dense = attention(q, k, v, locs, lens, 512, softmax_scale=scale)
@@ -194,7 +194,7 @@ class TestSparseNM:
             softmax_scale=scale,
             sparsity_n=n,
             sparsity_m=m,
-            num_sink_tokens=0,
+            dense_sink_tokens=0,
         )
         out_with_sink = attention(
             q,
@@ -206,7 +206,7 @@ class TestSparseNM:
             softmax_scale=scale,
             sparsity_n=n,
             sparsity_m=m,
-            num_sink_tokens=128,
+            dense_sink_tokens=128,
         )
         err_no_sink = (out_no_sink - out_dense).abs().mean().item()
         err_with_sink = (out_with_sink - out_dense).abs().mean().item()
@@ -397,15 +397,15 @@ class TestSparseNMIntegration:
             logits_dense = model_dense(input_ids=ids).logits
         del model_dense
 
-        # Sparse via mtsa.sparsify() with dense_window_size=0 to force sparsity on all tiles
+        # Sparse via mtsa.sparsify() with dense_recent_tokens=0 to force sparsity on all tiles
         sparse_cfg = {
             "sparse_cfg": {
                 "*attn*": {
                     "method": "triton_sparse_softmax",
                     "sparsity_n": 2,
                     "sparsity_m": 4,
-                    "num_sink_tokens": 0,
-                    "dense_window_size": 0,
+                    "dense_sink_tokens": 0,
+                    "dense_recent_tokens": 0,
                     "backend": "triton",
                     "enable": True,
                 },

--- a/tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_sparse_nm.py
+++ b/tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_sparse_nm.py
@@ -214,6 +214,53 @@ class TestSparseNM:
             f"Sink tokens should reduce error: no_sink={err_no_sink:.6f}, with_sink={err_with_sink:.6f}"
         )
 
+    def test_sparse_nm_with_skip_softmax(self):
+        """N:M sparse softmax and skip-softmax can run in the same prefill launch."""
+        batch, seq_len = 1, 4096
+        num_kv_heads, head_dim = 4, 64
+        total = batch * seq_len
+        scale = 1.0 / (head_dim**0.5)
+
+        torch.manual_seed(123)
+        k = torch.randn(total, num_kv_heads, head_dim, device="cuda", dtype=torch.float16)
+        v = torch.randn(total, num_kv_heads, head_dim, device="cuda", dtype=torch.float16)
+        q = k.clone()
+        locs, lens = make_varlen_meta([seq_len] * batch)
+
+        out = attention(
+            q,
+            k,
+            v,
+            locs,
+            lens,
+            seq_len,
+            is_causal=False,
+            softmax_scale=scale,
+            sparsity_n=2,
+            sparsity_m=4,
+            skip_softmax_threshold=0.99,
+            measure_sparsity=True,
+        )
+
+        assert out.shape == q.shape
+        assert not torch.isnan(out).any()
+        assert not torch.isinf(out).any()
+        assert out._sparsity_total > 0
+        assert out._sparsity_skipped > 0
+
+        out_skip_only = attention(
+            q,
+            k,
+            v,
+            locs,
+            lens,
+            seq_len,
+            is_causal=False,
+            softmax_scale=scale,
+            skip_softmax_threshold=0.99,
+        )
+        assert not torch.allclose(out, out_skip_only, atol=1e-3, rtol=1e-3)
+
     # NOTE: N:M sparse attention is for prefill only, not decode.
 
 

--- a/tests/gpu/torch/sparsity/attention_sparsity/test_triton_fa_paged.py
+++ b/tests/gpu/torch/sparsity/attention_sparsity/test_triton_fa_paged.py
@@ -1,0 +1,336 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU tests for paged KV cache mode of the Triton flash attention kernel."""
+
+import pytest
+import torch
+from conftest import make_qkv, make_varlen_meta
+
+pytestmark = [
+    pytest.mark.filterwarnings("ignore::UserWarning"),
+    pytest.mark.filterwarnings("ignore::RuntimeWarning"),
+    pytest.mark.filterwarnings("ignore::DeprecationWarning"),
+]
+
+from modelopt.torch.kernels import IS_AVAILABLE as TRITON_KERNEL_AVAILABLE
+
+if TRITON_KERNEL_AVAILABLE:
+    from modelopt.torch.kernels import attention
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _scatter_to_paged_cache(k, v, b_start_loc, b_seq_len, num_kv_heads, head_dim, page_size):
+    """Scatter contiguous K/V into a paged KV cache + block table.
+
+    Args:
+        k: [total_kv, num_kv_heads, head_dim] contiguous keys
+        v: [total_kv, num_kv_heads, head_dim] contiguous values
+        b_start_loc: [batch] start offsets
+        b_seq_len: [batch] sequence lengths
+        num_kv_heads: number of KV heads
+        head_dim: head dimension
+        page_size: tokens per page
+
+    Returns:
+        k_cache: [num_blocks, page_size, num_kv_heads, head_dim]
+        v_cache: [num_blocks, page_size, num_kv_heads, head_dim]
+        block_table: [batch, max_blocks_per_seq]
+    """
+    batch = b_seq_len.shape[0]
+    device = k.device
+    dtype = k.dtype
+
+    # Calculate blocks needed per sequence
+    blocks_per_seq = []
+    for b in range(batch):
+        slen = int(b_seq_len[b].item())
+        blocks_per_seq.append((slen + page_size - 1) // page_size)
+
+    max_blocks = max(blocks_per_seq)
+    num_blocks = sum(blocks_per_seq)
+
+    k_cache = torch.zeros(num_blocks, page_size, num_kv_heads, head_dim, device=device, dtype=dtype)
+    v_cache = torch.zeros(num_blocks, page_size, num_kv_heads, head_dim, device=device, dtype=dtype)
+    block_table = torch.zeros(batch, max_blocks, device=device, dtype=torch.int32)
+
+    global_block = 0
+    for b in range(batch):
+        start = int(b_start_loc[b].item())
+        slen = int(b_seq_len[b].item())
+        for blk in range(blocks_per_seq[b]):
+            block_table[b, blk] = global_block
+            tok_start = blk * page_size
+            tok_end = min(tok_start + page_size, slen)
+            n_toks = tok_end - tok_start
+            k_cache[global_block, :n_toks] = k[start + tok_start : start + tok_end]
+            v_cache[global_block, :n_toks] = v[start + tok_start : start + tok_end]
+            global_block += 1
+
+    return k_cache, v_cache, block_table
+
+
+# ---------------------------------------------------------------------------
+# Paged KV cache tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
+class TestPagedKV:
+    """Paged KV cache mode tests — verify paged output matches contiguous."""
+
+    def test_paged_matches_contiguous(self):
+        """Paged mode produces same output as contiguous mode with identical data."""
+        batch = 2
+        seq_len = 128
+        num_heads, num_kv_heads, head_dim = 4, 2, 64
+        page_size = 16
+        scale = 1.0 / (head_dim**0.5)
+        total = batch * seq_len
+
+        torch.manual_seed(42)
+        q, k, v = make_qkv(total, num_heads, num_kv_heads, head_dim)
+        locs, lens = make_varlen_meta([seq_len] * batch)
+
+        # Contiguous reference
+        out_contig = attention(q, k, v, locs, lens, seq_len, softmax_scale=scale)
+
+        # Build paged cache from the same K/V
+        locs_k, lens_k = locs, lens
+        k_cache, v_cache, block_table = _scatter_to_paged_cache(
+            k, v, locs_k, lens_k, num_kv_heads, head_dim, page_size
+        )
+
+        # Paged mode
+        out_paged = attention(
+            q,
+            k,
+            v,
+            locs,
+            lens,
+            seq_len,
+            softmax_scale=scale,
+            b_start_loc_k=locs_k,
+            b_seq_len_k=lens_k,
+            max_input_len_k=seq_len,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            block_table=block_table,
+            page_size=page_size,
+        )
+
+        torch.testing.assert_close(out_paged, out_contig, rtol=1e-2, atol=1e-2)
+
+    def test_paged_no_nan(self):
+        """Paged mode output is finite."""
+        batch = 2
+        seq_len = 256
+        num_heads, num_kv_heads, head_dim = 4, 2, 64
+        page_size = 16
+        scale = 1.0 / (head_dim**0.5)
+        total = batch * seq_len
+
+        torch.manual_seed(55)
+        q, k, v = make_qkv(total, num_heads, num_kv_heads, head_dim)
+        locs, lens = make_varlen_meta([seq_len] * batch)
+
+        k_cache, v_cache, block_table = _scatter_to_paged_cache(
+            k, v, locs, lens, num_kv_heads, head_dim, page_size
+        )
+
+        out = attention(
+            q,
+            k,
+            v,
+            locs,
+            lens,
+            seq_len,
+            softmax_scale=scale,
+            b_seq_len_k=lens,
+            max_input_len_k=seq_len,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            block_table=block_table,
+            page_size=page_size,
+        )
+
+        assert not torch.isnan(out).any(), "NaN in paged output"
+        assert not torch.isinf(out).any(), "Inf in paged output"
+
+    def test_paged_variable_length(self):
+        """Paged mode works with variable-length sequences."""
+        seq_lens = [64, 128]
+        num_heads, num_kv_heads, head_dim = 4, 2, 64
+        page_size = 16
+        scale = 1.0 / (head_dim**0.5)
+        total = sum(seq_lens)
+
+        torch.manual_seed(77)
+        q, k, v = make_qkv(total, num_heads, num_kv_heads, head_dim)
+        locs, lens = make_varlen_meta(seq_lens)
+
+        # Contiguous reference
+        out_contig = attention(q, k, v, locs, lens, max(seq_lens), softmax_scale=scale)
+
+        # Paged
+        k_cache, v_cache, block_table = _scatter_to_paged_cache(
+            k, v, locs, lens, num_kv_heads, head_dim, page_size
+        )
+
+        out_paged = attention(
+            q,
+            k,
+            v,
+            locs,
+            lens,
+            max(seq_lens),
+            softmax_scale=scale,
+            b_seq_len_k=lens,
+            max_input_len_k=max(seq_lens),
+            k_cache=k_cache,
+            v_cache=v_cache,
+            block_table=block_table,
+            page_size=page_size,
+        )
+
+        torch.testing.assert_close(out_paged, out_contig, rtol=1e-2, atol=1e-2)
+
+    @pytest.mark.parametrize("page_size", [16, 32, 64])
+    def test_paged_different_page_sizes(self, page_size):
+        """Paged mode works with different page sizes."""
+        batch = 2
+        seq_len = 128
+        num_heads, num_kv_heads, head_dim = 4, 2, 64
+        scale = 1.0 / (head_dim**0.5)
+        total = batch * seq_len
+
+        torch.manual_seed(88)
+        q, k, v = make_qkv(total, num_heads, num_kv_heads, head_dim)
+        locs, lens = make_varlen_meta([seq_len] * batch)
+
+        out_contig = attention(q, k, v, locs, lens, seq_len, softmax_scale=scale)
+
+        k_cache, v_cache, block_table = _scatter_to_paged_cache(
+            k, v, locs, lens, num_kv_heads, head_dim, page_size
+        )
+
+        out_paged = attention(
+            q,
+            k,
+            v,
+            locs,
+            lens,
+            seq_len,
+            softmax_scale=scale,
+            b_seq_len_k=lens,
+            max_input_len_k=seq_len,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            block_table=block_table,
+            page_size=page_size,
+        )
+
+        torch.testing.assert_close(out_paged, out_contig, rtol=1e-2, atol=1e-2)
+
+    def test_paged_with_sparsity(self):
+        """Paged mode works with N:M sparsity enabled."""
+        batch = 2
+        seq_len = 256
+        num_heads, num_kv_heads, head_dim = 4, 2, 64
+        page_size = 16
+        scale = 1.0 / (head_dim**0.5)
+        total = batch * seq_len
+
+        torch.manual_seed(99)
+        q, k, v = make_qkv(total, num_heads, num_kv_heads, head_dim)
+        locs, lens = make_varlen_meta([seq_len] * batch)
+
+        k_cache, v_cache, block_table = _scatter_to_paged_cache(
+            k, v, locs, lens, num_kv_heads, head_dim, page_size
+        )
+
+        out_paged_sparse = attention(
+            q,
+            k,
+            v,
+            locs,
+            lens,
+            seq_len,
+            softmax_scale=scale,
+            b_seq_len_k=lens,
+            max_input_len_k=seq_len,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            block_table=block_table,
+            page_size=page_size,
+            sparsity_n=2,
+            sparsity_m=4,
+        )
+
+        assert not torch.isnan(out_paged_sparse).any(), "NaN in paged + sparse output"
+        assert not torch.isinf(out_paged_sparse).any(), "Inf in paged + sparse output"
+        assert out_paged_sparse.shape == q.shape
+
+    def test_paged_decode(self):
+        """Paged mode works for decode (single Q token, long KV context)."""
+        batch = 2
+        seq_lens_k = [64, 128]
+        num_heads, num_kv_heads, head_dim = 4, 2, 64
+        page_size = 16
+        scale = 1.0 / (head_dim**0.5)
+        total_kv = sum(seq_lens_k)
+
+        torch.manual_seed(33)
+        q_flat = torch.randn(batch, num_heads, head_dim, device="cuda", dtype=torch.float16)
+        k_flat = torch.randn(total_kv, num_kv_heads, head_dim, device="cuda", dtype=torch.float16)
+        v_flat = torch.randn(total_kv, num_kv_heads, head_dim, device="cuda", dtype=torch.float16)
+
+        b_start_loc_q = torch.arange(batch, device="cuda", dtype=torch.int32)
+        b_seq_len_q = torch.ones(batch, device="cuda", dtype=torch.int32)
+        cumsum = [0]
+        for sl in seq_lens_k:
+            cumsum.append(cumsum[-1] + sl)
+        b_start_loc_k = torch.tensor(cumsum[:-1], device="cuda", dtype=torch.int32)
+        b_seq_len_k = torch.tensor(seq_lens_k, device="cuda", dtype=torch.int32)
+
+        # Build paged cache
+        k_cache, v_cache, block_table = _scatter_to_paged_cache(
+            k_flat, v_flat, b_start_loc_k, b_seq_len_k, num_kv_heads, head_dim, page_size
+        )
+
+        out = attention(
+            q_flat,
+            k_flat,
+            v_flat,
+            b_start_loc_q,
+            b_seq_len_q,
+            1,
+            is_causal=False,
+            softmax_scale=scale,
+            b_start_loc_k=b_start_loc_k,
+            b_seq_len_k=b_seq_len_k,
+            max_input_len_k=max(seq_lens_k),
+            k_cache=k_cache,
+            v_cache=v_cache,
+            block_table=block_table,
+            page_size=page_size,
+        )
+
+        assert out.shape == q_flat.shape
+        assert not torch.isnan(out).any(), "NaN in paged decode output"

--- a/tests/gpu/torch/sparsity/attention_sparsity/test_vllm_plugin.py
+++ b/tests/gpu/torch/sparsity/attention_sparsity/test_vllm_plugin.py
@@ -153,8 +153,8 @@ class TestModelOptSparseAttentionImpl:
 
         torch.testing.assert_close(out_paged, out_ref, rtol=1e-2, atol=1e-2)
 
-    def test_chunked_prefill_raises(self):
-        """Test that chunked prefill (max_query_len < max_seq_len) is rejected."""
+    def test_chunked_prefill_is_forwarded_to_kernel(self):
+        """Chunked prefill metadata is handled by the suffix-aware causal mask."""
         impl = _make_impl(num_heads=2, head_dim=64, num_kv_heads=2)
         attn_metadata = SimpleNamespace(
             num_actual_tokens=4,
@@ -166,19 +166,20 @@ class TestModelOptSparseAttentionImpl:
         )
         q = torch.zeros(4, 2, 64, device="cuda", dtype=torch.float16)
         kv_cache = torch.zeros(2, 1, 16, 2, 64, device="cuda", dtype=torch.float16)
-        with pytest.raises(NotImplementedError, match="Chunked prefill"):
-            impl.forward(
-                layer=None,
-                query=q,
-                key=q,
-                value=q,
-                kv_cache=kv_cache,
-                attn_metadata=attn_metadata,
-                output=torch.empty_like(q),
-            )
+        out = impl.forward(
+            layer=None,
+            query=q,
+            key=q,
+            value=q,
+            kv_cache=kv_cache,
+            attn_metadata=attn_metadata,
+            output=torch.empty_like(q),
+        )
 
-    def test_mixed_prefill_decode_raises(self):
-        """Mixed prefill/decode cannot use one global causal-mask mode."""
+        assert torch.isfinite(out).all()
+
+    def test_mixed_prefill_decode_is_forwarded_to_kernel(self):
+        """Mixed prefill/decode batches are valid with suffix-aware causal masking."""
         prefill_len = 64
         decode_q_len = 1
         total_q = prefill_len + decode_q_len
@@ -210,16 +211,17 @@ class TestModelOptSparseAttentionImpl:
         )
 
         impl = _make_impl(num_heads, head_dim, num_kv_heads)
-        with pytest.raises(NotImplementedError, match="Mixed prefill/decode"):
-            impl.forward(
-                layer=None,
-                query=q,
-                key=q,
-                value=q,
-                kv_cache=kv_cache,
-                attn_metadata=attn_metadata,
-                output=torch.empty_like(q),
-            )
+        out = impl.forward(
+            layer=None,
+            query=q,
+            key=q,
+            value=q,
+            kv_cache=kv_cache,
+            attn_metadata=attn_metadata,
+            output=torch.empty_like(q),
+        )
+
+        assert torch.isfinite(out).all()
 
     def test_profiling_run_returns_zeros(self):
         """attn_metadata=None (vLLM profiling pass) must zero-fill output and return."""

--- a/tests/gpu/torch/sparsity/attention_sparsity/test_vllm_plugin.py
+++ b/tests/gpu/torch/sparsity/attention_sparsity/test_vllm_plugin.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU tests for the vLLM sparse attention plugin (ModelOptSparseAttentionImpl).
+
+Covers the integration-critical metadata translation done in
+``ModelOptSparseAttentionImpl.forward``:
+
+* ``query_start_loc``       -> ``b_start_loc`` / ``b_seq_len``
+* ``seq_lens``              -> ``b_seq_len_k``
+* ``kv_cache.unbind(0)``    -> key_cache / value_cache (axis order)
+* ``k_cache.shape[1]``      -> ``page_size``
+
+Asserted against a contiguous reference call to the underlying Triton kernel.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytest.importorskip("vllm")
+
+from modelopt.torch.kernels.common.attention import IS_AVAILABLE as TRITON_KERNEL_AVAILABLE
+from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import ModelOptSparseAttentionImpl
+
+if TRITON_KERNEL_AVAILABLE:
+    from modelopt.torch.kernels.common.attention import attention as triton_attention
+
+
+def _make_paged_cache(k, v, b_start_loc, b_seq_len, num_kv_heads, head_dim, page_size):
+    """Scatter contiguous K/V into a paged KV cache stacked as [2, ...].
+
+    Returns a single ``kv_cache`` tensor (matching vLLM's layout that
+    ``ModelOptSparseAttentionImpl`` consumes via ``kv_cache.unbind(0)``).
+    """
+    batch = b_seq_len.shape[0]
+    device, dtype = k.device, k.dtype
+
+    blocks_per_seq = [(int(b_seq_len[b].item()) + page_size - 1) // page_size for b in range(batch)]
+    num_blocks = sum(blocks_per_seq)
+    max_blocks = max(blocks_per_seq)
+
+    k_cache = torch.zeros(num_blocks, page_size, num_kv_heads, head_dim, device=device, dtype=dtype)
+    v_cache = torch.zeros_like(k_cache)
+    block_table = torch.zeros(batch, max_blocks, device=device, dtype=torch.int32)
+
+    g = 0
+    for b in range(batch):
+        start = int(b_start_loc[b].item())
+        slen = int(b_seq_len[b].item())
+        for blk in range(blocks_per_seq[b]):
+            block_table[b, blk] = g
+            ts = blk * page_size
+            te = min(ts + page_size, slen)
+            n = te - ts
+            k_cache[g, :n] = k[start + ts : start + te]
+            v_cache[g, :n] = v[start + ts : start + te]
+            g += 1
+
+    # Stack on a new leading axis so kv_cache.unbind(0) recovers (k_cache, v_cache).
+    kv_cache = torch.stack([k_cache, v_cache], dim=0)
+    return kv_cache, block_table
+
+
+def _make_impl(num_heads, head_dim, num_kv_heads):
+    """Construct ModelOptSparseAttentionImpl with minimal valid kwargs."""
+    return ModelOptSparseAttentionImpl(
+        num_heads=num_heads,
+        head_size=head_dim,
+        scale=1.0 / (head_dim**0.5),
+        num_kv_heads=num_kv_heads,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+        logits_soft_cap=None,
+    )
+
+
+@pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
+class TestModelOptSparseAttentionImpl:
+    """Verify forward() metadata translation matches a contiguous reference."""
+
+    def test_prefill_matches_contiguous(self):
+        """Prefill: paged forward == contiguous Triton call on the same K/V."""
+        batch = 2
+        seq_len = 64
+        num_heads, num_kv_heads, head_dim = 4, 2, 64
+        page_size = 16
+        total = batch * seq_len
+        dtype = torch.float16
+
+        torch.manual_seed(0)
+        q = torch.randn(total, num_heads, head_dim, device="cuda", dtype=dtype)
+        k = torch.randn(total, num_kv_heads, head_dim, device="cuda", dtype=dtype)
+        v = torch.randn(total, num_kv_heads, head_dim, device="cuda", dtype=dtype)
+
+        # Per-sequence offsets / lengths.
+        seq_lens = torch.tensor([seq_len, seq_len], device="cuda", dtype=torch.int32)
+        # vLLM-style cumulative query_start_loc has shape [batch + 1].
+        query_start_loc = torch.tensor([0, seq_len, 2 * seq_len], device="cuda", dtype=torch.int32)
+        b_start_loc = query_start_loc[:batch]
+        b_seq_len = seq_lens
+
+        # Contiguous reference output (what the kernel would return without paging).
+        out_ref = triton_attention(
+            q,
+            k,
+            v,
+            b_start_loc,
+            b_seq_len,
+            seq_len,
+            softmax_scale=1.0 / (head_dim**0.5),
+        )
+
+        # Build paged kv_cache shaped [2, num_blocks, page_size, num_kv_heads, head_dim].
+        kv_cache, block_table = _make_paged_cache(
+            k, v, b_start_loc, b_seq_len, num_kv_heads, head_dim, page_size
+        )
+
+        attn_metadata = SimpleNamespace(
+            num_actual_tokens=total,
+            max_query_len=seq_len,
+            max_seq_len=seq_len,
+            query_start_loc=query_start_loc,
+            seq_lens=seq_lens,
+            block_table=block_table,
+        )
+
+        impl = _make_impl(num_heads, head_dim, num_kv_heads)
+        output = torch.empty_like(q)
+        out_paged = impl.forward(
+            layer=None,
+            query=q,
+            key=k,
+            value=v,
+            kv_cache=kv_cache,
+            attn_metadata=attn_metadata,
+            output=output,
+        )
+
+        torch.testing.assert_close(out_paged, out_ref, rtol=1e-2, atol=1e-2)
+
+    def test_chunked_prefill_raises(self):
+        """Test that chunked prefill (max_query_len < max_seq_len) is rejected."""
+        impl = _make_impl(num_heads=2, head_dim=64, num_kv_heads=2)
+        attn_metadata = SimpleNamespace(
+            num_actual_tokens=4,
+            max_query_len=4,  # chunk length
+            max_seq_len=16,  # full sequence length > chunk
+            query_start_loc=torch.tensor([0, 4], device="cuda", dtype=torch.int32),
+            seq_lens=torch.tensor([16], device="cuda", dtype=torch.int32),
+            block_table=torch.zeros(1, 1, device="cuda", dtype=torch.int32),
+        )
+        q = torch.zeros(4, 2, 64, device="cuda", dtype=torch.float16)
+        kv_cache = torch.zeros(2, 1, 16, 2, 64, device="cuda", dtype=torch.float16)
+        with pytest.raises(NotImplementedError, match="Chunked prefill"):
+            impl.forward(
+                layer=None,
+                query=q,
+                key=q,
+                value=q,
+                kv_cache=kv_cache,
+                attn_metadata=attn_metadata,
+                output=torch.empty_like(q),
+            )
+
+    def test_mixed_prefill_decode_raises(self):
+        """Mixed prefill/decode cannot use one global causal-mask mode."""
+        prefill_len = 64
+        decode_q_len = 1
+        total_q = prefill_len + decode_q_len
+        num_heads, num_kv_heads, head_dim = 2, 2, 64
+        page_size = 16
+        dtype = torch.float16
+
+        q = torch.zeros(total_q, num_heads, head_dim, device="cuda", dtype=dtype)
+
+        # Sequence 0 is a full prefill. Sequence 1 is decode with one query
+        # token but a longer KV cache. max_query_len == max_seq_len, so the
+        # older max-only guard would not catch this mixed batch.
+        seq_lens = torch.tensor([prefill_len, prefill_len], device="cuda", dtype=torch.int32)
+        query_start_loc = torch.tensor([0, prefill_len, total_q], device="cuda", dtype=torch.int32)
+        b_start_loc_k = torch.tensor([0, prefill_len], device="cuda", dtype=torch.int32)
+        k = torch.zeros(prefill_len * 2, num_kv_heads, head_dim, device="cuda", dtype=dtype)
+        v = torch.zeros_like(k)
+        kv_cache, block_table = _make_paged_cache(
+            k, v, b_start_loc_k, seq_lens, num_kv_heads, head_dim, page_size
+        )
+
+        attn_metadata = SimpleNamespace(
+            num_actual_tokens=total_q,
+            max_query_len=prefill_len,
+            max_seq_len=prefill_len,
+            query_start_loc=query_start_loc,
+            seq_lens=seq_lens,
+            block_table=block_table,
+        )
+
+        impl = _make_impl(num_heads, head_dim, num_kv_heads)
+        with pytest.raises(NotImplementedError, match="Mixed prefill/decode"):
+            impl.forward(
+                layer=None,
+                query=q,
+                key=q,
+                value=q,
+                kv_cache=kv_cache,
+                attn_metadata=attn_metadata,
+                output=torch.empty_like(q),
+            )
+
+    def test_profiling_run_returns_zeros(self):
+        """attn_metadata=None (vLLM profiling pass) must zero-fill output and return."""
+        impl = _make_impl(num_heads=2, head_dim=64, num_kv_heads=2)
+        output = torch.full((4, 2, 64), 7.0, device="cuda", dtype=torch.float16)
+        result = impl.forward(
+            layer=None,
+            query=output,
+            key=output,
+            value=output,
+            kv_cache=torch.empty(0),
+            attn_metadata=None,
+            output=output,
+        )
+        assert torch.all(result == 0)
+
+    def test_page_size_inferred_from_k_cache(self):
+        """page_size passed to the kernel must equal k_cache.shape[1]."""
+        # Use the smallest valid power-of-two page_size to confirm it's not hardcoded.
+        seq_len = 32
+        num_heads, num_kv_heads, head_dim = 2, 2, 64
+        page_size = 8  # deliberately != default 16
+        dtype = torch.float16
+
+        torch.manual_seed(1)
+        q = torch.randn(seq_len, num_heads, head_dim, device="cuda", dtype=dtype)
+        k = torch.randn(seq_len, num_kv_heads, head_dim, device="cuda", dtype=dtype)
+        v = torch.randn(seq_len, num_kv_heads, head_dim, device="cuda", dtype=dtype)
+        b_start_loc = torch.tensor([0], device="cuda", dtype=torch.int32)
+        b_seq_len = torch.tensor([seq_len], device="cuda", dtype=torch.int32)
+        query_start_loc = torch.tensor([0, seq_len], device="cuda", dtype=torch.int32)
+
+        out_ref = triton_attention(
+            q, k, v, b_start_loc, b_seq_len, seq_len, softmax_scale=1.0 / (head_dim**0.5)
+        )
+
+        kv_cache, block_table = _make_paged_cache(
+            k, v, b_start_loc, b_seq_len, num_kv_heads, head_dim, page_size
+        )
+        # Sanity: kv_cache axis 1 is page_size.
+        assert kv_cache.shape == (2, seq_len // page_size, page_size, num_kv_heads, head_dim)
+
+        attn_metadata = SimpleNamespace(
+            num_actual_tokens=seq_len,
+            max_query_len=seq_len,
+            max_seq_len=seq_len,
+            query_start_loc=query_start_loc,
+            seq_lens=b_seq_len,
+            block_table=block_table,
+        )
+
+        impl = _make_impl(num_heads, head_dim, num_kv_heads)
+        output = torch.empty_like(q)
+        out_paged = impl.forward(
+            layer=None,
+            query=q,
+            key=k,
+            value=v,
+            kv_cache=kv_cache,
+            attn_metadata=attn_metadata,
+            output=output,
+        )
+        torch.testing.assert_close(out_paged, out_ref, rtol=1e-2, atol=1e-2)

--- a/tests/gpu/torch/sparsity/attention_sparsity/test_vllm_plugin.py
+++ b/tests/gpu/torch/sparsity/attention_sparsity/test_vllm_plugin.py
@@ -33,11 +33,20 @@ import torch
 
 pytest.importorskip("vllm")
 
+from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
+
 from modelopt.torch.kernels.common.attention import IS_AVAILABLE as TRITON_KERNEL_AVAILABLE
 from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import ModelOptSparseAttentionImpl
 
 if TRITON_KERNEL_AVAILABLE:
     from modelopt.torch.kernels.common.attention import attention as triton_attention
+
+_ACTIVE_PREFILL_SPARSE_KW = {
+    "sparsity_n": 2,
+    "sparsity_m": 4,
+    "dense_sink_tokens": 0,
+    "dense_recent_tokens": 0,
+}
 
 
 def _make_paged_cache(k, v, b_start_loc, b_seq_len, num_kv_heads, head_dim, page_size):
@@ -123,6 +132,7 @@ class TestModelOptSparseAttentionImpl:
             b_seq_len,
             seq_len,
             softmax_scale=1.0 / (head_dim**0.5),
+            **_ACTIVE_PREFILL_SPARSE_KW,
         )
 
         # Build paged kv_cache shaped [2, num_blocks, page_size, num_kv_heads, head_dim].
@@ -140,6 +150,7 @@ class TestModelOptSparseAttentionImpl:
         )
 
         impl = _make_impl(num_heads, head_dim, num_kv_heads)
+        impl.sparse_kw = _ACTIVE_PREFILL_SPARSE_KW
         output = torch.empty_like(q)
         out_paged = impl.forward(
             layer=None,
@@ -156,6 +167,7 @@ class TestModelOptSparseAttentionImpl:
     def test_chunked_prefill_is_forwarded_to_kernel(self):
         """Chunked prefill metadata is handled by the suffix-aware causal mask."""
         impl = _make_impl(num_heads=2, head_dim=64, num_kv_heads=2)
+        impl.sparse_kw = _ACTIVE_PREFILL_SPARSE_KW
         attn_metadata = SimpleNamespace(
             num_actual_tokens=4,
             max_query_len=4,  # chunk length
@@ -211,6 +223,7 @@ class TestModelOptSparseAttentionImpl:
         )
 
         impl = _make_impl(num_heads, head_dim, num_kv_heads)
+        impl.sparse_kw = _ACTIVE_PREFILL_SPARSE_KW
         out = impl.forward(
             layer=None,
             query=q,
@@ -222,6 +235,74 @@ class TestModelOptSparseAttentionImpl:
         )
 
         assert torch.isfinite(out).all()
+
+    def test_decode_delegates_to_vllm(self, monkeypatch):
+        """Decode-only sparse work is not routed through the ModelOpt paged kernel."""
+        batch = 2
+        q_len = 1
+        kv_lens = torch.tensor([17, 33], device="cuda", dtype=torch.int32)
+        total_q = batch * q_len
+        num_heads, num_kv_heads, head_dim = 4, 2, 64
+        page_size = 16
+        dtype = torch.float16
+
+        torch.manual_seed(2)
+        q = torch.randn(total_q, num_heads, head_dim, device="cuda", dtype=dtype)
+        k = torch.randn(
+            int(kv_lens.sum().item()), num_kv_heads, head_dim, device="cuda", dtype=dtype
+        )
+        v = torch.randn_like(k)
+
+        query_start_loc = torch.tensor([0, 1, 2], device="cuda", dtype=torch.int32)
+        kv_start_loc = torch.tensor([0, int(kv_lens[0].item())], device="cuda", dtype=torch.int32)
+
+        kv_cache, block_table = _make_paged_cache(
+            k, v, kv_start_loc, kv_lens, num_kv_heads, head_dim, page_size
+        )
+        attn_metadata = SimpleNamespace(
+            num_actual_tokens=total_q,
+            max_query_len=q_len,
+            max_seq_len=int(kv_lens.max().item()),
+            query_start_loc=query_start_loc,
+            seq_lens=kv_lens,
+            block_table=block_table,
+        )
+
+        impl = _make_impl(num_heads, head_dim, num_kv_heads)
+        impl.sparse_kw = _ACTIVE_PREFILL_SPARSE_KW
+        output = torch.empty_like(q)
+        called = {}
+
+        def fake_forward(
+            self,
+            layer,
+            query,
+            key,
+            value,
+            kv_cache_arg,
+            attn_metadata_arg,
+            output_arg=None,
+            output_scale=None,
+            output_block_scale=None,
+        ):
+            called["attn_metadata"] = attn_metadata_arg
+            output_arg.fill_(9)
+            return output_arg
+
+        monkeypatch.setattr(FlashAttentionImpl, "forward", fake_forward)
+
+        result = impl.forward(
+            layer=None,
+            query=q,
+            key=q,
+            value=q,
+            kv_cache=kv_cache,
+            attn_metadata=attn_metadata,
+            output=output,
+        )
+        assert called["attn_metadata"] is attn_metadata
+        assert result is output
+        assert torch.all(result == 9)
 
     def test_profiling_run_returns_zeros(self):
         """attn_metadata=None (vLLM profiling pass) must zero-fill output and return."""
@@ -255,7 +336,14 @@ class TestModelOptSparseAttentionImpl:
         query_start_loc = torch.tensor([0, seq_len], device="cuda", dtype=torch.int32)
 
         out_ref = triton_attention(
-            q, k, v, b_start_loc, b_seq_len, seq_len, softmax_scale=1.0 / (head_dim**0.5)
+            q,
+            k,
+            v,
+            b_start_loc,
+            b_seq_len,
+            seq_len,
+            softmax_scale=1.0 / (head_dim**0.5),
+            **_ACTIVE_PREFILL_SPARSE_KW,
         )
 
         kv_cache, block_table = _make_paged_cache(
@@ -274,6 +362,7 @@ class TestModelOptSparseAttentionImpl:
         )
 
         impl = _make_impl(num_heads, head_dim, num_kv_heads)
+        impl.sparse_kw = _ACTIVE_PREFILL_SPARSE_KW
         output = torch.empty_like(q)
         out_paged = impl.forward(
             layer=None,

--- a/tests/gpu/torch/sparsity/attention_sparsity/test_wan22_skip_softmax.py
+++ b/tests/gpu/torch/sparsity/attention_sparsity/test_wan22_skip_softmax.py
@@ -79,14 +79,14 @@ _TINY_PIPE_KWARGS = {
 }
 
 
-def _skip_softmax_cfg(raw_threshold=-5.0):
+def _skip_softmax_cfg(threshold=0.03125):
     """Sparse config targeting Wan 2.2 self-attention (attn1) only."""
     return {
         "sparse_cfg": {
             "*attn1*": {
                 "method": "triton_skip_softmax",
                 "backend": "triton",
-                "skip_softmax_raw_threshold": raw_threshold,
+                "skip_softmax_threshold": threshold,
                 "enable": True,
             },
             "default": {"enable": False},
@@ -138,13 +138,13 @@ class TestWan22PipelineE2E:
 
     def test_skip_softmax_pipeline_runs_e2e(self, tiny_wan22_pipe):
         """Sparsified pipeline runs end-to-end producing finite frames."""
-        _sparsify_both_transformers(tiny_wan22_pipe, _skip_softmax_cfg(raw_threshold=-5.0))
+        _sparsify_both_transformers(tiny_wan22_pipe, _skip_softmax_cfg(threshold=0.03125))
         output = _run_pipe(tiny_wan22_pipe)
         assert output.frames is not None
         assert len(output.frames[0]) > 0
 
     def test_tight_threshold_matches_dense_within_tolerance(self, tiny_wan22_pipe, tiny_wan22_path):
-        """raw_threshold=-50 (effectively dense) → output close to unsparsified run."""
+        """A near-zero threshold is effectively dense and close to unsparsified."""
         from diffusers import WanPipeline
 
         # Dense run: fresh pipe, no sparsification
@@ -152,8 +152,10 @@ class TestWan22PipelineE2E:
         dense_pipe.to("cuda")
         dense_frame0 = _run_pipe(dense_pipe).frames[0][0]
 
-        # Sparse run: same seed, raw_threshold=-50 (≈ no tiles skipped)
-        _sparsify_both_transformers(tiny_wan22_pipe, _skip_softmax_cfg(raw_threshold=-50.0))
+        # Sparse run: same seed, threshold=2**-50 (≈ no tiles skipped)
+        _sparsify_both_transformers(
+            tiny_wan22_pipe, _skip_softmax_cfg(threshold=8.881784197001252e-16)
+        )
         sparse_frame0 = _run_pipe(tiny_wan22_pipe).frames[0][0]
 
         # Both are PIL images — convert to tensor and compare
@@ -172,7 +174,7 @@ class TestWan22PipelineE2E:
             TritonSkipSoftmaxMethod,
         )
 
-        _sparsify_both_transformers(tiny_wan22_pipe, _skip_softmax_cfg(raw_threshold=-2.0))
+        _sparsify_both_transformers(tiny_wan22_pipe, _skip_softmax_cfg(threshold=0.25))
 
         # Enable measurement + reset counters on every sparse module
         for module in (tiny_wan22_pipe.transformer, tiny_wan22_pipe.transformer_2):

--- a/tests/unit/torch/kernels/sparsity/attention/test_ltx_triton_attention.py
+++ b/tests/unit/torch/kernels/sparsity/attention/test_ltx_triton_attention.py
@@ -51,7 +51,6 @@ class TestThreadLocalContext:
             calibration_mode=False,
             threshold_trials=[0.01, 0.1],
             scale_factor=2.0,
-            raw_threshold=-5.0,
         )
         active, threshold, scale_factor = ltx_mod._get_ltx_triton_context()
         assert active is True

--- a/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attention_conversion.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attention_conversion.py
@@ -369,6 +369,10 @@ class TestExportSparseAttentionConfig:
                     "prefill": {"a": 3.14, "b": 7.5},
                     "decode": {"a": 0.5, "b": 9.0},
                 }
+                module._sparse_method_instance.target_sparse_ratio = {
+                    "prefill": 0.4,
+                    "decode": 0.6,
+                }
 
         out = export_sparse_attention_config(model)
         assert out is not None
@@ -376,4 +380,5 @@ class TestExportSparseAttentionConfig:
         tsf = out["threshold_scale_factor"]
         assert tsf["prefill"] == {"a": 3.14, "b": 7.5}
         assert tsf["decode"] == {"a": 0.5, "b": 9.0}
+        assert out["target_sparse_ratio"] == {"prefill": 0.4, "decode": 0.6}
         assert out["producer"]["name"] == "modelopt"

--- a/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attention_conversion.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attention_conversion.py
@@ -15,6 +15,8 @@
 
 """Tests for sparse attention conversion and replacement."""
 
+import copy
+
 import pytest
 
 pytest.importorskip("transformers")
@@ -30,6 +32,7 @@ from _test_utils.torch.sparsity.sparse_attention_common import (
 
 import modelopt.torch.opt as mto
 import modelopt.torch.sparsity.attention_sparsity as sparse_attn
+from modelopt.torch.sparsity.attention_sparsity.config import SKIP_SOFTMAX_CALIB_SPARSE24
 from modelopt.torch.sparsity.attention_sparsity.conversion import (
     _set_attn_implementation,
     disable_sparse_attention,
@@ -382,3 +385,71 @@ class TestExportSparseAttentionConfig:
         assert tsf["decode"] == {"a": 0.5, "b": 9.0}
         assert out["target_sparse_ratio"] == {"prefill": 0.4, "decode": 0.6}
         assert out["producer"]["name"] == "modelopt"
+
+    def test_exports_sparse_softmax_metadata(self):
+        """N:M sparse-softmax params are exported without calibration metadata."""
+        model = SimpleAttentionModel()
+        config = {
+            "sparse_cfg": {
+                "*attention*": {
+                    "method": "triton_sparse_softmax",
+                    "sparsity_n": 2,
+                    "sparsity_m": 4,
+                    "dense_sink_tokens": 4,
+                    "dense_recent_tokens": 128,
+                    "backend": "triton",
+                    "enable": True,
+                },
+                "default": {"enable": False},
+            }
+        }
+
+        with patch(
+            "modelopt.torch.kernels.sparsity.attention.register_triton_attention",
+            MagicMock(return_value=True),
+        ):
+            model = sparse_attn.sparsify(model, config)
+
+        out = export_sparse_attention_config(model)
+
+        assert out is not None
+        assert out["config_groups"]["group_0"]["sparse_algo"] == "sparse_softmax"
+        assert out["sparse_softmax"] == {
+            "sparsity_n": 2,
+            "sparsity_m": 4,
+            "dense_sink_tokens": 4,
+            "dense_recent_tokens": 128,
+        }
+        assert "threshold_scale_factor" not in out
+
+    def test_exports_calibrated_skip_softmax_with_sparse_softmax_overlay(self):
+        """Combined config exports both calibrated skip-softmax and N:M metadata."""
+        model = SimpleAttentionModel()
+        config = copy.deepcopy(SKIP_SOFTMAX_CALIB_SPARSE24)
+        config["sparse_cfg"].pop("calibration")
+        config["sparse_cfg"]["*attention*"] = config["sparse_cfg"].pop("*attn*")
+        model = sparse_attn.sparsify(model, config)
+
+        for module in model.modules():
+            if isinstance(module, SparseAttentionModule):
+                module._sparse_method_instance.calibration_params = {
+                    "prefill": {"a": 3.14, "b": 7.5},
+                }
+                module._sparse_method_instance.target_sparse_ratio = {
+                    "prefill": 0.4,
+                    "decode": 0.6,
+                }
+
+        out = export_sparse_attention_config(model)
+
+        assert out is not None
+        assert out["config_groups"]["group_0"]["sparse_algo"] == "softmax_skip"
+        assert out["config_groups"]["group_1"]["sparse_algo"] == "sparse_softmax"
+        assert out["threshold_scale_factor"]["prefill"] == {"a": 3.14, "b": 7.5}
+        assert out["target_sparse_ratio"] == {"prefill": 0.4, "decode": 0.6}
+        assert out["sparse_softmax"] == {
+            "sparsity_n": 2,
+            "sparsity_m": 4,
+            "dense_sink_tokens": 0,
+            "dense_recent_tokens": 64,
+        }

--- a/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_config.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_config.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for sparse attention checkpoint config helpers."""
+
+import types
+
+import modelopt.torch.sparsity.attention_sparsity as mtsa
+from modelopt.torch.sparsity.attention_sparsity.plugins.sparse_attn_config import (
+    load_from_checkpoint_metadata,
+    match_sparse_config,
+)
+
+
+class TestMatchSparseConfig:
+    """Test match_sparse_config name-pattern matching."""
+
+    def test_matches_glob(self):
+        """Test that a glob pattern matches a module name."""
+        cfg = {"sparse_cfg": {"*self_attn*": {"sparsity_n": 2}, "default": {"enable": False}}}
+        assert match_sparse_config("model.layers.3.self_attn", cfg) == {"sparsity_n": 2}
+
+    def test_returns_none_for_no_match(self):
+        """Test that a non-matching module name returns None."""
+        cfg = {"sparse_cfg": {"*self_attn*": {"sparsity_n": 2}, "default": {"enable": False}}}
+        assert match_sparse_config("embed_tokens", cfg) is None
+
+    def test_skips_default_and_calibration_keys(self):
+        """Test that ``default`` and ``calibration`` keys are treated as metadata."""
+        cfg = {
+            "sparse_cfg": {
+                "default": {"enable": False},
+                "calibration": {"dataset": "x"},
+                "*attn*": {"sparsity_n": 2},
+            }
+        }
+        assert match_sparse_config("default", cfg) is None
+        assert match_sparse_config("calibration", cfg) is None
+        assert match_sparse_config("model.layers.0.self_attn", cfg) == {"sparsity_n": 2}
+
+    def test_accepts_bare_sparse_cfg(self):
+        """Test that the bare inner dict is accepted alongside ``{sparse_cfg: {...}}``."""
+        bare = {"*attn*": {"sparsity_n": 2}, "default": {"enable": False}}
+        assert match_sparse_config("self_attn", bare) == {"sparsity_n": 2}
+
+    def test_first_match_wins(self):
+        """Test that patterns are tried in insertion order with first hit winning."""
+        cfg = {
+            "sparse_cfg": {
+                "*self_attn*": {"sparsity_n": 2, "scope": "broad"},
+                "*layers.0.self_attn*": {"scope": "specific"},
+                "default": {"enable": False},
+            }
+        }
+        matched = match_sparse_config("model.layers.0.self_attn", cfg)
+        assert matched["scope"] == "broad"
+
+
+class TestLoadFromCheckpointMetadata:
+    """Test load_from_checkpoint_metadata reading from a HF config object."""
+
+    def test_returns_none_for_missing_hf_config(self):
+        """Test that a None hf_config returns None."""
+        assert load_from_checkpoint_metadata(None) is None
+
+    def test_returns_none_when_attribute_missing(self):
+        """Test that an hf_config without sparse_attention_config returns None."""
+        hf_config = types.SimpleNamespace()
+        assert load_from_checkpoint_metadata(hf_config) is None
+
+    def test_returns_none_for_unknown_algo(self):
+        """Test that an unrecognized sparse_algo returns None."""
+        meta = {"config_groups": {"group_0": {"sparse_algo": "future_algo_v9000"}}}
+        hf_config = types.SimpleNamespace(sparse_attention_config=meta)
+        assert load_from_checkpoint_metadata(hf_config) is None
+
+    def test_maps_softmax_skip_to_preset(self):
+        """Test that softmax_skip resolves to SKIP_SOFTMAX_TRITON_DEFAULT."""
+        meta = {
+            "config_groups": {"group_0": {"sparse_algo": "softmax_skip"}},
+            "threshold_scale_factor": {"prefill": {"a": 7.93, "b": 8.61}},
+            "producer": {"name": "modelopt", "version": "0.37.0"},
+        }
+        hf_config = types.SimpleNamespace(sparse_attention_config=meta)
+        result = load_from_checkpoint_metadata(hf_config)
+        assert result is not None
+        cfg, preset_name = result
+        assert preset_name == "SKIP_SOFTMAX_TRITON_DEFAULT"
+        assert cfg is mtsa.SKIP_SOFTMAX_TRITON_DEFAULT
+
+    def test_handles_non_dict_metadata(self):
+        """Test that a non-dict sparse_attention_config returns None."""
+        hf_config = types.SimpleNamespace(sparse_attention_config="not a dict")
+        assert load_from_checkpoint_metadata(hf_config) is None
+
+    def test_handles_empty_config_groups(self):
+        """Test that an empty config_groups returns None."""
+        hf_config = types.SimpleNamespace(sparse_attention_config={"config_groups": {}})
+        assert load_from_checkpoint_metadata(hf_config) is None

--- a/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_config.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_config.py
@@ -128,6 +128,72 @@ class TestLoadFromCheckpointMetadata:
             "enable": True,
         }
 
+    def test_maps_sparse_softmax_to_dynamic_config(self):
+        """Test that checkpoint N:M sparse-softmax metadata restores layer params."""
+        meta = {
+            "config_groups": {"group_0": {"sparse_algo": "sparse_softmax"}},
+            "sparse_softmax": {
+                "sparsity_n": 2,
+                "sparsity_m": 4,
+                "dense_sink_tokens": 4,
+                "dense_recent_tokens": 128,
+            },
+            "producer": {"name": "modelopt", "version": "0.45.0"},
+        }
+        hf_config = types.SimpleNamespace(sparse_attention_config=meta)
+
+        result = load_from_checkpoint_metadata(hf_config)
+
+        assert result is not None
+        cfg, preset_name = result
+        assert preset_name == "CHECKPOINT_SPARSE_SOFTMAX"
+        layer_cfg = match_sparse_config("model.layers.0.self_attn", cfg)
+        assert layer_cfg == {
+            "method": "triton_sparse_softmax",
+            "sparsity_n": 2,
+            "sparsity_m": 4,
+            "dense_sink_tokens": 4,
+            "dense_recent_tokens": 128,
+            "backend": "triton",
+            "enable": True,
+        }
+
+    def test_maps_calibrated_softmax_skip_with_sparse_softmax_overlay(self):
+        """Test that vLLM restores combined skip-softmax plus N:M sparse-softmax."""
+        threshold_scale_factor = {
+            "formula": "a * exp(b * target_sparsity)",
+            "prefill": {"a": 2.0, "b": 3.0},
+        }
+        meta = {
+            "config_groups": {
+                "group_0": {"sparse_algo": "softmax_skip"},
+                "group_1": {"sparse_algo": "sparse_softmax"},
+            },
+            "threshold_scale_factor": threshold_scale_factor,
+            "target_sparse_ratio": {"prefill": 0.4, "decode": 0.6},
+            "sparse_softmax": {"sparsity_n": 2, "sparsity_m": 4},
+            "producer": {"name": "modelopt", "version": "0.45.0"},
+        }
+        hf_config = types.SimpleNamespace(sparse_attention_config=meta)
+
+        result = load_from_checkpoint_metadata(hf_config)
+
+        assert result is not None
+        cfg, preset_name = result
+        assert preset_name == "CHECKPOINT_CALIBRATED_SOFTMAX_SKIP_SPARSE_SOFTMAX"
+        layer_cfg = match_sparse_config("model.layers.0.self_attn", cfg)
+        assert layer_cfg == {
+            "method": "triton_skip_softmax",
+            "threshold_scale_factor": threshold_scale_factor,
+            "target_sparse_ratio": {"prefill": 0.4, "decode": 0.6},
+            "sparsity_n": 2,
+            "sparsity_m": 4,
+            "dense_sink_tokens": 0,
+            "dense_recent_tokens": 64,
+            "backend": "triton",
+            "enable": True,
+        }
+
     def test_handles_non_dict_metadata(self):
         """Test that a non-dict sparse_attention_config returns None."""
         hf_config = types.SimpleNamespace(sparse_attention_config="not a dict")

--- a/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_config.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_config.py
@@ -86,11 +86,10 @@ class TestLoadFromCheckpointMetadata:
         hf_config = types.SimpleNamespace(sparse_attention_config=meta)
         assert load_from_checkpoint_metadata(hf_config) is None
 
-    def test_maps_softmax_skip_to_preset(self):
-        """Test that softmax_skip resolves to SKIP_SOFTMAX_TRITON_DEFAULT."""
+    def test_maps_uncalibrated_softmax_skip_to_preset(self):
+        """Test that uncalibrated softmax_skip uses the static Triton preset."""
         meta = {
             "config_groups": {"group_0": {"sparse_algo": "softmax_skip"}},
-            "threshold_scale_factor": {"prefill": {"a": 7.93, "b": 8.61}},
             "producer": {"name": "modelopt", "version": "0.37.0"},
         }
         hf_config = types.SimpleNamespace(sparse_attention_config=meta)
@@ -99,6 +98,35 @@ class TestLoadFromCheckpointMetadata:
         cfg, preset_name = result
         assert preset_name == "SKIP_SOFTMAX_TRITON_DEFAULT"
         assert cfg is mtsa.SKIP_SOFTMAX_TRITON_DEFAULT
+
+    def test_maps_calibrated_softmax_skip_to_dynamic_config(self):
+        """Test that calibrated softmax_skip preserves checkpoint coefficients."""
+        threshold_scale_factor = {
+            "formula": "a * exp(b * target_sparsity)",
+            "prefill": {"a": 2.0, "b": 3.0},
+            "decode": {"a": 5.0, "b": 7.0},
+        }
+        meta = {
+            "config_groups": {"group_0": {"sparse_algo": "softmax_skip"}},
+            "threshold_scale_factor": threshold_scale_factor,
+            "target_sparse_ratio": {"prefill": 0.4, "decode": 0.6},
+            "producer": {"name": "modelopt", "version": "0.45.0"},
+        }
+        hf_config = types.SimpleNamespace(sparse_attention_config=meta)
+
+        result = load_from_checkpoint_metadata(hf_config)
+
+        assert result is not None
+        cfg, preset_name = result
+        assert preset_name == "CHECKPOINT_CALIBRATED_SOFTMAX_SKIP"
+        layer_cfg = match_sparse_config("model.layers.0.self_attn", cfg)
+        assert layer_cfg == {
+            "method": "triton_skip_softmax",
+            "threshold_scale_factor": threshold_scale_factor,
+            "target_sparse_ratio": {"prefill": 0.4, "decode": 0.6},
+            "backend": "triton",
+            "enable": True,
+        }
 
     def test_handles_non_dict_metadata(self):
         """Test that a non-dict sparse_attention_config returns None."""

--- a/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_worker.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_worker.py
@@ -16,6 +16,7 @@
 """Unit tests for sparse attention vLLM worker compatibility helpers."""
 
 import math
+from contextlib import nullcontext
 
 import pytest
 import torch
@@ -27,6 +28,7 @@ from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
 from modelopt.torch.sparsity.attention_sparsity.plugins import vllm as vllm_plugin
 from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
     ModelOptSparseAttentionImpl,
+    _build_sparse_kw,
     _clone_sparse_impl,
 )
 
@@ -67,17 +69,144 @@ def test_clone_sparse_impl_rejects_non_none_sinks():
         _clone_sparse_impl(old_impl)
 
 
+def test_forward_delegates_cascade_metadata_to_vllm(monkeypatch):
+    """Cascade/prefix-cache metadata should use vLLM's native implementation."""
+    impl = _clone_sparse_impl(_make_old_impl())
+    q = torch.zeros(1, impl.num_heads, impl.head_size, dtype=torch.float16)
+    kv_cache = torch.zeros(2, 1, 16, impl.num_kv_heads, impl.head_size, dtype=torch.float16)
+    output = torch.empty_like(q)
+    attn_metadata = type("AttnMetadata", (), {"use_cascade": True})()
+    called = {}
+
+    def fake_forward(
+        self,
+        layer,
+        query,
+        key,
+        value,
+        kv_cache_arg,
+        attn_metadata_arg,
+        output_arg=None,
+        output_scale=None,
+        output_block_scale=None,
+    ):
+        called["self"] = self
+        called["kv_cache"] = kv_cache_arg
+        called["attn_metadata"] = attn_metadata_arg
+        output_arg.fill_(3)
+        return output_arg
+
+    monkeypatch.setattr(FlashAttentionImpl, "forward", fake_forward)
+
+    result = impl.forward(
+        layer=None,
+        query=q,
+        key=q,
+        value=q,
+        kv_cache=kv_cache,
+        attn_metadata=attn_metadata,
+        output=output,
+    )
+
+    assert result is output
+    assert called == {
+        "self": impl,
+        "kv_cache": kv_cache,
+        "attn_metadata": attn_metadata,
+    }
+    assert torch.all(result == 3)
+
+
 @pytest.mark.parametrize(
-    ("max_query_len", "seq_len", "phase", "expected_scale"),
+    ("sparse_kw", "max_query_len", "max_seq_len"),
     [
-        (128, 128, "prefill", 2.0 * math.exp(3.0 * 0.4)),
-        (1, 256, "decode", 0.1 * math.exp(1.0 * 0.6)),
+        ({"skip_softmax_threshold": 0.001}, 1, 128),
+        (
+            {
+                "threshold_scale_factor": {
+                    "formula": "a * exp(b * target_sparsity)",
+                    "prefill": {"a": 10.0, "b": 0.0},
+                },
+                "target_sparse_ratio": {"prefill": 0.5},
+            },
+            4,
+            4,
+        ),
     ],
 )
-def test_forward_resolves_calibrated_skip_softmax_threshold(
-    monkeypatch, max_query_len, seq_len, phase, expected_scale
+def test_forward_delegates_launches_without_effective_sparse_work(
+    monkeypatch, sparse_kw, max_query_len, max_seq_len
 ):
+    """When no validated sparse path is active, use vLLM FlashAttention."""
+    impl = _clone_sparse_impl(_make_old_impl())
+    impl.sparse_kw = sparse_kw
+    q = torch.zeros(max_query_len, impl.num_heads, impl.head_size, dtype=torch.float16)
+    kv_cache = torch.zeros(
+        2, 1, max_seq_len, impl.num_kv_heads, impl.head_size, dtype=torch.float16
+    )
+    output = torch.empty_like(q)
+    attn_metadata = type(
+        "AttnMetadata",
+        (),
+        {
+            "num_actual_tokens": max_query_len,
+            "max_query_len": max_query_len,
+            "max_seq_len": max_seq_len,
+            "query_start_loc": torch.tensor([0, max_query_len], dtype=torch.int32),
+            "seq_lens": torch.tensor([max_seq_len], dtype=torch.int32),
+            "block_table": torch.zeros(1, 1, dtype=torch.int32),
+        },
+    )()
+    called = {}
+
+    def fake_attention(*args, **kwargs):
+        raise AssertionError("ModelOpt Triton kernel should not be called")
+
+    def fake_forward(
+        self,
+        layer,
+        query,
+        key,
+        value,
+        kv_cache_arg,
+        attn_metadata_arg,
+        output_arg=None,
+        output_scale=None,
+        output_block_scale=None,
+    ):
+        called["attn_metadata"] = attn_metadata_arg
+        output_arg.fill_(5)
+        return output_arg
+
+    monkeypatch.setattr(vllm_plugin, "triton_attention", fake_attention)
+    monkeypatch.setattr(FlashAttentionImpl, "forward", fake_forward)
+
+    maybe_warns = (
+        pytest.warns(UserWarning, match="outside the valid lambda range")
+        if "threshold_scale_factor" in sparse_kw
+        else nullcontext()
+    )
+    with maybe_warns:
+        result = impl.forward(
+            layer=None,
+            query=q,
+            key=q,
+            value=q,
+            kv_cache=kv_cache,
+            attn_metadata=attn_metadata,
+            output=output,
+        )
+
+    assert called["attn_metadata"] is attn_metadata
+    assert result is output
+    assert torch.all(result == 5)
+
+
+def test_forward_resolves_calibrated_skip_softmax_threshold(monkeypatch):
     """Forward should convert checkpoint calibration params to kernel threshold."""
+    max_query_len = 128
+    seq_len = 128
+    expected_scale = 2.0 * math.exp(3.0 * 0.4)
     impl = _clone_sparse_impl(_make_old_impl())
     impl.sparse_kw = {
         "threshold_scale_factor": {
@@ -119,10 +248,28 @@ def test_forward_resolves_calibrated_skip_softmax_threshold(
         output=torch.empty_like(q),
     )
 
-    assert phase in impl.sparse_kw["threshold_scale_factor"]
     assert captured["skip_softmax_threshold"] == pytest.approx(expected_scale / seq_len)
     assert "threshold_scale_factor" not in captured
     assert "target_sparse_ratio" not in captured
+
+
+def test_resolve_calibrated_skip_softmax_threshold_for_decode():
+    """Calibration conversion is phase-aware even when decode later delegates."""
+    sparse_kw = {
+        "threshold_scale_factor": {
+            "formula": "a * exp(b * target_sparsity)",
+            "decode": {"a": 0.1, "b": 1.0},
+        },
+        "target_sparse_ratio": {"decode": 0.6},
+    }
+
+    vllm_plugin._resolve_skip_softmax_calibration(
+        sparse_kw,
+        is_prefill=False,
+        max_seq_len=256,
+    )
+
+    assert sparse_kw == {"skip_softmax_threshold": pytest.approx(0.1 * math.exp(1.0 * 0.6) / 256)}
 
 
 def test_resolve_calibrated_skip_softmax_warns_and_disables_for_large_threshold():
@@ -147,9 +294,91 @@ def test_resolve_calibrated_skip_softmax_warns_and_disables_for_large_threshold(
     assert "target_sparse_ratio" not in sparse_kw
 
 
+def test_build_sparse_kw_restores_checkpoint_sparse_metadata():
+    """Checkpoint metadata is converted into ModelOpt Triton kwargs."""
+    layer_cfg = {
+        "sparsity_n": 2,
+        "sparsity_m": 4,
+        "dense_sink_tokens": 3,
+        "dense_recent_tokens": 64,
+        "threshold_scale_factor": {"prefill": {"a": 1.0, "b": 2.0}},
+        "target_sparse_ratio": {"prefill": 0.5},
+    }
+
+    assert _build_sparse_kw(layer_cfg) == {
+        "sparsity_n": 2,
+        "sparsity_m": 4,
+        "dense_sink_tokens": 3,
+        "dense_recent_tokens": 64,
+        "threshold_scale_factor": {"prefill": {"a": 1.0, "b": 2.0}},
+        "target_sparse_ratio": {"prefill": 0.5},
+    }
+
+
+def test_forward_delegates_sparse_nm_only_decode_to_vllm(monkeypatch):
+    """N:M sparse softmax is prefill-only, so N:M-only decode uses vLLM."""
+    impl = _clone_sparse_impl(_make_old_impl())
+    impl.sparse_kw = {
+        "sparsity_n": 2,
+        "sparsity_m": 4,
+        "dense_sink_tokens": 4,
+        "dense_recent_tokens": 128,
+    }
+    q = torch.zeros(1, impl.num_heads, impl.head_size, dtype=torch.float16)
+    kv_cache = torch.zeros(2, 1, 16, impl.num_kv_heads, impl.head_size, dtype=torch.float16)
+    attn_metadata = type(
+        "AttnMetadata",
+        (),
+        {
+            "num_actual_tokens": 1,
+            "max_query_len": 1,
+            "max_seq_len": 16,
+            "query_start_loc": torch.tensor([0, 1], dtype=torch.int32),
+            "seq_lens": torch.tensor([16], dtype=torch.int32),
+            "block_table": torch.zeros(1, 1, dtype=torch.int32),
+        },
+    )()
+
+    def fake_attention(q, **kwargs):
+        raise AssertionError("N:M-only decode should not call ModelOpt Triton")
+
+    def fake_forward(
+        self,
+        layer,
+        query,
+        key,
+        value,
+        kv_cache_arg,
+        attn_metadata_arg,
+        output_arg=None,
+        output_scale=None,
+        output_block_scale=None,
+    ):
+        output_arg.fill_(7)
+        return output_arg
+
+    monkeypatch.setattr(vllm_plugin, "triton_attention", fake_attention)
+    monkeypatch.setattr(FlashAttentionImpl, "forward", fake_forward)
+
+    output = torch.empty_like(q)
+    result = impl.forward(
+        layer=None,
+        query=q,
+        key=q,
+        value=q,
+        kv_cache=kv_cache,
+        attn_metadata=attn_metadata,
+        output=output,
+    )
+
+    assert result is output
+    assert torch.all(result == 7)
+
+
 def test_forward_allows_chunked_prefill_metadata(monkeypatch):
     """vLLM V1 can pass suffix-Q/chunked-prefill metadata; the kernel handles it."""
     impl = _clone_sparse_impl(_make_old_impl())
+    impl.sparse_kw = {"sparsity_n": 2, "sparsity_m": 4}
     q_len = 4
     kv_len = 10
     q = torch.zeros(q_len, impl.num_heads, impl.head_size, dtype=torch.float16)

--- a/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_worker.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_worker.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for sparse attention vLLM worker compatibility helpers."""
+
+import pytest
+
+pytest.importorskip("vllm")
+
+from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
+    ModelOptSparseAttentionImpl,
+    _clone_sparse_impl,
+)
+from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
+
+
+def _make_old_impl():
+    """Create a vLLM FlashAttention impl with initialized runtime state."""
+    return FlashAttentionImpl(
+        num_heads=2,
+        head_size=64,
+        scale=0.125,
+        num_kv_heads=2,
+        alibi_slopes=None,
+        sliding_window=128,
+        kv_cache_dtype="auto",
+    )
+
+
+def test_clone_sparse_impl_preserves_runtime_state():
+    """Clone helper should preserve vLLM's initialized impl state."""
+    old_impl = _make_old_impl()
+    old_impl.future_attr = object()
+
+    new_impl = _clone_sparse_impl(old_impl)
+
+    assert isinstance(new_impl, ModelOptSparseAttentionImpl)
+    assert new_impl is not old_impl
+    assert new_impl.sliding_window == old_impl.sliding_window
+    assert new_impl.future_attr is old_impl.future_attr
+    assert new_impl.__dict__.items() >= old_impl.__dict__.items()
+
+
+def test_clone_sparse_impl_rejects_non_none_sinks():
+    """vLLM attention sinks must fail fast until the sparse kernel supports them."""
+    old_impl = _make_old_impl()
+    old_impl.sinks = object()
+
+    with pytest.raises(NotImplementedError, match="sinks"):
+        _clone_sparse_impl(old_impl)

--- a/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_worker.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_worker.py
@@ -70,8 +70,8 @@ def test_clone_sparse_impl_rejects_non_none_sinks():
 @pytest.mark.parametrize(
     ("max_query_len", "seq_len", "phase", "expected_scale"),
     [
-        (8, 8, "prefill", 2.0 * math.exp(3.0 * 0.4)),
-        (1, 16, "decode", 5.0 * math.exp(7.0 * 0.6)),
+        (128, 128, "prefill", 2.0 * math.exp(3.0 * 0.4)),
+        (1, 256, "decode", 0.1 * math.exp(1.0 * 0.6)),
     ],
 )
 def test_forward_resolves_calibrated_skip_softmax_threshold(
@@ -83,7 +83,7 @@ def test_forward_resolves_calibrated_skip_softmax_threshold(
         "threshold_scale_factor": {
             "formula": "a * exp(b * target_sparsity)",
             "prefill": {"a": 2.0, "b": 3.0},
-            "decode": {"a": 5.0, "b": 7.0},
+            "decode": {"a": 0.1, "b": 1.0},
         },
         "target_sparse_ratio": {"prefill": 0.4, "decode": 0.6},
     }
@@ -123,3 +123,67 @@ def test_forward_resolves_calibrated_skip_softmax_threshold(
     assert captured["skip_softmax_threshold"] == pytest.approx(expected_scale / seq_len)
     assert "threshold_scale_factor" not in captured
     assert "target_sparse_ratio" not in captured
+
+
+def test_resolve_calibrated_skip_softmax_warns_and_disables_for_large_threshold():
+    """A derived lambda >= 1 is invalid and disables calibrated skip-softmax."""
+    sparse_kw = {
+        "threshold_scale_factor": {
+            "formula": "a * exp(b * target_sparsity)",
+            "decode": {"a": 925.492, "b": 0.0},
+        },
+        "target_sparse_ratio": {"decode": 0.5},
+    }
+
+    with pytest.warns(UserWarning, match="outside the valid lambda range"):
+        vllm_plugin._resolve_skip_softmax_calibration(
+            sparse_kw,
+            is_prefill=False,
+            max_seq_len=256,
+        )
+
+    assert "skip_softmax_threshold" not in sparse_kw
+    assert "threshold_scale_factor" not in sparse_kw
+    assert "target_sparse_ratio" not in sparse_kw
+
+
+def test_forward_allows_chunked_prefill_metadata(monkeypatch):
+    """vLLM V1 can pass suffix-Q/chunked-prefill metadata; the kernel handles it."""
+    impl = _clone_sparse_impl(_make_old_impl())
+    q_len = 4
+    kv_len = 10
+    q = torch.zeros(q_len, impl.num_heads, impl.head_size, dtype=torch.float16)
+    kv_cache = torch.zeros(2, 1, 16, impl.num_kv_heads, impl.head_size, dtype=torch.float16)
+    attn_metadata = type(
+        "AttnMetadata",
+        (),
+        {
+            "num_actual_tokens": q_len,
+            "max_query_len": q_len,
+            "max_seq_len": kv_len,
+            "query_start_loc": torch.tensor([0, q_len], dtype=torch.int32),
+            "seq_lens": torch.tensor([kv_len], dtype=torch.int32),
+            "block_table": torch.zeros(1, 1, dtype=torch.int32),
+        },
+    )()
+    captured = {}
+
+    def fake_attention(q, **kwargs):
+        captured.update(kwargs)
+        return torch.zeros_like(q)
+
+    monkeypatch.setattr(vllm_plugin, "triton_attention", fake_attention)
+
+    impl.forward(
+        layer=None,
+        query=q,
+        key=q,
+        value=q,
+        kv_cache=kv_cache,
+        attn_metadata=attn_metadata,
+        output=torch.empty_like(q),
+    )
+
+    assert captured["is_causal"] is True
+    torch.testing.assert_close(captured["b_seq_len"], torch.tensor([q_len], dtype=torch.int32))
+    torch.testing.assert_close(captured["b_seq_len_k"], torch.tensor([kv_len], dtype=torch.int32))

--- a/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_worker.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_worker.py
@@ -15,15 +15,20 @@
 
 """Unit tests for sparse attention vLLM worker compatibility helpers."""
 
+import math
+
 import pytest
+import torch
 
 pytest.importorskip("vllm")
 
+from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
+
+from modelopt.torch.sparsity.attention_sparsity.plugins import vllm as vllm_plugin
 from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
     ModelOptSparseAttentionImpl,
     _clone_sparse_impl,
 )
-from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
 
 
 def _make_old_impl():
@@ -60,3 +65,61 @@ def test_clone_sparse_impl_rejects_non_none_sinks():
 
     with pytest.raises(NotImplementedError, match="sinks"):
         _clone_sparse_impl(old_impl)
+
+
+@pytest.mark.parametrize(
+    ("max_query_len", "seq_len", "phase", "expected_scale"),
+    [
+        (8, 8, "prefill", 2.0 * math.exp(3.0 * 0.4)),
+        (1, 16, "decode", 5.0 * math.exp(7.0 * 0.6)),
+    ],
+)
+def test_forward_resolves_calibrated_skip_softmax_threshold(
+    monkeypatch, max_query_len, seq_len, phase, expected_scale
+):
+    """Forward should convert checkpoint calibration params to kernel threshold."""
+    impl = _clone_sparse_impl(_make_old_impl())
+    impl.sparse_kw = {
+        "threshold_scale_factor": {
+            "formula": "a * exp(b * target_sparsity)",
+            "prefill": {"a": 2.0, "b": 3.0},
+            "decode": {"a": 5.0, "b": 7.0},
+        },
+        "target_sparse_ratio": {"prefill": 0.4, "decode": 0.6},
+    }
+    q = torch.zeros(max_query_len, impl.num_heads, impl.head_size, dtype=torch.float16)
+    kv_cache = torch.zeros(2, 1, seq_len, impl.num_kv_heads, impl.head_size, dtype=torch.float16)
+    attn_metadata = type(
+        "AttnMetadata",
+        (),
+        {
+            "num_actual_tokens": max_query_len,
+            "max_query_len": max_query_len,
+            "max_seq_len": seq_len,
+            "query_start_loc": torch.tensor([0, max_query_len], dtype=torch.int32),
+            "seq_lens": torch.tensor([seq_len], dtype=torch.int32),
+            "block_table": torch.zeros(1, 1, dtype=torch.int32),
+        },
+    )()
+    captured = {}
+
+    def fake_attention(q, **kwargs):
+        captured.update(kwargs)
+        return torch.zeros_like(q)
+
+    monkeypatch.setattr(vllm_plugin, "triton_attention", fake_attention)
+
+    impl.forward(
+        layer=None,
+        query=q,
+        key=q,
+        value=q,
+        kv_cache=kv_cache,
+        attn_metadata=attn_metadata,
+        output=torch.empty_like(q),
+    )
+
+    assert phase in impl.sparse_kw["threshold_scale_factor"]
+    assert captured["skip_softmax_threshold"] == pytest.approx(expected_scale / seq_len)
+    assert "threshold_scale_factor" not in captured
+    assert "target_sparse_ratio" not in captured

--- a/tests/unit/torch/sparsity/attention_sparsity/test_triton_skip_softmax.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_triton_skip_softmax.py
@@ -30,16 +30,12 @@ class TestInit:
     def test_default_config(self):
         m = TritonSkipSoftmaxMethod()
         assert m.skip_softmax_threshold == 0.1
-        assert m.skip_softmax_raw_threshold is None
         assert m._threshold_trials is None
         assert m._measure_sparsity is False
 
     def test_custom_config(self):
-        m = TritonSkipSoftmaxMethod(
-            {"skip_softmax_threshold": 0.05, "skip_softmax_raw_threshold": -3.0}
-        )
+        m = TritonSkipSoftmaxMethod({"skip_softmax_threshold": 0.05})
         assert m.skip_softmax_threshold == 0.05
-        assert m.skip_softmax_raw_threshold == -3.0
 
     def test_name(self):
         assert TritonSkipSoftmaxMethod().name == "triton_skip_softmax"


### PR DESCRIPTION
### What does this PR do?

Type of change: New feature, new example, new tests, documentation.

Adds vLLM integration for ModelOpt sparse attention with paged KV cache support.

This PR extends the ModelOpt Triton flash attention path so K/V can be read directly from vLLM's paged KV cache through `block_table` lookup. This avoids gather-to-contiguous copies when serving exported sparse-attention checkpoints with vLLM.

The vLLM integration swaps vLLM's `FlashAttentionImpl` with `ModelOptSparseAttentionImpl` after model load. The sparse configuration is read from the exported checkpoint's `config.json` `sparse_attention_config` block, written by `examples/llm_sparsity/attention_sparsity/hf_sa.py`.

The restored checkpoint metadata supports:

- calibrated skip-softmax metadata (`threshold_scale_factor`, `target_sparse_ratio`)
- N:M sparse-softmax metadata (`sparsity_n`, `sparsity_m`)
- dense token preservation metadata (`dense_sink_tokens`, `dense_recent_tokens`)

The vLLM path uses ModelOpt Triton for sparse prefill launches. Decode-only launches, cascade/prefix-cache metadata, and launches without active sparse work delegate back to vLLM FlashAttention.

### Limitations

- Sparse attention is enabled for sparse prefill only.
- Decode-only launches currently fall back to vLLM FlashAttention.
- Attention sinks from vLLM FlashAttention are rejected until the ModelOpt Triton path supports them.
- CUDA graph capture is not validated with this sparse attention path yet; use `--enforce-eager`.
- Quant-only serving remains covered by `vllm_serve_fakequant.py`.
- Combined sparse attention + quantization serving is not handled by this launcher in this PR and is planned as follow-up work.

### Usage

Export a checkpoint with calibrated skip-softmax and sparse24 metadata:

```bash
python examples/llm_sparsity/attention_sparsity/hf_sa.py \
    --pyt_ckpt_path /path/to/hf-model \
    --sparse_attn skip_softmax_calib_sparse24 \
    --target_sparse_ratio 0.5 \
    --calib_samples 64 \
    --calib_max_seqlen 16384 \
    --calib_chunk_size 4096 \
    --seq_len 2048 \
    --export_dir /path/to/modelopt-skipsoftmax-sparse24-export
```

Serve the exported checkpoint with the vLLM sparse-attention launcher:

```bash
PYTHONPATH=$PWD python examples/vllm_serve/vllm_serve_sparse_attn.py \
    /path/to/modelopt-skipsoftmax-sparse24-export \
    --tensor-parallel-size 8 \
    --host 0.0.0.0 \
    --port 8000 \
    --trust-remote-code \
    --enforce-eager
```

Send a request through the OpenAI-compatible endpoint:

```bash
curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
      "model": "/path/to/modelopt-skipsoftmax-sparse24-export",
      "messages": [{"role": "user", "content": "Explain sparse attention in one paragraph."}],
      "max_tokens": 128
    }'
```

### Testing

GitHub CI on the latest commit is green:

- DCO
- code-quality
- docs build / deploy preview
- unit tests, including Linux, Windows, multi-version, partial-install, and launcher jobs
- example tests
- GPU tests, including required GPU gate
- regression tests, including required regression gate
- `codecov/project`

Focused test coverage added/updated for this PR includes:

- `tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_worker.py`
- `tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_config.py`
- `tests/unit/torch/sparsity/attention_sparsity/test_sparse_attention_conversion.py`
- `tests/unit/torch/sparsity/attention_sparsity/test_triton_skip_softmax.py`
- `tests/gpu/torch/sparsity/attention_sparsity/test_vllm_plugin.py`
- `tests/gpu/torch/kernels/common/attention/test_triton_fa_paged.py`
- `tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_skip_softmax.py`
- `tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_sparse_nm.py`
- `tests/gpu/torch/kernels/sparsity/attention/test_triton_fa_calibrate.py`

Manual / NEL eval validation:

- Served a ModelOpt exported sparse-attention checkpoint through `examples/vllm_serve/vllm_serve_sparse_attn.py`.
- Launched RULER64K NEL evals on DFW with `coreai_nvfm_llm`.
- Current partial RULER64K prediction scores, before final `results.yml` is written:
  - `skipsoftmax-only`: 98.59% over 4500 flushed samples
  - `skipsoftmax-r0.7`: 99.70% over 1000 flushed samples
  - `skipsoftmax-r0.9`: 99.70% over 1000 flushed samples

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A - no new PIP dependency.
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A - documentation, examples, and tests are updated for this vLLM integration path.

### Additional Information

Follow-up work:

- Validate and enable CUDA graph capture for the sparse vLLM path.
- Add combined sparse attention + quantization serving once the combined path is tested.
- Investigate whether skip-softmax should also be enabled during decode.