### PR TITLE
Add Z-Image (NextDiT/Lumina2) PTQ quantization support in diffusers example

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,17 @@ NVIDIA Model Optimizer Changelog
 **Bug Fixes**
 
 - ONNX Runtime dependency upgraded to 1.24 to solve missing graph outputs when using the TensorRT Execution Provider.
+- Fix broken ``AttentionModuleMixin`` import in the diffusers quantization example (path changed from
+  ``modelopt.torch.quantization.plugins.diffusers`` to ``modelopt.torch.quantization.plugins.diffusion.diffusers``
+  in 0.42.0).
 
 **New Features**
 
+- Add Z-Image (``Tongyi-MAI/Z-Image``) and Z-Image-Turbo quantization support in the diffusers quantization
+  example. Supports FP8, INT8, and INT4 PTQ on the NextDiT/Lumina2 transformer backbone via the new
+  ``--model zimage`` and ``--model zimage-turbo`` CLI options.
+- Add ``ZImageTransformer2DModel`` dummy input generation in ``generate_diffusion_dummy_inputs()``, resolving
+  a QKV fusion warning during HF checkpoint export for Z-Image.
 - User does not need to manually register MOE modules to cover experts calibration coverage in PTQ workflow.
 - ``hf_ptq.py`` now saves the quantization summary and moe expert token count table to the export directory.
 - Add ``--moe_calib_experts_ratio`` flag in ``hf_ptq.py`` to specify the ratio of experts to calibrate during forward pass to improve expert coverage during calibration. Default to all the experts.

--- a/examples/diffusers/quantization/models_utils.py
+++ b/examples/diffusers/quantization/models_utils.py
@@ -24,12 +24,14 @@ from diffusers import (
     LTXConditionPipeline,
     StableDiffusion3Pipeline,
     WanPipeline,
+    ZImagePipeline,
 )
 from utils import (
     filter_func_default,
     filter_func_flux_dev,
     filter_func_ltx_video,
     filter_func_wan_video,
+    filter_func_zimage,
 )
 
 
@@ -46,6 +48,8 @@ class ModelType(str, Enum):
     LTX2 = "ltx-2"
     WAN22_T2V_14b = "wan2.2-t2v-14b"
     WAN22_T2V_5b = "wan2.2-t2v-5b"
+    ZIMAGE = "zimage"
+    ZIMAGE_TURBO = "zimage-turbo"
 
 
 def get_model_filter_func(model_type: ModelType) -> Callable[[str], bool]:
@@ -69,6 +73,8 @@ def get_model_filter_func(model_type: ModelType) -> Callable[[str], bool]:
         ModelType.LTX2: filter_func_ltx_video,
         ModelType.WAN22_T2V_14b: filter_func_wan_video,
         ModelType.WAN22_T2V_5b: filter_func_wan_video,
+        ModelType.ZIMAGE: filter_func_zimage,
+        ModelType.ZIMAGE_TURBO: filter_func_zimage,
     }
 
     return filter_func_map.get(model_type, filter_func_default)
@@ -86,6 +92,8 @@ MODEL_REGISTRY: dict[ModelType, str] = {
     ModelType.LTX2: "Lightricks/LTX-2",
     ModelType.WAN22_T2V_14b: "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
     ModelType.WAN22_T2V_5b: "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+    ModelType.ZIMAGE: "Tongyi-MAI/Z-Image",
+    ModelType.ZIMAGE_TURBO: "Tongyi-MAI/Z-Image-Turbo",
 }
 
 MODEL_PIPELINE: dict[ModelType, type[DiffusionPipeline] | None] = {
@@ -99,6 +107,8 @@ MODEL_PIPELINE: dict[ModelType, type[DiffusionPipeline] | None] = {
     ModelType.LTX2: None,
     ModelType.WAN22_T2V_14b: WanPipeline,
     ModelType.WAN22_T2V_5b: WanPipeline,
+    ModelType.ZIMAGE: ZImagePipeline,
+    ModelType.ZIMAGE_TURBO: ZImagePipeline,
 }
 
 # Shared dataset configurations
@@ -139,6 +149,17 @@ _FLUX_BASE_CONFIG: dict[str, Any] = {
 _WAN_BASE_CONFIG: dict[str, Any] = {
     "backbone": "transformer",
     "dataset": _OPENVID_DATASET,
+}
+
+_ZIMAGE_BASE_CONFIG: dict[str, Any] = {
+    "backbone": "transformer",
+    "dataset": _SD_PROMPTS_DATASET,
+    "inference_extra_args": {
+        "height": 512,
+        "width": 512,
+        "guidance_scale": 4.0,
+        "cfg_normalization": False,
+    },
 }
 
 # Model-specific default arguments for calibration
@@ -205,6 +226,15 @@ MODEL_DEFAULTS: dict[ModelType, dict[str, Any]] = {
                 "，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，"  # noqa: RUF001
                 "手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"  # noqa: RUF001
             ),
+        },
+    },
+    ModelType.ZIMAGE: _ZIMAGE_BASE_CONFIG,
+    ModelType.ZIMAGE_TURBO: {
+        **_ZIMAGE_BASE_CONFIG,
+        "inference_extra_args": {
+            **_ZIMAGE_BASE_CONFIG["inference_extra_args"],
+            "guidance_scale": 1.0,
+            # num_inference_steps intentionally omitted — pass --n-steps 8 on the CLI
         },
     },
 }

