### PR TITLE
Generic Fused MoE Quantization + Export for transformers 5.0+

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ Changelog
 
 - [Security] Changed the default of ``weights_only`` to ``True`` in ``torch.load`` for secure checkpoint loading. If you need to load a checkpoint that requires unpickling arbitrary objects, first register the class in ``torch.serialization.add_safe_globals([cls])`` before loading. Added :meth:`safe_save <modelopt.torch.utils.serialization.safe_save>` and :meth:`safe_load <modelopt.torch.utils.serialization.safe_load>` API to save and load checkpoints securely.
 - Bump minimum required PyTorch version to 2.8.
-- [Experimental] Add support for transformers>=5.0. Unified Hugging Face checkpoint export for quantized checkpoints may not work for MoE models with transformers>=5.0 yet.
+- [Experimental] Add support for transformers>=5.0, including generic PTQ and unified HF checkpoint export for fused MoE expert modules (Mixtral, Qwen2-MoE, Qwen3-MoE, Qwen3.5-MoE, DeepSeek-V3, Jamba, OLMoE, etc.).
 - Improve ``megatron_preprocess_data``: add ``--reasoning_content`` support for Nemotron v3 datasets, eliminate intermediate JSONL for HuggingFace datasets, return output file prefixes from the Python API, add gzip input support (``.jsonl.gz``), add ``--strip_newlines`` flag for plain-text pretraining data, add ``--hf_streaming`` for very large datasets (only consumed rows downloaded), and auto-shuffle when ``--hf_max_samples_per_split`` is set to avoid biased sampling.
 
 0.43 (2026-04-09)

--- a/modelopt/torch/export/layer_utils.py
+++ b/modelopt/torch/export/layer_utils.py
@@ -965,6 +965,12 @@ def get_expert_linear_names(module: nn.Module) -> list[str]:
         """
         return any(name.lower() in type(module).__name__.lower() for name in name_list)
 
+    # Structural detection: after _export_fused_experts, fused expert modules
+    # have per-expert submodules with gate_proj/up_proj/down_proj.
+    # Also handles models that originally used this naming (Qwen, DeepSeek, etc.).
+    if hasattr(module, "experts") and hasattr(module.experts, "gate_up_proj_weight_quantizers"):
+        return ["gate_up_proj", "down_proj"]
+
     if module_match_name_list(
         module,
         [
@@ -973,15 +979,16 @@ def get_expert_linear_names(module: nn.Module) -> list[str]:
             "Qwen3NextSparseMoeBlock",
             "Qwen3_5MoeSparseMoeBlock",
             "DeepseekMoE",
+            "MixtralSparseMoeBlock",
         ],
     ):
         return ["gate_proj", "down_proj", "up_proj"]
     elif module_match_name_list(module, ["MixtralMoeSparseMoeBlock"]):
+        # Older transformers naming for Mixtral
         return ["linear_fc1", "linear_fc2"]
     elif module_match_name_list(module, ["DBRXMoeSparseMoeBlock"]):
         return ["w1_linear", "w2_linear", "v1_linear"]
     elif module_match_name_list(module, ["GptOssMoE"]):
-        # GPT-OSS MoE modules use gate_up_proj and down_proj
         return ["gate_up_proj", "down_proj"]
     else:
         # assuming w1, w2, w3 by default

--- a/modelopt/torch/export/layer_utils.py
+++ b/modelopt/torch/export/layer_utils.py
@@ -979,10 +979,14 @@ def get_expert_linear_names(module: nn.Module) -> list[str]:
             "Qwen3NextSparseMoeBlock",
             "Qwen3_5MoeSparseMoeBlock",
             "DeepseekMoE",
-            "MixtralSparseMoeBlock",
         ],
     ):
         return ["gate_proj", "down_proj", "up_proj"]
+    elif module_match_name_list(module, ["MixtralSparseMoeBlock"]):
+        # Old-style Mixtral (iterable experts) uses w1/w2/w3.
+        # Fused Mixtral (transformers 5.0+) is already handled by the
+        # structural gate_up_proj_weight_quantizers check above.
+        return ["w1", "w2", "w3"]
     elif module_match_name_list(module, ["MixtralMoeSparseMoeBlock"]):
         # Older transformers naming for Mixtral
         return ["linear_fc1", "linear_fc2"]

--- a/modelopt/torch/export/moe_utils.py
+++ b/modelopt/torch/export/moe_utils.py
@@ -43,7 +43,6 @@ def _export_fused_experts(module: nn.Module, dtype: torch.dtype) -> None:
            {E}.up_proj.weight, {E}.up_proj.weight_scale, ...
            {E}.down_proj.weight, {E}.down_proj.weight_scale, ...
     """
-    from modelopt.torch.export.layer_utils import set_expert_quantizer_amax
     from modelopt.torch.export.unified_export_hf import _export_quantized_weight
     from modelopt.torch.quantization.plugins.huggingface import _get_fused_expert_intermediate_dim
 

--- a/modelopt/torch/export/moe_utils.py
+++ b/modelopt/torch/export/moe_utils.py
@@ -93,7 +93,11 @@ def _export_fused_experts(module: nn.Module, dtype: torch.dtype) -> None:
 
             # For per-channel amax (dim >= 1), proportionally slice dim-0
             # to match the split weight.
-            if hasattr(w_quantizer, "_amax") and w_quantizer._amax is not None and w_quantizer._amax.dim() >= 1:
+            if (
+                hasattr(w_quantizer, "_amax")
+                and w_quantizer._amax is not None
+                and w_quantizer._amax.dim() >= 1
+            ):
                 amax = w_quantizer._amax
                 amax_dim0 = amax.shape[0]
                 if fused_total % amax_dim0 == 0:

--- a/modelopt/torch/export/moe_utils.py
+++ b/modelopt/torch/export/moe_utils.py
@@ -16,6 +16,7 @@
 """Utilities for Mixture-of-Experts (MoE) model export."""
 
 import copy
+import warnings
 from pathlib import Path
 
 import torch
@@ -49,17 +50,9 @@ def _export_fused_experts(module: nn.Module, dtype: torch.dtype) -> None:
     n = module.num_experts
     expert_dim = _get_fused_expert_intermediate_dim(module)
 
-    # 1. Input amax fallback — borrow from calibrated peers.
-    for quantizer_list in [
-        module.gate_up_proj_input_quantizers,
-        module.down_proj_input_quantizers,
-    ]:
-        wrappers = []
-        for q in quantizer_list:
-            w = nn.Module()
-            w.input_quantizer = q
-            wrappers.append(w)
-        set_expert_quantizer_amax(modules=wrappers, quantizer_attrs=["input_quantizer"])
+    # 1. Shared input quantizers — one per projection type, shared across all experts.
+    gate_up_input_q = module.gate_up_proj_input_quantizer
+    down_input_q = module.down_proj_input_quantizer
 
     gate_up = module.gate_up_proj.data
     down = module.down_proj.data
@@ -82,11 +75,7 @@ def _export_fused_experts(module: nn.Module, dtype: torch.dtype) -> None:
                 if is_gate_up
                 else module.down_proj_weight_quantizers[idx]
             )
-            i_quantizer = (
-                module.gate_up_proj_input_quantizers[idx]
-                if is_gate_up
-                else module.down_proj_input_quantizers[idx]
-            )
+            i_quantizer = gate_up_input_q if is_gate_up else down_input_q
 
             # gate/up share a weight quantizer — clone so each gets independent amax.
             w_quantizer = copy.deepcopy(w_quantizer_src) if is_gate_up else w_quantizer_src
@@ -116,6 +105,12 @@ def _export_fused_experts(module: nn.Module, dtype: torch.dtype) -> None:
                 )
             ):
                 w_quantizer.amax = weight_slice.abs().amax().to(torch.float32)
+                warnings.warn(
+                    f"Expert {idx} {proj_name} weight quantizer was not calibrated "
+                    f"(amax missing or zero). Using weight-derived amax as fallback. "
+                    f"Consider using more calibration data to activate all experts.",
+                    stacklevel=2,
+                )
 
             wrapper = nn.Module()
             wrapper.weight = nn.Parameter(weight_slice.contiguous(), requires_grad=False)
@@ -139,9 +134,9 @@ def _export_fused_experts(module: nn.Module, dtype: torch.dtype) -> None:
         "gate_up_proj",
         "down_proj",
         "gate_up_proj_weight_quantizers",
