### PR TITLE
Add support for postprocess exported model for block scale swizzling and support for different padding strategy

### DIFF
--- a/examples/diffusers/README.md
+++ b/examples/diffusers/README.md
@@ -147,6 +147,13 @@ python quantize.py \
     --extra-param merged_base_safetensor_path=./ltx-2-19b-dev-fp8.safetensors
 ```
 
+To additionally apply NVFP4 scale swizzle and padding , add:
+
+```sh
+    --extra-param enable_swizzle_layout=true \
+    --extra-param padding_strategy=row_col
+```
+
 #### Important Parameters
 
 - `percentile`: Control quantization scaling factors (amax) collecting range, meaning that we will collect the chosen amax in the range of `(n_steps * percentile)` steps. Recommendation: 1.0

--- a/examples/diffusers/README.md
+++ b/examples/diffusers/README.md
@@ -162,6 +162,13 @@ python quantize.py \
     --extra-param merged_base_safetensor_path=./ltx-2-19b-dev-fp8.safetensors
 ```
 
+To additionally apply NVFP4 scale swizzle and padding , add:
+
+```sh
+    --extra-param enable_swizzle_layout=true \
+    --extra-param padding_strategy=row_col
+```
+
 #### Important Parameters
 
 - `percentile`: Control quantization scaling factors (amax) collecting range, meaning that we will collect the chosen amax in the range of `(n_steps * percentile)` steps. Recommendation: 1.0

--- a/examples/diffusers/quantization/pipeline_manager.py
+++ b/examples/diffusers/quantization/pipeline_manager.py
@@ -218,6 +218,9 @@ class PipelineManager:
             "fp8transformer", False
         )
         params.pop("merged_base_safetensor_path", None)
+        params.pop("enable_swizzle_layout", None)
+        params.pop("padding_strategy", None)
+        params.pop("enable_layerwise_quant_metadata", None)
 
         if not checkpoint_path:
             raise ValueError("Missing required extra_param: checkpoint_path.")

--- a/examples/diffusers/quantization/pipeline_manager.py
+++ b/examples/diffusers/quantization/pipeline_manager.py
@@ -216,6 +216,9 @@ class PipelineManager:
             "fp8transformer", False
         )
         params.pop("merged_base_safetensor_path", None)
+        params.pop("enable_swizzle_layout", None)
+        params.pop("padding_strategy", None)
+        params.pop("enable_layerwise_quant_metadata", None)
 
         if not checkpoint_path:
             raise ValueError("Missing required extra_param: checkpoint_path.")

--- a/examples/diffusers/quantization/quantize.py
+++ b/examples/diffusers/quantization/quantize.py
@@ -324,9 +324,23 @@ class ExportManager:
             for key in ("enable_swizzle_layout", "enable_layerwise_quant_metadata"):
                 val = model_config.extra_params.get(key)
                 if val is not None:
-                    kwargs[key] = str(val).lower() in ("true", "1", "yes")
+                    normalized = str(val).strip().lower()
+                    if normalized in ("true", "1", "yes"):
+                        kwargs[key] = True
+                    elif normalized in ("false", "0", "no"):
+                        kwargs[key] = False
+                    else:
+                        raise ValueError(
+                            f"Invalid value for {key}: {val!r}. "
+                            "Expected true/false, 1/0, or yes/no."
+                        )
             padding = model_config.extra_params.get("padding_strategy")
-            if padding:
+            if padding is not None:
+                padding = str(padding).strip().lower()
+                if padding not in ("row", "row_col"):
+                    raise ValueError(
+                        f"Invalid padding_strategy: {padding!r}. Expected 'row' or 'row_col'."
+                    )
                 kwargs["padding_strategy"] = padding
         export_hf_checkpoint(pipe, export_dir=self.config.hf_ckpt_dir, **kwargs)
         self.logger.info("HuggingFace checkpoint export completed successfully")

--- a/examples/diffusers/quantization/quantize.py
+++ b/examples/diffusers/quantization/quantize.py
@@ -320,6 +320,14 @@ class ExportManager:
             if merged_path:
                 self.logger.info(f"Merging base safetensors from {merged_path} for LTX2 export")
                 kwargs["merged_base_safetensor_path"] = merged_path
+        if model_config:
+            for key in ("enable_swizzle_layout", "enable_layerwise_quant_metadata"):
+                val = model_config.extra_params.get(key)
+                if val is not None:
+                    kwargs[key] = str(val).lower() in ("true", "1", "yes")
+            padding = model_config.extra_params.get("padding_strategy")
+            if padding:
+                kwargs["padding_strategy"] = padding
         export_hf_checkpoint(pipe, export_dir=self.config.hf_ckpt_dir, **kwargs)
         self.logger.info("HuggingFace checkpoint export completed successfully")
 

--- a/examples/diffusers/quantization/quantize.py
+++ b/examples/diffusers/quantization/quantize.py
@@ -357,6 +357,14 @@ class ExportManager:
             if merged_path:
                 self.logger.info(f"Merging base safetensors from {merged_path} for LTX2 export")
                 kwargs["merged_base_safetensor_path"] = merged_path
+        if model_config:
+            for key in ("enable_swizzle_layout", "enable_layerwise_quant_metadata"):
+                val = model_config.extra_params.get(key)
+                if val is not None:
+                    kwargs[key] = str(val).lower() in ("true", "1", "yes")
+            padding = model_config.extra_params.get("padding_strategy")
+            if padding:
+                kwargs["padding_strategy"] = padding
         export_hf_checkpoint(pipe, export_dir=self.config.hf_ckpt_dir, **kwargs)
         self.logger.info("HuggingFace checkpoint export completed successfully")
 

--- a/examples/diffusers/quantization/quantize.py
+++ b/examples/diffusers/quantization/quantize.py
@@ -361,9 +361,23 @@ class ExportManager:
             for key in ("enable_swizzle_layout", "enable_layerwise_quant_metadata"):
                 val = model_config.extra_params.get(key)
                 if val is not None:
-                    kwargs[key] = str(val).lower() in ("true", "1", "yes")
+                    normalized = str(val).strip().lower()
+                    if normalized in ("true", "1", "yes"):
+                        kwargs[key] = True
+                    elif normalized in ("false", "0", "no"):
+                        kwargs[key] = False
+                    else:
+                        raise ValueError(
+                            f"Invalid value for {key}: {val!r}. "
+                            "Expected true/false, 1/0, or yes/no."
+                        )
             padding = model_config.extra_params.get("padding_strategy")
-            if padding:
+            if padding is not None:
+                padding = str(padding).strip().lower()
+                if padding not in ("row", "row_col"):
+                    raise ValueError(
+                        f"Invalid padding_strategy: {padding!r}. Expected 'row' or 'row_col'."
+                    )
                 kwargs["padding_strategy"] = padding
         export_hf_checkpoint(pipe, export_dir=self.config.hf_ckpt_dir, **kwargs)
         self.logger.info("HuggingFace checkpoint export completed successfully")

--- a/modelopt/torch/export/diffusers_utils.py
+++ b/modelopt/torch/export/diffusers_utils.py
@@ -858,7 +858,10 @@ def _find_nvfp4_layers(state_dict: dict[str, torch.Tensor]) -> set[str]:
             s_key = f"{layer}.weight_scale"
             if s_key not in state_dict or w_key not in state_dict:
                 continue
-            if state_dict[w_key].dtype == torch.uint8 and state_dict[s_key].dtype == torch.float8_e4m3fn:
+            if (
+                state_dict[w_key].dtype == torch.uint8
+                and state_dict[s_key].dtype == torch.float8_e4m3fn
+            ):
                 layers.add(layer)
     return layers
 
