### PR TITLE
Expose Distillation Parameters 

### DIFF
--- a/examples/megatron_bridge/distill.py
+++ b/examples/megatron_bridge/distill.py
@@ -104,7 +104,9 @@ def get_args():
     parser.add_argument(
         "--train_iters", type=int, required=True, help="Number of training iterations"
     )
-    parser.add_argument("--no_skip_lm_loss", action="store_true", help="Skip language model loss")
+    parser.add_argument(
+        "--no_skip_lm_loss", action="store_true", help="Disable skipping language model loss"
+    )
     parser.add_argument("--kd_loss_scale", type=float, default=1.0, help="KD loss weight")
     parser.add_argument("--lr", type=float, default=1e-4, help="Peak learning rate")
     parser.add_argument("--min_lr", type=float, default=1e-5, help="Minimum learning rate")


### PR DESCRIPTION
### What does this PR do?

This PR exposes distillation parameters `skip_lm_loss` and `kd_loss_scale` to be able to overwrite the defaults. Allows to experiments with different settings for the total distillation loss.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new command-line options to the distillation example: --no_skip_lm_loss (boolean) and --kd_loss_scale (float, default: 1.0).
  * Choose whether language-model loss is skipped and adjust the weighting of knowledge-distillation loss during distillation runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->