### PR TITLE
Fix[bug] ONNX models generated by llm_export.py are missing some i/o 

### DIFF
--- a/examples/torch_onnx/llm_export.py
+++ b/examples/torch_onnx/llm_export.py
@@ -363,7 +363,26 @@ def main(args):
         onnx_dir = args.output_dir + "_raw" if args.save_original else args.output_dir
         # Surgeon graph based on precision
         raw_onnx_path = f"{onnx_dir}/model.onnx"
-        extra_inputs, extra_dyn_axes = {}, {}
+
+        batch_size = 1
+        seq_len = 8
+        dummy_input_ids = torch.randint(0, 1000, (batch_size, seq_len), dtype=torch.long)
+        dummy_attention_mask = torch.ones((batch_size, seq_len), dtype=torch.long)
+        dummy_position_ids = torch.arange(seq_len).unsqueeze(0).repeat(batch_size, 1)
+
+        # Correct assignment — no trailing comma
+        extra_inputs = {
+            "input_ids": dummy_input_ids,
+            "attention_mask": dummy_attention_mask,
+            "position_ids": dummy_position_ids,
+        }
+        extra_dyn_axes = {
+            "input_ids": {0: "batch", 1: "seq_len"},
+            "attention_mask": {0: "batch", 1: "seq_len"},
+            "position_ids": {0: "batch", 1: "seq_len"},
+            "logits": {0: "batch", 1: "seq_len"},
+        }
+
         export_raw_llm(
             model=model,
             output_dir=onnx_dir,


### PR DESCRIPTION
### What does this PR do?

Fixes the missing input and output nodes in ONNX models generated by `llm_export.py` (#1147).  
Now the following nodes are properly included:

- `attention_mask`
- `position_ids`
- `past_key_values*`

This ensures ONNX models are fully compatible with downstream TensorRT workflows and standard LLM inference pipelines.

Type of change: **Bug fix**

### Usage

```python
from modelopt.onnx.llm_export import llm_export

# Export HuggingFace model to ONNX with all necessary inputs/outputs
llm_export(
    hf_model_path="meta-llama/Llama-3.1-8B-Instruct",
    dtype="int4_awq",
    output_dir="models/Llama-3.1-8B-Instruct-ONNX-INT4"
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **LLM ONNX Export** – Enhanced the LLM export example to use concrete dummy tensor inputs with proper attention masks and position IDs instead of empty placeholders. Added dynamic-axes mappings for batch and sequence dimensions to improve ONNX model compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->