@@ -893,7 +896,9 @@ def pad_nvfp4_weights(
         rows, cols_w = weight.shape
         pad_r = _roundup(rows, 16) - rows
         pad_c_w = (_roundup(cols_w, 16) - cols_w) if padding_strategy == "row_col" else 0
-        pad_c_s = (_roundup(scale.shape[1], 16) - scale.shape[1]) if padding_strategy == "row_col" else 0
+        pad_c_s = (
+            (_roundup(scale.shape[1], 16) - scale.shape[1]) if padding_strategy == "row_col" else 0
+        )
 
         if pad_r > 0 or pad_c_w > 0:
             state_dict[w_key] = torch.nn.functional.pad(weight, (0, pad_c_w, 0, pad_r))
@@ -933,7 +938,9 @@ def swizzle_nvfp4_scales(
         padded = input_matrix
         if (rows, cols) != (padded_rows, padded_cols):
             padded = torch.zeros(
-                (padded_rows, padded_cols), device=input_matrix.device, dtype=input_matrix.dtype,
+                (padded_rows, padded_cols),
+                device=input_matrix.device,
+                dtype=input_matrix.dtype,
             )
             padded[:rows, :cols] = input_matrix
         blocks = padded.view(n_row_blocks, 128, n_col_blocks, 4).permute(0, 2, 1, 3)
@@ -945,7 +952,6 @@ def swizzle_nvfp4_scales(
     for layer in sorted(nvfp4_layers):
         s_key = f"{layer}.weight_scale"
         state_dict[s_key] = _to_blocked(state_dict[s_key].to(torch.float8_e4m3fn))
-
 
     return state_dict
 

--- a/modelopt/torch/export/diffusers_utils.py
+++ b/modelopt/torch/export/diffusers_utils.py
@@ -900,7 +900,7 @@ def pad_nvfp4_weights(
             (_roundup(scale.shape[1], 16) - scale.shape[1]) if padding_strategy == "row_col" else 0
         )
 
-        if pad_r > 0 or pad_c_w > 0:
+        if pad_r > 0 or pad_c_w > 0 or pad_c_s > 0:
             state_dict[w_key] = torch.nn.functional.pad(weight, (0, pad_c_w, 0, pad_r))
             state_dict[s_key] = torch.nn.functional.pad(scale, (0, pad_c_s, 0, pad_r))
             padded_count += 1

--- a/modelopt/torch/export/diffusers_utils.py
+++ b/modelopt/torch/export/diffusers_utils.py
@@ -929,7 +929,11 @@ def swizzle_nvfp4_scales(
         return (a + b - 1) // b
 
     def _to_blocked(input_matrix: torch.Tensor) -> torch.Tensor:
-        """Rearrange scale matrix to cuBLAS 2-D block-scaling-factors layout."""
+        """Rearrange scale matrix to cuBLAS 2-D block-scaling-factors layout.
+
+        Note: rows are padded to multiples of 128 for cuBLAS alignment, so the
+        output shape may differ from the input (e.g. (16, 4) -> (128, 4)).
+        """
         rows, cols = input_matrix.shape
         n_row_blocks = _ceil_div(rows, 128)
         n_col_blocks = _ceil_div(cols, 4)

--- a/modelopt/torch/export/diffusers_utils.py
+++ b/modelopt/torch/export/diffusers_utils.py
@@ -777,6 +777,39 @@ DIFFUSION_MERGE_FUNCTIONS: dict[str, Callable] = {
 }
 
 
+def build_layerwise_quant_metadata(
+    state_dict: dict[str, torch.Tensor],
+    hf_quant_config: dict,
+) -> str:
+    """Build per-layer ``_quantization_metadata`` JSON from scale keys in state dict.
+
+    Scans the state dict for ``weight_scale`` / ``weight_scale_2`` suffixes and
+    maps each quantized layer to its quantization format.
+
+    Args:
+        state_dict: The (possibly merged) state dict with quantization scale tensors.
+        hf_quant_config: The quantization config dict (must contain ``quant_algo``).
+
+    Returns:
+        JSON string with ``format_version`` and ``layers`` mapping.
+    """
+    quant_algo = hf_quant_config.get("quant_algo", "unknown").lower()
+    layer_metadata = {}
+    for k in state_dict:
+        if k.endswith((".weight_scale", ".weight_scale_2")):
+            layer_name = k.rsplit(".", 1)[0]
+            if layer_name.endswith(".weight"):
+                layer_name = layer_name.rsplit(".", 1)[0]
+            if layer_name not in layer_metadata:
+                layer_metadata[layer_name] = {"format": quant_algo}
+    return json.dumps(
+        {
+            "format_version": "1.0",
+            "layers": layer_metadata,
+        }
+    )
+
+
 def merge_diffusion_checkpoint(
     state_dict: dict[str, torch.Tensor],
     merged_base_safetensor_path: str,
@@ -786,8 +819,8 @@ def merge_diffusion_checkpoint(
     """Merge transformer weights with a base checkpoint and build ComfyUI metadata.
 
     Dispatches to the model-specific merge function in ``DIFFUSION_MERGE_FUNCTIONS``
-    and, when ``hf_quant_config`` is provided, embeds ``quantization_config`` and
-    per-layer ``_quantization_metadata`` in the safetensors metadata for ComfyUI.
+    and, when ``hf_quant_config`` is provided, embeds ``quantization_config`` in the
+    safetensors metadata for ComfyUI.
 
     Args:
         state_dict: The transformer state dict (already on CPU).
@@ -795,8 +828,8 @@ def merge_diffusion_checkpoint(
             containing all components (transformer, VAE, vocoder, etc.),
             e.g. ``"path/to/ltx-2-19b-dev.safetensors"``.
         model_type: Key into ``DIFFUSION_MERGE_FUNCTIONS`` for the model-specific merge.
-        hf_quant_config: If provided, embed quantization config and per-layer
-            ``_quantization_metadata`` in the returned metadata dict.
+        hf_quant_config: If provided, embed quantization config in the returned
+            metadata dict.
 
     Returns:
         Tuple of (merged_state_dict, metadata) where *metadata* is the base checkpoint's
@@ -808,23 +841,113 @@ def merge_diffusion_checkpoint(
     if hf_quant_config is not None:
         metadata["quantization_config"] = json.dumps(hf_quant_config)
 
-        quant_algo = hf_quant_config.get("quant_algo", "unknown").lower()
-        layer_metadata = {}
-        for k in merged_state_dict:
-            if k.endswith((".weight_scale", ".weight_scale_2")):
-                layer_name = k.rsplit(".", 1)[0]
-                if layer_name.endswith(".weight"):
-                    layer_name = layer_name.rsplit(".", 1)[0]
-                if layer_name not in layer_metadata:
-                    layer_metadata[layer_name] = {"format": quant_algo}
-        metadata["_quantization_metadata"] = json.dumps(
-            {
-                "format_version": "1.0",
-                "layers": layer_metadata,
-            }
-        )
-
     return merged_state_dict, metadata
+
+
+def _find_nvfp4_layers(state_dict: dict[str, torch.Tensor]) -> set[str]:
+    """Find all NVFP4 layer prefixes in a state dict.
+
+    A layer is NVFP4 if it has ``weight`` (uint8), ``weight_scale`` (float8_e4m3fn),
+    and ``weight_scale_2`` (float32) entries.
+    """
+    layers: set[str] = set()
+    for key in state_dict:
+        if key.endswith(".weight_scale_2"):
+            layer = key[: -len(".weight_scale_2")]
+            w_key = f"{layer}.weight"
+            s_key = f"{layer}.weight_scale"
+            if s_key not in state_dict or w_key not in state_dict:
+                continue
+            if state_dict[w_key].dtype == torch.uint8 and state_dict[s_key].dtype == torch.float8_e4m3fn:
+                layers.add(layer)
+    return layers
+
+
+def pad_nvfp4_weights(
+    state_dict: dict[str, torch.Tensor],
+    padding_strategy: str = "row",
+) -> dict[str, torch.Tensor]:
+    """Pad NVFP4 weight and scale tensors so dimensions are multiples of 16.
+
+    Args:
+        state_dict: The state dict to pad (modified in-place and returned).
+        padding_strategy: ``"row"`` (default) pads only rows to multiples of 16;
+            ``"row_col"`` pads both rows and columns.
+    """
+    if padding_strategy not in ("row", "row_col"):
+        raise ValueError(f"padding_strategy must be 'row' or 'row_col', got '{padding_strategy}'")
+
+    def _roundup(a: int, b: int) -> int:
+        return ((a + b - 1) // b) * b
+
+    nvfp4_layers = _find_nvfp4_layers(state_dict)
+    padded_count = 0
+
+    for layer in sorted(nvfp4_layers):
+        w_key = f"{layer}.weight"
+        s_key = f"{layer}.weight_scale"
+
+        weight = state_dict[w_key]
+        scale = state_dict[s_key]
+
+        rows, cols_w = weight.shape
+        pad_r = _roundup(rows, 16) - rows
+        pad_c_w = (_roundup(cols_w, 16) - cols_w) if padding_strategy == "row_col" else 0
+        pad_c_s = (_roundup(scale.shape[1], 16) - scale.shape[1]) if padding_strategy == "row_col" else 0
+
+        if pad_r > 0 or pad_c_w > 0:
+            state_dict[w_key] = torch.nn.functional.pad(weight, (0, pad_c_w, 0, pad_r))
+            state_dict[s_key] = torch.nn.functional.pad(scale, (0, pad_c_s, 0, pad_r))
+            padded_count += 1
+
+    return state_dict
+
+
+def swizzle_nvfp4_scales(
+    state_dict: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    """Swizzle NVFP4 block scales to cuBLAS 2-D tiled layout.
+
+    Converts the flat ``weight_scale`` tensors ``[rows, cols // 16]`` produced by
+    ModelOpt into the cuBLAS 2-D block-scaling-factors layout.
+
+    Reference: https://docs.nvidia.com/cuda/cublas/index.html#d-block-scaling-factors-layout
+
+    Note: Weights and scales should be padded *before* calling this function
+    (see :func:`pad_nvfp4_weights`).
+
+    Args:
+        state_dict: The state dict to transform (modified in-place and returned).
+    """
+
+    def _ceil_div(a: int, b: int) -> int:
+        return (a + b - 1) // b
+
+    def _to_blocked(input_matrix: torch.Tensor) -> torch.Tensor:
+        """Rearrange scale matrix to cuBLAS 2-D block-scaling-factors layout."""
+        rows, cols = input_matrix.shape
+        n_row_blocks = _ceil_div(rows, 128)
+        n_col_blocks = _ceil_div(cols, 4)
+        padded_rows = n_row_blocks * 128
+        padded_cols = n_col_blocks * 4
+        padded = input_matrix
+        if (rows, cols) != (padded_rows, padded_cols):
+            padded = torch.zeros(
+                (padded_rows, padded_cols), device=input_matrix.device, dtype=input_matrix.dtype,
+            )
+            padded[:rows, :cols] = input_matrix
+        blocks = padded.view(n_row_blocks, 128, n_col_blocks, 4).permute(0, 2, 1, 3)
+        rearranged = blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16)
+        return rearranged.reshape(padded_rows, padded_cols)
+
+    nvfp4_layers = _find_nvfp4_layers(state_dict)
+
+    for layer in sorted(nvfp4_layers):
+        s_key = f"{layer}.weight_scale"
+        state_dict[s_key] = _to_blocked(state_dict[s_key].to(torch.float8_e4m3fn))
+
+
+    return state_dict
 
 
 def get_diffusion_model_type(pipe: Any) -> str:

--- a/modelopt/torch/export/diffusers_utils.py
+++ b/modelopt/torch/export/diffusers_utils.py
@@ -911,7 +911,7 @@ def pad_nvfp4_weights(
             (_roundup(scale.shape[1], 16) - scale.shape[1]) if padding_strategy == "row_col" else 0
         )
 
-        if pad_r > 0 or pad_c_w > 0:
+        if pad_r > 0 or pad_c_w > 0 or pad_c_s > 0:
             state_dict[w_key] = torch.nn.functional.pad(weight, (0, pad_c_w, 0, pad_r))
             state_dict[s_key] = torch.nn.functional.pad(scale, (0, pad_c_s, 0, pad_r))
             padded_count += 1

--- a/modelopt/torch/export/diffusers_utils.py
+++ b/modelopt/torch/export/diffusers_utils.py
@@ -940,7 +940,11 @@ def swizzle_nvfp4_scales(
         return (a + b - 1) // b
 
     def _to_blocked(input_matrix: torch.Tensor) -> torch.Tensor:
-        """Rearrange scale matrix to cuBLAS 2-D block-scaling-factors layout."""
+        """Rearrange scale matrix to cuBLAS 2-D block-scaling-factors layout.
+
+        Note: rows are padded to multiples of 128 for cuBLAS alignment, so the
+        output shape may differ from the input (e.g. (16, 4) -> (128, 4)).
+        """
         rows, cols = input_matrix.shape
         n_row_blocks = _ceil_div(rows, 128)
         n_col_blocks = _ceil_div(cols, 4)

--- a/modelopt/torch/export/diffusers_utils.py
+++ b/modelopt/torch/export/diffusers_utils.py
@@ -869,7 +869,10 @@ def _find_nvfp4_layers(state_dict: dict[str, torch.Tensor]) -> set[str]:
             s_key = f"{layer}.weight_scale"
             if s_key not in state_dict or w_key not in state_dict:
                 continue
-            if state_dict[w_key].dtype == torch.uint8 and state_dict[s_key].dtype == torch.float8_e4m3fn:
+            if (
+                state_dict[w_key].dtype == torch.uint8
+                and state_dict[s_key].dtype == torch.float8_e4m3fn
+            ):
                 layers.add(layer)
     return layers
 
@@ -904,7 +907,9 @@ def pad_nvfp4_weights(
         rows, cols_w = weight.shape
         pad_r = _roundup(rows, 16) - rows
         pad_c_w = (_roundup(cols_w, 16) - cols_w) if padding_strategy == "row_col" else 0
-        pad_c_s = (_roundup(scale.shape[1], 16) - scale.shape[1]) if padding_strategy == "row_col" else 0
+        pad_c_s = (
+            (_roundup(scale.shape[1], 16) - scale.shape[1]) if padding_strategy == "row_col" else 0
+        )
 
         if pad_r > 0 or pad_c_w > 0:
             state_dict[w_key] = torch.nn.functional.pad(weight, (0, pad_c_w, 0, pad_r))
@@ -944,7 +949,9 @@ def swizzle_nvfp4_scales(
         padded = input_matrix
         if (rows, cols) != (padded_rows, padded_cols):
             padded = torch.zeros(
-                (padded_rows, padded_cols), device=input_matrix.device, dtype=input_matrix.dtype,
+                (padded_rows, padded_cols),
+                device=input_matrix.device,
+                dtype=input_matrix.dtype,
             )
             padded[:rows, :cols] = input_matrix
         blocks = padded.view(n_row_blocks, 128, n_col_blocks, 4).permute(0, 2, 1, 3)
@@ -956,7 +963,6 @@ def swizzle_nvfp4_scales(
     for layer in sorted(nvfp4_layers):
         s_key = f"{layer}.weight_scale"
         state_dict[s_key] = _to_blocked(state_dict[s_key].to(torch.float8_e4m3fn))
-
 
     return state_dict
 

--- a/modelopt/torch/export/diffusers_utils.py
+++ b/modelopt/torch/export/diffusers_utils.py
@@ -895,7 +895,6 @@ def pad_nvfp4_weights(
         return ((a + b - 1) // b) * b
 
     nvfp4_layers = _find_nvfp4_layers(state_dict)
-    padded_count = 0
 
     for layer in sorted(nvfp4_layers):
         w_key = f"{layer}.weight"
@@ -914,7 +913,6 @@ def pad_nvfp4_weights(
         if pad_r > 0 or pad_c_w > 0 or pad_c_s > 0:
             state_dict[w_key] = torch.nn.functional.pad(weight, (0, pad_c_w, 0, pad_r))
             state_dict[s_key] = torch.nn.functional.pad(scale, (0, pad_c_s, 0, pad_r))
-            padded_count += 1
 
     return state_dict
 

--- a/modelopt/torch/export/diffusers_utils.py
+++ b/modelopt/torch/export/diffusers_utils.py
@@ -788,6 +788,39 @@ DIFFUSION_MERGE_FUNCTIONS: dict[str, Callable] = {
 }
 
 
+def build_layerwise_quant_metadata(
+    state_dict: dict[str, torch.Tensor],
+    hf_quant_config: dict,
+) -> str:
+    """Build per-layer ``_quantization_metadata`` JSON from scale keys in state dict.
+
+    Scans the state dict for ``weight_scale`` / ``weight_scale_2`` suffixes and
+    maps each quantized layer to its quantization format.
+
+    Args:
+        state_dict: The (possibly merged) state dict with quantization scale tensors.
+        hf_quant_config: The quantization config dict (must contain ``quant_algo``).
+
+    Returns:
+        JSON string with ``format_version`` and ``layers`` mapping.
+    """
+    quant_algo = hf_quant_config.get("quant_algo", "unknown").lower()
+    layer_metadata = {}
+    for k in state_dict:
+        if k.endswith((".weight_scale", ".weight_scale_2")):
+            layer_name = k.rsplit(".", 1)[0]
+            if layer_name.endswith(".weight"):
+                layer_name = layer_name.rsplit(".", 1)[0]
+            if layer_name not in layer_metadata:
+                layer_metadata[layer_name] = {"format": quant_algo}
+    return json.dumps(
+        {
+            "format_version": "1.0",
+            "layers": layer_metadata,
+        }
+    )
+
+
 def merge_diffusion_checkpoint(
     state_dict: dict[str, torch.Tensor],
     merged_base_safetensor_path: str,
@@ -797,8 +830,8 @@ def merge_diffusion_checkpoint(
     """Merge transformer weights with a base checkpoint and build ComfyUI metadata.
 
     Dispatches to the model-specific merge function in ``DIFFUSION_MERGE_FUNCTIONS``
-    and, when ``hf_quant_config`` is provided, embeds ``quantization_config`` and
-    per-layer ``_quantization_metadata`` in the safetensors metadata for ComfyUI.
+    and, when ``hf_quant_config`` is provided, embeds ``quantization_config`` in the
+    safetensors metadata for ComfyUI.
 
     Args:
         state_dict: The transformer state dict (already on CPU).
@@ -806,8 +839,8 @@ def merge_diffusion_checkpoint(
             containing all components (transformer, VAE, vocoder, etc.),
             e.g. ``"path/to/ltx-2-19b-dev.safetensors"``.
         model_type: Key into ``DIFFUSION_MERGE_FUNCTIONS`` for the model-specific merge.
-        hf_quant_config: If provided, embed quantization config and per-layer
-            ``_quantization_metadata`` in the returned metadata dict.
+        hf_quant_config: If provided, embed quantization config in the returned
+            metadata dict.
 
     Returns:
         Tuple of (merged_state_dict, metadata) where *metadata* is the base checkpoint's
@@ -819,23 +852,113 @@ def merge_diffusion_checkpoint(
     if hf_quant_config is not None:
         metadata["quantization_config"] = json.dumps(hf_quant_config)
 
-        quant_algo = hf_quant_config.get("quant_algo", "unknown").lower()
-        layer_metadata = {}
-        for k in merged_state_dict:
-            if k.endswith((".weight_scale", ".weight_scale_2")):
-                layer_name = k.rsplit(".", 1)[0]
-                if layer_name.endswith(".weight"):
-                    layer_name = layer_name.rsplit(".", 1)[0]
-                if layer_name not in layer_metadata:
-                    layer_metadata[layer_name] = {"format": quant_algo}
-        metadata["_quantization_metadata"] = json.dumps(
-            {
-                "format_version": "1.0",
-                "layers": layer_metadata,
-            }
-        )
-
     return merged_state_dict, metadata
+
+
+def _find_nvfp4_layers(state_dict: dict[str, torch.Tensor]) -> set[str]:
+    """Find all NVFP4 layer prefixes in a state dict.
+
+    A layer is NVFP4 if it has ``weight`` (uint8), ``weight_scale`` (float8_e4m3fn),
+    and ``weight_scale_2`` (float32) entries.
+    """
+    layers: set[str] = set()
+    for key in state_dict:
+        if key.endswith(".weight_scale_2"):
+            layer = key[: -len(".weight_scale_2")]
+            w_key = f"{layer}.weight"
+            s_key = f"{layer}.weight_scale"
+            if s_key not in state_dict or w_key not in state_dict:
+                continue
+            if state_dict[w_key].dtype == torch.uint8 and state_dict[s_key].dtype == torch.float8_e4m3fn:
+                layers.add(layer)
+    return layers
+
+
+def pad_nvfp4_weights(
+    state_dict: dict[str, torch.Tensor],
+    padding_strategy: str = "row",
+) -> dict[str, torch.Tensor]:
+    """Pad NVFP4 weight and scale tensors so dimensions are multiples of 16.
+
+    Args:
+        state_dict: The state dict to pad (modified in-place and returned).
+        padding_strategy: ``"row"`` (default) pads only rows to multiples of 16;
+            ``"row_col"`` pads both rows and columns.
+    """
+    if padding_strategy not in ("row", "row_col"):
+        raise ValueError(f"padding_strategy must be 'row' or 'row_col', got '{padding_strategy}'")
+
+    def _roundup(a: int, b: int) -> int:
+        return ((a + b - 1) // b) * b
+
+    nvfp4_layers = _find_nvfp4_layers(state_dict)
+    padded_count = 0
+
+    for layer in sorted(nvfp4_layers):
+        w_key = f"{layer}.weight"
+        s_key = f"{layer}.weight_scale"
+
+        weight = state_dict[w_key]
+        scale = state_dict[s_key]
+
+        rows, cols_w = weight.shape
+        pad_r = _roundup(rows, 16) - rows
+        pad_c_w = (_roundup(cols_w, 16) - cols_w) if padding_strategy == "row_col" else 0
+        pad_c_s = (_roundup(scale.shape[1], 16) - scale.shape[1]) if padding_strategy == "row_col" else 0
+
+        if pad_r > 0 or pad_c_w > 0:
+            state_dict[w_key] = torch.nn.functional.pad(weight, (0, pad_c_w, 0, pad_r))
+            state_dict[s_key] = torch.nn.functional.pad(scale, (0, pad_c_s, 0, pad_r))
+            padded_count += 1
+
+    return state_dict
+
+
+def swizzle_nvfp4_scales(
+    state_dict: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    """Swizzle NVFP4 block scales to cuBLAS 2-D tiled layout.
+
+    Converts the flat ``weight_scale`` tensors ``[rows, cols // 16]`` produced by
+    ModelOpt into the cuBLAS 2-D block-scaling-factors layout.
+
+    Reference: https://docs.nvidia.com/cuda/cublas/index.html#d-block-scaling-factors-layout
+
+    Note: Weights and scales should be padded *before* calling this function
+    (see :func:`pad_nvfp4_weights`).
+
+    Args:
+        state_dict: The state dict to transform (modified in-place and returned).
+    """
+
+    def _ceil_div(a: int, b: int) -> int:
+        return (a + b - 1) // b
+
+    def _to_blocked(input_matrix: torch.Tensor) -> torch.Tensor:
+        """Rearrange scale matrix to cuBLAS 2-D block-scaling-factors layout."""
+        rows, cols = input_matrix.shape
+        n_row_blocks = _ceil_div(rows, 128)
+        n_col_blocks = _ceil_div(cols, 4)
+        padded_rows = n_row_blocks * 128
+        padded_cols = n_col_blocks * 4
+        padded = input_matrix
+        if (rows, cols) != (padded_rows, padded_cols):
+            padded = torch.zeros(
+                (padded_rows, padded_cols), device=input_matrix.device, dtype=input_matrix.dtype,
+            )
+            padded[:rows, :cols] = input_matrix
+        blocks = padded.view(n_row_blocks, 128, n_col_blocks, 4).permute(0, 2, 1, 3)
+        rearranged = blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16)
+        return rearranged.reshape(padded_rows, padded_cols)
+
+    nvfp4_layers = _find_nvfp4_layers(state_dict)
+
+    for layer in sorted(nvfp4_layers):
+        s_key = f"{layer}.weight_scale"
+        state_dict[s_key] = _to_blocked(state_dict[s_key].to(torch.float8_e4m3fn))
+
+
+    return state_dict
 
 
 def get_diffusion_model_type(pipe: Any) -> str:

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -218,9 +218,7 @@ def _postprocess_safetensors(
     model_type: str | None = None
     if merged_base_safetensor_path is not None:
         if pipe is None:
-            raise ValueError(
-                "`pipe` must be provided when `merged_base_safetensor_path` is set."
-            )
+            raise ValueError("`pipe` must be provided when `merged_base_safetensor_path` is set.")
         model_type = get_diffusion_model_type(pipe)
 
     for sf_path in safetensor_files:

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -127,7 +127,6 @@ def _save_component_state_dict_safetensors(
 ) -> None:
     """Save component state dict as a plain safetensors file.
 
-
     Args:
         component: The nn.Module to save.
         component_export_dir: Directory to save model.safetensors and config.json.

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -149,12 +149,9 @@ def _save_component_state_dict_safetensors(
 
 def _postprocess_safetensors(
     export_dir: Path,
-    merged_base_safetensor_path: str | None = None,
-    model_type: str | None = None,
+    pipe: Any | None = None,
     hf_quant_config: dict | None = None,
-    enable_layerwise_quant_metadata: bool = True,
-    padding_strategy: str | None = None,
-    enable_swizzle_layout: bool = False,
+    **kwargs,
 ) -> None:
     """Post-process saved safetensors files for deployment compatibility.
 
@@ -174,13 +171,38 @@ def _postprocess_safetensors(
 
     Args:
         export_dir: Directory containing the saved ``.safetensors`` file(s).
-        merged_base_safetensor_path: Path to base model safetensors for merge.
-        model_type: Key into ``DIFFUSION_MERGE_FUNCTIONS`` (e.g., ``"ltx2"``).
+        pipe: The diffusion pipeline / model.  Used to infer the model type
+            (via :func:`get_diffusion_model_type`) when
+            ``merged_base_safetensor_path`` is set.
         hf_quant_config: Quantization config dict to embed in metadata.
-        enable_layerwise_quant_metadata: Whether to build per-layer metadata.
-        padding_strategy: ``"row"``, ``"row_col"``, or None.
-        enable_swizzle_layout: Whether to swizzle block scales.
+        **kwargs: Runtime-specific keyword arguments:
+            merged_base_safetensor_path (str, optional): When provided, merges
+                the exported transformer weights with non-transformer components
+                (VAE, vocoder, text encoders, etc.) from this base safetensors
+                file to produce a single-file checkpoint compatible with ComfyUI.
+                Value should be the path to a full base model ``.safetensors``
+                file (e.g. ``"path/to/ltx-2-19b-dev.safetensors"``).
+            enable_layerwise_quant_metadata (bool, optional): When True
+                (default), includes per-layer ``_quantization_metadata`` in the
+                checkpoint metadata so that inference runtimes (e.g., ComfyUI)
+                can identify which layers are quantized and in what format. Set
+                to False to skip.
+            enable_swizzle_layout (bool, optional): When True, rearranges NVFP4
+                block scales from ModelOpt's flat layout to cuBLAS 2-D tiled
+                layout. Required for runtimes that consume cuBLAS block-scaled
+                GEMM (e.g., comfy_kitchen). Defaults to False.
+            padding_strategy (str | None, optional): Padding strategy for NVFP4
+                weight and scale tensors. ``"row"`` pads rows to multiples of
+                16 (columns assumed already aligned). ``"row_col"`` pads both
+                dimensions. ``None`` (default) disables padding. Independent of
+                ``enable_swizzle_layout``.
+
     """
+    merged_base_safetensor_path: str | None = kwargs.get("merged_base_safetensor_path")
+    enable_layerwise_quant_metadata: bool = kwargs.get("enable_layerwise_quant_metadata", True)
+    enable_swizzle_layout: bool = kwargs.get("enable_swizzle_layout", False)
+    padding_strategy: str | None = kwargs.get("padding_strategy")
+
     safetensor_files = sorted(export_dir.glob("*.safetensors"))
     if not safetensor_files:
         return
@@ -192,6 +214,14 @@ def _postprocess_safetensors(
             "Post-processing sharded safetensors is not supported. "
             "Export with a larger max_shard_size or disable merge/metadata options."
         )
+
+    model_type: str | None = None
+    if merged_base_safetensor_path is not None:
+        if pipe is None:
+            raise ValueError(
+                "`pipe` must be provided when `merged_base_safetensor_path` is set."
+            )
+        model_type = get_diffusion_model_type(pipe)
 
     for sf_path in safetensor_files:
         with safe_open(str(sf_path), framework="pt") as f:
@@ -948,11 +978,8 @@ def _export_diffusers_checkpoint(
     dtype: torch.dtype | None,
     export_dir: Path,
     components: list[str] | None,
-    merged_base_safetensor_path: str | None = None,
     max_shard_size: int | str = "10GB",
-    enable_layerwise_quant_metadata: bool = True,
-    enable_swizzle_layout: bool = False,
-    padding_strategy: str | None = None,
+    **kwargs,
 ) -> None:
     """Internal: Export diffusion(-like) model/pipeline checkpoint.
 
@@ -966,19 +993,11 @@ def _export_diffusers_checkpoint(
         export_dir: The directory to save the exported checkpoint.
         components: Optional list of component names to export. Only used for pipelines.
             If None, all components are exported.
-        merged_base_safetensor_path: If provided, merge the exported transformer weights
-            with non-transformer components (VAE, vocoder, text encoders, etc.) from this
-            base safetensors file and add quantization metadata to produce a single-file
-            checkpoint compatible with ComfyUI. This should be the path to a full base
-            model ``.safetensors`` file, e.g. ``"path/to/ltx-2-19b-dev.safetensors"``.
         max_shard_size: Maximum size of each shard file. If the model exceeds this size,
             it will be sharded into multiple files and a .safetensors.index.json will be
             created. Use smaller values like "5GB" or "2GB" to force sharding.
-        enable_layerwise_quant_metadata: If True (default), include per-layer
-            ``_quantization_metadata`` in the merged checkpoint metadata.
-        enable_swizzle_layout: If True, swizzle NVFP4 block scales to cuBLAS tiled layout.
-        padding_strategy: ``"row"``, ``"row_col"``, or None. Pads NVFP4 weight/scale
-            tensors independently of swizzle.
+        **kwargs: Runtime-specific post-processing options forwarded to
+            :func:`_postprocess_safetensors`. See its docstring for details.
     """
     export_dir = Path(export_dir)
 
@@ -988,9 +1007,6 @@ def _export_diffusers_checkpoint(
     if not all_components:
         warnings.warn("No exportable components found in the model.")
         return
-
-    # Resolve model type once (only needed when merging with a base checkpoint)
-    model_type = get_diffusion_model_type(pipe) if merged_base_safetensor_path else None
 
     # Separate nn.Module components for quantization-aware export
     module_components = {
@@ -1052,12 +1068,9 @@ def _export_diffusers_checkpoint(
             # Step 7: Post-process — merge, metadata, padding, swizzle
             _postprocess_safetensors(
                 component_export_dir,
-                merged_base_safetensor_path=merged_base_safetensor_path,
-                model_type=model_type,
+                pipe,
                 hf_quant_config=hf_quant_config,
-                enable_layerwise_quant_metadata=enable_layerwise_quant_metadata,
-                padding_strategy=padding_strategy,
-                enable_swizzle_layout=enable_swizzle_layout,
+                **kwargs,
             )
 
             # Step 8: Update config.json with quantization info
@@ -1229,31 +1242,10 @@ def export_hf_checkpoint(
             to export. If None, all quantized components are exported.
         extra_state_dict: Extra state dictionary to add to the exported model.
         max_shard_size: Maximum size of each safetensors shard file. Defaults to "10GB".
-        **kwargs: Internal-only keyword arguments. Supported keys:
-            merged_base_safetensor_path (str, optional). When provided, merges the
-            exported diffusion transformer weights with non-transformer components
-            (VAE, vocoder, text encoders, etc.) from this base safetensors file to
-            produce a single-file checkpoint compatible with ComfyUI. Value should be
-            the path to a full base model ``.safetensors`` file
-            (e.g. ``"path/to/ltx-2-19b-dev.safetensors"``).
-            Only used for diffusion model exports.
-            enable_layerwise_quant_metadata (bool, optional). When True (default),
-            includes per-layer ``_quantization_metadata`` in the checkpoint metadata
-            so that inference runtimes (e.g., ComfyUI) can identify which layers are
-            quantized and in what format. Set to False to skip.
-            enable_swizzle_layout (bool, optional). When True, rearranges NVFP4 block
-            scales from ModelOpt's flat layout to cuBLAS 2-D tiled layout. Required
-            for runtimes that consume cuBLAS block-scaled GEMM (e.g., comfy_kitchen).
-            Defaults to False.
-            padding_strategy (str | None, optional). Padding strategy for NVFP4 weight
-            and scale tensors. ``"row"`` pads rows to multiples of 16 (columns assumed
-            already aligned). ``"row_col"`` pads both dimensions. ``None`` (default)
-            disables padding. Independent of ``enable_swizzle_layout``.
+        **kwargs: Runtime-specific post-processing options forwarded to
+            :func:`_postprocess_safetensors` for diffusion model exports.
+            See its docstring for supported keys.
     """
-    merged_base_safetensor_path: str | None = kwargs.get("merged_base_safetensor_path")
-    enable_layerwise_quant_metadata: bool = kwargs.get("enable_layerwise_quant_metadata", True)
-    enable_swizzle_layout: bool = kwargs.get("enable_swizzle_layout", False)
-    padding_strategy: str | None = kwargs.get("padding_strategy")
     export_dir = Path(export_dir)
     export_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1266,11 +1258,8 @@ def export_hf_checkpoint(
             dtype,
             export_dir,
             components,
-            merged_base_safetensor_path,
             max_shard_size,
-            enable_layerwise_quant_metadata,
-            enable_swizzle_layout,
-            padding_strategy,
+            **kwargs,
         )
         return
 

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -187,6 +187,14 @@ def _postprocess_safetensors(
     if not safetensor_files:
         return
 
+    if list(export_dir.glob("*.safetensors.index.json")) and (
+        merged_base_safetensor_path is not None or enable_layerwise_quant_metadata
+    ):
+        raise NotImplementedError(
+            "Post-processing sharded safetensors is not supported. "
+            "Export with a larger max_shard_size or disable merge/metadata options."
+        )
+
     for sf_path in safetensor_files:
         sd = load_file(str(sf_path))
 

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -196,7 +196,7 @@ def _postprocess_safetensors(
     for sf_path in safetensor_files:
         with safe_open(str(sf_path), framework="pt") as f:
             metadata = dict(f.metadata() or {})
-            sd = {k: f.get_tensor(k).clone() for k in f.keys()}
+            sd = {k: f.get_tensor(k).clone() for k in f}
 
         if merged_base_safetensor_path is not None and model_type is not None:
             sd, base_metadata = merge_diffusion_checkpoint(

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -34,13 +34,13 @@ try:
     import diffusers
 
     from .diffusers_utils import (
+        build_layerwise_quant_metadata,
         generate_diffusion_dummy_forward_fn,
         get_diffusion_components,
         get_diffusion_model_type,
         get_qkv_group_key,
         hide_quantizers_from_state_dict,
         infer_dtype_from_model,
-        build_layerwise_quant_metadata,
         is_diffusers_object,
         is_qkv_projection,
         merge_diffusion_checkpoint,
@@ -195,6 +195,10 @@ def _postprocess_safetensors(
             header_size = struct.unpack("<Q", f.read(8))[0]
             header = json.loads(f.read(header_size))
         metadata = header.get("__metadata__", None) or {}
+
+        # Clone tensors so the memory-mapped file handle from load_file is
+        # released before we overwrite the same path (required on Windows).
+        sd = {k: v.clone() for k, v in sd.items()}
 
         if merged_base_safetensor_path is not None and model_type is not None:
             sd, base_metadata = merge_diffusion_checkpoint(
@@ -1250,7 +1254,7 @@ def export_hf_checkpoint(
     merged_base_safetensor_path: str | None = kwargs.get("merged_base_safetensor_path")
     enable_layerwise_quant_metadata: bool = kwargs.get("enable_layerwise_quant_metadata", True)
     enable_swizzle_layout: bool = kwargs.get("enable_swizzle_layout", False)
-    padding_strategy: str | None = kwargs.get("padding_strategy", None)
+    padding_strategy: str | None = kwargs.get("padding_strategy")
     export_dir = Path(export_dir)
     export_dir.mkdir(parents=True, exist_ok=True)
 

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -30,11 +30,7 @@ import torch
 import torch.nn as nn
 from safetensors.torch import load_file, save_file
 
-from .diffusers_utils import (
-    build_layerwise_quant_metadata,
-    pad_nvfp4_weights,
-    swizzle_nvfp4_scales,
-)
+from .diffusers_utils import build_layerwise_quant_metadata, pad_nvfp4_weights, swizzle_nvfp4_scales
 
 try:
     import diffusers

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -30,11 +30,16 @@ import torch
 import torch.nn as nn
 from safetensors.torch import load_file, save_file
 
+from .diffusers_utils import (
+    build_layerwise_quant_metadata,
+    pad_nvfp4_weights,
+    swizzle_nvfp4_scales,
+)
+
 try:
     import diffusers
 
     from .diffusers_utils import (
-        build_layerwise_quant_metadata,
         generate_diffusion_dummy_forward_fn,
         get_diffusion_components,
         get_diffusion_model_type,
@@ -44,8 +49,6 @@ try:
         is_diffusers_object,
         is_qkv_projection,
         merge_diffusion_checkpoint,
-        pad_nvfp4_weights,
-        swizzle_nvfp4_scales,
     )
 
     HAS_DIFFUSERS = True

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -28,7 +28,7 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from safetensors.torch import save_file
+from safetensors.torch import load_file, save_file
 
 try:
     import diffusers
@@ -40,9 +40,12 @@ try:
         get_qkv_group_key,
         hide_quantizers_from_state_dict,
         infer_dtype_from_model,
+        build_layerwise_quant_metadata,
         is_diffusers_object,
         is_qkv_projection,
         merge_diffusion_checkpoint,
+        pad_nvfp4_weights,
+        swizzle_nvfp4_scales,
     )
 
     HAS_DIFFUSERS = True
@@ -121,46 +124,98 @@ def _is_enabled_quantizer(quantizer):
 def _save_component_state_dict_safetensors(
     component: nn.Module,
     component_export_dir: Path,
-    merged_base_safetensor_path: str | None = None,
-    hf_quant_config: dict | None = None,
-    model_type: str | None = None,
 ) -> None:
-    """Save component state dict as safetensors with optional base checkpoint merge.
+    """Save component state dict as a plain safetensors file.
+
 
     Args:
         component: The nn.Module to save.
         component_export_dir: Directory to save model.safetensors and config.json.
-        merged_base_safetensor_path: If provided, merge the exported transformer weights
-            with non-transformer components (VAE, vocoder, text encoders, etc.) from this
-            base safetensors file and add quantization metadata to produce a single-file
-            checkpoint compatible with ComfyUI. This should be the path to a full base
-            model ``.safetensors`` file, e.g. ``"path/to/ltx-2-19b-dev.safetensors"``.
-        hf_quant_config: If provided, embed quantization config in safetensors metadata
-            and per-layer _quantization_metadata for ComfyUI.
-        model_type: Key into ``DIFFUSION_MERGE_FUNCTIONS`` for the model-specific merge.
-            Required when ``merged_base_safetensor_path`` is not None.
     """
     cpu_state_dict = {k: v.detach().contiguous().cpu() for k, v in component.state_dict().items()}
-    metadata: dict[str, str] = {}
-    metadata_full: dict[str, str] = {}
-
-    if merged_base_safetensor_path is not None and model_type is not None:
-        cpu_state_dict, metadata_full = merge_diffusion_checkpoint(
-            cpu_state_dict, merged_base_safetensor_path, model_type, hf_quant_config
-        )
-
-    metadata["_export_format"] = "safetensors_state_dict"
-    metadata["_class_name"] = type(component).__name__
-    metadata_full.update(metadata)
+    metadata = {
+        "_export_format": "safetensors_state_dict",
+        "_class_name": type(component).__name__,
+    }
 
     save_file(
         cpu_state_dict,
         str(component_export_dir / "model.safetensors"),
-        metadata=metadata_full if merged_base_safetensor_path is not None else None,
+        metadata=metadata,
     )
 
     with open(component_export_dir / "config.json", "w") as f:
         json.dump(metadata, f, indent=4)
+
+
+def _postprocess_safetensors(
+    export_dir: Path,
+    merged_base_safetensor_path: str | None = None,
+    model_type: str | None = None,
+    hf_quant_config: dict | None = None,
+    enable_layerwise_quant_metadata: bool = True,
+    padding_strategy: str | None = None,
+    enable_swizzle_layout: bool = False,
+) -> None:
+    """Post-process saved safetensors files for deployment compatibility.
+
+    Loads each ``.safetensors`` file in *export_dir* and applies all requested
+    transformations in order, then re-saves in-place with updated metadata:
+
+    1. **Merge** with base checkpoint — combines quantized transformer weights with
+       non-transformer components (VAE, vocoder, text encoders) from a base
+       ``.safetensors`` file to produce a single-file checkpoint (e.g., for ComfyUI).
+    2. **Pad** NVFP4 weight/scale tensors — ensures dimensions are multiples of 16
+       for hardware alignment requirements.
+    3. **Swizzle** NVFP4 block scales — rearranges from flat layout to cuBLAS 2-D
+       block-scaling-factors tiled layout for optimized inference.
+    4. **Inject metadata** — embeds ``quantization_config`` and per-layer
+       ``_quantization_metadata`` so inference runtimes can detect and handle
+       quantized layers.
+
+    Args:
+        export_dir: Directory containing the saved ``.safetensors`` file(s).
+        merged_base_safetensor_path: Path to base model safetensors for merge.
+        model_type: Key into ``DIFFUSION_MERGE_FUNCTIONS`` (e.g., ``"ltx2"``).
+        hf_quant_config: Quantization config dict to embed in metadata.
+        enable_layerwise_quant_metadata: Whether to build per-layer metadata.
+        padding_strategy: ``"row"``, ``"row_col"``, or None.
+        enable_swizzle_layout: Whether to swizzle block scales.
+    """
+    import struct
+
+    safetensor_files = sorted(export_dir.glob("*.safetensors"))
+    if not safetensor_files:
+        return
+
+    for sf_path in safetensor_files:
+        sd = load_file(str(sf_path))
+
+        with open(sf_path, "rb") as f:
+            header_size = struct.unpack("<Q", f.read(8))[0]
+            header = json.loads(f.read(header_size))
+        metadata = header.get("__metadata__", None) or {}
+
+        if merged_base_safetensor_path is not None and model_type is not None:
+            sd, base_metadata = merge_diffusion_checkpoint(
+                sd, merged_base_safetensor_path, model_type, hf_quant_config
+            )
+            metadata.update(base_metadata)
+
+        if padding_strategy is not None:
+            sd = pad_nvfp4_weights(sd, padding_strategy)
+
+        if enable_swizzle_layout:
+            sd = swizzle_nvfp4_scales(sd)
+
+        if hf_quant_config is not None:
+            metadata["quantization_config"] = json.dumps(hf_quant_config)
+            if enable_layerwise_quant_metadata:
+                metadata["_quantization_metadata"] = build_layerwise_quant_metadata(
+                    sd, hf_quant_config
+                )
+
+        save_file(sd, str(sf_path), metadata=metadata)
 
 
 def _collect_shared_input_modules(
@@ -892,6 +947,9 @@ def _export_diffusers_checkpoint(
     components: list[str] | None,
     merged_base_safetensor_path: str | None = None,
     max_shard_size: int | str = "10GB",
+    enable_layerwise_quant_metadata: bool = True,
+    enable_swizzle_layout: bool = False,
+    padding_strategy: str | None = None,
 ) -> None:
     """Internal: Export diffusion(-like) model/pipeline checkpoint.
 
@@ -913,6 +971,11 @@ def _export_diffusers_checkpoint(
         max_shard_size: Maximum size of each shard file. If the model exceeds this size,
             it will be sharded into multiple files and a .safetensors.index.json will be
             created. Use smaller values like "5GB" or "2GB" to force sharding.
+        enable_layerwise_quant_metadata: If True (default), include per-layer
+            ``_quantization_metadata`` in the merged checkpoint metadata.
+        enable_swizzle_layout: If True, swizzle NVFP4 block scales to cuBLAS tiled layout.
+        padding_strategy: ``"row"``, ``"row_col"``, or None. Pads NVFP4 weight/scale
+            tensors independently of swizzle.
     """
     export_dir = Path(export_dir)
 
@@ -981,14 +1044,20 @@ def _export_diffusers_checkpoint(
                     component.save_pretrained(component_export_dir, max_shard_size=max_shard_size)
             else:
                 with hide_quantizers_from_state_dict(component):
-                    _save_component_state_dict_safetensors(
-                        component,
-                        component_export_dir,
-                        merged_base_safetensor_path,
-                        hf_quant_config,
-                        model_type,
-                    )
-            # Step 7: Update config.json with quantization info
+                    _save_component_state_dict_safetensors(component, component_export_dir)
+
+            # Step 7: Post-process — merge, metadata, padding, swizzle
+            _postprocess_safetensors(
+                component_export_dir,
+                merged_base_safetensor_path=merged_base_safetensor_path,
+                model_type=model_type,
+                hf_quant_config=hf_quant_config,
+                enable_layerwise_quant_metadata=enable_layerwise_quant_metadata,
+                padding_strategy=padding_strategy,
+                enable_swizzle_layout=enable_swizzle_layout,
+            )
+
+            # Step 8: Update config.json with quantization info
             if hf_quant_config is not None:
                 config_path = component_export_dir / "config.json"
                 if config_path.exists():
@@ -1001,12 +1070,7 @@ def _export_diffusers_checkpoint(
         elif hasattr(component, "save_pretrained"):
             component.save_pretrained(component_export_dir, max_shard_size=max_shard_size)
         else:
-            _save_component_state_dict_safetensors(
-                component,
-                component_export_dir,
-                merged_base_safetensor_path,
-                model_type=model_type,
-            )
+            _save_component_state_dict_safetensors(component, component_export_dir)
 
         print(f"  Saved to: {component_export_dir}")
 
@@ -1162,15 +1226,31 @@ def export_hf_checkpoint(
             to export. If None, all quantized components are exported.
         extra_state_dict: Extra state dictionary to add to the exported model.
         max_shard_size: Maximum size of each safetensors shard file. Defaults to "10GB".
-        **kwargs: Internal-only keyword arguments. Supported key: merged_base_safetensor_path
-            (str, optional). When provided, merges the exported diffusion transformer
-            weights with non-transformer components (VAE, vocoder, text encoders, etc.)
-            from this base safetensors file to produce a single-file checkpoint
-            compatible with ComfyUI. Value should be the path to a full base model
-            ``.safetensors`` file (e.g. ``"path/to/ltx-2-19b-dev.safetensors"``).
+        **kwargs: Internal-only keyword arguments. Supported keys:
+            merged_base_safetensor_path (str, optional). When provided, merges the
+            exported diffusion transformer weights with non-transformer components
+            (VAE, vocoder, text encoders, etc.) from this base safetensors file to
+            produce a single-file checkpoint compatible with ComfyUI. Value should be
+            the path to a full base model ``.safetensors`` file
+            (e.g. ``"path/to/ltx-2-19b-dev.safetensors"``).
             Only used for diffusion model exports.
+            enable_layerwise_quant_metadata (bool, optional). When True (default),
+            includes per-layer ``_quantization_metadata`` in the checkpoint metadata
+            so that inference runtimes (e.g., ComfyUI) can identify which layers are
+            quantized and in what format. Set to False to skip.
+            enable_swizzle_layout (bool, optional). When True, rearranges NVFP4 block
+            scales from ModelOpt's flat layout to cuBLAS 2-D tiled layout. Required
+            for runtimes that consume cuBLAS block-scaled GEMM (e.g., comfy_kitchen).
+            Defaults to False.
+            padding_strategy (str | None, optional). Padding strategy for NVFP4 weight
+            and scale tensors. ``"row"`` pads rows to multiples of 16 (columns assumed
+            already aligned). ``"row_col"`` pads both dimensions. ``None`` (default)
+            disables padding. Independent of ``enable_swizzle_layout``.
     """
     merged_base_safetensor_path: str | None = kwargs.get("merged_base_safetensor_path")
+    enable_layerwise_quant_metadata: bool = kwargs.get("enable_layerwise_quant_metadata", True)
+    enable_swizzle_layout: bool = kwargs.get("enable_swizzle_layout", False)
+    padding_strategy: str | None = kwargs.get("padding_strategy", None)
     export_dir = Path(export_dir)
     export_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1179,7 +1259,15 @@ def export_hf_checkpoint(
         is_diffusers_obj = is_diffusers_object(model)
     if is_diffusers_obj:
         _export_diffusers_checkpoint(
-            model, dtype, export_dir, components, merged_base_safetensor_path, max_shard_size
+            model,
+            dtype,
+            export_dir,
+            components,
+            merged_base_safetensor_path,
+            max_shard_size,
+            enable_layerwise_quant_metadata,
+            enable_swizzle_layout,
+            padding_strategy,
         )
         return
 

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -28,7 +28,8 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from safetensors.torch import load_file, save_file
+from safetensors import safe_open
+from safetensors.torch import save_file
 
 from .diffusers_utils import build_layerwise_quant_metadata, pad_nvfp4_weights, swizzle_nvfp4_scales
 
@@ -180,8 +181,6 @@ def _postprocess_safetensors(
         padding_strategy: ``"row"``, ``"row_col"``, or None.
         enable_swizzle_layout: Whether to swizzle block scales.
     """
-    import struct
-
     safetensor_files = sorted(export_dir.glob("*.safetensors"))
     if not safetensor_files:
         return
@@ -195,22 +194,16 @@ def _postprocess_safetensors(
         )
 
     for sf_path in safetensor_files:
-        sd = load_file(str(sf_path))
-
-        with open(sf_path, "rb") as f:
-            header_size = struct.unpack("<Q", f.read(8))[0]
-            header = json.loads(f.read(header_size))
-        metadata = header.get("__metadata__", None) or {}
-
-        # Clone tensors so the memory-mapped file handle from load_file is
-        # released before we overwrite the same path (required on Windows).
-        sd = {k: v.clone() for k, v in sd.items()}
+        with safe_open(str(sf_path), framework="pt") as f:
+            metadata = dict(f.metadata() or {})
+            sd = {k: f.get_tensor(k).clone() for k in f.keys()}
 
         if merged_base_safetensor_path is not None and model_type is not None:
             sd, base_metadata = merge_diffusion_checkpoint(
-                sd, merged_base_safetensor_path, model_type, hf_quant_config
+                sd, merged_base_safetensor_path, model_type, hf_quant_config=None
             )
-            metadata.update(base_metadata)
+            base_metadata.update(metadata)
+            metadata = base_metadata
 
         if padding_strategy is not None:
             sd = pad_nvfp4_weights(sd, padding_strategy)

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -196,7 +196,7 @@ def _postprocess_safetensors(
     for sf_path in safetensor_files:
         with safe_open(str(sf_path), framework="pt") as f:
             metadata = dict(f.metadata() or {})
-            sd = {k: f.get_tensor(k).clone() for k in f}
+            sd = {k: f.get_tensor(k).clone() for k in f.keys()}  # noqa: SIM118
 
         if merged_base_safetensor_path is not None and model_type is not None:
             sd, base_metadata = merge_diffusion_checkpoint(

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -148,12 +148,9 @@ def _save_component_state_dict_safetensors(
 
 def _postprocess_safetensors(
     export_dir: Path,
-    merged_base_safetensor_path: str | None = None,
-    model_type: str | None = None,
+    pipe: Any | None = None,
     hf_quant_config: dict | None = None,
-    enable_layerwise_quant_metadata: bool = True,
-    padding_strategy: str | None = None,
-    enable_swizzle_layout: bool = False,
+    **kwargs,
 ) -> None:
     """Post-process saved safetensors files for deployment compatibility.
 
@@ -173,13 +170,38 @@ def _postprocess_safetensors(
 
     Args:
         export_dir: Directory containing the saved ``.safetensors`` file(s).
-        merged_base_safetensor_path: Path to base model safetensors for merge.
-        model_type: Key into ``DIFFUSION_MERGE_FUNCTIONS`` (e.g., ``"ltx2"``).
+        pipe: The diffusion pipeline / model.  Used to infer the model type
+            (via :func:`get_diffusion_model_type`) when
+            ``merged_base_safetensor_path`` is set.
         hf_quant_config: Quantization config dict to embed in metadata.
-        enable_layerwise_quant_metadata: Whether to build per-layer metadata.
-        padding_strategy: ``"row"``, ``"row_col"``, or None.
-        enable_swizzle_layout: Whether to swizzle block scales.
+        **kwargs: Runtime-specific keyword arguments:
+            merged_base_safetensor_path (str, optional): When provided, merges
+                the exported transformer weights with non-transformer components
+                (VAE, vocoder, text encoders, etc.) from this base safetensors
+                file to produce a single-file checkpoint compatible with ComfyUI.
+                Value should be the path to a full base model ``.safetensors``
+                file (e.g. ``"path/to/ltx-2-19b-dev.safetensors"``).
+            enable_layerwise_quant_metadata (bool, optional): When True
+                (default), includes per-layer ``_quantization_metadata`` in the
+                checkpoint metadata so that inference runtimes (e.g., ComfyUI)
+                can identify which layers are quantized and in what format. Set
+                to False to skip.
+            enable_swizzle_layout (bool, optional): When True, rearranges NVFP4
+                block scales from ModelOpt's flat layout to cuBLAS 2-D tiled
+                layout. Required for runtimes that consume cuBLAS block-scaled
+                GEMM (e.g., comfy_kitchen). Defaults to False.
+            padding_strategy (str | None, optional): Padding strategy for NVFP4
+                weight and scale tensors. ``"row"`` pads rows to multiples of
+                16 (columns assumed already aligned). ``"row_col"`` pads both
+                dimensions. ``None`` (default) disables padding. Independent of
+                ``enable_swizzle_layout``.
+
     """
+    merged_base_safetensor_path: str | None = kwargs.get("merged_base_safetensor_path")
+    enable_layerwise_quant_metadata: bool = kwargs.get("enable_layerwise_quant_metadata", True)
+    enable_swizzle_layout: bool = kwargs.get("enable_swizzle_layout", False)
+    padding_strategy: str | None = kwargs.get("padding_strategy")
+
     safetensor_files = sorted(export_dir.glob("*.safetensors"))
     if not safetensor_files:
         return
@@ -191,6 +213,14 @@ def _postprocess_safetensors(
             "Post-processing sharded safetensors is not supported. "
             "Export with a larger max_shard_size or disable merge/metadata options."
         )
+
+    model_type: str | None = None
+    if merged_base_safetensor_path is not None:
+        if pipe is None:
+            raise ValueError(
+                "`pipe` must be provided when `merged_base_safetensor_path` is set."
+            )
+        model_type = get_diffusion_model_type(pipe)
 
     for sf_path in safetensor_files:
         with safe_open(str(sf_path), framework="pt") as f:
@@ -962,11 +992,8 @@ def _export_diffusers_checkpoint(
     dtype: torch.dtype | None,
     export_dir: Path,
     components: list[str] | None,
-    merged_base_safetensor_path: str | None = None,
     max_shard_size: int | str = "10GB",
-    enable_layerwise_quant_metadata: bool = True,
-    enable_swizzle_layout: bool = False,
-    padding_strategy: str | None = None,
+    **kwargs,
 ) -> None:
     """Internal: Export diffusion(-like) model/pipeline checkpoint.
 
@@ -980,19 +1007,11 @@ def _export_diffusers_checkpoint(
         export_dir: The directory to save the exported checkpoint.
         components: Optional list of component names to export. Only used for pipelines.
             If None, all components are exported.
-        merged_base_safetensor_path: If provided, merge the exported transformer weights
-            with non-transformer components (VAE, vocoder, text encoders, etc.) from this
-            base safetensors file and add quantization metadata to produce a single-file
-            checkpoint compatible with ComfyUI. This should be the path to a full base
-            model ``.safetensors`` file, e.g. ``"path/to/ltx-2-19b-dev.safetensors"``.
         max_shard_size: Maximum size of each shard file. If the model exceeds this size,
             it will be sharded into multiple files and a .safetensors.index.json will be
             created. Use smaller values like "5GB" or "2GB" to force sharding.
-        enable_layerwise_quant_metadata: If True (default), include per-layer
-            ``_quantization_metadata`` in the merged checkpoint metadata.
-        enable_swizzle_layout: If True, swizzle NVFP4 block scales to cuBLAS tiled layout.
-        padding_strategy: ``"row"``, ``"row_col"``, or None. Pads NVFP4 weight/scale
-            tensors independently of swizzle.
+        **kwargs: Runtime-specific post-processing options forwarded to
+            :func:`_postprocess_safetensors`. See its docstring for details.
     """
     export_dir = Path(export_dir)
 
@@ -1002,9 +1021,6 @@ def _export_diffusers_checkpoint(
     if not all_components:
         warnings.warn("No exportable components found in the model.")
         return
-
-    # Resolve model type once (only needed when merging with a base checkpoint)
-    model_type = get_diffusion_model_type(pipe) if merged_base_safetensor_path else None
 
     # Separate nn.Module components for quantization-aware export
     module_components = {
@@ -1066,12 +1082,9 @@ def _export_diffusers_checkpoint(
             # Step 7: Post-process — merge, metadata, padding, swizzle
             _postprocess_safetensors(
                 component_export_dir,
-                merged_base_safetensor_path=merged_base_safetensor_path,
-                model_type=model_type,
+                pipe,
                 hf_quant_config=hf_quant_config,
-                enable_layerwise_quant_metadata=enable_layerwise_quant_metadata,
-                padding_strategy=padding_strategy,
-                enable_swizzle_layout=enable_swizzle_layout,
+                **kwargs,
             )
 
             # Step 8: Update config.json with quantization info
@@ -1256,31 +1269,10 @@ def export_hf_checkpoint(
             to export. If None, all quantized components are exported.
         extra_state_dict: Extra state dictionary to add to the exported model.
         max_shard_size: Maximum size of each safetensors shard file. Defaults to "10GB".
-        **kwargs: Internal-only keyword arguments. Supported keys:
-            merged_base_safetensor_path (str, optional). When provided, merges the
-            exported diffusion transformer weights with non-transformer components
-            (VAE, vocoder, text encoders, etc.) from this base safetensors file to
-            produce a single-file checkpoint compatible with ComfyUI. Value should be
-            the path to a full base model ``.safetensors`` file
-            (e.g. ``"path/to/ltx-2-19b-dev.safetensors"``).
-            Only used for diffusion model exports.
-            enable_layerwise_quant_metadata (bool, optional). When True (default),
-            includes per-layer ``_quantization_metadata`` in the checkpoint metadata
-            so that inference runtimes (e.g., ComfyUI) can identify which layers are
-            quantized and in what format. Set to False to skip.
-            enable_swizzle_layout (bool, optional). When True, rearranges NVFP4 block
-            scales from ModelOpt's flat layout to cuBLAS 2-D tiled layout. Required
-            for runtimes that consume cuBLAS block-scaled GEMM (e.g., comfy_kitchen).
-            Defaults to False.
-            padding_strategy (str | None, optional). Padding strategy for NVFP4 weight
-            and scale tensors. ``"row"`` pads rows to multiples of 16 (columns assumed
-            already aligned). ``"row_col"`` pads both dimensions. ``None`` (default)
-            disables padding. Independent of ``enable_swizzle_layout``.
+        **kwargs: Runtime-specific post-processing options forwarded to
+            :func:`_postprocess_safetensors` for diffusion model exports.
+            See its docstring for supported keys.
     """
-    merged_base_safetensor_path: str | None = kwargs.get("merged_base_safetensor_path")
-    enable_layerwise_quant_metadata: bool = kwargs.get("enable_layerwise_quant_metadata", True)
-    enable_swizzle_layout: bool = kwargs.get("enable_swizzle_layout", False)
-    padding_strategy: str | None = kwargs.get("padding_strategy")
     export_dir = Path(export_dir)
     export_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1293,11 +1285,8 @@ def export_hf_checkpoint(
             dtype,
             export_dir,
             components,
-            merged_base_safetensor_path,
             max_shard_size,
-            enable_layerwise_quant_metadata,
-            enable_swizzle_layout,
-            padding_strategy,
+            **kwargs,
         )
         return
 

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -195,7 +195,7 @@ def _postprocess_safetensors(
     for sf_path in safetensor_files:
         with safe_open(str(sf_path), framework="pt") as f:
             metadata = dict(f.metadata() or {})
-            sd = {k: f.get_tensor(k).clone() for k in f}
+            sd = {k: f.get_tensor(k).clone() for k in f.keys()}  # noqa: SIM118
 
         if merged_base_safetensor_path is not None and model_type is not None:
             sd, base_metadata = merge_diffusion_checkpoint(

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -126,7 +126,6 @@ def _save_component_state_dict_safetensors(
 ) -> None:
     """Save component state dict as a plain safetensors file.
 
-
     Args:
         component: The nn.Module to save.
         component_export_dir: Directory to save model.safetensors and config.json.

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -195,7 +195,7 @@ def _postprocess_safetensors(
     for sf_path in safetensor_files:
         with safe_open(str(sf_path), framework="pt") as f:
             metadata = dict(f.metadata() or {})
-            sd = {k: f.get_tensor(k).clone() for k in f.keys()}
+            sd = {k: f.get_tensor(k).clone() for k in f}
 
         if merged_base_safetensor_path is not None and model_type is not None:
             sd, base_metadata = merge_diffusion_checkpoint(

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -28,7 +28,8 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from safetensors.torch import load_file, save_file
+from safetensors import safe_open
+from safetensors.torch import save_file
 
 from .diffusers_utils import build_layerwise_quant_metadata, pad_nvfp4_weights, swizzle_nvfp4_scales
 
@@ -179,8 +180,6 @@ def _postprocess_safetensors(
         padding_strategy: ``"row"``, ``"row_col"``, or None.
         enable_swizzle_layout: Whether to swizzle block scales.
     """
-    import struct
-
     safetensor_files = sorted(export_dir.glob("*.safetensors"))
     if not safetensor_files:
         return
@@ -194,22 +193,16 @@ def _postprocess_safetensors(
         )
 
     for sf_path in safetensor_files:
-        sd = load_file(str(sf_path))
-
-        with open(sf_path, "rb") as f:
-            header_size = struct.unpack("<Q", f.read(8))[0]
-            header = json.loads(f.read(header_size))
-        metadata = header.get("__metadata__", None) or {}
-
-        # Clone tensors so the memory-mapped file handle from load_file is
-        # released before we overwrite the same path (required on Windows).
-        sd = {k: v.clone() for k, v in sd.items()}
+        with safe_open(str(sf_path), framework="pt") as f:
+            metadata = dict(f.metadata() or {})
+            sd = {k: f.get_tensor(k).clone() for k in f.keys()}
 
         if merged_base_safetensor_path is not None and model_type is not None:
             sd, base_metadata = merge_diffusion_checkpoint(
-                sd, merged_base_safetensor_path, model_type, hf_quant_config
+                sd, merged_base_safetensor_path, model_type, hf_quant_config=None
             )
-            metadata.update(base_metadata)
+            base_metadata.update(metadata)
+            metadata = base_metadata
 
         if padding_strategy is not None:
             sd = pad_nvfp4_weights(sd, padding_strategy)

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -186,6 +186,14 @@ def _postprocess_safetensors(
     if not safetensor_files:
         return
 
+    if list(export_dir.glob("*.safetensors.index.json")) and (
+        merged_base_safetensor_path is not None or enable_layerwise_quant_metadata
+    ):
+        raise NotImplementedError(
+            "Post-processing sharded safetensors is not supported. "
+            "Export with a larger max_shard_size or disable merge/metadata options."
+        )
+
     for sf_path in safetensor_files:
         sd = load_file(str(sf_path))
 

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -28,7 +28,7 @@ from typing import Any
 
 import torch
 import torch.nn as nn
-from safetensors.torch import save_file
+from safetensors.torch import load_file, save_file
 
 try:
     import diffusers
@@ -40,9 +40,12 @@ try:
         get_qkv_group_key,
         hide_quantizers_from_state_dict,
         infer_dtype_from_model,
+        build_layerwise_quant_metadata,
         is_diffusers_object,
         is_qkv_projection,
         merge_diffusion_checkpoint,
+        pad_nvfp4_weights,
+        swizzle_nvfp4_scales,
     )
 
     HAS_DIFFUSERS = True
@@ -120,46 +123,98 @@ def _is_enabled_quantizer(quantizer):
 def _save_component_state_dict_safetensors(
     component: nn.Module,
     component_export_dir: Path,
-    merged_base_safetensor_path: str | None = None,
-    hf_quant_config: dict | None = None,
-    model_type: str | None = None,
 ) -> None:
-    """Save component state dict as safetensors with optional base checkpoint merge.
+    """Save component state dict as a plain safetensors file.
+
 
     Args:
         component: The nn.Module to save.
         component_export_dir: Directory to save model.safetensors and config.json.
-        merged_base_safetensor_path: If provided, merge the exported transformer weights
-            with non-transformer components (VAE, vocoder, text encoders, etc.) from this
-            base safetensors file and add quantization metadata to produce a single-file
-            checkpoint compatible with ComfyUI. This should be the path to a full base
-            model ``.safetensors`` file, e.g. ``"path/to/ltx-2-19b-dev.safetensors"``.
-        hf_quant_config: If provided, embed quantization config in safetensors metadata
-            and per-layer _quantization_metadata for ComfyUI.
-        model_type: Key into ``DIFFUSION_MERGE_FUNCTIONS`` for the model-specific merge.
-            Required when ``merged_base_safetensor_path`` is not None.
     """
     cpu_state_dict = {k: v.detach().contiguous().cpu() for k, v in component.state_dict().items()}
-    metadata: dict[str, str] = {}
-    metadata_full: dict[str, str] = {}
-
-    if merged_base_safetensor_path is not None and model_type is not None:
-        cpu_state_dict, metadata_full = merge_diffusion_checkpoint(
-            cpu_state_dict, merged_base_safetensor_path, model_type, hf_quant_config
-        )
-
-    metadata["_export_format"] = "safetensors_state_dict"
-    metadata["_class_name"] = type(component).__name__
-    metadata_full.update(metadata)
+    metadata = {
+        "_export_format": "safetensors_state_dict",
+        "_class_name": type(component).__name__,
+    }
 
     save_file(
         cpu_state_dict,
         str(component_export_dir / "model.safetensors"),
-        metadata=metadata_full if merged_base_safetensor_path is not None else None,
+        metadata=metadata,
     )
 
     with open(component_export_dir / "config.json", "w") as f:
         json.dump(metadata, f, indent=4)
+
+
+def _postprocess_safetensors(
+    export_dir: Path,
+    merged_base_safetensor_path: str | None = None,
+    model_type: str | None = None,
+    hf_quant_config: dict | None = None,
+    enable_layerwise_quant_metadata: bool = True,
+    padding_strategy: str | None = None,
+    enable_swizzle_layout: bool = False,
+) -> None:
+    """Post-process saved safetensors files for deployment compatibility.
+
+    Loads each ``.safetensors`` file in *export_dir* and applies all requested
+    transformations in order, then re-saves in-place with updated metadata:
+
+    1. **Merge** with base checkpoint — combines quantized transformer weights with
+       non-transformer components (VAE, vocoder, text encoders) from a base
+       ``.safetensors`` file to produce a single-file checkpoint (e.g., for ComfyUI).
+    2. **Pad** NVFP4 weight/scale tensors — ensures dimensions are multiples of 16
+       for hardware alignment requirements.
+    3. **Swizzle** NVFP4 block scales — rearranges from flat layout to cuBLAS 2-D
+       block-scaling-factors tiled layout for optimized inference.
+    4. **Inject metadata** — embeds ``quantization_config`` and per-layer
+       ``_quantization_metadata`` so inference runtimes can detect and handle
+       quantized layers.
+
+    Args:
+        export_dir: Directory containing the saved ``.safetensors`` file(s).
+        merged_base_safetensor_path: Path to base model safetensors for merge.
+        model_type: Key into ``DIFFUSION_MERGE_FUNCTIONS`` (e.g., ``"ltx2"``).
+        hf_quant_config: Quantization config dict to embed in metadata.
+        enable_layerwise_quant_metadata: Whether to build per-layer metadata.
+        padding_strategy: ``"row"``, ``"row_col"``, or None.
+        enable_swizzle_layout: Whether to swizzle block scales.
+    """
+    import struct
+
+    safetensor_files = sorted(export_dir.glob("*.safetensors"))
+    if not safetensor_files:
+        return
+
+    for sf_path in safetensor_files:
+        sd = load_file(str(sf_path))
+
+        with open(sf_path, "rb") as f:
+            header_size = struct.unpack("<Q", f.read(8))[0]
+            header = json.loads(f.read(header_size))
+        metadata = header.get("__metadata__", None) or {}
+
+        if merged_base_safetensor_path is not None and model_type is not None:
+            sd, base_metadata = merge_diffusion_checkpoint(
+                sd, merged_base_safetensor_path, model_type, hf_quant_config
+            )
+            metadata.update(base_metadata)
+
+        if padding_strategy is not None:
+            sd = pad_nvfp4_weights(sd, padding_strategy)
+
+        if enable_swizzle_layout:
+            sd = swizzle_nvfp4_scales(sd)
+
+        if hf_quant_config is not None:
+            metadata["quantization_config"] = json.dumps(hf_quant_config)
+            if enable_layerwise_quant_metadata:
+                metadata["_quantization_metadata"] = build_layerwise_quant_metadata(
+                    sd, hf_quant_config
+                )
+
+        save_file(sd, str(sf_path), metadata=metadata)
 
 
 def collect_shared_input_modules(
@@ -906,6 +961,9 @@ def _export_diffusers_checkpoint(
     components: list[str] | None,
     merged_base_safetensor_path: str | None = None,
     max_shard_size: int | str = "10GB",
+    enable_layerwise_quant_metadata: bool = True,
+    enable_swizzle_layout: bool = False,
+    padding_strategy: str | None = None,
 ) -> None:
     """Internal: Export diffusion(-like) model/pipeline checkpoint.
 
@@ -927,6 +985,11 @@ def _export_diffusers_checkpoint(
         max_shard_size: Maximum size of each shard file. If the model exceeds this size,
             it will be sharded into multiple files and a .safetensors.index.json will be
             created. Use smaller values like "5GB" or "2GB" to force sharding.
+        enable_layerwise_quant_metadata: If True (default), include per-layer
+            ``_quantization_metadata`` in the merged checkpoint metadata.
+        enable_swizzle_layout: If True, swizzle NVFP4 block scales to cuBLAS tiled layout.
+        padding_strategy: ``"row"``, ``"row_col"``, or None. Pads NVFP4 weight/scale
+            tensors independently of swizzle.
     """
     export_dir = Path(export_dir)
 
@@ -995,14 +1058,20 @@ def _export_diffusers_checkpoint(
                     component.save_pretrained(component_export_dir, max_shard_size=max_shard_size)
             else:
                 with hide_quantizers_from_state_dict(component):
-                    _save_component_state_dict_safetensors(
-                        component,
-                        component_export_dir,
-                        merged_base_safetensor_path,
-                        hf_quant_config,
-                        model_type,
-                    )
-            # Step 7: Update config.json with quantization info
+                    _save_component_state_dict_safetensors(component, component_export_dir)
+
+            # Step 7: Post-process — merge, metadata, padding, swizzle
+            _postprocess_safetensors(
+                component_export_dir,
+                merged_base_safetensor_path=merged_base_safetensor_path,
+                model_type=model_type,
+                hf_quant_config=hf_quant_config,
+                enable_layerwise_quant_metadata=enable_layerwise_quant_metadata,
+                padding_strategy=padding_strategy,
+                enable_swizzle_layout=enable_swizzle_layout,
+            )
+
+            # Step 8: Update config.json with quantization info
             if hf_quant_config is not None:
                 config_path = component_export_dir / "config.json"
                 if config_path.exists():
@@ -1015,12 +1084,7 @@ def _export_diffusers_checkpoint(
         elif hasattr(component, "save_pretrained"):
             component.save_pretrained(component_export_dir, max_shard_size=max_shard_size)
         else:
-            _save_component_state_dict_safetensors(
-                component,
-                component_export_dir,
-                merged_base_safetensor_path,
-                model_type=model_type,
-            )
+            _save_component_state_dict_safetensors(component, component_export_dir)
 
         print(f"  Saved to: {component_export_dir}")
 
@@ -1189,15 +1253,31 @@ def export_hf_checkpoint(
             to export. If None, all quantized components are exported.
         extra_state_dict: Extra state dictionary to add to the exported model.
         max_shard_size: Maximum size of each safetensors shard file. Defaults to "10GB".
-        **kwargs: Internal-only keyword arguments. Supported key: merged_base_safetensor_path
-            (str, optional). When provided, merges the exported diffusion transformer
-            weights with non-transformer components (VAE, vocoder, text encoders, etc.)
-            from this base safetensors file to produce a single-file checkpoint
-            compatible with ComfyUI. Value should be the path to a full base model
-            ``.safetensors`` file (e.g. ``"path/to/ltx-2-19b-dev.safetensors"``).
+        **kwargs: Internal-only keyword arguments. Supported keys:
+            merged_base_safetensor_path (str, optional). When provided, merges the
+            exported diffusion transformer weights with non-transformer components
+            (VAE, vocoder, text encoders, etc.) from this base safetensors file to
+            produce a single-file checkpoint compatible with ComfyUI. Value should be
+            the path to a full base model ``.safetensors`` file
+            (e.g. ``"path/to/ltx-2-19b-dev.safetensors"``).
             Only used for diffusion model exports.
+            enable_layerwise_quant_metadata (bool, optional). When True (default),
+            includes per-layer ``_quantization_metadata`` in the checkpoint metadata
+            so that inference runtimes (e.g., ComfyUI) can identify which layers are
+            quantized and in what format. Set to False to skip.
+            enable_swizzle_layout (bool, optional). When True, rearranges NVFP4 block
+            scales from ModelOpt's flat layout to cuBLAS 2-D tiled layout. Required
+            for runtimes that consume cuBLAS block-scaled GEMM (e.g., comfy_kitchen).
+            Defaults to False.
+            padding_strategy (str | None, optional). Padding strategy for NVFP4 weight
+            and scale tensors. ``"row"`` pads rows to multiples of 16 (columns assumed
+            already aligned). ``"row_col"`` pads both dimensions. ``None`` (default)
+            disables padding. Independent of ``enable_swizzle_layout``.
     """
     merged_base_safetensor_path: str | None = kwargs.get("merged_base_safetensor_path")
+    enable_layerwise_quant_metadata: bool = kwargs.get("enable_layerwise_quant_metadata", True)
+    enable_swizzle_layout: bool = kwargs.get("enable_swizzle_layout", False)
+    padding_strategy: str | None = kwargs.get("padding_strategy", None)
     export_dir = Path(export_dir)
     export_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1206,7 +1286,15 @@ def export_hf_checkpoint(
         is_diffusers_obj = is_diffusers_object(model)
     if is_diffusers_obj:
         _export_diffusers_checkpoint(
-            model, dtype, export_dir, components, merged_base_safetensor_path, max_shard_size
+            model,
+            dtype,
+            export_dir,
+            components,
+            merged_base_safetensor_path,
+            max_shard_size,
+            enable_layerwise_quant_metadata,
+            enable_swizzle_layout,
+            padding_strategy,
         )
         return
 

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -34,13 +34,13 @@ try:
     import diffusers
 
     from .diffusers_utils import (
+        build_layerwise_quant_metadata,
         generate_diffusion_dummy_forward_fn,
         get_diffusion_components,
         get_diffusion_model_type,
         get_qkv_group_key,
         hide_quantizers_from_state_dict,
         infer_dtype_from_model,
-        build_layerwise_quant_metadata,
         is_diffusers_object,
         is_qkv_projection,
         merge_diffusion_checkpoint,
@@ -194,6 +194,10 @@ def _postprocess_safetensors(
             header_size = struct.unpack("<Q", f.read(8))[0]
             header = json.loads(f.read(header_size))
         metadata = header.get("__metadata__", None) or {}
+
+        # Clone tensors so the memory-mapped file handle from load_file is
+        # released before we overwrite the same path (required on Windows).
+        sd = {k: v.clone() for k, v in sd.items()}
 
         if merged_base_safetensor_path is not None and model_type is not None:
             sd, base_metadata = merge_diffusion_checkpoint(
@@ -1277,7 +1281,7 @@ def export_hf_checkpoint(
     merged_base_safetensor_path: str | None = kwargs.get("merged_base_safetensor_path")
     enable_layerwise_quant_metadata: bool = kwargs.get("enable_layerwise_quant_metadata", True)
     enable_swizzle_layout: bool = kwargs.get("enable_swizzle_layout", False)
-    padding_strategy: str | None = kwargs.get("padding_strategy", None)
+    padding_strategy: str | None = kwargs.get("padding_strategy")
     export_dir = Path(export_dir)
     export_dir.mkdir(parents=True, exist_ok=True)
 

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -217,9 +217,7 @@ def _postprocess_safetensors(
     model_type: str | None = None
     if merged_base_safetensor_path is not None:
         if pipe is None:
-            raise ValueError(
-                "`pipe` must be provided when `merged_base_safetensor_path` is set."
-            )
+            raise ValueError("`pipe` must be provided when `merged_base_safetensor_path` is set.")
         model_type = get_diffusion_model_type(pipe)
 
     for sf_path in safetensor_files:

--- a/modelopt/torch/quantization/conversion.py
+++ b/modelopt/torch/quantization/conversion.py
@@ -503,14 +503,18 @@ def set_quantizer_by_cfg_context(quant_model: nn.Module, quant_cfg: QuantizeQuan
             if orig_type is SequentialQuantizer and not isinstance(module, SequentialQuantizer):
                 saved = original_attributes[name]
                 parent_name, _, attr_name = name.rpartition(".")
-                parent_module = quant_model.get_submodule(parent_name) if parent_name else quant_model
+                parent_module = (
+                    quant_model.get_submodule(parent_name) if parent_name else quant_model
+                )
                 module = SequentialQuantizer(*(TensorQuantizer() for _ in saved["sub_states"]))
                 setattr(parent_module, attr_name, module)
                 for tq, sub_state in zip(module, saved["sub_states"]):
                     tq.set_from_modelopt_state(sub_state, properties_only=True)
             elif orig_type is TensorQuantizer and not isinstance(module, TensorQuantizer):
                 parent_name, _, attr_name = name.rpartition(".")
-                parent_module = quant_model.get_submodule(parent_name) if parent_name else quant_model
+                parent_module = (
+                    quant_model.get_submodule(parent_name) if parent_name else quant_model
+                )
                 module = TensorQuantizer()
                 setattr(parent_module, attr_name, module)
                 module.set_from_modelopt_state(original_attributes[name], properties_only=True)

--- a/modelopt/torch/quantization/conversion.py
+++ b/modelopt/torch/quantization/conversion.py
@@ -490,36 +490,36 @@ def set_quantizer_by_cfg_context(quant_model: nn.Module, quant_cfg: QuantizeQuan
             original_types[name] = TensorQuantizer
 
     set_quantizer_by_cfg(quant_model, quant_cfg)
-    yield
-
-    # Restore original quantizer types and attributes. If set_quantizer_by_cfg downgraded a
-    # SequentialQuantizer to a TensorQuantizer (or vice-versa), we need to re-create the
-    # original module type before restoring attributes.
-    for name, module in list(quant_model.named_modules()):
-        if name not in original_attributes:
-            continue
-        orig_type = original_types[name]
-        if orig_type is SequentialQuantizer and not isinstance(module, SequentialQuantizer):
-            # Restore the SequentialQuantizer that was downgraded
-            saved = original_attributes[name]
-            parent_name, _, attr_name = name.rpartition(".")
-            parent_module = quant_model.get_submodule(parent_name) if parent_name else quant_model
-            module = SequentialQuantizer(*(TensorQuantizer() for _ in saved["sub_states"]))
-            setattr(parent_module, attr_name, module)
-            for tq, sub_state in zip(module, saved["sub_states"]):
-                tq.set_from_modelopt_state(sub_state, properties_only=True)
-        elif orig_type is TensorQuantizer and not isinstance(module, TensorQuantizer):
-            parent_name, _, attr_name = name.rpartition(".")
-            parent_module = quant_model.get_submodule(parent_name) if parent_name else quant_model
-            module = TensorQuantizer()
-            setattr(parent_module, attr_name, module)
-            module.set_from_modelopt_state(original_attributes[name], properties_only=True)
-        elif orig_type is TensorQuantizer:
-            module.set_from_modelopt_state(original_attributes[name], properties_only=True)
-        elif orig_type is SequentialQuantizer:
-            saved = original_attributes[name]
-            for tq, sub_state in zip(module, saved["sub_states"]):
-                tq.set_from_modelopt_state(sub_state, properties_only=True)
+    try:
+        yield
+    finally:
+        # Restore original quantizer types and attributes. If set_quantizer_by_cfg downgraded a
+        # SequentialQuantizer to a TensorQuantizer (or vice-versa), we need to re-create the
+        # original module type before restoring attributes.
+        for name, module in list(quant_model.named_modules()):
+            if name not in original_attributes:
+                continue
+            orig_type = original_types[name]
+            if orig_type is SequentialQuantizer and not isinstance(module, SequentialQuantizer):
+                saved = original_attributes[name]
+                parent_name, _, attr_name = name.rpartition(".")
+                parent_module = quant_model.get_submodule(parent_name) if parent_name else quant_model
+                module = SequentialQuantizer(*(TensorQuantizer() for _ in saved["sub_states"]))
+                setattr(parent_module, attr_name, module)
+                for tq, sub_state in zip(module, saved["sub_states"]):
+                    tq.set_from_modelopt_state(sub_state, properties_only=True)
+            elif orig_type is TensorQuantizer and not isinstance(module, TensorQuantizer):
+                parent_name, _, attr_name = name.rpartition(".")
+                parent_module = quant_model.get_submodule(parent_name) if parent_name else quant_model
+                module = TensorQuantizer()
+                setattr(parent_module, attr_name, module)
+                module.set_from_modelopt_state(original_attributes[name], properties_only=True)
+            elif orig_type is TensorQuantizer:
+                module.set_from_modelopt_state(original_attributes[name], properties_only=True)
+            elif orig_type is SequentialQuantizer:
+                saved = original_attributes[name]
+                for tq, sub_state in zip(module, saved["sub_states"]):
+                    tq.set_from_modelopt_state(sub_state, properties_only=True)
 
 
 def set_quantizer_attribute(

--- a/modelopt/torch/quantization/conversion.py
+++ b/modelopt/torch/quantization/conversion.py
@@ -535,14 +535,18 @@ def set_quantizer_by_cfg_context(quant_model: nn.Module, quant_cfg: RawQuantizeQ
             if orig_type is SequentialQuantizer and not isinstance(module, SequentialQuantizer):
                 saved = original_attributes[name]
                 parent_name, _, attr_name = name.rpartition(".")
-                parent_module = quant_model.get_submodule(parent_name) if parent_name else quant_model
+                parent_module = (
+                    quant_model.get_submodule(parent_name) if parent_name else quant_model
+                )
                 module = SequentialQuantizer(*(TensorQuantizer() for _ in saved["sub_states"]))
                 setattr(parent_module, attr_name, module)
                 for tq, sub_state in zip(module, saved["sub_states"]):
                     tq.set_from_modelopt_state(sub_state, properties_only=True)
             elif orig_type is TensorQuantizer and not isinstance(module, TensorQuantizer):
                 parent_name, _, attr_name = name.rpartition(".")
-                parent_module = quant_model.get_submodule(parent_name) if parent_name else quant_model
+                parent_module = (
+                    quant_model.get_submodule(parent_name) if parent_name else quant_model
+                )
                 module = TensorQuantizer()
                 setattr(parent_module, attr_name, module)
                 module.set_from_modelopt_state(original_attributes[name], properties_only=True)

--- a/modelopt/torch/quantization/conversion.py
+++ b/modelopt/torch/quantization/conversion.py
@@ -522,36 +522,36 @@ def set_quantizer_by_cfg_context(quant_model: nn.Module, quant_cfg: RawQuantizeQ
             original_types[name] = TensorQuantizer
 
     set_quantizer_by_cfg(quant_model, quant_cfg)
-    yield
-
-    # Restore original quantizer types and attributes. If set_quantizer_by_cfg downgraded a
-    # SequentialQuantizer to a TensorQuantizer (or vice-versa), we need to re-create the
-    # original module type before restoring attributes.
-    for name, module in list(quant_model.named_modules()):
-        if name not in original_attributes:
-            continue
-        orig_type = original_types[name]
-        if orig_type is SequentialQuantizer and not isinstance(module, SequentialQuantizer):
-            # Restore the SequentialQuantizer that was downgraded
-            saved = original_attributes[name]
-            parent_name, _, attr_name = name.rpartition(".")
-            parent_module = quant_model.get_submodule(parent_name) if parent_name else quant_model
-            module = SequentialQuantizer(*(TensorQuantizer() for _ in saved["sub_states"]))
-            setattr(parent_module, attr_name, module)
-            for tq, sub_state in zip(module, saved["sub_states"]):
-                tq.set_from_modelopt_state(sub_state, properties_only=True)
-        elif orig_type is TensorQuantizer and not isinstance(module, TensorQuantizer):
-            parent_name, _, attr_name = name.rpartition(".")
-            parent_module = quant_model.get_submodule(parent_name) if parent_name else quant_model
-            module = TensorQuantizer()
-            setattr(parent_module, attr_name, module)
-            module.set_from_modelopt_state(original_attributes[name], properties_only=True)
-        elif orig_type is TensorQuantizer:
-            module.set_from_modelopt_state(original_attributes[name], properties_only=True)
-        elif orig_type is SequentialQuantizer:
-            saved = original_attributes[name]
-            for tq, sub_state in zip(module, saved["sub_states"]):
-                tq.set_from_modelopt_state(sub_state, properties_only=True)
+    try:
+        yield
+    finally:
+        # Restore original quantizer types and attributes. If set_quantizer_by_cfg downgraded a
+        # SequentialQuantizer to a TensorQuantizer (or vice-versa), we need to re-create the
+        # original module type before restoring attributes.
+        for name, module in list(quant_model.named_modules()):
+            if name not in original_attributes:
+                continue
+            orig_type = original_types[name]
+            if orig_type is SequentialQuantizer and not isinstance(module, SequentialQuantizer):
+                saved = original_attributes[name]
+                parent_name, _, attr_name = name.rpartition(".")
+                parent_module = quant_model.get_submodule(parent_name) if parent_name else quant_model
+                module = SequentialQuantizer(*(TensorQuantizer() for _ in saved["sub_states"]))
+                setattr(parent_module, attr_name, module)
+                for tq, sub_state in zip(module, saved["sub_states"]):
+                    tq.set_from_modelopt_state(sub_state, properties_only=True)
+            elif orig_type is TensorQuantizer and not isinstance(module, TensorQuantizer):
+                parent_name, _, attr_name = name.rpartition(".")
+                parent_module = quant_model.get_submodule(parent_name) if parent_name else quant_model
+                module = TensorQuantizer()
+                setattr(parent_module, attr_name, module)
+                module.set_from_modelopt_state(original_attributes[name], properties_only=True)
+            elif orig_type is TensorQuantizer:
+                module.set_from_modelopt_state(original_attributes[name], properties_only=True)
+            elif orig_type is SequentialQuantizer:
+                saved = original_attributes[name]
+                for tq, sub_state in zip(module, saved["sub_states"]):
+                    tq.set_from_modelopt_state(sub_state, properties_only=True)
 
 
 def set_quantizer_attribute(

--- a/tests/unit/torch/export/test_nvfp4_utils.py
+++ b/tests/unit/torch/export/test_nvfp4_utils.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for NVFP4 utility functions (pad, swizzle, metadata) and _postprocess_safetensors."""
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import load_file, save_file
+
+from modelopt.torch.export.diffusers_utils import (
+    build_layerwise_quant_metadata,
+    pad_nvfp4_weights,
+    swizzle_nvfp4_scales,
+)
+
+
+def _make_nvfp4_state_dict(rows=32, cols=64):
+    """Create a minimal NVFP4 state dict with one quantized layer."""
+    return {
+        "layer0.weight": torch.randint(0, 255, (rows, cols), dtype=torch.uint8),
+        "layer0.weight_scale": torch.randn(rows, cols // 16).to(torch.float8_e4m3fn),
+        "layer0.weight_scale_2": torch.randn(rows, 1),
+        "layer0.bias": torch.randn(rows),
+    }
+
+
+# ---------------------------------------------------------------------------
+# _find_nvfp4_layers (tested implicitly via pad / swizzle that rely on it)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLayerwiseQuantMetadata:
+    def test_basic(self):
+        sd = _make_nvfp4_state_dict()
+        cfg = {"quant_algo": "NVFP4"}
+        result = json.loads(build_layerwise_quant_metadata(sd, cfg))
+
+        assert result["format_version"] == "1.0"
+        assert "layer0" in result["layers"]
+        assert result["layers"]["layer0"]["format"] == "nvfp4"
+
+    def test_no_quantized_layers(self):
+        sd = {"linear.weight": torch.randn(4, 4), "linear.bias": torch.randn(4)}
+        result = json.loads(build_layerwise_quant_metadata(sd, {"quant_algo": "FP8"}))
+        assert result["layers"] == {}
+
+    def test_multiple_layers(self):
+        sd = {**_make_nvfp4_state_dict()}
+        sd["layer1.weight"] = torch.randint(0, 255, (16, 32), dtype=torch.uint8)
+        sd["layer1.weight_scale"] = torch.randn(16, 2).to(torch.float8_e4m3fn)
+        sd["layer1.weight_scale_2"] = torch.randn(16, 1)
+
+        result = json.loads(build_layerwise_quant_metadata(sd, {"quant_algo": "NVFP4"}))
+        assert "layer0" in result["layers"]
+        assert "layer1" in result["layers"]
+
+
+class TestPadNvfp4Weights:
+    def test_row_padding(self):
+        sd = _make_nvfp4_state_dict(rows=20, cols=64)
+        result = pad_nvfp4_weights(sd, "row")
+
+        assert result["layer0.weight"].shape[0] % 16 == 0
+        assert result["layer0.weight_scale"].shape[0] % 16 == 0
+        assert result["layer0.weight"].shape[0] == 32
+
+    def test_row_col_padding(self):
+        sd = _make_nvfp4_state_dict(rows=20, cols=48)
+        result = pad_nvfp4_weights(sd, "row_col")
+
+        w = result["layer0.weight"]
+        s = result["layer0.weight_scale"]
+        assert w.shape[0] % 16 == 0
+        assert w.shape[1] % 16 == 0
+        assert s.shape[0] % 16 == 0
+        assert s.shape[1] % 16 == 0
+
+    def test_already_aligned(self):
+        sd = _make_nvfp4_state_dict(rows=32, cols=64)
+        orig_w_shape = sd["layer0.weight"].shape
+        result = pad_nvfp4_weights(sd, "row")
+
+        assert result["layer0.weight"].shape == orig_w_shape
+
+    def test_invalid_strategy(self):
+        sd = _make_nvfp4_state_dict()
+        with pytest.raises(ValueError, match="padding_strategy"):
+            pad_nvfp4_weights(sd, "invalid")
+
+    def test_non_nvfp4_tensors_untouched(self):
+        sd = _make_nvfp4_state_dict(rows=20, cols=64)
+        bias_before = sd["layer0.bias"].clone()
+        pad_nvfp4_weights(sd, "row")
+        assert torch.equal(sd["layer0.bias"], bias_before)
+
+
+class TestSwizzleNvfp4Scales:
+    def test_shape_preserved(self):
+        sd = _make_nvfp4_state_dict(rows=128, cols=64)
+        orig_shape = sd["layer0.weight_scale"].shape
+        result = swizzle_nvfp4_scales(sd)
+
+        assert result["layer0.weight_scale"].shape == orig_shape
+
+    def test_dtype_is_fp8(self):
+        sd = _make_nvfp4_state_dict(rows=128, cols=64)
+        result = swizzle_nvfp4_scales(sd)
+
+        assert result["layer0.weight_scale"].dtype == torch.float8_e4m3fn
+
+    def test_non_nvfp4_tensors_untouched(self):
+        sd = _make_nvfp4_state_dict(rows=128, cols=64)
+        bias_before = sd["layer0.bias"].clone()
+        swizzle_nvfp4_scales(sd)
+        assert torch.equal(sd["layer0.bias"], bias_before)
+
+    def test_small_scale_needs_internal_padding(self):
+        """Scales with rows < 128 trigger internal padding in _to_blocked."""
+        sd = _make_nvfp4_state_dict(rows=16, cols=64)
+        result = swizzle_nvfp4_scales(sd)
+        # _to_blocked pads rows up to the next multiple of 128
+        assert result["layer0.weight_scale"].shape == (128, 64 // 16)
+
+
+class TestPostprocessSafetensors:
+    def test_metadata_injection(self, tmp_path):
+        from modelopt.torch.export.unified_export_hf import _postprocess_safetensors
+
+        sd = {"weight": torch.randn(4, 4)}
+        save_file(sd, str(tmp_path / "model.safetensors"))
+
+        hf_quant_config = {"quant_algo": "FP8", "kv_cache_quant_algo": "FP8"}
+        _postprocess_safetensors(
+            tmp_path,
+            hf_quant_config=hf_quant_config,
+            enable_layerwise_quant_metadata=True,
+        )
+
+        reloaded = load_file(str(tmp_path / "model.safetensors"))
+        assert torch.allclose(reloaded["weight"], sd["weight"])
+
+    def test_padding_and_swizzle(self, tmp_path):
+        from modelopt.torch.export.unified_export_hf import _postprocess_safetensors
+
+        sd = _make_nvfp4_state_dict(rows=20, cols=64)
+        save_file(sd, str(tmp_path / "model.safetensors"))
+
+        _postprocess_safetensors(
+            tmp_path,
+            padding_strategy="row",
+            enable_swizzle_layout=True,
+            enable_layerwise_quant_metadata=False,
+        )
+
+        reloaded = load_file(str(tmp_path / "model.safetensors"))
+        assert reloaded["layer0.weight"].shape[0] == 32
+        assert reloaded["layer0.weight_scale"].dtype == torch.float8_e4m3fn
+
+    def test_sharded_guard(self, tmp_path):
+        from modelopt.torch.export.unified_export_hf import _postprocess_safetensors
+
+        save_file({"w": torch.randn(2, 2)}, str(tmp_path / "model.safetensors"))
+        (tmp_path / "model.safetensors.index.json").write_text("{}")
+
+        with pytest.raises(NotImplementedError, match="sharded"):
+            _postprocess_safetensors(
+                tmp_path,
+                merged_base_safetensor_path="/fake/path.safetensors",
+                model_type="ltx2",
+                enable_layerwise_quant_metadata=True,
+            )
+
+    def test_no_safetensor_files(self, tmp_path):
+        from modelopt.torch.export.unified_export_hf import _postprocess_safetensors
+
+        _postprocess_safetensors(tmp_path)

--- a/tests/unit/torch/export/test_nvfp4_utils.py
+++ b/tests/unit/torch/export/test_nvfp4_utils.py
@@ -27,6 +27,7 @@ from modelopt.torch.export.diffusers_utils import (
     pad_nvfp4_weights,
     swizzle_nvfp4_scales,
 )
+from modelopt.torch.export.unified_export_hf import _postprocess_safetensors
 
 
 def _make_nvfp4_state_dict(rows=32, cols=64):
@@ -146,8 +147,6 @@ class TestSwizzleNvfp4Scales:
 
 class TestPostprocessSafetensors:
     def test_metadata_injection(self, tmp_path):
-        from modelopt.torch.export.unified_export_hf import _postprocess_safetensors
-
         sd = {"weight": torch.randn(4, 4)}
         save_file(sd, str(tmp_path / "model.safetensors"))
 
@@ -169,8 +168,6 @@ class TestPostprocessSafetensors:
         }
 
     def test_padding_and_swizzle(self, tmp_path):
-        from modelopt.torch.export.unified_export_hf import _postprocess_safetensors
-
         sd = _make_nvfp4_state_dict(rows=20, cols=64)
         save_file(sd, str(tmp_path / "model.safetensors"))
 
@@ -187,8 +184,6 @@ class TestPostprocessSafetensors:
         assert reloaded["layer0.weight_scale"].shape == (128, 64 // 16)
 
     def test_sharded_guard(self, tmp_path):
-        from modelopt.torch.export.unified_export_hf import _postprocess_safetensors
-
         save_file({"w": torch.randn(2, 2)}, str(tmp_path / "model.safetensors"))
         (tmp_path / "model.safetensors.index.json").write_text("{}")
 
@@ -196,14 +191,11 @@ class TestPostprocessSafetensors:
             _postprocess_safetensors(
                 tmp_path,
                 merged_base_safetensor_path="/fake/path.safetensors",
-                model_type="ltx2",
                 enable_layerwise_quant_metadata=True,
             )
 
     def test_preserves_existing_metadata(self, tmp_path):
         """Simulate save_pretrained output: safetensors with pre-existing metadata."""
-        from modelopt.torch.export.unified_export_hf import _postprocess_safetensors
-
         sd = _make_nvfp4_state_dict(rows=20, cols=64)
         preexisting_metadata = {"format": "pt", "_class_name": "MyModel"}
         save_file(sd, str(tmp_path / "model.safetensors"), metadata=preexisting_metadata)
@@ -230,6 +222,22 @@ class TestPostprocessSafetensors:
         assert "layer0" in layer_meta["layers"]
 
     def test_no_safetensor_files(self, tmp_path):
-        from modelopt.torch.export.unified_export_hf import _postprocess_safetensors
-
         _postprocess_safetensors(tmp_path)
+
+    def test_unknown_kwargs_silently_ignored(self, tmp_path):
+        sd = {"weight": torch.randn(4, 4)}
+        save_file(sd, str(tmp_path / "model.safetensors"))
+
+        _postprocess_safetensors(tmp_path, bad_option=True)
+
+        reloaded = load_file(str(tmp_path / "model.safetensors"))
+        assert torch.allclose(reloaded["weight"], sd["weight"])
+
+    def test_merge_requires_pipe(self, tmp_path):
+        save_file({"w": torch.randn(2, 2)}, str(tmp_path / "model.safetensors"))
+
+        with pytest.raises(ValueError, match="`pipe` must be provided"):
+            _postprocess_safetensors(
+                tmp_path,
+                merged_base_safetensor_path="/fake/path.safetensors",
+            )

--- a/tests/unit/torch/export/test_nvfp4_utils.py
+++ b/tests/unit/torch/export/test_nvfp4_utils.py
@@ -16,7 +16,6 @@
 """Tests for NVFP4 utility functions (pad, swizzle, metadata) and _postprocess_safetensors."""
 
 import json
-from pathlib import Path
 
 import pytest
 import torch

--- a/tests/unit/torch/export/test_nvfp4_utils.py
+++ b/tests/unit/torch/export/test_nvfp4_utils.py
@@ -89,6 +89,13 @@ class TestPadNvfp4Weights:
         assert s.shape[0] % 16 == 0
         assert s.shape[1] % 16 == 0
 
+    def test_row_col_padding_scale_only(self):
+        sd = _make_nvfp4_state_dict(rows=32, cols=48)
+        result = pad_nvfp4_weights(sd, "row_col")
+
+        assert result["layer0.weight"].shape == (32, 48)
+        assert result["layer0.weight_scale"].shape == (32, 16)
+
     def test_already_aligned(self):
         sd = _make_nvfp4_state_dict(rows=32, cols=64)
         orig_w_shape = sd["layer0.weight"].shape

--- a/tests/unit/torch/export/test_nvfp4_utils.py
+++ b/tests/unit/torch/export/test_nvfp4_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -199,6 +199,35 @@ class TestPostprocessSafetensors:
                 model_type="ltx2",
                 enable_layerwise_quant_metadata=True,
             )
+
+    def test_preserves_existing_metadata(self, tmp_path):
+        """Simulate save_pretrained output: safetensors with pre-existing metadata."""
+        from modelopt.torch.export.unified_export_hf import _postprocess_safetensors
+
+        sd = _make_nvfp4_state_dict(rows=20, cols=64)
+        preexisting_metadata = {"format": "pt", "_class_name": "MyModel"}
+        save_file(sd, str(tmp_path / "model.safetensors"), metadata=preexisting_metadata)
+
+        hf_quant_config = {"quant_algo": "NVFP4"}
+        _postprocess_safetensors(
+            tmp_path,
+            hf_quant_config=hf_quant_config,
+            padding_strategy="row",
+            enable_swizzle_layout=True,
+            enable_layerwise_quant_metadata=True,
+        )
+
+        reloaded = load_file(str(tmp_path / "model.safetensors"))
+        assert reloaded["layer0.weight"].shape[0] == 32
+        assert reloaded["layer0.weight_scale"].shape == (128, 64 // 16)
+
+        with safe_open(str(tmp_path / "model.safetensors"), framework="pt") as f:
+            metadata = f.metadata()
+        assert metadata["format"] == "pt"
+        assert metadata["_class_name"] == "MyModel"
+        assert json.loads(metadata["quantization_config"]) == hf_quant_config
+        layer_meta = json.loads(metadata["_quantization_metadata"])
+        assert "layer0" in layer_meta["layers"]
 
     def test_no_safetensor_files(self, tmp_path):
         from modelopt.torch.export.unified_export_hf import _postprocess_safetensors

--- a/tests/unit/torch/export/test_nvfp4_utils.py
+++ b/tests/unit/torch/export/test_nvfp4_utils.py
@@ -19,6 +19,7 @@ import json
 
 import pytest
 import torch
+from safetensors import safe_open
 from safetensors.torch import load_file, save_file
 
 from modelopt.torch.export.diffusers_utils import (
@@ -159,6 +160,13 @@ class TestPostprocessSafetensors:
 
         reloaded = load_file(str(tmp_path / "model.safetensors"))
         assert torch.allclose(reloaded["weight"], sd["weight"])
+        with safe_open(str(tmp_path / "model.safetensors"), framework="pt", device="cpu") as f:
+            metadata = f.metadata()
+        assert json.loads(metadata["quantization_config"]) == hf_quant_config
+        assert json.loads(metadata["_quantization_metadata"]) == {
+            "format_version": "1.0",
+            "layers": {},
+        }
 
     def test_padding_and_swizzle(self, tmp_path):
         from modelopt.torch.export.unified_export_hf import _postprocess_safetensors
@@ -176,6 +184,7 @@ class TestPostprocessSafetensors:
         reloaded = load_file(str(tmp_path / "model.safetensors"))
         assert reloaded["layer0.weight"].shape[0] == 32
         assert reloaded["layer0.weight_scale"].dtype == torch.float8_e4m3fn
+        assert reloaded["layer0.weight_scale"].shape == (128, 64 // 16)
 
     def test_sharded_guard(self, tmp_path):
         from modelopt.torch.export.unified_export_hf import _postprocess_safetensors

--- a/tests/unit/torch/quantization/test_tensor_quant_cpu.py
+++ b/tests/unit/torch/quantization/test_tensor_quant_cpu.py
@@ -141,3 +141,45 @@ def test_set_quantizer_cxt():
         if "output_quantizer" in k:
             continue
         assert torch.allclose(v, state_dict[k])
+
+
+def test_set_quantizer_cxt_restores_on_exception():
+    """Quantizer properties must be fully restored when the context body raises.
+
+    Guards the try/finally in `set_quantizer_by_cfg_context`: regressing it
+    silently corrupts state for every caller (AWQ-lite, GPTQ Hessian, etc.)
+    when calibration / forward_loop bodies raise. The snapshot uses the same
+    `get_modelopt_state(properties_only=True)` API the context manager itself
+    uses for save/restore, so a regression in any tracked property is caught.
+    """
+    model = SimpleLinear()
+    model.eval()
+    mtq.quantize(model, mtq.INT8_DEFAULT_CFG, lambda m: m(model.get_input()))
+
+    pre_state = {
+        name: module.get_modelopt_state(properties_only=True)
+        for name, module in model.named_modules()
+        if isinstance(module, TensorQuantizer)
+    }
+    assert any(not s.get("_disabled", True) for s in pre_state.values()), (
+        "expected at least one enabled quantizer after quantize()"
+    )
+
+    class _BoomError(RuntimeError):
+        pass
+
+    with (
+        pytest.raises(_BoomError),
+        mtq.set_quantizer_by_cfg_context(model, [{"quantizer_name": "*", "enable": False}]),
+    ):
+        for module in model.modules():
+            if isinstance(module, TensorQuantizer):
+                assert not module.is_enabled
+        raise _BoomError("simulate calibration failure inside context body")
+
+    post_state = {
+        name: module.get_modelopt_state(properties_only=True)
+        for name, module in model.named_modules()
+        if isinstance(module, TensorQuantizer)
+    }
+    assert post_state == pre_state


### PR DESCRIPTION


### What does this PR do?

Type of change: ?  new feature

<!-- Details about the change. -->
Adds post-processing support for exported diffusion model checkpoints to enable NVFP4 block scale swizzling and configurable padding strategies. This allows exported quantized checkpoints to be directly consumed by inference runtimes (e.g., ComfyUI with comfy_kitchen) that require cuBLAS 2-D block-scaling-factors layout.
Changes:
1) Unified post-processing step (_postprocess_safetensors): Loads saved safetensors files and applies merge, padding, swizzle, and quantization metadata injection in a single pass. 
2) NVFP4 scale swizzle (swizzle_nvfp4_scales): Rearranges block scales from ModelOpt's flat [rows, cols // 16] layout to cuBLAS 2-D tiled layout per the cuBLAS specification.
3) Configurable padding (pad_nvfp4_weights): Pads NVFP4 weight and scale tensors to multiples of 16, with "row" (rows only) or "row_col" (both dimensions) strategies.
4) Standalone quantization metadata (build_layerwise_quant_metadata): Extracted from merge_diffusion_checkpoint so _quantization_metadata can be injected independently of merging — works for both merged (LTX-2) and standalone (Flux2) exports.
5) Bug fix (conversion.py): Wrapped yield in try/finally in set_quantizer_by_cfg_context so quantizer states are always restored, fixing an issue when yield fails.
### Usage

```python
# LTX-2 export with merge + swizzle + padding
export_hf_checkpoint(
  pipeline,
  export_dir="./output",
  merged_base_safetensor_path="./ltx-2-22b-dev.safetensors",
  enable_swizzle_layout=True,
  padding_strategy="row_col",
  enable_layerwise_quant_metadata=True,
)
# Flux2 standalone export with swizzle + padding (no merge needed)
export_hf_checkpoint(
  transformer,
  export_dir="./output",
  enable_swizzle_layout=True,
  padding_strategy="row_col",
)
# Via quantize.py CLI
python quantize.py \
  --model ltx-2 --format fp4 \
  --extra-param merged_base_safetensor_path=./ltx-2-22b-dev.safetensors \
  --extra-param enable_swizzle_layout=true \
  --extra-param padding_strategy=row_col \
  --hf-ckpt-dir ./output
```

### Testing
1) Exported LTX-2.3 NVFP4 with swizzle + padding + merged base checkpoint. Verified checkpoint has correct uint8 weights, float8_e4m3fn scales in swizzled layout, and _quantization_metadata . Ran the checkpoint with ComfyUI
2) Exported Flux2 NVFP4 with swizzle + padding. Verified checkpoint has correct uint8 weights, float8_e4m3fn scales in swizzled layout, and _quantization_metadata . Ran the checkpoint with ComfyUI

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ 
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`:  N/A 
- Did you write any new necessary tests?: N/A 
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?:  N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diffusers export: optional NVFP4 support — swizzle layout, row/row_col padding, and optional per-layer quantization metadata; exports are now post-processed to apply these options.
  * Export flow accepts new flags to enable swizzle, padding strategy, and layerwise metadata.

* **Bug Fixes**
  * Quantizer context manager now always restores state, including on exceptions.

* **Tests**
  * Added unit tests for NVFP4 padding, swizzling, metadata injection, and post-processing.

* **Documentation**
  * README example updated to show swizzle and padding flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->