### PR TITLE
Add Gemma4 MoE quantization support

### DIFF
--- a/examples/llm_ptq/hf_ptq.py
+++ b/examples/llm_ptq/hf_ptq.py
@@ -331,9 +331,9 @@ def auto_quantize(
         for qformat in qformat_list
     ), "One or more quantization formats provided are not supported for unified checkpoint export"
 
-    # For VLMs like Gemma4, the extracted language_model is a base text model without
-    # lm_head, so it cannot produce logits or loss directly. In that case, use the
-    # full_model's lm_head to compute logits/loss from the language model's hidden states.
+    # Gemma4-specific: its language_model is a base text model (Gemma4TextModel) without
+    # lm_head, unlike other VLMs (LLaVA, Qwen2.5-VL, PaliGemma) whose language_model
+    # includes lm_head. Use full_model's lm_head to compute logits/loss from hidden states.
     is_base_model = (
         full_model is not None
         and language_model is not full_model
@@ -344,6 +344,9 @@ def auto_quantize(
     if is_base_model:
         assert full_model is not None
         lm_head = full_model.lm_head
+
+        def _model_inputs(batch):
+            return {k: v for k, v in batch.items() if k != "labels"}
 
         def loss_func(output, data):
             logits = lm_head(output.last_hidden_state)
@@ -357,12 +360,12 @@ def auto_quantize(
         if auto_quantize_method == "gradient":
 
             def forward_step(model, batch):
-                return model(**batch)
+                return model(**_model_inputs(batch))
 
         elif auto_quantize_method == "kl_div":
 
             def forward_step(model, batch):
-                hidden_states = model(**batch).last_hidden_state
+                hidden_states = model(**_model_inputs(batch)).last_hidden_state
                 return lm_head(hidden_states)
 
         else:
@@ -1067,6 +1070,9 @@ def quantize_main(
             args,
             language_model,
             calib_dataloader,
+            auto_quantize_method=args.auto_quantize_method,
+            auto_quantize_score_size=args.auto_quantize_score_size,
+            auto_quantize_checkpoint=args.auto_quantize_checkpoint,
             full_model=full_model,
         )
 

--- a/examples/llm_ptq/hf_ptq.py
+++ b/examples/llm_ptq/hf_ptq.py
@@ -292,6 +292,7 @@ def auto_quantize(
     auto_quantize_method="gradient",
     auto_quantize_score_size=128,
     auto_quantize_checkpoint=None,
+    full_model: torch.nn.Module | None = None,
 ):
     """Auto search quantization of multiple formats."""
 
@@ -330,23 +331,57 @@ def auto_quantize(
         for qformat in qformat_list
     ), "One or more quantization formats provided are not supported for unified checkpoint export"
 
-    def loss_func(output, data):
-        # For transformers AutoModelForCausalLM models, the outputs are wrapped in `CausalLMOutputWithPast`
-        # which contains the loss attribute.
-        return output.loss
+    # For VLMs like Gemma4, the extracted language_model is a base text model without
+    # lm_head, so it cannot produce logits or loss directly. In that case, use the
+    # full_model's lm_head to compute logits/loss from the language model's hidden states.
+    is_base_model = (
+        full_model is not None
+        and language_model is not full_model
+        and not hasattr(language_model, "lm_head")
+        and hasattr(full_model, "lm_head")
+    )
 
-    if auto_quantize_method == "gradient":
-        # For gradient-based method, return full output with loss
-        def forward_step(model, batch):
-            return model(**batch)
-    elif auto_quantize_method == "kl_div":
-        # For KL divergence method, return only logits
-        def forward_step(model, batch):
-            return model(**batch).logits
+    if is_base_model:
+        lm_head = full_model.lm_head
+
+        def loss_func(output, data):
+            logits = lm_head(output.last_hidden_state)
+            labels = data["labels"]
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+            return torch.nn.functional.cross_entropy(
+                shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1)
+            )
+
+        if auto_quantize_method == "gradient":
+            def forward_step(model, batch):
+                return model(**batch)
+        elif auto_quantize_method == "kl_div":
+            def forward_step(model, batch):
+                hidden_states = model(**batch).last_hidden_state
+                return lm_head(hidden_states)
+        else:
+            raise ValueError(
+                f"Invalid auto_quantize_method: {auto_quantize_method}. Must be 'gradient' or 'kl_div'"
+            )
     else:
-        raise ValueError(
-            f"Invalid auto_quantize_method: {auto_quantize_method}. Must be 'gradient' or 'kl_div'"
-        )
+        def loss_func(output, data):
+            # For transformers AutoModelForCausalLM models, the outputs are wrapped in `CausalLMOutputWithPast`
+            # which contains the loss attribute.
+            return output.loss
+
+        if auto_quantize_method == "gradient":
+            # For gradient-based method, return full output with loss
+            def forward_step(model, batch):
+                return model(**batch)
+        elif auto_quantize_method == "kl_div":
+            # For KL divergence method, return only logits
+            def forward_step(model, batch):
+                return model(**batch).logits
+        else:
+            raise ValueError(
+                f"Invalid auto_quantize_method: {auto_quantize_method}. Must be 'gradient' or 'kl_div'"
+            )
 
     language_model, _ = mtq.auto_quantize(
         language_model,
@@ -1022,6 +1057,7 @@ def quantize_main(
             args,
             language_model,
             calib_dataloader,
+            full_model=full_model,
         )
 
     else:

--- a/examples/llm_ptq/hf_ptq.py
+++ b/examples/llm_ptq/hf_ptq.py
@@ -342,6 +342,7 @@ def auto_quantize(
     )
 
     if is_base_model:
+        assert full_model is not None
         lm_head = full_model.lm_head
 
         def loss_func(output, data):
@@ -354,17 +355,22 @@ def auto_quantize(
             )
 
         if auto_quantize_method == "gradient":
+
             def forward_step(model, batch):
                 return model(**batch)
+
         elif auto_quantize_method == "kl_div":
+
             def forward_step(model, batch):
                 hidden_states = model(**batch).last_hidden_state
                 return lm_head(hidden_states)
+
         else:
             raise ValueError(
                 f"Invalid auto_quantize_method: {auto_quantize_method}. Must be 'gradient' or 'kl_div'"
             )
     else:
+
         def loss_func(output, data):
             # For transformers AutoModelForCausalLM models, the outputs are wrapped in `CausalLMOutputWithPast`
             # which contains the loss attribute.
@@ -372,12 +378,16 @@ def auto_quantize(
 
         if auto_quantize_method == "gradient":
             # For gradient-based method, return full output with loss
+
             def forward_step(model, batch):
                 return model(**batch)
+
         elif auto_quantize_method == "kl_div":
             # For KL divergence method, return only logits
+
             def forward_step(model, batch):
                 return model(**batch).logits
+
         else:
             raise ValueError(
                 f"Invalid auto_quantize_method: {auto_quantize_method}. Must be 'gradient' or 'kl_div'"

--- a/examples/llm_ptq/hf_ptq.py
+++ b/examples/llm_ptq/hf_ptq.py
@@ -331,9 +331,8 @@ def auto_quantize(
         for qformat in qformat_list
     ), "One or more quantization formats provided are not supported for unified checkpoint export"
 
-    # Gemma4-specific: its language_model is a base text model (Gemma4TextModel) without
-    # lm_head, unlike other VLMs (LLaVA, Qwen2.5-VL, PaliGemma) whose language_model
-    # includes lm_head. Use full_model's lm_head to compute logits/loss from hidden states.
+    # When language_model is a base text model without lm_head (e.g. Gemma4TextModel),
+    # use full_model's lm_head to compute logits/loss from hidden states.
     is_base_model = (
         full_model is not None
         and language_model is not full_model
@@ -345,9 +344,6 @@ def auto_quantize(
         assert full_model is not None
         lm_head = full_model.lm_head
 
-        def _model_inputs(batch):
-            return {k: v for k, v in batch.items() if k != "labels"}
-
         def loss_func(output, data):
             logits = lm_head(output.last_hidden_state)
             labels = data["labels"]
@@ -357,44 +353,31 @@ def auto_quantize(
                 shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1)
             )
 
-        if auto_quantize_method == "gradient":
-
-            def forward_step(model, batch):
-                return model(**_model_inputs(batch))
-
-        elif auto_quantize_method == "kl_div":
-
-            def forward_step(model, batch):
-                hidden_states = model(**_model_inputs(batch)).last_hidden_state
-                return lm_head(hidden_states)
-
-        else:
-            raise ValueError(
-                f"Invalid auto_quantize_method: {auto_quantize_method}. Must be 'gradient' or 'kl_div'"
-            )
     else:
 
         def loss_func(output, data):
-            # For transformers AutoModelForCausalLM models, the outputs are wrapped in `CausalLMOutputWithPast`
-            # which contains the loss attribute.
             return output.loss
 
-        if auto_quantize_method == "gradient":
-            # For gradient-based method, return full output with loss
+    if auto_quantize_method == "gradient":
 
-            def forward_step(model, batch):
-                return model(**batch)
+        def forward_step(model, batch):
+            inputs = {k: v for k, v in batch.items() if k != "labels"} if is_base_model else batch
+            return model(**inputs)
 
-        elif auto_quantize_method == "kl_div":
-            # For KL divergence method, return only logits
+    elif auto_quantize_method == "kl_div":
 
-            def forward_step(model, batch):
-                return model(**batch).logits
+        def forward_step(model, batch):
+            inputs = {k: v for k, v in batch.items() if k != "labels"} if is_base_model else batch
+            output = model(**inputs)
+            if is_base_model:
+                assert full_model is not None
+                return full_model.lm_head(output.last_hidden_state)
+            return output.logits
 
-        else:
-            raise ValueError(
-                f"Invalid auto_quantize_method: {auto_quantize_method}. Must be 'gradient' or 'kl_div'"
-            )
+    else:
+        raise ValueError(
+            f"Invalid auto_quantize_method: {auto_quantize_method}. Must be 'gradient' or 'kl_div'"
+        )
 
     language_model, _ = mtq.auto_quantize(
         language_model,

--- a/modelopt/torch/export/layer_utils.py
+++ b/modelopt/torch/export/layer_utils.py
@@ -315,7 +315,14 @@ def is_moe(module: nn.Module) -> bool:
     if name.endswith("sparsemoeblock") or "moelayer" in name:
         return True
     # Explicit matches for non-standard naming
-    return any(key in name for key in ["arcticmoe", "deepseekmoe", "dbrxffn", "nemotronhmoe"])
+    if any(key in name for key in ["arcticmoe", "deepseekmoe", "dbrxffn", "nemotronhmoe"]):
+        return True
+    # Structural detection: modules with router + experts (e.g. Gemma4TextDecoderLayer)
+    return (
+        hasattr(module, "router")
+        and hasattr(module, "experts")
+        and isinstance(module.experts, nn.Module)
+    )
 
 
 def is_quantlinear(module: nn.Module) -> bool:
@@ -1007,6 +1014,9 @@ def get_expert_linear_names(module: nn.Module) -> list[str]:
     elif module_match_name_list(module, ["NemotronHMOE"]):
         # NemotronHMOE experts (NemotronHMLP) use up_proj and down_proj only (no gate).
         return ["up_proj", "down_proj"]
+    elif module_match_name_list(module, ["Gemma4TextDecoderLayer"]):
+        # Gemma4 MoE experts are unfused into per-expert nn.Linear layers
+        return ["gate_proj", "down_proj", "up_proj"]
     else:
         # assuming w1, w2, w3 by default
         return ["w1", "w2", "w3"]

--- a/modelopt/torch/export/layer_utils.py
+++ b/modelopt/torch/export/layer_utils.py
@@ -108,6 +108,8 @@ def get_experts_list(
         linear_names = ["gate_proj", "down_proj", "up_proj"]
     elif "nemotronhforcausallm" in model_type:
         linear_names = ["up_proj", "down_proj"]
+    elif "gemma4" in model_type:
+        linear_names = ["gate_proj", "down_proj", "up_proj"]
     else:
         raise NotImplementedError(f" {model_type} not supported")
 

--- a/modelopt/torch/quantization/config.py
+++ b/modelopt/torch/quantization/config.py
@@ -799,8 +799,8 @@ MXFP4_MLP_WEIGHT_ONLY_CFG = {
 NVFP4_MLP_WEIGHT_ONLY_CFG = _nvfp4_selective_quant_cfg(
     ["*mlp*", "*block_sparse_moe*"], quantizer=_nvfp4_cfg_bs32, weight_only=True
 )
-NVFP4_EXPERTS_ONLY_CFG = _nvfp4_selective_quant_cfg(["*mlp.experts*", "*block_sparse_moe*"])
-NVFP4_MLP_ONLY_CFG = _nvfp4_selective_quant_cfg(["*mlp*", "*block_sparse_moe*"])
+NVFP4_EXPERTS_ONLY_CFG = _nvfp4_selective_quant_cfg(["*mlp.experts*", "*block_sparse_moe*", "*.experts.*"])
+NVFP4_MLP_ONLY_CFG = _nvfp4_selective_quant_cfg(["*mlp*", "*block_sparse_moe*", "*.experts.*"])
 NVFP4_OMLP_ONLY_CFG = _nvfp4_selective_quant_cfg(["*o_proj*", "*mlp*", "*block_sparse_moe*"])
 
 # DO NOT ADD NEW CONFIGS HERE. If you want to add a new general recipe, add it to

--- a/modelopt/torch/quantization/config.py
+++ b/modelopt/torch/quantization/config.py
@@ -799,7 +799,9 @@ MXFP4_MLP_WEIGHT_ONLY_CFG = {
 NVFP4_MLP_WEIGHT_ONLY_CFG = _nvfp4_selective_quant_cfg(
     ["*mlp*", "*block_sparse_moe*"], quantizer=_nvfp4_cfg_bs32, weight_only=True
 )
-NVFP4_EXPERTS_ONLY_CFG = _nvfp4_selective_quant_cfg(["*mlp.experts*", "*block_sparse_moe*", "*.experts.*"])
+NVFP4_EXPERTS_ONLY_CFG = _nvfp4_selective_quant_cfg(
+    ["*mlp.experts*", "*block_sparse_moe*", "*.experts.*"]
+)
 NVFP4_MLP_ONLY_CFG = _nvfp4_selective_quant_cfg(["*mlp*", "*block_sparse_moe*", "*.experts.*"])
 NVFP4_OMLP_ONLY_CFG = _nvfp4_selective_quant_cfg(["*o_proj*", "*mlp*", "*block_sparse_moe*"])
 

--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -1230,8 +1230,6 @@ except ImportError:
     pass
 
 
-
-
 class _QuantGptOssExperts(_QuantFunctionalMixin):
     """Quantized wrapper for `transformers.GptOssExperts`.
 

--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -1230,6 +1230,8 @@ except ImportError:
     pass
 
 
+
+
 class _QuantGptOssExperts(_QuantFunctionalMixin):
     """Quantized wrapper for `transformers.GptOssExperts`.
 

--- a/modelopt_recipes/general/ptq/nvfp4_mlp_only-fp8_kv.yaml
+++ b/modelopt_recipes/general/ptq/nvfp4_mlp_only-fp8_kv.yaml
@@ -53,6 +53,22 @@ quantize:
           type: dynamic
           scale_bits: e4m3
         num_bits: e2m1
+    - quantizer_name: '*.experts.*weight_quantizer'
+      enable: true
+      cfg:
+        block_sizes:
+          -1: 16
+          type: dynamic
+          scale_bits: e4m3
+        num_bits: e2m1
+    - quantizer_name: '*.experts.*input_quantizer'
+      enable: true
+      cfg:
+        block_sizes:
+          -1: 16
+          type: dynamic
+          scale_bits: e4m3
+        num_bits: e2m1
     - quantizer_name: '*[kv]_bmm_quantizer'
       enable: true
       cfg:

--- a/tests/unit/torch/export/test_layer_utils.py
+++ b/tests/unit/torch/export/test_layer_utils.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for modelopt.torch.export.layer_utils — MoE detection and expert naming."""
+
+import pytest
+import torch.nn as nn
+
+from modelopt.torch.export.layer_utils import get_expert_linear_names, is_moe
+
+# ---------------------------------------------------------------------------
+# is_moe tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeSparseMoeBlock(nn.Module):
+    """Name ends with 'sparsemoeblock' — detected by naming convention."""
+
+
+class _FakeMoeLayer(nn.Module):
+    """Name contains 'moelayer' — detected by naming convention."""
+
+
+class _FakeArcticMoe(nn.Module):
+    """Name contains 'arcticmoe' — detected by explicit match."""
+
+
+class _StructuralMoeModule(nn.Module):
+    """Has router + experts attributes — detected by structural check."""
+
+    def __init__(self):
+        super().__init__()
+        self.router = nn.Linear(8, 4)
+        self.experts = nn.ModuleList([nn.Linear(8, 8) for _ in range(4)])
+
+
+class _NotMoeModule(nn.Module):
+    """Plain module — should NOT be classified as MoE."""
+
+    def __init__(self):
+        super().__init__()
+        self.fc = nn.Linear(8, 8)
+
+
+class _PartialStructuralModule(nn.Module):
+    """Has router but no experts — should NOT be classified as MoE."""
+
+    def __init__(self):
+        super().__init__()
+        self.router = nn.Linear(8, 4)
+
+
+@pytest.mark.parametrize(
+    "module_cls",
+    [_FakeSparseMoeBlock, _FakeMoeLayer, _FakeArcticMoe],
+)
+def test_is_moe_name_based(module_cls):
+    assert is_moe(module_cls())
+
+
+def test_is_moe_structural():
+    assert is_moe(_StructuralMoeModule())
+
+
+def test_is_moe_negative():
+    assert not is_moe(_NotMoeModule())
+
+
+def test_is_moe_partial_structural():
+    assert not is_moe(_PartialStructuralModule())
+
+
+# ---------------------------------------------------------------------------
+# get_expert_linear_names tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeGemma4TextDecoderLayer(nn.Module):
+    pass
+
+
+class _FakeMixtralSparseMoeBlock(nn.Module):
+    pass
+
+
+class _FakeNemotronHMOE(nn.Module):
+    pass
+
+
+def test_get_expert_linear_names_gemma4():
+    assert get_expert_linear_names(_FakeGemma4TextDecoderLayer()) == [
+        "gate_proj",
+        "down_proj",
+        "up_proj",
+    ]
+
+
+def test_get_expert_linear_names_mixtral():
+    assert get_expert_linear_names(_FakeMixtralSparseMoeBlock()) == ["w1", "w2", "w3"]
+
+
+def test_get_expert_linear_names_nemotron():
+    assert get_expert_linear_names(_FakeNemotronHMOE()) == ["up_proj", "down_proj"]


### PR DESCRIPTION
## Summary
- Register `Gemma4TextExperts` with `_QuantQwen35MoeExperts` plugin to unfuse fused 3D expert tensors into per-expert `nn.Linear` layers for quantization
- Add structural `is_moe()` detection for modules with `router` + `experts` attributes (Gemma4 has no dedicated `SparseMoeBlock` class — the decoder layer directly owns `router` and `experts`)
- Add `Gemma4TextDecoderLayer` to `get_expert_linear_names()` returning `["gate_proj", "down_proj", "up_proj"]`
- Add `"*.experts.*"` pattern to `NVFP4_MLP_ONLY_CFG` and `NVFP4_EXPERTS_ONLY_CFG` to match Gemma4's expert path (`model.layers.X.experts.*`, not nested under `mlp`)

**Context:** Gemma4 MoE models (e.g. `google/gemma-4-26B-A4B-it`) store expert weights as fused 3D `nn.Parameter` tensors (`gate_up_proj`, `down_proj`) instead of `nn.ModuleList` of `nn.Linear`. Since ModelOpt's quantizer only discovers `nn.Linear` modules, it silently skips the expert weights — the bulk of the model remains unquantized.

**Companion vLLM PR:** https://github.com/vllm-project/vllm/pull/39406 (robust quantized MoE weight loading for Gemma4)

## Test plan
- [x] `hf_ptq.py --pyt_ckpt_path google/gemma-4-26B-A4B-it --qformat nvfp4_mlp_only` — 35k+ quantizers inserted, 17GB output (vs 49GB BF16)
- [x] `vllm serve <path> --quantization modelopt` — loads and serves successfully
- [x] Text generation: correct ("The capital of France is **Paris**.")
- [x] Vision: correct (describes image content accurately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support quantizing models with separate base/full components (handles heads present only on the full model)
  * Enhanced Mixture-of-Experts detection and explicit support for Gemma4 expert layer layouts
  * Extended NVFP4 selective quantization presets and recipes to include expert-layer patterns and enable FP8 for expert modules

* **Bug Fixes**
  * Improved loss/logit handling and clearer errors for unsupported quantization methods
<!-- end of auto-generated comment: release notes by coderabbit.ai -->