### PR TITLE
[NVBug 6045859]Fix export support for Qwen3VL MoE experts

### DIFF
--- a/modelopt/torch/export/layer_utils.py
+++ b/modelopt/torch/export/layer_utils.py
@@ -997,7 +997,7 @@ def get_expert_linear_names(module: nn.Module) -> list[str]:
             "Qwen3MoeSparseMoeBlock",
             "Qwen3NextSparseMoeBlock",
             "Qwen3_5MoeSparseMoeBlock",
-            "Qwen3VLMoeSparseMoeBlock",
+            "Qwen3VLMoeTextSparseMoeBlock",
             "DeepseekMoE",
         ],
     ):

--- a/modelopt/torch/export/layer_utils.py
+++ b/modelopt/torch/export/layer_utils.py
@@ -997,6 +997,7 @@ def get_expert_linear_names(module: nn.Module) -> list[str]:
             "Qwen3MoeSparseMoeBlock",
             "Qwen3NextSparseMoeBlock",
             "Qwen3_5MoeSparseMoeBlock",
+            "Qwen3VLMoeSparseMoeBlock",
             "DeepseekMoE",
         ],
     ):

--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -725,9 +725,27 @@ class _QuantDbrxExpertGLU(QuantModule):
         return self.w2_linear[expert_idx](x1)
 
 
+class _Qwen3VLMoeExpertModule(nn.Module):
+    """Container for a single Qwen3VL MoE expert's linear layers.
+
+    Produces the naming pattern: experts.{id}.gate_proj.weight
+    (consistent with standard Qwen3 MoE per-expert module structure).
+    """
+
+    def __init__(self, hidden_size: int, expert_dim: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, expert_dim, bias=False)
+        self.up_proj = nn.Linear(hidden_size, expert_dim, bias=False)
+        self.down_proj = nn.Linear(expert_dim, hidden_size, bias=False)
+
+
 class _QuantQwen3VLMoeTextExperts(QuantModule):
     def _setup(self):
-        """Modify the Qwen3VLMoeTextExperts by using nn.Linear layers."""
+        """Modify the Qwen3VLMoeTextExperts by using per-expert nn.Module containers.
+
+        This produces the naming pattern: experts.{id}.gate_proj.weight
+        (consistent with standard Qwen3 MoE per-expert module structure).
+        """
         from accelerate import init_empty_weights
 
         dtype, device = self.gate_up_proj.dtype, self.gate_up_proj.device
@@ -747,35 +765,37 @@ class _QuantQwen3VLMoeTextExperts(QuantModule):
             raise AttributeError("Could not find intermediate dimension size in model")
 
         with init_empty_weights():
