### PR TITLE
fix: megatron export correctness for TP>1 GQA, single-file MTP, and Hub remote code

### DIFF
--- a/modelopt/torch/export/plugins/hf_checkpoint_utils.py
+++ b/modelopt/torch/export/plugins/hf_checkpoint_utils.py
@@ -21,6 +21,7 @@ import shutil
 from pathlib import Path
 
 import torch
+from huggingface_hub import hf_hub_download, list_repo_files
 from safetensors.torch import safe_open
 from tqdm import tqdm
 
@@ -35,24 +36,27 @@ def copy_remote_code(
     we need to copy them to the export directory for seamless integration with inference
     frameworks.
 
-    Args:
-        pretrained_model_path: Path to the pretrained model.
-        save_directory: Path to the save directory.
+    If ``pretrained_model_path`` is a local directory, Python files are copied directly.
+    If it is a HuggingFace Hub model ID, Python files are downloaded from the Hub first.
 
-    Raises:
-        ValueError: If the pretrained model path is not a directory.
+    Args:
+        pretrained_model_path: Local path to the pretrained model or HuggingFace Hub model ID.
+        save_directory: Path to the save directory.
     """
     hf_checkpoint_path = Path(pretrained_model_path)
     save_dir = Path(save_directory)
 
-    if not hf_checkpoint_path.is_dir():
-        raise ValueError(
-            f"Invalid pretrained model path: {pretrained_model_path}. It should be a directory."
-        )
-
-    for py_file in hf_checkpoint_path.glob("*.py"):
-        if py_file.is_file():
-            shutil.copy(py_file, save_dir / py_file.name)
+    if hf_checkpoint_path.is_dir():
+        for py_file in hf_checkpoint_path.glob("*.py"):
+            if py_file.is_file():
+                shutil.copy(py_file, save_dir / py_file.name)
+    else:
+        # Hub model ID: download any top-level .py files (custom modeling code)
+        repo_id = str(pretrained_model_path)
+        for filename in list_repo_files(repo_id):
+            if "/" not in filename and filename.endswith(".py"):
+                local_path = hf_hub_download(repo_id=repo_id, filename=filename)
+                shutil.copy(local_path, save_dir / filename)
 
 
 def load_multimodal_components(

--- a/modelopt/torch/export/unified_export_megatron.py
+++ b/modelopt/torch/export/unified_export_megatron.py
@@ -28,6 +28,8 @@ from typing import Any
 import torch
 import torch.distributed
 from huggingface_hub import hf_hub_download
+from huggingface_hub.errors import EntryNotFoundError
+from safetensors import safe_open
 from safetensors.torch import save_file
 
 from modelopt import __version__
@@ -534,29 +536,57 @@ class GPTModelExporter:
         # TODO Implement MTP export for quantized MTP
         # Hacky version for now: copy MTP weights from pretrained model
         mtp_state_dict = {}
-        if self._hf_pretrained_model_name:
-            if os.path.isdir(self._hf_pretrained_model_name):
-                safetensors_index_file = (
-                    Path(self._hf_pretrained_model_name) / "model.safetensors.index.json"
-                )
-            else:
-                safetensors_index_file = hf_hub_download(
-                    repo_id=self._hf_pretrained_model_name, filename="model.safetensors.index.json"
-                )
+        if not self._hf_pretrained_model_name:
+            return mtp_state_dict
 
+        mtp_exists = False
+
+        if os.path.isdir(self._hf_pretrained_model_name):
+            safetensors_index_file = (
+                Path(self._hf_pretrained_model_name) / "model.safetensors.index.json"
+            )
+            single_safetensors_file = Path(self._hf_pretrained_model_name) / "model.safetensors"
+        else:
+            try:
+                safetensors_index_file = Path(
+                    hf_hub_download(
+                        repo_id=self._hf_pretrained_model_name,
+                        filename="model.safetensors.index.json",
+                    )
+                )
+                single_safetensors_file = None
+            except EntryNotFoundError:
+                # Model uses a single unsharded safetensors file — check it for MTP weights.
+                safetensors_index_file = None
+                try:
+                    single_safetensors_file = Path(
+                        hf_hub_download(
+                            repo_id=self._hf_pretrained_model_name,
+                            filename="model.safetensors",
+                        )
+                    )
+                except EntryNotFoundError:
+                    return mtp_state_dict
+
+        if safetensors_index_file is not None and safetensors_index_file.exists():
             print(f"Exporting MTP: using safetensors_index_file: {safetensors_index_file}")
-            mtp_exists = False
-            if safetensors_index_file and os.path.exists(safetensors_index_file):
-                with open(safetensors_index_file) as f:
-                    safetensors_index = json.load(f)
-                model_dir = Path(safetensors_index_file).parent
-                for key in safetensors_index["weight_map"]:
+            with open(safetensors_index_file) as f:
+                safetensors_index = json.load(f)
+            model_dir = safetensors_index_file.parent
+            for key in safetensors_index["weight_map"]:
+                if key.startswith("mtp.") and key not in self._state_dict:
+                    mtp_state_dict[key] = get_safetensor(model_dir, key)
+                    mtp_exists = True
+        elif single_safetensors_file is not None and single_safetensors_file.exists():
+            print(f"Exporting MTP: using single safetensors file: {single_safetensors_file}")
+            with safe_open(str(single_safetensors_file), framework="pt", device="cpu") as f:
+                for key in f.keys():  # noqa: SIM118
                     if key.startswith("mtp.") and key not in self._state_dict:
-                        mtp_state_dict[key] = get_safetensor(model_dir, key)
+                        mtp_state_dict[key] = f.get_tensor(key)
                         mtp_exists = True
 
-            if mtp_exists:
-                self.exclude_modules.append("mtp*")
+        if mtp_exists:
+            self.exclude_modules.append("mtp*")
         return mtp_state_dict
 
     def _get_mamba_layer_state_dict(self, layer, layer_id):
@@ -987,17 +1017,22 @@ class GPTModelExporter:
             )
             hidden_size = 2 * hidden_size
 
-        weight = weight.reshape([qkv_total_dim, head_size, hidden_size])
+        # When TP > 1 the weight tensor is already sharded: shape[0] = per_rank_qkv_dim, not
+        # qkv_total_dim.  Derive the per-rank dimensions from the actual tensor shape so that
+        # all subsequent reshape/slice operations are correct regardless of TP degree.
+        per_rank_qkv_dim = weight.shape[0] // head_size
+        num_query_groups_local = num_query_groups * per_rank_qkv_dim // qkv_total_dim
+        weight = weight.reshape([per_rank_qkv_dim, head_size, hidden_size])
         weight_scale, weight_scale_2 = self._get_weight_scales(name_to_value, qformat)
 
         q_slice = torch.cat(
             [
                 torch.arange((heads_per_group + 2) * i, (heads_per_group + 2) * i + heads_per_group)
-                for i in range(num_query_groups)
+                for i in range(num_query_groups_local)
             ]
         )
-        k_slice = torch.arange(heads_per_group, qkv_total_dim, (heads_per_group + 2))
-        v_slice = torch.arange(heads_per_group + 1, qkv_total_dim, (heads_per_group + 2))
+        k_slice = torch.arange(heads_per_group, per_rank_qkv_dim, (heads_per_group + 2))
+        v_slice = torch.arange(heads_per_group + 1, per_rank_qkv_dim, (heads_per_group + 2))
         ## Example of slices
         ## 7b: num_query_groups = head_num = 32,
         ## q_slice = [0, 3, 6, 9 , ... 90, 93]
@@ -1022,7 +1057,7 @@ class GPTModelExporter:
                 weight_scale_dtype = weight_scale.dtype
                 weight_scale_hidden_size = weight_scale.shape[-1]
                 weight_scale = weight_scale.to(dtype=float).reshape(
-                    [qkv_total_dim, head_size, weight_scale_hidden_size]
+                    [per_rank_qkv_dim, head_size, weight_scale_hidden_size]
                 )
                 proj_weight_scales = [
                     weight_scale[s]
@@ -1063,7 +1098,7 @@ class GPTModelExporter:
             if key == "bias":
                 # Slice bias similar to weight
                 bias = val.detach().clone()
-                bias = bias.reshape([qkv_total_dim, head_size])
+                bias = bias.reshape([per_rank_qkv_dim, head_size])
                 proj_biases = [bias[s].reshape(-1) for s in slices]
                 proj_bias_keys = [q_proj_prefix + key, k_proj_prefix + key, v_proj_prefix + key]
                 for bias_tensor, bias_key in zip(proj_biases, proj_bias_keys):

--- a/tests/gpu_megatron/torch/export/test_hf_checkpoint_utils.py
+++ b/tests/gpu_megatron/torch/export/test_hf_checkpoint_utils.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for modelopt/torch/export/plugins/hf_checkpoint_utils.py"""
+
+from unittest.mock import patch
+
+from modelopt.torch.export.plugins.hf_checkpoint_utils import copy_remote_code
+
+
+def test_copy_remote_code_local_dir(tmp_path):
+    """copy_remote_code copies top-level .py files from a local directory."""
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "modeling_custom.py").write_text("# custom model")
+    (src_dir / "configuration_custom.py").write_text("# custom config")
+    (src_dir / "not_python.txt").write_text("not python")
+    (src_dir / "subdir").mkdir()
+    (src_dir / "subdir" / "nested.py").write_text("# nested — should not be copied")
+
+    dst_dir = tmp_path / "dst"
+    dst_dir.mkdir()
+
+    copy_remote_code(src_dir, dst_dir)
+
+    assert (dst_dir / "modeling_custom.py").read_text() == "# custom model"
+    assert (dst_dir / "configuration_custom.py").read_text() == "# custom config"
+    assert not (dst_dir / "not_python.txt").exists(), "non-.py files should not be copied"
+    assert not (dst_dir / "nested.py").exists(), "nested .py files should not be copied"
+
+
+def test_copy_remote_code_local_dir_no_py_files(tmp_path):
+    """copy_remote_code is a no-op when the local directory has no .py files."""
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "config.json").write_text("{}")
+
+    dst_dir = tmp_path / "dst"
+    dst_dir.mkdir()
+
+    copy_remote_code(src_dir, dst_dir)  # should not raise
+
+    assert list(dst_dir.iterdir()) == [], "no files should be copied"
+
+
+def test_copy_remote_code_hub_id(tmp_path):
+    """copy_remote_code downloads and copies top-level .py files from a Hub model ID."""
+    dst_dir = tmp_path / "dst"
+    dst_dir.mkdir()
+
+    # Create a fake cached file that hf_hub_download would return
+    cached_py = tmp_path / "cached_modeling_custom.py"
+    cached_py.write_text("# custom hub model")
+
+    repo_files = [
+        "modeling_custom.py",  # top-level .py — should be downloaded
+        "config.json",  # non-.py — skip
+        "model.safetensors",  # non-.py — skip
+        "subdir/nested.py",  # subdirectory .py — skip (contains "/")
+    ]
+
+    with (
+        patch(
+            "modelopt.torch.export.plugins.hf_checkpoint_utils.list_repo_files",
+            return_value=repo_files,
+        ) as mock_list,
+        patch(
+            "modelopt.torch.export.plugins.hf_checkpoint_utils.hf_hub_download",
+            return_value=str(cached_py),
+        ) as mock_download,
+    ):
+        copy_remote_code("meta-llama/Llama-3.2-1B", dst_dir)
+
+    mock_list.assert_called_once_with("meta-llama/Llama-3.2-1B")
+    # Only the top-level .py should have been downloaded
+    mock_download.assert_called_once_with(
+        repo_id="meta-llama/Llama-3.2-1B", filename="modeling_custom.py"
+    )
+    assert (dst_dir / "modeling_custom.py").read_text() == "# custom hub model"
+
+
+def test_copy_remote_code_hub_id_no_py_files(tmp_path):
+    """copy_remote_code is a no-op when the Hub repo has no top-level .py files."""
+    dst_dir = tmp_path / "dst"
+    dst_dir.mkdir()
+
+    with (
+        patch(
+            "modelopt.torch.export.plugins.hf_checkpoint_utils.list_repo_files",
+            return_value=["config.json", "model.safetensors"],
+        ),
+        patch("modelopt.torch.export.plugins.hf_checkpoint_utils.hf_hub_download") as mock_download,
+    ):
+        copy_remote_code("meta-llama/Llama-3.2-1B", dst_dir)
+
+    mock_download.assert_not_called()
+    assert list(dst_dir.iterdir()) == []