-        "gate_up_proj_input_quantizers",
+        "gate_up_proj_input_quantizer",
         "down_proj_weight_quantizers",
-        "down_proj_input_quantizers",
+        "down_proj_input_quantizer",
     ):
         if hasattr(module, attr):
             delattr(module, attr)

--- a/modelopt/torch/export/moe_utils.py
+++ b/modelopt/torch/export/moe_utils.py
@@ -64,7 +64,7 @@ def _export_fused_experts(module: nn.Module, dtype: torch.dtype) -> None:
     gate_up = module.gate_up_proj.data
     down = module.down_proj.data
 
-    # 2–3. Split + export each per-expert projection.
+    # 2-3. Split + export each per-expert projection.
     fused_dim0 = gate_up.shape[1]  # 2 * expert_dim
 
     for idx in range(n):

--- a/modelopt/torch/export/moe_utils.py
+++ b/modelopt/torch/export/moe_utils.py
@@ -92,6 +92,13 @@ def _export_fused_experts(module: nn.Module, dtype: torch.dtype) -> None:
                     slice_start = fused_start * amax_dim0 // fused_total
                     slice_end = (fused_start + weight_slice.shape[0]) * amax_dim0 // fused_total
                     w_quantizer.amax = amax[slice_start:slice_end].contiguous()