--- a/examples/diffusers/quantization/utils.py
+++ b/examples/diffusers/quantization/utils.py
@@ -89,6 +89,29 @@ def filter_func_wan_video(name: str) -> bool:
     return pattern.match(name) is not None
 
 
+def filter_func_zimage(name: str) -> bool:
+    """Filter function for Z-Image (NextDiT / S3-DiT backbone).
+
+    Returns True for layers that should NOT be quantized.
+    Skips: patch embedder, timestep/caption embedding, final projection, norms,
+    and the first/last 2 transformer layers (boundary protection for quality).
+    Quantizes: all JointAttention (qkv, out) and FFN (w1, w2, w3) linears in
+    layers 2–27.
+    """
+    pattern = re.compile(
+        r".*("
+        r"x_embedder"
+        r"|final_layer"
+        r"|time_caption_embed"
+        r"|cap_embedder"
+        r"|norm"
+        r"|pos_embed"
+        r"|layers\.(0|1|28|29)\."
+        r").*"
+    )
+    return pattern.match(name) is not None
+
+
 def load_calib_prompts(
     batch_size,
     calib_data_path: str | Path = "Gustavosta/Stable-Diffusion-Prompts",

--- a/modelopt/torch/export/diffusers_utils.py
+++ b/modelopt/torch/export/diffusers_utils.py
@@ -126,6 +126,11 @@ def generate_diffusion_dummy_inputs(
         "UNet2DConditionModel",
         "unet" in model_class_name.lower(),
     )
+    is_zimage = _is_model_type(
+        "diffusers.models.transformers",
+        "ZImageTransformer2DModel",
+        model_class_name == "ZImageTransformer2DModel",
+    )
 
     cfg = getattr(model, "config", None)
 
@@ -274,6 +279,31 @@ def generate_diffusion_dummy_inputs(
             "return_dict": False,
         }
 
+    def _zimage_inputs() -> dict[str, torch.Tensor]:
+        """Build dummy inputs for ZImageTransformer2DModel (NextDiT backbone)."""
+        # ZImageTransformer2DModel (NextDiT): 3D hidden_states (batch, seq_len, in_channels)
+        # Requires: hidden_states, timestep, encoder_hidden_states
+        in_channels = getattr(cfg, "in_channels", 16)
+        # Qwen3-4B encoder hidden size; fall back to caption_channels if present
+        encoder_hidden_size = getattr(
+            cfg, "encoder_hidden_size", getattr(cfg, "caption_channels", 2560)
+        )
+
+        # Small seq_len: 4x4 patch grid
+        img_seq_len = 16
+        text_seq_len = 8
+
+        return {
+            "hidden_states": torch.randn(
+                batch_size, img_seq_len, in_channels, device=device, dtype=dtype
+            ),
+            "timestep": torch.tensor([0.5], device=device, dtype=dtype).expand(batch_size),
+            "encoder_hidden_states": torch.randn(
+                batch_size, text_seq_len, encoder_hidden_size, device=device, dtype=dtype
+            ),
+            "return_dict": False,
+        }
+
     def _generic_transformer_inputs() -> dict[str, torch.Tensor] | None:
         # Try generic transformer handling for other model types
         # Check if model has common transformer attributes
@@ -318,6 +348,7 @@ def generate_diffusion_dummy_inputs(
         ("dit", is_dit, _dit_inputs),
         ("wan", is_wan, _wan_inputs),
         ("unet", is_unet, _unet_inputs),
+        ("zimage", is_zimage, _zimage_inputs),
     ]
 
     for _, matches, build_inputs in model_input_builders:

--- a/tests/examples/diffusers/test_diffusers.py
+++ b/tests/examples/diffusers/test_diffusers.py
@@ -187,3 +187,63 @@ def test_diffusion_trt_torch(
     if torch_compile:
         cmd_args.append("--torch-compile")
     run_example_command(cmd_args, "diffusers/quantization")
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # Layers that should be skipped (filter returns True)
+        ("transformer.x_embedder.weight", True),
+        ("transformer.final_layer.linear.weight", True),
+        ("transformer.time_caption_embed.mlp.0.weight", True),
+        ("transformer.cap_embedder.weight", True),
+        ("transformer.layers.0.norm1.weight", True),
+        ("transformer.pos_embed", True),
+        # Boundary layers (first/last 2) — skipped for quality
+        ("transformer.layers.0.attention.wq.weight", True),
+        ("transformer.layers.1.feed_forward.w1.weight", True),
+        ("transformer.layers.28.attention.wo.weight", True),
+        ("transformer.layers.29.feed_forward.w3.weight", True),
+        # Interior layers that should be quantized (filter returns False)
+        ("transformer.layers.2.attention.wq.weight", False),
+        ("transformer.layers.2.attention.wk.weight", False),
+        ("transformer.layers.2.attention.wv.weight", False),
+        ("transformer.layers.2.attention.wo.weight", False),
+        ("transformer.layers.2.feed_forward.w1.weight", False),
+        ("transformer.layers.2.feed_forward.w2.weight", False),
+        ("transformer.layers.2.feed_forward.w3.weight", False),
+        ("transformer.layers.15.feed_forward.w1.weight", False),
+    ],
+    ids=[
+        "skip_x_embedder",
+        "skip_final_layer",
+        "skip_time_caption_embed",
+        "skip_cap_embedder",
+        "skip_norm",
+        "skip_pos_embed",
+        "skip_boundary_layer0_attn",
+        "skip_boundary_layer1_ffn",
+        "skip_boundary_layer28_attn",
+        "skip_boundary_layer29_ffn",
+        "quant_attn_wq",
+        "quant_attn_wk",
+        "quant_attn_wv",
+        "quant_attn_wo",
+        "quant_ffn_w1",
+        "quant_ffn_w2",
+        "quant_ffn_w3",
+        "quant_ffn_w1_mid_layer",
+    ],
+)
+def test_filter_func_zimage(name: str, expected: bool) -> None:
+    """filter_func_zimage must skip conditioning/norm/boundary layers and quantize interior linears."""
+    import sys
+
+    example_path = str(Path(__file__).parents[3] / "examples/diffusers/quantization")
+    sys.path.insert(0, example_path)
+    try:
+        from utils import filter_func_zimage
+
+        assert filter_func_zimage(name) == expected
+    finally:
+        sys.path.remove(example_path)