--- a/tests/gpu_megatron/torch/export/test_unified_export_megatron.py
+++ b/tests/gpu_megatron/torch/export/test_unified_export_megatron.py
@@ -341,7 +341,7 @@ def test_mtp_state_dict_no_mtp_keys(tmp_path):
 
 
 def test_mtp_state_dict_index_file(tmp_path):
-    """Bug 6058198: MTP weights are collected from a sharded checkpoint (index file path)."""
+    """MTP weights are collected from a sharded checkpoint (index file path)."""
     model_dir = tmp_path / "fake_hf_model"
     model_dir.mkdir()
 

--- a/tests/gpu_megatron/torch/export/test_unified_export_megatron.py
+++ b/tests/gpu_megatron/torch/export/test_unified_export_megatron.py
@@ -24,10 +24,12 @@ import transformers
 from _test_utils.torch.megatron.models import get_mcore_gpt_model
 from _test_utils.torch.megatron.utils import get_forward
 from _test_utils.torch.transformers_models import create_tiny_llama_dir
+from safetensors.torch import save_file
 
 import modelopt.torch.quantization as mtq
 import modelopt.torch.speculative as mtsp
 from modelopt.torch.export import KV_CACHE_FP8, export_mcore_gpt_to_hf, import_mcore_gpt_from_hf