-            gate_proj = nn.ModuleList(
+            expert_modules = nn.ModuleList(
                 [
-                    nn.Linear(self.hidden_size, expert_dim, bias=False)
-                    for _ in range(self.num_experts)
-                ]
-            )
-            up_proj = nn.ModuleList(
-                [
-                    nn.Linear(self.hidden_size, expert_dim, bias=False)
-                    for _ in range(self.num_experts)
-                ]
-            )
-            down_proj = nn.ModuleList(
-                [
-                    nn.Linear(expert_dim, self.hidden_size, bias=False)
+                    _Qwen3VLMoeExpertModule(self.hidden_size, expert_dim)
                     for _ in range(self.num_experts)
                 ]
             )
 
         for idx in range(self.num_experts):
-            _copy_weight(gate_proj[idx], self.gate_up_proj[idx, :, :expert_dim].T)
-            _copy_weight(up_proj[idx], self.gate_up_proj[idx, :, expert_dim:].T)
-            _copy_weight(down_proj[idx], self.down_proj[idx, :].T)
+            _copy_weight(expert_modules[idx].gate_proj, self.gate_up_proj[idx, :, :expert_dim].T)
+            _copy_weight(expert_modules[idx].up_proj, self.gate_up_proj[idx, :, expert_dim:].T)
+            _copy_weight(expert_modules[idx].down_proj, self.down_proj[idx, :].T)
 
         delattr(self, "gate_up_proj")
         delattr(self, "down_proj")
-        self.gate_proj = gate_proj
-        self.up_proj = up_proj
-        self.down_proj = down_proj
+        # Register expert modules directly as numbered children
+        # so the naming pattern is: experts.{id}.gate_proj.weight (no extra nesting)
+        for idx in range(self.num_experts):
+            self.add_module(str(idx), expert_modules[idx])
+
+    def __len__(self):
+        """Support len() so the module is iterable like standard MoE experts."""
+        return self.num_experts
+
+    def __iter__(self):
+        """Support iteration over expert modules."""
+        for idx in range(self.num_experts):
+            yield getattr(self, str(idx))
+
+    def __getitem__(self, idx):
+        """Support indexing to get individual expert modules."""
+        return getattr(self, str(int(idx)))
 
     def forward(
         self,
@@ -791,13 +811,15 @@ class _QuantQwen3VLMoeTextExperts(QuantModule):
             expert_mask = expert_mask.permute(2, 1, 0)
             expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
         for expert_idx in expert_hit:
+            expert_idx = expert_idx[0]
             with torch.no_grad():
-                _, token_idx = torch.where(expert_mask[expert_idx[0]])
+                _, token_idx = torch.where(expert_mask[expert_idx])
             current_state = hidden_states[token_idx]
-            gate = self.gate_proj[expert_idx](current_state)
-            up = self.up_proj[expert_idx](current_state)
+            expert = self[expert_idx]
+            gate = expert.gate_proj(current_state)
+            up = expert.up_proj(current_state)
             gated_output = up * self.act_fn(gate)
-            out = self.down_proj[expert_idx](gated_output)
+            out = expert.down_proj(gated_output)
             weighted_output = out * routing_weights[token_idx, expert_idx, None]
             next_states.index_add_(0, token_idx, weighted_output.to(hidden_states.dtype))
         next_states = next_states.view(batch_size, -1, self.hidden_size)

--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -764,10 +764,17 @@ class _QuantQwen3VLMoeTextExperts(QuantModule):
         else:
             raise AttributeError("Could not find intermediate dimension size in model")
 
+        if hasattr(self, "hidden_size"):
+            self._dynamicmodule_hidden_size = self.hidden_size
+        elif hasattr(self, "intermediate_dim"):
+            self._dynamicmodule_hidden_size = self.hidden_dim
+        else:
+            raise AttributeError("Could not find hidden_size/hidden_dim in model")
+
         with init_empty_weights():
             expert_modules = nn.ModuleList(
                 [
-                    _Qwen3VLMoeExpertModule(self.hidden_size, expert_dim)
+                    _Qwen3VLMoeExpertModule(self._dynamicmodule_hidden_size, expert_dim)
                     for _ in range(self.num_experts)
                 ]
             )
@@ -804,7 +811,7 @@ class _QuantQwen3VLMoeTextExperts(QuantModule):
         router_indices: torch.Tensor,
     ) -> torch.Tensor:
         batch_size = hidden_states.shape[0]
-        hidden_states = hidden_states.reshape(-1, self.hidden_size)
+        hidden_states = hidden_states.reshape(-1, self._dynamicmodule_hidden_size)
         next_states = torch.zeros_like(hidden_states)
         with torch.no_grad():
             expert_mask = torch.nn.functional.one_hot(router_indices, num_classes=self.num_experts)
@@ -822,7 +829,7 @@ class _QuantQwen3VLMoeTextExperts(QuantModule):
             out = expert.down_proj(gated_output)
             weighted_output = out * routing_weights[token_idx, expert_idx, None]
             next_states.index_add_(0, token_idx, weighted_output.to(hidden_states.dtype))
-        next_states = next_states.view(batch_size, -1, self.hidden_size)
+        next_states = next_states.view(batch_size, -1, self._dynamicmodule_hidden_size)
 
         return next_states
 


### PR DESCRIPTION
## What does this PR do?

Fix HF checkpoint export support for Qwen3-VL MoE models (e.g. `Qwen/Qwen3-VL-30B-A3B-Instruct`).

Previously, running `hf_ptq.py` on Qwen3-VL MoE models failed during `export_hf_checkpoint` with:
```
NotImplementedError: MoE model with experts type 'QuantQwen3VLMoeTextExperts' is not supported in export.
```

**Root cause:** `_QuantQwen3VLMoeTextExperts` stored expert weights as flat `nn.ModuleList`s (one per projection type), making the module non-iterable. The export code requires `sub_module.experts` to be iterable to handle input quantizer amax and gate/up amax sync.

**Fix:** Refactor `_QuantQwen3VLMoeTextExperts` to use per-expert module containers, matching the established `_QuantQwen35MoeExperts` pattern:
- Add `_Qwen3VLMoeExpertModule` container class with `gate_proj`, `up_proj`, `down_proj`
- Register experts as numbered children producing state dict keys like `experts.{id}.gate_proj.weight` (standard Qwen3 MoE naming, compatible with vLLM)
- Implement `__len__`/`__iter__`/`__getitem__` for iterability
- Add `Qwen3VLMoeSparseMoeBlock` to `get_expert_linear_names` in `layer_utils.py`

**Files changed:**
- `modelopt/torch/quantization/plugins/huggingface.py` — refactored expert module structure
- `modelopt/torch/export/layer_utils.py` — added Qwen3VLMoe to expert linear name mapping

## Testing

- [ x ] FP8 PTQ + export on `Qwen/Qwen3-VL-30B-A3B-Instruct`:
  ```
  python examples/llm_ptq/hf_ptq.py \
    --pyt_ckpt_path=Qwen/Qwen3-VL-30B-A3B-Instruct \
    --export_path=<output_dir> \
    --qformat=fp8 --calib_size=8 --batch_size=1
  ```
- [ x ] Verify exported checkpoint loads in vLLM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recognition for an additional Qwen3 VLM Mixture-of-Experts variant.

* **Improvements**
  * Improved expert module handling and naming so expert layers are detected and used consistently.
  * Streamlined expert container behavior for more reliable routing and weight assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->