### PR TITLE
Add VLM base model support for auto_quantize in hf_ptq

### DIFF
--- a/examples/llm_ptq/hf_ptq.py
+++ b/examples/llm_ptq/hf_ptq.py
@@ -350,6 +350,7 @@ def auto_quantize(
     )
 
     if is_base_model:
+        assert full_model is not None
         lm_head = full_model.lm_head
 
         def loss_func(output, data):
@@ -362,17 +363,22 @@ def auto_quantize(
             )
 
         if auto_quantize_method == "gradient":
+
             def forward_step(model, batch):
                 return model(**batch)
+
         elif auto_quantize_method == "kl_div":
+
             def forward_step(model, batch):
                 hidden_states = model(**batch).last_hidden_state
                 return lm_head(hidden_states)
+
         else:
             raise ValueError(
                 f"Invalid auto_quantize_method: {auto_quantize_method}. Must be 'gradient' or 'kl_div'"
             )
     else:
+
         def loss_func(output, data):
             # For transformers AutoModelForCausalLM models, the outputs are wrapped in `CausalLMOutputWithPast`
             # which contains the loss attribute.
@@ -380,12 +386,16 @@ def auto_quantize(
 
         if auto_quantize_method == "gradient":
             # For gradient-based method, return full output with loss
+
             def forward_step(model, batch):
                 return model(**batch)
+
         elif auto_quantize_method == "kl_div":
             # For KL divergence method, return only logits
+
             def forward_step(model, batch):
                 return model(**batch).logits
+
         else:
             raise ValueError(
                 f"Invalid auto_quantize_method: {auto_quantize_method}. Must be 'gradient' or 'kl_div'"

--- a/examples/llm_ptq/hf_ptq.py
+++ b/examples/llm_ptq/hf_ptq.py
@@ -301,6 +301,7 @@ def auto_quantize(
     auto_quantize_method="gradient",
     auto_quantize_score_size=128,
     auto_quantize_checkpoint=None,
+    full_model: torch.nn.Module | None = None,
 ):
     """Auto search quantization of multiple formats."""
 
@@ -338,23 +339,57 @@ def auto_quantize(
         for qformat in qformat_list
     ), "One or more quantization formats provided are not supported for unified checkpoint export"
 
-    def loss_func(output, data):
-        # For transformers AutoModelForCausalLM models, the outputs are wrapped in `CausalLMOutputWithPast`
-        # which contains the loss attribute.
-        return output.loss
+    # For VLMs like Gemma4, the extracted language_model is a base text model without
+    # lm_head, so it cannot produce logits or loss directly. In that case, use the
+    # full_model's lm_head to compute logits/loss from the language model's hidden states.
+    is_base_model = (
+        full_model is not None
+        and language_model is not full_model
+        and not hasattr(language_model, "lm_head")
+        and hasattr(full_model, "lm_head")
+    )
 
-    if auto_quantize_method == "gradient":
-        # For gradient-based method, return full output with loss
-        def forward_step(model, batch):
-            return model(**batch)
-    elif auto_quantize_method == "kl_div":
-        # For KL divergence method, return only logits
-        def forward_step(model, batch):
-            return model(**batch).logits
+    if is_base_model:
+        lm_head = full_model.lm_head
+
+        def loss_func(output, data):
+            logits = lm_head(output.last_hidden_state)
+            labels = data["labels"]
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+            return torch.nn.functional.cross_entropy(
+                shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1)
+            )
+
+        if auto_quantize_method == "gradient":
+            def forward_step(model, batch):
+                return model(**batch)
+        elif auto_quantize_method == "kl_div":
+            def forward_step(model, batch):
+                hidden_states = model(**batch).last_hidden_state
+                return lm_head(hidden_states)
+        else:
+            raise ValueError(
+                f"Invalid auto_quantize_method: {auto_quantize_method}. Must be 'gradient' or 'kl_div'"
+            )
     else:
-        raise ValueError(
-            f"Invalid auto_quantize_method: {auto_quantize_method}. Must be 'gradient' or 'kl_div'"
-        )
+        def loss_func(output, data):
+            # For transformers AutoModelForCausalLM models, the outputs are wrapped in `CausalLMOutputWithPast`
+            # which contains the loss attribute.
+            return output.loss
+
+        if auto_quantize_method == "gradient":
+            # For gradient-based method, return full output with loss
+            def forward_step(model, batch):
+                return model(**batch)
+        elif auto_quantize_method == "kl_div":
+            # For KL divergence method, return only logits
+            def forward_step(model, batch):
+                return model(**batch).logits
+        else:
+            raise ValueError(
+                f"Invalid auto_quantize_method: {auto_quantize_method}. Must be 'gradient' or 'kl_div'"
+            )
 
     language_model, _ = mtq.auto_quantize(
         language_model,
@@ -1048,6 +1083,7 @@ def quantize_main(
             args,
             language_model,
             calib_dataloader,
+            full_model=full_model,
         )
 
     else:


### PR DESCRIPTION
For VLMs like Gemma4 where the extracted language_model lacks lm_head, use the full_model's lm_head to compute logits/loss from hidden states.

How to run:
```bash
cd /opt/Model-Optimizer/examples/llm_ptq && python hf_ptq.py \
  --pyt_ckpt_path /lustre/fsw/portfolios/coreai/users/yueshen/models/gemma-4-31B-it \
  --qformat nvfp4,fp8 \
  --auto_quantize_bits 6.0 \
  --calib_size 512 \
  --dataset cnn_dailymail \
  --export_path /lustre/fsw/portfolios/coreai/users/yueshen/models/gemma-4-31B-it-autoquant-6.0
```

### What does this PR do?

Type of change: New feature

For VLMs like Gemma4, the extracted `language_model` is a base text model without `lm_head`, so it cannot produce logits or loss directly. This PR updates `auto_quantize()` to accept a `full_model` parameter and use its `lm_head` to compute logits/loss from the language model's hidden states, enabling auto-quantization for such architectures.

### Usage

```python
# In hf_ptq.py, auto_quantize now accepts full_model for VLMs:
auto_quantize(
    language_model,
    ...,
    full_model=model,  # pass the full VLM so lm_head can be used
)
```

### Testing

Tested with Gemma-4-31B-it using `--qformat nvfp4,fp8 --auto_quantize_bits 6.0`.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ❌
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌

### Additional Information

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the LLM post-training quantization example to better support Vision–Language variants that separate base text models from heads. Loss and logit computations now correctly use the provided full model's head when needed, and the quantization flow passes the full model through when auto-quantization is enabled, increasing compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->