### PR TITLE
[NVBug 5996622] skip syncing for Llama4 experts

### DIFF
--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -557,8 +557,13 @@ class _QuantSparseMoe(QuantModule):
         """Sync input_quantizer amax across experts so all share the same amax per quantizer.
 
         Skipped when _moe_calib_experts_ratio is set, as each expert is calibrated independently.
+        Also skipped when experts is a fused module (e.g. Llama4TextExperts) with shared quantizers.
         """
         if self._moe_calib_experts_ratio is not None:
+            return
+        try:
+            iter(self.experts)
+        except TypeError:
             return
         sync_moe_expert_amax(self.experts)
 


### PR DESCRIPTION


### What does this PR do?

Type of change: But fix

Llama4 experts are already fused


### Testing

Rerun NVBug 5996622 QA test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of quantization synchronization for expert modules with shared quantizers, preventing unnecessary synchronization attempts.
  
* **Documentation**
  * Updated documentation to clarify quantization behavior for fused expert module configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->