### PR TITLE
[NVBug 5996631] NemotronH models do not work correctly with accelerate

### DIFF
--- a/examples/llm_ptq/hf_ptq.py
+++ b/examples/llm_ptq/hf_ptq.py
@@ -425,7 +425,9 @@ def load_model(args: argparse.Namespace):
     elif is_nemotron_vl_model and args.calib_with_images:
         # For Nemotron VL image calibration, we need an AutoProcessor to build multimodal inputs.
         processor = AutoProcessor.from_pretrained(
-            args.pyt_ckpt_path, trust_remote_code=args.trust_remote_code, padding_side="left"
+            args.pyt_ckpt_path,
+            trust_remote_code=args.trust_remote_code,
+            padding_side="left",
         )
 
         if hasattr(processor, "tokenizer") and processor.tokenizer is not None:
@@ -736,6 +738,11 @@ def pre_quantize(
         generated_ids_before_ptq = None
     elif model_type == "deepseek":
         # DeepSeek generation may go OOM, so we skip it
+        generated_ids_before_ptq = None
+    elif model_type == "nemotron_h":
+        # NemotronH (SSM/Mamba hybrid) modeling code does not work with accelerate's big model inference
+        # when multiple GPUs are used. So we skip generation for NemotronH models. The issue presents in
+        # the remote code and also in transformers library integration code from v5.3
         generated_ids_before_ptq = None
     elif is_nemotron_vl_model and tokenizer is not None:
         generated_ids_before_ptq = run_nemotron_vl_preview(

--- a/modelopt/torch/export/model_utils.py
+++ b/modelopt/torch/export/model_utils.py
@@ -51,6 +51,7 @@ MODEL_NAME_TO_TYPE = {
     "GLM": "glm",
     "InternLM2ForCausalLM": "internlm",
     "ExaoneForCausalLM": "exaone",
+    "NemotronH": "nemotron_h",
     "Nemotron": "gpt",
     "Deepseek": "deepseek",
     "Whisper": "whisper",


### PR DESCRIPTION
### What does this PR do?

Type of change: But fix

NemotronH (SSM/Mamba hybrid) uses a custom KV cache (NemotronHHybridDynamicCache) that pre-allocates all SSM states on a single device at construction time. When accelerate's big model inference spreads layers across multiple GPUs, the cached ssm_states tensors remain on cuda:0 while layers assigned to other GPUs compute dA/dBx on their local device, causing a device mismatch at the in-place state update:

    cache_params.ssm_states[self.layer_idx] * dA + dBx
    RuntimeError: Expected all tensors to be on the same device,
    but found at least two devices, cuda:0 and cuda:1!

This is unlike standard attention KV caches, where K/V tensors are created during each layer's forward pass and naturally reside on the layer's execution device. It also does not affect calibration, because calibration runs full-sequence forward passes with cache_params=None (has_previous_state=False), which allocates ssm_state locally per call.

Changes:
- Add "NemotronH" -> "nemotron_h" to MODEL_NAME_TO_TYPE before the existing "Nemotron" -> "gpt" entry, so that NemotronHForCausalLM is correctly identified instead of falling through to the GPT type.
- Skip pre/post-quantize generate() for nemotron_h model type, matching the existing DeepSeek workaround.

Modeling issue reported at:
https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/discussions/23



### Testing

Rerurn NVBug 5996631 QA test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit support for NemotronH models in the quantization pipeline.
  * NemotronH models now skip pre- and post-quantization generation steps to streamline and speed up quantization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->