+from modelopt.torch.export.unified_export_megatron import GPTModelExporter
 from modelopt.torch.speculative.eagle.default_config import default_eagle_config
 from modelopt.torch.speculative.plugins.megatron_eagle import _DynamicEagleGPTModel
 from modelopt.torch.speculative.plugins.megatron_medusa import _DynamicMedusaGPTModel
@@ -216,3 +218,155 @@ def test_unified_import_megatron(dist_workers, tmp_path):
     num_gpus = torch.cuda.device_count()
     tiny_llama_dir = create_tiny_llama_dir(tmp_path, num_key_value_heads=num_gpus)
     dist_workers.run(partial(_test_unified_import_megatron, tiny_llama_dir))
+
+
+def _test_qkv_slicing_gqa_tp2(tmp_path, rank, size):
+    """Export a GQA model with TP=2 to verify _qkv_slicing handles sharded weights."""
+    num_layers = 2
+    hidden_size = 64
+    num_attention_heads = 8
+    num_query_groups = 2  # GQA: fewer KV heads than Q heads; both divisible by TP=2
+    ffn_hidden_size = 128
+    max_sequence_length = 32
+    vocab_size = 64
+
+    model = get_mcore_gpt_model(
+        tensor_model_parallel_size=size,
+        pipeline_model_parallel_size=1,
+        initialize_megatron=True,
+        num_layers=num_layers,
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+        num_query_groups=num_query_groups,
+        ffn_hidden_size=ffn_hidden_size,
+        max_sequence_length=max_sequence_length,
+        vocab_size=vocab_size,
+        activation_func="swiglu",
+        normalization="RMSNorm",
+        transformer_impl="modelopt",
+    ).cuda()
+
+    # Quantize with FP8 to also exercise the per-channel weight_scale reshape in _qkv_slicing
+    forward = get_forward(model)
+    model = mtq.quantize(model, mtq.FP8_DEFAULT_CFG, forward)
+
+    pretrained_config = {
+        "architectures": ["LlamaForCausalLM"],
+        "attention_bias": False,
+        "hidden_size": hidden_size,
+        "intermediate_size": ffn_hidden_size,
+        "max_position_embeddings": max_sequence_length,
+        "model_type": "llama",
+        "num_attention_heads": num_attention_heads,
+        "num_hidden_layers": num_layers,
+        "num_key_value_heads": num_query_groups,
+        "torch_dtype": "bfloat16",
+    }
+    with open(tmp_path / "config.json", "w") as f:
+        json.dump(pretrained_config, f)
+
+    export_dir = tmp_path / "export"
+    export_mcore_gpt_to_hf(
+        model,
+        tmp_path,
+        dtype=torch.bfloat16,
+        export_dir=str(export_dir),
+    )
+
+    # Verify Q/K/V projections were exported (collect keys from all shard files)
+    if rank == 0:
+        from safetensors import safe_open
+
+        safetensors_files = list(export_dir.glob("*.safetensors"))
+        assert safetensors_files, "no safetensors files found in export dir"
+        keys = []
+        for sf in safetensors_files:
+            with safe_open(str(sf), framework="pt", device="cpu") as f:
+                keys.extend(f.keys())
+        assert any("q_proj.weight" in k for k in keys), "q_proj.weight missing from export"
+        assert any("k_proj.weight" in k for k in keys), "k_proj.weight missing from export"
+        assert any("v_proj.weight" in k for k in keys), "v_proj.weight missing from export"
+
+
+def test_qkv_slicing_gqa_tp2(dist_workers_size_2, tmp_path):
+    """Export with TP=2 on a GQA model should not raise a reshape error in _qkv_slicing."""
+    dist_workers_size_2.run(partial(_test_qkv_slicing_gqa_tp2, tmp_path))
+
+
+def _make_exporter_for_mtp(model_dir: Path) -> GPTModelExporter:
+    """Create a minimal GPTModelExporter instance for testing _get_mtp_state_dict."""
+    exporter = object.__new__(GPTModelExporter)
+    exporter._hf_pretrained_model_name = str(model_dir)
+    exporter._state_dict = {}  # MTP keys are absent — they should be picked up
+    exporter.exclude_modules = []
+    return exporter
+
+
+def test_mtp_state_dict_single_safetensors(tmp_path):
+    """MTP weights are collected from a model with a single model.safetensors file."""
+    model_dir = tmp_path / "fake_hf_model"
+    model_dir.mkdir()
+
+    tensors = {
+        "model.embed_tokens.weight": torch.zeros(64, 32),
+        "mtp.0.enorm.weight": torch.ones(32),
+        "mtp.0.hnorm.weight": torch.full((32,), 2.0),
+    }
+    save_file(tensors, str(model_dir / "model.safetensors"))
+
+    exporter = _make_exporter_for_mtp(model_dir)
+    mtp_state_dict = exporter._get_mtp_state_dict()
+
+    assert "mtp.0.enorm.weight" in mtp_state_dict
+    assert "mtp.0.hnorm.weight" in mtp_state_dict
+    assert "model.embed_tokens.weight" not in mtp_state_dict, "non-MTP key should not be included"
+    assert torch.allclose(mtp_state_dict["mtp.0.enorm.weight"], torch.ones(32))
+    assert torch.allclose(mtp_state_dict["mtp.0.hnorm.weight"], torch.full((32,), 2.0))
+    assert "mtp*" in exporter.exclude_modules
+
+
+def test_mtp_state_dict_no_mtp_keys(tmp_path):
+    """_get_mtp_state_dict returns empty dict and leaves exclude_modules unchanged when no MTP keys."""
+    model_dir = tmp_path / "fake_hf_model"
+    model_dir.mkdir()
+
+    tensors = {"model.embed_tokens.weight": torch.zeros(64, 32)}
+    save_file(tensors, str(model_dir / "model.safetensors"))
+
+    exporter = _make_exporter_for_mtp(model_dir)
+    mtp_state_dict = exporter._get_mtp_state_dict()
+
+    assert mtp_state_dict == {}
+    assert exporter.exclude_modules == []
+
+
+def test_mtp_state_dict_index_file(tmp_path):
+    """Bug 6058198: MTP weights are collected from a sharded checkpoint (index file path)."""
+    model_dir = tmp_path / "fake_hf_model"
+    model_dir.mkdir()
+
+    shard1 = {
+        "model.embed_tokens.weight": torch.zeros(64, 32),
+        "mtp.0.enorm.weight": torch.ones(32),
+    }
+    shard2 = {"mtp.0.hnorm.weight": torch.full((32,), 3.0)}
+    save_file(shard1, str(model_dir / "model-00001-of-00002.safetensors"))
+    save_file(shard2, str(model_dir / "model-00002-of-00002.safetensors"))
+
+    index = {
+        "weight_map": {
+            "model.embed_tokens.weight": "model-00001-of-00002.safetensors",
+            "mtp.0.enorm.weight": "model-00001-of-00002.safetensors",
+            "mtp.0.hnorm.weight": "model-00002-of-00002.safetensors",
+        }
+    }
+    with open(model_dir / "model.safetensors.index.json", "w") as f:
+        json.dump(index, f)
+
+    exporter = _make_exporter_for_mtp(model_dir)
+    mtp_state_dict = exporter._get_mtp_state_dict()
+
+    assert "mtp.0.enorm.weight" in mtp_state_dict
+    assert "mtp.0.hnorm.weight" in mtp_state_dict
+    assert torch.allclose(mtp_state_dict["mtp.0.hnorm.weight"], torch.full((32,), 3.0))
+    assert "mtp*" in exporter.exclude_modules


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Three correctness fixes for the Megatron Core GPT export pipeline:

**1. `_qkv_slicing`: reshape failure with TP>1 on GQA models**

When tensor parallelism is enabled, the `linear_qkv` weight tensor arriving in `_qkv_slicing` is already TP-sharded, so `weight.shape[0]` equals `per_rank_qkv_dim * head_size`, not `qkv_total_dim * head_size`. All five reshape/`arange` operations were using the global `qkv_total_dim`, causing a runtime shape mismatch for any GQA model with TP > 1. The fix derives `per_rank_qkv_dim` and `num_query_groups_local` from the actual tensor shape, making the logic correct for any TP degree (a no-op for TP=1).

**2. `_get_mtp_state_dict`: `EntryNotFoundError` for non-sharded models**

`hf_hub_download("model.safetensors.index.json")` raises `EntryNotFoundError` for small models that ship a single `model.safetensors` rather than a sharded index. The function now catches this and falls back to downloading/reading `model.safetensors` directly, scanning its keys with `safe_open`. The same two-path logic applies to local directories.

**3. `copy_remote_code`: `ValueError` for Hub model IDs**

`copy_remote_code` only accepted local directory paths and raised `ValueError` for HuggingFace Hub model IDs (e.g. `"meta-llama/Llama-3.2-1B"`). The function now falls back to `list_repo_files` + `hf_hub_download` to fetch and copy top-level `.py` files (custom modeling code) when the path is not a local directory.