### PR DESCRIPTION
## What does this PR do?

**Type of change:** New feature + Bug fix

Adds PTQ quantization support for Z-Image and Z-Image-Turbo (`Tongyi-MAI/Z-Image`, `Tongyi-MAI/Z-Image-Turbo`) in the diffusers quantization example. Z-Image is built on the NextDiT (Lumina2) transformer backbone with a Qwen3-4B text encoder.

Also fixes a hard `ImportError` introduced in modelopt 0.42.0: `AttentionModuleMixin` moved from `modelopt.torch.quantization.plugins.diffusers` to `modelopt.torch.quantization.plugins.diffusion.diffusers`.

### Changes

- **`examples/diffusers/quantization/utils.py`**: Fix import path; add `filter_func_zimage()` to skip patch embedder, final projection, conditioning MLPs, and norm layers while quantizing all attention (`qkv`/`out`) and FFN (`w1`/`w2`/`w3`) linears.
- **`examples/diffusers/quantization/models_utils.py`**: Register `zimage` and `zimage-turbo` model types with HF model IDs, `ZImagePipeline`, and calibration defaults. `num_inference_steps` is intentionally omitted from `inference_extra_args` to avoid a `TypeError: got multiple values` collision with the `--n-steps` CLI argument.
- **`modelopt/torch/export/diffusers_utils.py`**: Add `ZImageTransformer2DModel` dummy input generation in `generate_diffusion_dummy_inputs()`, resolving a QKV fusion warning during HF checkpoint export.
- **`tests/`**: Add `ZIMAGE_PATH` constant, integration test parametrize case (skipped when `MODELOPT_LOCAL_MODEL_ROOT` is unset — no tiny pipe on `hf-internal-testing`), and 14-case unit test for `filter_func_zimage`.

### Usage

```bash
python quantize.py \
  --model zimage \
  --model-dtype BFloat16 \
  --format fp8 \
  --batch-size 1 \
  --calib-size 128 \
  --n-steps 20 \
  --hf-ckpt-dir ./exports/zimage-fp8-hf
```

### Testing

Tested end-to-end on DGX Spark (GB10, 128 GB unified memory):
- FP8 calibration over 128 samples from `Gustavosta/Stable-Diffusion-Prompts` (998 quantizers inserted)
- HF checkpoint export via `--hf-ckpt-dir`
- Inference via `ZImagePipeline.from_pretrained()` with `enable_huggingface_checkpointing()`

### Before your PR is "Ready for review"

- Is this change backward compatible? ✅ Purely additive — new enum values, new dict entries, new `elif` branch
- Did you write any new necessary tests? ✅
- Did you update Changelog? ✅

### Additional notes

A separate issue will be filed for `export_hf_checkpoint` not writing `quant_type` to `transformer/config.json` — this affects `NVIDIAModelOptConfig`-consuming loaders in diffusers and is a separate concern in the export path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Z-Image and Z-Image-Turbo model quantization support
  * New `--model zimage` and `--model zimage-turbo` CLI options
  * FP8/INT8/INT4 quantization support for specified transformers

* **Bug Fixes**
  * Fixed import path for quantization utilities
  * Resolved dummy input generation for Z-Image models

* **Tests**
  * Added filter function tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->