### PR TITLE
Add FP8 QKVO + NVFP4 MLP PTQ recipe

### DIFF
--- a/modelopt_recipes/general/ptq/fp8_qkvo-nvfp4_mlp.yml
+++ b/modelopt_recipes/general/ptq/fp8_qkvo-nvfp4_mlp.yml
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metadata:
+  recipe_type: ptq
+  description: FP8 per-tensor weight and activation for attention QKVO projections (W8A8), NVFP4 static weight and dynamic activation for MLP layers (W4A4), max calibration.
+ptq_cfg:
+  algorithm: max
+  quant_cfg:
+    # NVFP4 W4A4 for MLP / MoE layers
+    '*mlp*weight_quantizer':
+      num_bits: e2m1
+      block_sizes:
+        -1: 16
+        type: dynamic
+        scale_bits: e4m3
+      enable: true
+    '*mlp*input_quantizer':
+      num_bits: e2m1
+      block_sizes:
+        -1: 16
+        type: dynamic
+        scale_bits: e4m3
+      enable: true
+    '*block_sparse_moe*weight_quantizer':
+      num_bits: e2m1
+      block_sizes:
+        -1: 16
+        type: dynamic
+        scale_bits: e4m3
+      enable: true
+    '*block_sparse_moe*input_quantizer':
+      num_bits: e2m1
+      block_sizes:
+        -1: 16
+        type: dynamic
+        scale_bits: e4m3
+      enable: true
+    # FP8 W8A8 for attention Q, K, V, O projections
+    '*q_proj*weight_quantizer':
+      num_bits: e4m3
+      axis:
+      enable: true
+    '*q_proj*input_quantizer':
+      num_bits: e4m3
+      axis:
+      enable: true
+    '*k_proj*weight_quantizer':
+      num_bits: e4m3
+      axis:
+      enable: true
+    '*k_proj*input_quantizer':
+      num_bits: e4m3
+      axis:
+      enable: true
+    '*v_proj*weight_quantizer':
+      num_bits: e4m3
+      axis:
+      enable: true
+    '*v_proj*input_quantizer':
+      num_bits: e4m3
+      axis:
+      enable: true
+    '*o_proj*weight_quantizer':
+      num_bits: e4m3
+      axis:
+      enable: true
+    '*o_proj*input_quantizer':
+      num_bits: e4m3
+      axis:
+      enable: true
+    # Standard disables (routers, norms, lm_head, etc.)
+    default:
+      enable: false
+    '*block_sparse_moe.gate*':
+      enable: false
+    '*linear_attn.conv1d*':
+      enable: false
+    '*lm_head*':
+      enable: false
+    '*mixer.conv1d*':
+      enable: false
+    '*mlp.gate.*':
+      enable: false
+    '*mlp.shared_expert_gate.*':
+      enable: false
+    '*output_layer*':
+      enable: false
+    '*proj_out.*':
+      enable: false
+    '*router*':
+      enable: false
+    output.*:
+      enable: false
+    nn.BatchNorm1d:
+      '*':
+        enable: false
+    nn.BatchNorm2d:
+      '*':
+        enable: false
+    nn.BatchNorm3d:
+      '*':
+        enable: false
+    nn.LeakyReLU:
+      '*':
+        enable: false

--- a/modelopt_recipes/general/ptq/fp8_qkvo-nvfp4_mlp.yml
+++ b/modelopt_recipes/general/ptq/fp8_qkvo-nvfp4_mlp.yml
@@ -15,7 +15,8 @@
 
 metadata:
   recipe_type: ptq
-  description: FP8 per-tensor weight and activation for attention QKVO projections (W8A8), NVFP4 static weight and dynamic activation for MLP layers (W4A4), max calibration.
+  description: FP8 per-tensor weight and activation for attention QKVO projections (W8A8), NVFP4 static weight and dynamic activation for MLP layers (W4A4),
+    max calibration.
 ptq_cfg:
   algorithm: max
   quant_cfg:


### PR DESCRIPTION
Add a new PTQ recipe that applies FP8 per-tensor (W8A8) quantization to attention Q/K/V/O projections and NVFP4 block-wise (W4A4) quantization to MLP/MoE layers with max calibration.

Example usage on Gemma-4-31B-IT:

```
cd /opt/Model-Optimizer/examples/llm_ptq && python hf_ptq.py \
  --pyt_ckpt_path /models/gemma-4-31B-it \
  --recipe general/ptq/fp8_qkvo-nvfp4_mlp \
  --calib_size 512 \
  --dataset cnn_dailymail \
  --export_path /models/gemma-4-31B-it-fp8qkvo-nvfp4mlp
```

### What does this PR do?

Type of change: New feature

Adds a new built-in PTQ recipe `fp8_qkvo-nvfp4_mlp` that combines two quantization strategies:
- **FP8 W8A8** (e4m3, per-tensor) for attention Q, K, V, O projections
- **NVFP4 W4A4** (e2m1, block size 16, dynamic scaling with e4m3 scales) for MLP and MoE layers

This mixed-precision recipe targets a balance between model quality and inference performance — keeping attention projections at higher precision (FP8) while aggressively quantizing MLP layers (NVFP4). Standard components (routers, norms, lm_head, BatchNorm, etc.) are left unquantized.

### Usage

```bash
cd /opt/Model-Optimizer/examples/llm_ptq && python hf_ptq.py \
  --pyt_ckpt_path /models/gemma-4-31B-it \
  --recipe general/ptq/fp8_qkvo-nvfp4_mlp \
  --calib_size 512 \
  --dataset cnn_dailymail \
  --export_path /models/gemma-4-31B-it-fp8qkvo-nvfp4mlp
```

### Testing

- Verified recipe loads correctly via `load_recipe("general/ptq/fp8_qkvo-nvfp4_mlp")`
- Tested end-to-end PTQ + export on Gemma-4-31B-IT

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ (additive recipe only)
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A (YAML recipe, no new code)
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌ (can add if needed)

### Additional Information

Recipe file: `modelopt_recipes/general/ptq/fp8_qkvo-nvfp4_mlp.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new post-training quantization recipe that applies FP8 precision to attention projection weights/activations and NVFP4 precision to MLP and MoE layers, with targeted enable/disable rules to restrict quantization to intended components for more efficient, fine-grained model compression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->