### Usage

```python
# TP>1 GQA export now works (previously raised RuntimeError on reshape)
export_mcore_gpt_to_hf(gqa_model, "meta-llama/Llama-3.2-1B", export_dir="./out", dtype=torch.bfloat16)

# Models with a single model.safetensors now have their MTP weights exported
export_mcore_gpt_to_hf(model, "./small_model_dir", export_dir="./out", dtype=torch.bfloat16)

# Hub model IDs no longer raise ValueError in copy_remote_code
export_mcore_gpt_to_hf(model, "org/custom-model-with-remote-code", export_dir="./out", dtype=torch.bfloat16)
```

### Testing

New tests added in `tests/gpu_megatron/torch/export/`:

- `test_unified_export_megatron.py::test_qkv_slicing_gqa_tp2` — FP8-quantized GQA model export with TP=2 (`num_query_groups=2 < num_attention_heads=8`), exercises both the weight reshape and per-channel weight-scale reshape paths.
- `test_unified_export_megatron.py::test_mtp_state_dict_single_safetensors` — unit test verifying MTP weights are collected from a single `model.safetensors` file.
- `test_unified_export_megatron.py::test_mtp_state_dict_index_file` — unit test verifying MTP weights are collected from a sharded checkpoint.
- `test_unified_export_megatron.py::test_mtp_state_dict_no_mtp_keys` — edge case: no MTP keys → empty dict, no side effects.
- `test_hf_checkpoint_utils.py` — four tests covering `copy_remote_code` for local directories and Hub model IDs (with and without `.py` files).

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A

### Additional Information

Fixes reported against Megatron export when running quantization with TP>1, small non-sharded HF models, and HuggingFace Hub model IDs passed to `export_mcore_gpt_to_hf`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export functionality now supports downloading code directly from Hugging Face Hub model repositories in addition to local directories.

* **Bug Fixes**
  * Improved safetensors loading with better error handling for missing model entries and support for both single and sharded weight files.
  * Enhanced tensor slicing behavior for multi-GPU distributed export scenarios.

* **Tests**
  * Added comprehensive test coverage for Hugging Face integration and export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->