+                else:
+                    warnings.warn(
+                        f"Expert {idx} {proj_name}: fused amax dim0 ({amax_dim0}) does not "
+                        f"evenly divide fused_total ({fused_total}). Skipping amax slicing, "
+                        f"which may produce incorrect quantization scales.",
+                        stacklevel=2,
+                    )
 
             # If the weight quantizer was never calibrated, compute amax from weights.
             if (

--- a/modelopt/torch/export/moe_utils.py
+++ b/modelopt/torch/export/moe_utils.py
@@ -15,9 +15,132 @@
 
 """Utilities for Mixture-of-Experts (MoE) model export."""
 
+import copy
 from pathlib import Path
 
+import torch
 import torch.nn as nn
+
+
+def _export_fused_experts(module: nn.Module, dtype: torch.dtype) -> None:
+    """Split fused MoE expert weights and export per-expert quantization scales.
+
+    Works with any module wrapped by ``_QuantFusedExperts`` — i.e. any HF
+    transformers 5.0+ fused expert container that stores ``gate_up_proj`` and
+    ``down_proj`` as 3-D ``nn.Parameter`` tensors with per-expert quantizer
+    ``nn.ModuleList`` s.
+
+    Steps:
+
+    1. Handle amax fallback for uncalibrated expert input quantizers.
+    2. Split fused 3-D weights into per-expert 2-D projections
+       (``gate_proj``, ``up_proj``, ``down_proj``).
+    3. Call ``_export_quantized_weight`` on each projection.
+    4. Register results under the standard naming convention::
+
+           {E}.gate_proj.weight, {E}.gate_proj.weight_scale, ...
+           {E}.up_proj.weight, {E}.up_proj.weight_scale, ...
+           {E}.down_proj.weight, {E}.down_proj.weight_scale, ...
+    """
+    from modelopt.torch.export.layer_utils import set_expert_quantizer_amax
+    from modelopt.torch.export.unified_export_hf import _export_quantized_weight
+    from modelopt.torch.quantization.plugins.huggingface import _get_fused_expert_intermediate_dim
+
+    n = module.num_experts
+    expert_dim = _get_fused_expert_intermediate_dim(module)
+
+    # 1. Input amax fallback — borrow from calibrated peers.
+    for quantizer_list in [
+        module.gate_up_proj_input_quantizers,
+        module.down_proj_input_quantizers,
+    ]:
+        wrappers = []
+        for q in quantizer_list:
+            w = nn.Module()
+            w.input_quantizer = q
+            wrappers.append(w)
+        set_expert_quantizer_amax(modules=wrappers, quantizer_attrs=["input_quantizer"])
+
+    gate_up = module.gate_up_proj.data
+    down = module.down_proj.data
+
+    # 2–3. Split + export each per-expert projection.
+    fused_dim0 = gate_up.shape[1]  # 2 * expert_dim
+
+    for idx in range(n):
+        expert = nn.Module()
+
+        projections = [
+            ("gate_proj", gate_up[idx, :expert_dim, :], 0, fused_dim0, True),
+            ("up_proj", gate_up[idx, expert_dim:, :], expert_dim, fused_dim0, True),
+            ("down_proj", down[idx], 0, down.shape[1], False),
+        ]
+
+        for proj_name, weight_slice, fused_start, fused_total, is_gate_up in projections:
+            w_quantizer_src = (
+                module.gate_up_proj_weight_quantizers[idx]
+                if is_gate_up
+                else module.down_proj_weight_quantizers[idx]
+            )
+            i_quantizer = (
+                module.gate_up_proj_input_quantizers[idx]
+                if is_gate_up
+                else module.down_proj_input_quantizers[idx]
+            )
+
+            # gate/up share a weight quantizer — clone so each gets independent amax.
+            w_quantizer = copy.deepcopy(w_quantizer_src) if is_gate_up else w_quantizer_src
+
+            # For per-channel amax (dim >= 1), proportionally slice dim-0
+            # to match the split weight.
+            if hasattr(w_quantizer, "_amax") and w_quantizer._amax is not None and w_quantizer._amax.dim() >= 1:
+                amax = w_quantizer._amax
+                amax_dim0 = amax.shape[0]
+                if fused_total % amax_dim0 == 0:
+                    slice_start = fused_start * amax_dim0 // fused_total
+                    slice_end = (fused_start + weight_slice.shape[0]) * amax_dim0 // fused_total
+                    w_quantizer.amax = amax[slice_start:slice_end].contiguous()
+
+            # If the weight quantizer was never calibrated, compute amax from weights.
+            if (
+                hasattr(w_quantizer, "is_enabled")
+                and w_quantizer.is_enabled
+                and (
+                    not hasattr(w_quantizer, "_amax")
+                    or w_quantizer._amax is None
+                    or torch.all(w_quantizer._amax == 0)
+                )
+            ):
+                w_quantizer.amax = weight_slice.abs().amax().to(torch.float32)
+
+            wrapper = nn.Module()
+            wrapper.weight = nn.Parameter(weight_slice.contiguous(), requires_grad=False)
+            wrapper.weight_quantizer = w_quantizer
+            wrapper.input_quantizer = i_quantizer
+
+            _export_quantized_weight(wrapper, dtype)
+
+            proj = nn.Module()
+            proj.weight = wrapper.weight
+            for attr in ("weight_scale", "weight_scale_2", "input_scale"):
+                if hasattr(wrapper, attr):
+                    proj.register_buffer(attr, getattr(wrapper, attr))
+
+            expert.add_module(proj_name, proj)
+
+        module.add_module(str(idx), expert)
+
+    # 4. Remove fused params and quantizer lists — replaced by per-expert submodules
+    for attr in (
+        "gate_up_proj",
+        "down_proj",
+        "gate_up_proj_weight_quantizers",
+        "gate_up_proj_input_quantizers",
+        "down_proj_weight_quantizers",
+        "down_proj_input_quantizers",
+    ):
+        if hasattr(module, attr):
+            delattr(module, attr)
 
 
 def save_expert_token_count_table(model: nn.Module, output_dir: str | Path | None = None):

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -677,6 +677,13 @@ def _process_quantized_modules(
                 with fsdp2_aware_weight_update(model, sub_module, reshard=False):
                     for weight_name in ["gate_up_proj", "down_proj"]:
                         _export_quantized_weight(sub_module, dtype, weight_name)
+            elif hasattr(sub_module, "gate_up_proj_weight_quantizers"):
+                # Generic fused MoE experts (_QuantFusedExperts) with per-expert
+                # quantizer ModuleLists. Split into per-expert modules and export.
+                from modelopt.torch.export.moe_utils import _export_fused_experts
+
+                with fsdp2_aware_weight_update(model, sub_module, reshard=False):
+                    _export_fused_experts(sub_module, dtype)
 
 
 def _export_transformers_checkpoint(
@@ -721,6 +728,9 @@ def _export_transformers_checkpoint(
                                 modules=list(linear_modulelist),
                                 quantizer_attrs=["input_quantizer"],
                             )
+                elif hasattr(sub_module.experts, "gate_up_proj_weight_quantizers"):
+                    # _QuantFusedExperts: amax fallback is handled in _export_fused_experts
+                    break
                 elif "QuantGptOssExperts" in type(sub_module.experts).__name__:
                     # Handle GPT-OSS experts specifically
                     # GPT-OSS experts use gate_up_proj and down_proj

--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -786,7 +786,6 @@ class _QuantQwen3VLMoeTextExperts(QuantModule):
         return next_states
 
 
-
 def _get_fused_expert_intermediate_dim(module):
     """Resolve the intermediate (expert) dimension from a fused expert module.
 

--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -786,106 +786,6 @@ class _QuantQwen3VLMoeTextExperts(QuantModule):
         return next_states
 
 
-class _Qwen35MoeExpertModule(nn.Module):
-    """Container for a single Qwen3.5 MoE expert's linear layers.
-
-    Produces the naming pattern: experts.{id}.gate_proj.weight
-    (consistent with standard Qwen3 MoE per-expert module structure).
-    """
-
-    def __init__(self, hidden_dim: int, expert_dim: int):
-        super().__init__()
-        self.gate_proj = nn.Linear(hidden_dim, expert_dim, bias=False)
-        self.up_proj = nn.Linear(hidden_dim, expert_dim, bias=False)
-        self.down_proj = nn.Linear(expert_dim, hidden_dim, bias=False)
-
-
-class _QuantQwen35MoeExperts(QuantModule):
-    def _setup(self):
-        """Modify the Qwen3_5MoeExperts by using per-expert nn.Module containers.
-
-        This produces the naming pattern: experts.{id}.gate_proj.weight
-        (consistent with standard Qwen3 MoE).
-        """
-        from accelerate import init_empty_weights
-
-        dtype, device = self.gate_up_proj.dtype, self.gate_up_proj.device
-
-        def _copy_weight(module, weight):
-            module.to_empty(device=device)
-            with torch.no_grad():
-                module.weight.data = weight.detach().data.to(dtype=dtype, device=device)
-
-        expert_dim = self.intermediate_dim
-
-        with init_empty_weights():
-            expert_modules = nn.ModuleList(
-                [
-                    _Qwen35MoeExpertModule(self.hidden_dim, expert_dim)
-                    for _ in range(self.num_experts)
-                ]
-            )
-
-        for idx in range(self.num_experts):
-            # gate_up_proj shape: (num_experts, 2*intermediate_dim, hidden_dim)
-            # Already in (out_features, in_features) format, no transpose needed
-            _copy_weight(expert_modules[idx].gate_proj, self.gate_up_proj[idx, :expert_dim, :])
-            _copy_weight(expert_modules[idx].up_proj, self.gate_up_proj[idx, expert_dim:, :])
-            # down_proj shape: (num_experts, hidden_dim, intermediate_dim)
-            # Already in (out_features, in_features) format
-            _copy_weight(expert_modules[idx].down_proj, self.down_proj[idx])
-
-        delattr(self, "gate_up_proj")
-        delattr(self, "down_proj")
-        # Register expert modules directly as numbered children (like nn.ModuleList)
-        # so the naming pattern is: experts.{id}.gate_proj.weight (no extra nesting)
-        for idx in range(self.num_experts):
-            self.add_module(str(idx), expert_modules[idx])
-
-    def __len__(self):
-        """Support len() so the module is iterable like standard MoE experts."""
-        return self.num_experts
-
-    def __iter__(self):
-        """Support iteration over expert modules."""
-        for idx in range(self.num_experts):
-            yield getattr(self, str(idx))
-
-    def __getitem__(self, idx):
-        """Support indexing to get individual expert modules."""
-        return getattr(self, str(int(idx)))
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        top_k_index: torch.Tensor,
-        top_k_weights: torch.Tensor,
-    ) -> torch.Tensor:
-        final_hidden_states = torch.zeros_like(hidden_states)
-        with torch.no_grad():
-            expert_mask = torch.nn.functional.one_hot(top_k_index, num_classes=self.num_experts)
-            expert_mask = expert_mask.permute(2, 1, 0)
-            expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
-        for expert_idx in expert_hit:
-            expert_idx = expert_idx[0]
-            if expert_idx == self.num_experts:
-                continue
-            with torch.no_grad():
-                top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
-            current_state = hidden_states[token_idx]
-            expert = self[expert_idx]
-            gate = expert.gate_proj(current_state)
-            up = expert.up_proj(current_state)
-            current_hidden_states = self.act_fn(gate) * up
-            current_hidden_states = expert.down_proj(current_hidden_states)
-            current_hidden_states = (
-                current_hidden_states * top_k_weights[token_idx, top_k_pos, None]
-            )
-            final_hidden_states.index_add_(
-                0, token_idx, current_hidden_states.to(final_hidden_states.dtype)
-            )
-        return final_hidden_states
-
 
 def _get_fused_expert_intermediate_dim(module):
     """Resolve the intermediate (expert) dimension from a fused expert module.
@@ -1285,20 +1185,6 @@ except ImportError:
     pass
 
 
-try:
-    from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeExperts
-
-    # Qwen3_5MoeSparseMoeBlock registration is handled by register_sparse_moe_on_the_fly
-    # (auto-detected via gate.top_k + gate.num_experts + experts pattern).
-    # Only the fused expert weights need explicit registration.
-    if Qwen3_5MoeExperts not in QuantModuleRegistry:
-        QuantModuleRegistry.register({Qwen3_5MoeExperts: "hf.Qwen3_5MoeExperts"})(
-            _QuantQwen35MoeExperts
-        )
-except ImportError:
-    pass
-
-
 class _QuantGptOssExperts(_QuantFunctionalMixin):
     """Quantized wrapper for `transformers.GptOssExperts`.
 
@@ -1659,8 +1545,8 @@ class _QuantMoELinear(QuantModule):
     weights and scales back into the original 3D format.
 
     Note: we use expansion-then-reconstruction rather than the add_module() approach
-    (as in _QuantQwen35MoeExperts) because vLLM requires stacked 3D scaling factors;
-    per-expert expanded keys are not accepted by the downstream serving engine.
+    because vLLM requires stacked 3D scaling factors; per-expert expanded keys are
+    not accepted by the downstream serving engine.
     """
 
     def _setup(self):

--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -887,6 +887,102 @@ class _QuantQwen35MoeExperts(QuantModule):
         return final_hidden_states
 
 
+def _get_fused_expert_intermediate_dim(module):
+    """Resolve the intermediate (expert) dimension from a fused expert module.
+
+    Different transformers versions use ``intermediate_size`` or ``intermediate_dim``.
+    """
+    for attr in ("intermediate_dim", "intermediate_size", "moe_intermediate_size"):
+        if hasattr(module, attr):
+            return getattr(module, attr)
+    return module.gate_up_proj.shape[1] // 2
+
+
+class _QuantFusedExperts(_QuantFunctionalMixin):
+    """Generic quantized wrapper for HuggingFace fused MoE expert modules.
+
+    Handles any module following the standard HF transformers 5.0+ fused expert
+    pattern (``@use_experts_implementation``):
+
+    * ``gate_up_proj``: 3-D ``nn.Parameter`` of shape ``(num_experts, 2*intermediate_dim, hidden_dim)``
+    * ``down_proj``:    3-D ``nn.Parameter`` of shape ``(num_experts, hidden_dim, intermediate_dim)``
+    * ``act_fn``:       activation function applied between gate/up and down projections
+    * ``forward``:      calls ``F.linear`` exactly twice per expert (gate_up then down)
+
+    Per-expert quantization is achieved by intercepting ``F.linear`` and recovering
+    the expert index from the weight tensor's storage offset into the 3-D parameter.
+    Each expert gets its own weight quantizers (``nn.ModuleList``), while input
+    quantizers are shared across all experts (single ``TensorQuantizer``) to match
+    the shared input quantization scale used by downstream inference frameworks.
+
+    Verified compatible models: Mixtral, Qwen2-MoE, Qwen3-MoE, Qwen3.5-MoE,
+    DeepSeek-V3, Jamba, OLMoE.
+
+    Limitation: only works when ``experts_implementation="eager"`` (default).
+    ``batched_mm`` / ``grouped_mm`` backends use ``torch.bmm`` /
+    ``torch._grouped_mm`` instead of ``F.linear`` and are not intercepted.
+    """
+
+    def _get_expert_idx_from_gate_up(self, weight: torch.Tensor) -> int:
+        """Recover expert index from a ``gate_up_proj`` weight slice's storage offset.
+
+        When HF indexes ``gate_up_proj[idx]``, the result is a view sharing the
+        same underlying storage.  The offset delta divided by the stride along
+        dim-0 gives the expert index.
+
+        The invariant breaks if the tensor is ``.contiguous()``-copied or
+        redistributed by certain distributed wrappers (FSDP2, tensor parallel).
+        """
+        base_offset = self.gate_up_proj.storage_offset()
+        stride = self.gate_up_proj.stride(0)
+        if stride == 0:
+            return 0
+        idx = (weight.storage_offset() - base_offset) // stride
+        assert 0 <= idx < self.num_experts, (
+            f"Computed expert index {idx} out of range [0, {self.num_experts}). "
+            "This can happen if the weight was .contiguous()-copied or redistributed."
+        )
+        return idx
+
+    def _setup(self):
+        n = self.num_experts
+        self.gate_up_proj_input_quantizer = TensorQuantizer()
+        self.gate_up_proj_weight_quantizers = nn.ModuleList([TensorQuantizer() for _ in range(n)])
+        self.down_proj_input_quantizer = TensorQuantizer()
+        self.down_proj_weight_quantizers = nn.ModuleList([TensorQuantizer() for _ in range(n)])
+
+        self._register_temp_attribute("_down_proj_linear", False)
+        self._register_temp_attribute("_current_expert_idx", 0)
+
+    @property
+    def functionals_to_replace(self):
+        _orig_linear = torch.nn.functional.linear
+
+        # The HF fused expert forward calls F.linear exactly twice per expert
+        # in strict alternation: first for gate_up_proj, then for down_proj.
+        # forward() resets the toggle before each call to super().forward().
+        def _quantized_linear(input, weight, bias=None):
+            if self._down_proj_linear:
+                idx = self._current_expert_idx
+                input = self.down_proj_input_quantizer(input)
+                weight = self.down_proj_weight_quantizers[idx](weight)
+            else:
+                idx = self._get_expert_idx_from_gate_up(weight)
+                self._current_expert_idx = idx
+                input = self.gate_up_proj_input_quantizer(input)
+                weight = self.gate_up_proj_weight_quantizers[idx](weight)
+            self._down_proj_linear = not self._down_proj_linear
+            return _orig_linear(input, weight, bias)
+
+        return [
+            (torch.nn.functional, "linear", _quantized_linear),
+        ]
+
+    def forward(self, *args, **kwargs):
+        self._down_proj_linear = False
+        return super().forward(*args, **kwargs)
+
+
 class _QuantDbrxFFN(_QuantSparseSequentialMoe):
     @property
     def num_experts(self):
@@ -1388,6 +1484,60 @@ def register_sparse_moe_on_the_fly(model):
             )
 
 
+def _is_fused_experts_module(module):
+    """Check if a module is a fused MoE expert container compatible with _QuantFusedExperts.
+
+    Detects the standardized HuggingFace transformers 5.0+ fused expert pattern:
+    ``gate_up_proj`` (3-D parameter), ``down_proj`` (3-D parameter), ``num_experts``,
+    and ``act_fn``.  Matches ``MixtralExperts``, ``Qwen2MoeExperts``,
+    ``Qwen3MoeExperts``, ``Qwen3_5MoeExperts``, ``DeepseekV3NaiveMoe``,
+    ``JambaExperts``, ``OlmoeExperts``, etc.
+
+    Returns ``False`` for non-standard layouts (DBRX, GptOss, GraniteMoE,
+    Llama4TextExperts) which have their own explicit registrations.
+    """
+    if not hasattr(module, "gate_up_proj") or not hasattr(module, "down_proj"):
+        return False
+    if not hasattr(module, "num_experts") or not hasattr(module, "act_fn"):
+        return False
+    gate_up = getattr(module, "gate_up_proj")
+    down = getattr(module, "down_proj")
+    if not isinstance(gate_up, (nn.Parameter, Tensor)) or gate_up.dim() != 3:
+        return False
+    if not isinstance(down, (nn.Parameter, Tensor)) or down.dim() != 3:
+        return False
+    return True
+
+
+def register_fused_experts_on_the_fly(model):
+    """Auto-detect and register fused MoE expert modules as _QuantFusedExperts.
+
+    Walks the model tree, identifies fused expert containers by their structural
+    attributes (``gate_up_proj`` + ``down_proj`` 3-D parameters), and registers
+    unregistered ones with ``_QuantFusedExperts``.
+
+    Skips modules that are already registered (e.g. Llama4TextExperts, GptOssExperts
+    have their own explicit registrations with different quantization strategies).
+    """
+    visited_types = set()
+    for name, module in model.named_modules():
+        mod_type = type(module)
+
+        if mod_type in visited_types or QuantModuleRegistry.get(mod_type) is not None:
+            continue
+
+        visited_types.add(mod_type)
+
+        if _is_fused_experts_module(module):
+            print(
+                f"\033[1mDetected fused MoE experts '{name}' of type {mod_type.__name__}, "
+                f"registering with _QuantFusedExperts.\033[0m"
+            )
+            QuantModuleRegistry.register({mod_type: f"hf.{mod_type.__name__}"})(
+                _QuantFusedExperts
+            )
+
+
 def _is_supported_hf_model(model):
     """Check if the model a valid model for transformers quantization specific support."""
     supported_models = [transformers.PreTrainedModel]
@@ -1614,6 +1764,7 @@ CUSTOM_MODEL_PLUGINS.update(
         register_falcon_linears_on_the_fly,
         register_dbrx_moe_on_the_fly,
         register_step3p5_moe_on_the_fly,
+        register_fused_experts_on_the_fly,
         register_sparse_moe_on_the_fly,
         register_hf_attentions_on_the_fly,
         convert_hf_parallel_linears_on_the_fly,

--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -1504,9 +1504,7 @@ def _is_fused_experts_module(module):
     down = getattr(module, "down_proj")
     if not isinstance(gate_up, (nn.Parameter, Tensor)) or gate_up.dim() != 3:
         return False
-    if not isinstance(down, (nn.Parameter, Tensor)) or down.dim() != 3:
-        return False
-    return True
+    return isinstance(down, (nn.Parameter, Tensor)) and down.dim() == 3
 
 
 def register_fused_experts_on_the_fly(model):

--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -1533,9 +1533,7 @@ def register_fused_experts_on_the_fly(model):
                 f"\033[1mDetected fused MoE experts '{name}' of type {mod_type.__name__}, "
                 f"registering with _QuantFusedExperts.\033[0m"
             )
-            QuantModuleRegistry.register({mod_type: f"hf.{mod_type.__name__}"})(
-                _QuantFusedExperts
-            )
+            QuantModuleRegistry.register({mod_type: f"hf.{mod_type.__name__}"})(_QuantFusedExperts)
 
 
 def _is_supported_hf_model(model):

--- a/tests/_test_utils/torch/transformers_models.py
+++ b/tests/_test_utils/torch/transformers_models.py
@@ -139,6 +139,20 @@ def get_tiny_gpt_oss(**config_kwargs) -> PreTrainedModel:
     return tiny_gpt_oss
 
 
+def create_tiny_gpt_oss_dir(
+    tmp_path: Path | str, with_tokenizer: bool = False, **config_kwargs
+) -> Path:
+    gpt_oss_dir = Path(tmp_path) / "tiny_gpt_oss"
+    if with_tokenizer:
+        tokenizer = AutoTokenizer.from_pretrained(
+            "hf-internal-testing/tiny-random-LlamaForCausalLM"
+        )
+        tokenizer.save_pretrained(gpt_oss_dir)
+        config_kwargs["vocab_size"] = tokenizer.vocab_size
+    get_tiny_gpt_oss(**config_kwargs).save_pretrained(gpt_oss_dir)
+    return gpt_oss_dir
+
+
 ##### LLAMA #####
 def get_tiny_llama(**config_kwargs) -> PreTrainedModel:
     set_seed(SEED)

--- a/tests/_test_utils/torch/transformers_models.py
+++ b/tests/_test_utils/torch/transformers_models.py
@@ -104,6 +104,20 @@ def get_tiny_qwen3_moe(**config_kwargs) -> PreTrainedModel:
     return tiny_qwen3_moe
 
 
+def create_tiny_qwen3_moe_dir(
+    tmp_path: Path | str, with_tokenizer: bool = False, **config_kwargs
+) -> Path:
+    qwen3_moe_dir = Path(tmp_path) / "tiny_qwen3_moe"
+    if with_tokenizer:
+        tokenizer = AutoTokenizer.from_pretrained(
+            "hf-internal-testing/tiny-random-LlamaForCausalLM"
+        )
+        tokenizer.save_pretrained(qwen3_moe_dir)
+        config_kwargs["vocab_size"] = tokenizer.vocab_size
+    get_tiny_qwen3_moe(**config_kwargs).save_pretrained(qwen3_moe_dir)
+    return qwen3_moe_dir
+
+
 ##### GPT-OSS #####
 def get_tiny_gpt_oss(**config_kwargs) -> PreTrainedModel:
     set_seed(SEED)

--- a/tests/gpu/torch/export/test_unified_hf_export_and_check_safetensors.py
+++ b/tests/gpu/torch/export/test_unified_hf_export_and_check_safetensors.py
@@ -40,6 +40,9 @@ from safetensors import safe_open
     [
         # Dense model (llama)
         ("fp8", "tiny_llama-fp8", True, False, True, True, False),
+        ("nvfp4", "tiny_llama-nvfp4", True, False, True, True, False),
+        ("nvfp4_mse", "tiny_llama-nvfp4-mse", True, False, True, True, False),
+        ("nvfp4_awq", "tiny_llama-nvfp4-awq", True, False, True, True, False),
         ("int4_awq", "tiny_llama-int4-awq", True, False, True, True, False),
         ("w4a8_awq", "tiny_llama-w4a8-awq", True, False, True, True, False),
         ("int8_wo", "tiny_llama-int8-wo", False, False, False, False, False),

--- a/tests/gpu/torch/export/test_unified_hf_export_and_check_safetensors.py
+++ b/tests/gpu/torch/export/test_unified_hf_export_and_check_safetensors.py
@@ -38,19 +38,15 @@ from safetensors import safe_open
         "fuse_svdquant_lora_a",
     ),
     [
+        # Dense model (llama)
         ("fp8", "tiny_llama-fp8", True, False, True, True, False),
-        ("nvfp4", "tiny_llama-nvfp4", True, False, True, True, False),
-        ("nvfp4_mse", "tiny_llama-nvfp4-mse", True, False, True, True, False),
-        ("nvfp4_awq", "tiny_llama-nvfp4-awq", True, False, True, True, False),
         ("int4_awq", "tiny_llama-int4-awq", True, False, True, True, False),
         ("w4a8_awq", "tiny_llama-w4a8-awq", True, False, True, True, False),
         ("int8_wo", "tiny_llama-int8-wo", False, False, False, False, False),
         ("nvfp4_svdquant", "tiny_llama-nvfp4-svdquant", True, False, True, True, True),
-        # MoE models
-        ("fp8", "tiny_qwen3_moe-fp8", True, False, True, True, False),
+        # MoE models (fused experts: Qwen3 MoE, GPT-OSS)
         ("nvfp4", "tiny_qwen3_moe-nvfp4", True, False, True, True, False),
         ("fp8", "tiny_gpt_oss-fp8", True, False, True, True, False),
-        ("nvfp4", "tiny_gpt_oss-nvfp4", True, False, True, True, False),
     ],
 )
 def test_unified_hf_export_and_check_safetensors(

--- a/tests/gpu/torch/export/test_unified_hf_export_and_check_safetensors.py
+++ b/tests/gpu/torch/export/test_unified_hf_export_and_check_safetensors.py
@@ -18,6 +18,7 @@ import pytest
 import torch
 from _test_utils.examples.run_command import extend_cmd_parts, run_example_command
 from _test_utils.torch.transformers_models import (
+    create_tiny_gpt_oss_dir,
     create_tiny_llama_dir,
     create_tiny_qwen3_moe_dir,
     create_tiny_t5_dir,
@@ -45,9 +46,11 @@ from safetensors import safe_open
         ("w4a8_awq", "tiny_llama-w4a8-awq", True, False, True, True, False),
         ("int8_wo", "tiny_llama-int8-wo", False, False, False, False, False),
         ("nvfp4_svdquant", "tiny_llama-nvfp4-svdquant", True, False, True, True, True),
-        # MoE model (Qwen3 MoE with fused experts)
+        # MoE models
         ("fp8", "tiny_qwen3_moe-fp8", True, False, True, True, False),
         ("nvfp4", "tiny_qwen3_moe-nvfp4", True, False, True, True, False),
+        ("fp8", "tiny_gpt_oss-fp8", True, False, True, True, False),
+        ("nvfp4", "tiny_gpt_oss-nvfp4", True, False, True, True, False),
     ],
 )
 def test_unified_hf_export_and_check_safetensors(
@@ -76,6 +79,10 @@ def test_unified_hf_export_and_check_safetensors(
         )
     elif expected_suffix.startswith("tiny_qwen3_moe"):
         tiny_model_dir = create_tiny_qwen3_moe_dir(
+            tmp_path, with_tokenizer=True, num_hidden_layers=1
+        )
+    elif expected_suffix.startswith("tiny_gpt_oss"):
+        tiny_model_dir = create_tiny_gpt_oss_dir(
             tmp_path, with_tokenizer=True, num_hidden_layers=1
         )
     else:

--- a/tests/gpu/torch/export/test_unified_hf_export_and_check_safetensors.py
+++ b/tests/gpu/torch/export/test_unified_hf_export_and_check_safetensors.py
@@ -82,9 +82,7 @@ def test_unified_hf_export_and_check_safetensors(
             tmp_path, with_tokenizer=True, num_hidden_layers=1
         )
     elif expected_suffix.startswith("tiny_gpt_oss"):
-        tiny_model_dir = create_tiny_gpt_oss_dir(
-            tmp_path, with_tokenizer=True, num_hidden_layers=1
-        )
+        tiny_model_dir = create_tiny_gpt_oss_dir(tmp_path, with_tokenizer=True, num_hidden_layers=1)
     else:
         tiny_model_dir = create_tiny_llama_dir(tmp_path, with_tokenizer=True, num_hidden_layers=1)
 

--- a/tests/gpu/torch/export/test_unified_hf_export_and_check_safetensors.py
+++ b/tests/gpu/torch/export/test_unified_hf_export_and_check_safetensors.py
@@ -17,7 +17,11 @@ import os
 import pytest
 import torch
 from _test_utils.examples.run_command import extend_cmd_parts, run_example_command
-from _test_utils.torch.transformers_models import create_tiny_llama_dir, create_tiny_t5_dir
+from _test_utils.torch.transformers_models import (
+    create_tiny_llama_dir,
+    create_tiny_qwen3_moe_dir,
+    create_tiny_t5_dir,
+)
 from safetensors import safe_open
 
 
@@ -41,6 +45,9 @@ from safetensors import safe_open
         ("w4a8_awq", "tiny_llama-w4a8-awq", True, False, True, True, False),
         ("int8_wo", "tiny_llama-int8-wo", False, False, False, False, False),
         ("nvfp4_svdquant", "tiny_llama-nvfp4-svdquant", True, False, True, True, True),
+        # MoE model (Qwen3 MoE with fused experts)
+        ("fp8", "tiny_qwen3_moe-fp8", True, False, True, True, False),
+        ("nvfp4", "tiny_qwen3_moe-nvfp4", True, False, True, True, False),
     ],
 )
 def test_unified_hf_export_and_check_safetensors(
@@ -66,6 +73,10 @@ def test_unified_hf_export_and_check_safetensors(
     if expected_suffix.startswith("t5_tiny"):
         tiny_model_dir = create_tiny_t5_dir(
             tmp_path, with_tokenizer=True, num_hidden_layers=1, use_cache=False
+        )
+    elif expected_suffix.startswith("tiny_qwen3_moe"):
+        tiny_model_dir = create_tiny_qwen3_moe_dir(
+            tmp_path, with_tokenizer=True, num_hidden_layers=1
         )
     else:
         tiny_model_dir = create_tiny_llama_dir(tmp_path, with_tokenizer=True, num_hidden_layers=1)

--- a/tests/unit/torch/quantization/plugins/test_fused_experts.py
+++ b/tests/unit/torch/quantization/plugins/test_fused_experts.py
@@ -226,7 +226,7 @@ class TestQuantFusedExperts:
             out_ref = ref_experts(hidden_states, top_k_index, top_k_weights)
             out_test = converted(hidden_states, top_k_index, top_k_weights)
 
-        assert torch.allclose(out_ref, out_test, atol=1e-5), (
+        assert torch.allclose(out_ref, out_test, atol=1e-4), (
             f"Max diff: {(out_ref - out_test).abs().max().item()}"
         )
         self._cleanup_registry(expert_type)

--- a/tests/unit/torch/quantization/plugins/test_fused_experts.py
+++ b/tests/unit/torch/quantization/plugins/test_fused_experts.py
@@ -24,9 +24,9 @@ pytest.importorskip("transformers")
 
 from modelopt.torch.quantization.nn import QuantModuleRegistry
 from modelopt.torch.quantization.plugins.huggingface import (
-    _QuantFusedExperts,
     _is_fused_experts_module,
     _is_sparse_moe_block,
+    _QuantFusedExperts,
     register_fused_experts_on_the_fly,
     register_sparse_moe_on_the_fly,
 )
@@ -51,9 +51,7 @@ class _SyntheticFusedExperts(nn.Module):
         self.gate_up_proj = nn.Parameter(
             torch.randn(NUM_EXPERTS, 2 * INTERMEDIATE_DIM, HIDDEN_DIM) * 0.02
         )
-        self.down_proj = nn.Parameter(
-            torch.randn(NUM_EXPERTS, HIDDEN_DIM, INTERMEDIATE_DIM) * 0.02
-        )
+        self.down_proj = nn.Parameter(torch.randn(NUM_EXPERTS, HIDDEN_DIM, INTERMEDIATE_DIM) * 0.02)
         self.act_fn = nn.SiLU()
 
     def forward(self, hidden_states, top_k_index, top_k_weights):
@@ -70,7 +68,9 @@ class _SyntheticFusedExperts(nn.Module):
             gate, up = F.linear(current_state, self.gate_up_proj[expert_idx]).chunk(2, dim=-1)
             current_hidden_states = self.act_fn(gate) * up
             current_hidden_states = F.linear(current_hidden_states, self.down_proj[expert_idx])
-            current_hidden_states = current_hidden_states * top_k_weights[token_idx, top_k_pos, None]
+            current_hidden_states = (
+                current_hidden_states * top_k_weights[token_idx, top_k_pos, None]
+            )
             final_hidden_states.index_add_(
                 0, token_idx, current_hidden_states.to(final_hidden_states.dtype)
             )
@@ -254,9 +254,6 @@ class TestExportFusedExperts:
     def test_export_creates_per_expert_submodules(self):
         """_export_fused_experts should create per-expert submodules with standard naming."""
         from modelopt.torch.export.moe_utils import _export_fused_experts
-        from modelopt.torch.quantization.plugins.huggingface import (
-            _get_fused_expert_intermediate_dim,
-        )
 
         experts = _SyntheticFusedExperts()
         expert_type = type(experts)

--- a/tests/unit/torch/quantization/plugins/test_fused_experts.py
+++ b/tests/unit/torch/quantization/plugins/test_fused_experts.py
@@ -189,7 +189,7 @@ class TestQuantFusedExperts:
         self._cleanup_registry(block_type)
 
     def test_convert_creates_quantizers(self):
-        """After conversion, fused experts should have per-expert quantizer ModuleLists."""
+        """After conversion, fused experts should have shared input and per-expert weight quantizers."""
         model = _TinyMoEModel()
         expert_type = type(model.moe.experts)
         self._cleanup_registry(expert_type)
@@ -197,11 +197,13 @@ class TestQuantFusedExperts:
         register_fused_experts_on_the_fly(model)
         converted = QuantModuleRegistry.convert(model.moe.experts)
 
-        assert hasattr(converted, "gate_up_proj_input_quantizers")
+        # Shared input quantizers (single TensorQuantizer, not ModuleList)
+        assert hasattr(converted, "gate_up_proj_input_quantizer")
+        assert hasattr(converted, "down_proj_input_quantizer")
+        # Per-expert weight quantizers (ModuleList)
         assert hasattr(converted, "gate_up_proj_weight_quantizers")
-        assert hasattr(converted, "down_proj_input_quantizers")
         assert hasattr(converted, "down_proj_weight_quantizers")
-        assert len(converted.gate_up_proj_input_quantizers) == NUM_EXPERTS
+        assert len(converted.gate_up_proj_weight_quantizers) == NUM_EXPERTS
         assert len(converted.down_proj_weight_quantizers) == NUM_EXPERTS
         self._cleanup_registry(expert_type)
 

--- a/tests/unit/torch/quantization/plugins/test_fused_experts.py
+++ b/tests/unit/torch/quantization/plugins/test_fused_experts.py
@@ -25,7 +25,7 @@ pytest.importorskip("transformers")
 from modelopt.torch.quantization.nn import QuantModuleRegistry
 from modelopt.torch.quantization.plugins.huggingface import (
     _is_fused_experts_module,
-    _is_sparse_moe_block,
+    _is_sparse_sequaential_moe_block,
     _QuantFusedExperts,
     register_fused_experts_on_the_fly,
     register_sparse_moe_on_the_fly,
@@ -149,9 +149,10 @@ class TestIsFusedExpertsModule:
         block = _SyntheticSparseMoeBlock()
         assert _is_fused_experts_module(block) is False
 
-    def test_sparse_moe_block_detected_as_sparse(self):
+    def test_fused_moe_block_not_detected_as_sequential(self):
+        """Fused MoE blocks (non-iterable experts) should not be detected as sequential."""
         block = _SyntheticSparseMoeBlock()
-        assert _is_sparse_moe_block(block) is True
+        assert _is_sparse_sequaential_moe_block(block) is False
 
 
 # ---------------------------------------------------------------------------
@@ -173,8 +174,8 @@ class TestQuantFusedExperts:
         assert QuantModuleRegistry.get(expert_type) is not None
         self._cleanup_registry(expert_type)
 
-    def test_two_level_registration(self):
-        """Both fused experts and the MoE block should be registered."""
+    def test_fused_experts_only_registration(self):
+        """Fused MoE: only the expert module is registered, not the block (non-iterable experts)."""
         model = _TinyMoEModel()
         expert_type = type(model.moe.experts)
         block_type = type(model.moe)
@@ -184,9 +185,9 @@ class TestQuantFusedExperts:
         register_fused_experts_on_the_fly(model)
         register_sparse_moe_on_the_fly(model)
         assert QuantModuleRegistry.get(expert_type) is not None
-        assert QuantModuleRegistry.get(block_type) is not None
+        # Block is NOT registered because fused experts are not iterable
+        assert QuantModuleRegistry.get(block_type) is None
         self._cleanup_registry(expert_type)
-        self._cleanup_registry(block_type)
 
     def test_convert_creates_quantizers(self):
         """After conversion, fused experts should have shared input and per-expert weight quantizers."""

--- a/tests/unit/torch/quantization/plugins/test_fused_experts.py
+++ b/tests/unit/torch/quantization/plugins/test_fused_experts.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for _QuantFusedExperts: generic fused MoE quantization and export."""
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+pytest.importorskip("transformers")
+
+from modelopt.torch.quantization.nn import QuantModuleRegistry
+from modelopt.torch.quantization.plugins.huggingface import (
+    _QuantFusedExperts,
+    _is_fused_experts_module,
+    _is_sparse_moe_block,
+    register_fused_experts_on_the_fly,
+    register_sparse_moe_on_the_fly,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic fused expert module matching the HF transformers 5.0+ pattern
+# ---------------------------------------------------------------------------
+NUM_EXPERTS = 4
+HIDDEN_DIM = 32
+INTERMEDIATE_DIM = 16
+TOP_K = 2
+
+
+class _SyntheticFusedExperts(nn.Module):
+    """Mimics MixtralExperts / Qwen3MoeExperts / DeepseekV3NaiveMoe from transformers 5.x."""
+
+    def __init__(self):
+        super().__init__()
+        self.num_experts = NUM_EXPERTS
+        self.hidden_dim = HIDDEN_DIM
+        self.intermediate_dim = INTERMEDIATE_DIM
+        self.gate_up_proj = nn.Parameter(
+            torch.randn(NUM_EXPERTS, 2 * INTERMEDIATE_DIM, HIDDEN_DIM) * 0.02
+        )
+        self.down_proj = nn.Parameter(
+            torch.randn(NUM_EXPERTS, HIDDEN_DIM, INTERMEDIATE_DIM) * 0.02
+        )
+        self.act_fn = nn.SiLU()
+
+    def forward(self, hidden_states, top_k_index, top_k_weights):
+        final_hidden_states = torch.zeros_like(hidden_states)
+        with torch.no_grad():
+            expert_mask = F.one_hot(top_k_index, num_classes=self.num_experts).permute(2, 1, 0)
+            expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+        for expert_idx in expert_hit:
+            expert_idx = expert_idx[0]
+            if expert_idx == self.num_experts:
+                continue
+            top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+            current_state = hidden_states[token_idx]
+            gate, up = F.linear(current_state, self.gate_up_proj[expert_idx]).chunk(2, dim=-1)
+            current_hidden_states = self.act_fn(gate) * up
+            current_hidden_states = F.linear(current_hidden_states, self.down_proj[expert_idx])
+            current_hidden_states = current_hidden_states * top_k_weights[token_idx, top_k_pos, None]
+            final_hidden_states.index_add_(
+                0, token_idx, current_hidden_states.to(final_hidden_states.dtype)
+            )
+        return final_hidden_states
+
+
+class _SyntheticTopKRouter(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.top_k = TOP_K
+        self.num_experts = NUM_EXPERTS
+        self.weight = nn.Parameter(torch.randn(NUM_EXPERTS, HIDDEN_DIM) * 0.02)
+
+    def forward(self, hidden_states):
+        router_logits = F.linear(hidden_states, self.weight)
+        router_logits = F.softmax(router_logits.float(), dim=-1)
+        router_top_value, router_indices = torch.topk(router_logits, self.top_k, dim=-1)
+        router_top_value = router_top_value / router_top_value.sum(dim=-1, keepdim=True)
+        return router_logits, router_top_value, router_indices
+
+
+class _SyntheticSparseMoeBlock(nn.Module):
+    """Mimics MixtralSparseMoeBlock / Qwen3MoeSparseMoeBlock."""
+
+    def __init__(self):
+        super().__init__()
+        self.gate = _SyntheticTopKRouter()
+        self.experts = _SyntheticFusedExperts()
+
+    def forward(self, hidden_states):
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+        _, top_k_weights, top_k_index = self.gate(hidden_states)
+        hidden_states = self.experts(hidden_states, top_k_index, top_k_weights)
+        return hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+
+
+class _TinyMoEModel(nn.Module):
+    """Minimal model containing a single MoE block."""
+
+    def __init__(self):
+        super().__init__()
+        self.moe = _SyntheticSparseMoeBlock()
+
+    def forward(self, x):
+        return self.moe(x)
+
+
+# ---------------------------------------------------------------------------
+# Tests for _is_fused_experts_module
+# ---------------------------------------------------------------------------
+class TestIsFusedExpertsModule:
+    def test_synthetic_fused_experts_detected(self):
+        module = _SyntheticFusedExperts()
+        assert _is_fused_experts_module(module) is True
+
+    def test_plain_module_not_detected(self):
+        assert _is_fused_experts_module(nn.Linear(8, 8)) is False
+
+    def test_module_with_2d_gate_up_not_detected(self):
+        module = nn.Module()
+        module.gate_up_proj = nn.Parameter(torch.randn(16, 8))
+        module.down_proj = nn.Parameter(torch.randn(8, 16))
+        module.num_experts = 4
+        module.act_fn = nn.SiLU()
+        assert _is_fused_experts_module(module) is False
+
+    def test_module_missing_act_fn_not_detected(self):
+        module = nn.Module()
+        module.gate_up_proj = nn.Parameter(torch.randn(4, 16, 8))
+        module.down_proj = nn.Parameter(torch.randn(4, 8, 16))
+        module.num_experts = 4
+        assert _is_fused_experts_module(module) is False
+
+    def test_sparse_moe_block_not_detected_as_fused(self):
+        block = _SyntheticSparseMoeBlock()
+        assert _is_fused_experts_module(block) is False
+
+    def test_sparse_moe_block_detected_as_sparse(self):
+        block = _SyntheticSparseMoeBlock()
+        assert _is_sparse_moe_block(block) is True
+
+
+# ---------------------------------------------------------------------------
+# Tests for registration and quantization
+# ---------------------------------------------------------------------------
+class TestQuantFusedExperts:
+    @staticmethod
+    def _cleanup_registry(mod_type):
+        if QuantModuleRegistry.get(mod_type) is not None:
+            QuantModuleRegistry.unregister(mod_type)
+
+    def test_register_fused_experts_on_the_fly(self):
+        model = _TinyMoEModel()
+        expert_type = type(model.moe.experts)
+        self._cleanup_registry(expert_type)
+        self._cleanup_registry(type(model.moe))
+
+        register_fused_experts_on_the_fly(model)
+        assert QuantModuleRegistry.get(expert_type) is not None
+        self._cleanup_registry(expert_type)
+
+    def test_two_level_registration(self):
+        """Both fused experts and the MoE block should be registered."""
+        model = _TinyMoEModel()
+        expert_type = type(model.moe.experts)
+        block_type = type(model.moe)
+        self._cleanup_registry(expert_type)
+        self._cleanup_registry(block_type)
+
+        register_fused_experts_on_the_fly(model)
+        register_sparse_moe_on_the_fly(model)
+        assert QuantModuleRegistry.get(expert_type) is not None
+        assert QuantModuleRegistry.get(block_type) is not None
+        self._cleanup_registry(expert_type)
+        self._cleanup_registry(block_type)
+
+    def test_convert_creates_quantizers(self):
+        """After conversion, fused experts should have per-expert quantizer ModuleLists."""
+        model = _TinyMoEModel()
+        expert_type = type(model.moe.experts)
+        self._cleanup_registry(expert_type)
+
+        register_fused_experts_on_the_fly(model)
+        converted = QuantModuleRegistry.convert(model.moe.experts)
+
+        assert hasattr(converted, "gate_up_proj_input_quantizers")
+        assert hasattr(converted, "gate_up_proj_weight_quantizers")
+        assert hasattr(converted, "down_proj_input_quantizers")
+        assert hasattr(converted, "down_proj_weight_quantizers")
+        assert len(converted.gate_up_proj_input_quantizers) == NUM_EXPERTS
+        assert len(converted.down_proj_weight_quantizers) == NUM_EXPERTS
+        self._cleanup_registry(expert_type)
+
+    def test_forward_passthrough_matches(self):
+        """Forward through _QuantFusedExperts should match the original (quantizers disabled)."""
+        model = _TinyMoEModel()
+        expert_type = type(model.moe.experts)
+        self._cleanup_registry(expert_type)
+
+        ref_experts = _SyntheticFusedExperts()
+        ref_experts.load_state_dict(model.moe.experts.state_dict())
+
+        register_fused_experts_on_the_fly(model)
+        converted = QuantModuleRegistry.convert(model.moe.experts)
+
+        seq_len = 8
+        hidden_states = torch.randn(seq_len, HIDDEN_DIM)
+        top_k_index = torch.randint(0, NUM_EXPERTS, (seq_len, TOP_K))
+        top_k_weights = torch.softmax(torch.randn(seq_len, TOP_K), dim=-1)
+
+        with torch.no_grad():
+            out_ref = ref_experts(hidden_states, top_k_index, top_k_weights)
+            out_test = converted(hidden_states, top_k_index, top_k_weights)
+
+        assert torch.allclose(out_ref, out_test, atol=1e-5), (
+            f"Max diff: {(out_ref - out_test).abs().max().item()}"
+        )
+        self._cleanup_registry(expert_type)
+
+    def test_expert_index_recovery(self):
+        """Storage-offset based expert index recovery should be correct."""
+        experts = _SyntheticFusedExperts()
+        expert_type = type(experts)
+        self._cleanup_registry(expert_type)
+
+        register_fused_experts_on_the_fly(_TinyMoEModel())
+        converted = QuantModuleRegistry.convert(experts)
+
+        for idx in range(NUM_EXPERTS):
+            weight_slice = converted.gate_up_proj[idx]
+            recovered_idx = converted._get_expert_idx_from_gate_up(weight_slice)
+            assert recovered_idx == idx, f"Expected {idx}, got {recovered_idx}"
+        self._cleanup_registry(expert_type)
+
+
+# ---------------------------------------------------------------------------
+# Tests for export
+# ---------------------------------------------------------------------------
+class TestExportFusedExperts:
+    def test_export_creates_per_expert_submodules(self):
+        """_export_fused_experts should create per-expert submodules with standard naming."""
+        from modelopt.torch.export.moe_utils import _export_fused_experts
+        from modelopt.torch.quantization.plugins.huggingface import (
+            _get_fused_expert_intermediate_dim,
+        )
+
+        experts = _SyntheticFusedExperts()
+        expert_type = type(experts)
+
+        # Manually register and convert
+        if QuantModuleRegistry.get(expert_type) is None:
+            QuantModuleRegistry.register({expert_type: "test.SyntheticFusedExperts"})(
+                _QuantFusedExperts
+            )
+        converted = QuantModuleRegistry.convert(experts)
+
+        # Run a forward pass to calibrate (set amaxes)
+        seq_len = 16
+        hidden_states = torch.randn(seq_len, HIDDEN_DIM)
+        top_k_index = torch.randint(0, NUM_EXPERTS, (seq_len, TOP_K))
+        top_k_weights = torch.softmax(torch.randn(seq_len, TOP_K), dim=-1)
+        with torch.no_grad():
+            converted(hidden_states, top_k_index, top_k_weights)
+
+        _export_fused_experts(converted, torch.float16)
+
+        # Verify per-expert submodules exist
+        for idx in range(NUM_EXPERTS):
+            expert_mod = getattr(converted, str(idx), None)
+            assert expert_mod is not None, f"Missing expert submodule {idx}"
+            assert hasattr(expert_mod, "gate_proj"), f"Expert {idx} missing gate_proj"
+            assert hasattr(expert_mod, "up_proj"), f"Expert {idx} missing up_proj"
+            assert hasattr(expert_mod, "down_proj"), f"Expert {idx} missing down_proj"
+
+            assert expert_mod.gate_proj.weight.shape == (INTERMEDIATE_DIM, HIDDEN_DIM)
+            assert expert_mod.up_proj.weight.shape == (INTERMEDIATE_DIM, HIDDEN_DIM)
+            assert expert_mod.down_proj.weight.shape == (HIDDEN_DIM, INTERMEDIATE_DIM)
+
+        # Verify fused params are removed
+        assert not hasattr(converted, "gate_up_proj")
+        assert not hasattr(converted, "down_proj")
+        assert not hasattr(converted, "gate_up_proj_weight_quantizers")
+
+        if QuantModuleRegistry.get(expert_type) is not None:
+            QuantModuleRegistry.unregister(expert_type)


### PR DESCRIPTION
## What does this PR do?

Add generic quantization and export support for **fused MoE expert modules** in HuggingFace transformers 5.0+.

In transformers 5.0+, all major MoE models switched from sequential per-expert `nn.ModuleList` to **fused 3D tensor parameters** (`gate_up_proj`, `down_proj`). This breaks ModelOpt's existing per-expert quantization and export pipeline, which assumes iterable expert submodules.

**Affected models (verified against transformers v5.5.0 source):**
- `MixtralExperts` (Mixtral)
- `Qwen2MoeExperts` (Qwen2-MoE)
- `Qwen3MoeExperts` (Qwen3-MoE)
- `Qwen3_5MoeExperts` (Qwen3.5-MoE)
- `DeepseekV3NaiveMoe` (DeepSeek-V3)
- `JambaExperts`, `OlmoeExperts`, and any future model following the same HF standard pattern

**Key insight:** All these models share an identical fused expert structure and forward pattern. A single generic solution replaces N model-specific implementations.

### Context: relationship to PR #975 and PR #1170

- **PR #975** (`kmorabi/bump-transformers-5.0`): Adds experimental transformers 5.0 support but explicitly skips batched MoE experts. This PR fills that gap.
- **PR #1170** (`chenjiel/refactor_qwen35`): Handles only Qwen3.5 using `_QuantFunctionalMixin`. This PR generalizes that approach to all fused MoE models.

### Changes

**Quantization** (`modelopt/torch/quantization/plugins/huggingface.py`):
- `_QuantFusedExperts(_QuantFunctionalMixin)` -- Generic wrapper that intercepts `F.linear` calls and applies per-expert quantization via storage-offset-based expert index recovery. Each expert gets its own weight and input quantizers (`nn.ModuleList`).
- `_is_fused_experts_module()` -- Structural detector: `gate_up_proj` (3D) + `down_proj` (3D) + `num_experts` + `act_fn`.
- `register_fused_experts_on_the_fly()` -- Auto-registration callback, added to `CUSTOM_MODEL_PLUGINS` before `register_sparse_moe_on_the_fly` so explicit registrations (Llama4, GptOss, etc.) take priority.
- `_get_fused_expert_intermediate_dim()` -- Helper for cross-version attribute name resolution (`intermediate_dim` / `intermediate_size` / fallback to shape).

**Export** (`modelopt/torch/export/moe_utils.py`, `unified_export_hf.py`, `layer_utils.py`):
- `_export_fused_experts()` -- Splits fused 3D weights into per-expert 2D projections (`gate_proj`, `up_proj`, `down_proj`), handles amax fallback for uncalibrated experts, proportionally slices per-channel amax, and registers results under the standard `experts.{E}.gate_proj.weight` naming convention.
- Integration in `_process_quantized_modules` and `_export_transformers_checkpoint` to dispatch to `_export_fused_experts` for fused expert modules.
- Structural detection in `get_expert_linear_names` for fused experts. Added `MixtralSparseMoeBlock` to the `gate_proj`/`down_proj`/`up_proj` group (transformers 5.0 naming).

**Tests** (`tests/unit/torch/quantization/plugins/test_fused_experts.py`):
- Synthetic fused expert model matching the exact HF 5.0+ pattern.
- Tests for structural detection, auto-registration, two-level registration (block + expert), quantizer creation, forward pass-through correctness, expert index recovery, and export output structure.

### Two-level registration design

SparseMoeBlock --> _QuantSparseMoe (calibration control, token counting, top_k override) .experts --> _QuantFusedExperts (per-expert F.linear interception + quantization)


`register_fused_experts_on_the_fly` runs first to register the inner expert module; `register_sparse_moe_on_the_fly` then registers the outer block. `_QuantSparseMoe.layer_sync_moe_local_experts_amax` skips fused experts (they are not iterable), as per-expert amax is managed internally by `_QuantFusedExperts`.
### Known limitations
- **`@use_experts_implementation` backends**: The `F.linear` interception only works with `experts_implementation="eager"` (default). `batched_mm` / `grouped_mm` use `torch.bmm` / `torch._grouped_mm` instead and are not intercepted.
- **Storage offset fragility**: Expert index recovery via `storage_offset()` breaks under `.contiguous()`, FSDP2 redistribution, or `torch.compile` materialization. Runtime assertions are included.
- **Toggle state machine**: Assumes exactly 2 `F.linear` calls per expert. Documented in docstrings.
- **Non-standard MoE models**: DBRX, GptOss, Llama4, Step3p5 have different layouts and are already explicitly handled. The generic solution does not attempt to cover these.
### Testing
- [x] Unit tests with synthetic fused expert model: detection, registration, quantization, export
- [x] Verify existing sequential MoE tests still pass (`test_sparse_moe.py`)
- [ ] GPU test with a real MoE model on transformers 5.x
### Before your PR is "Ready for review"
- Is this change backward compatible?: Yes -- existing explicit registrations take priority; sequential MoE models are unaffected.
- Did you write any new necessary tests?: Yes
- Did you update Changelog?: No (pending)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quantization support for fused Mixture-of-Experts (MoE) modules with automatic detection, per-expert quantization handling, and export to per-expert submodules; unified checkpoint export now supports fused MoE experts.

* **Tests**
  * Added end-to-end tests covering fused-experts detection, conversion, forward correctness, expert index recovery, and export.

* **Changelog**
  * Updated release notes to announce fused MoE expert support for Hugging Face exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->