### PR TITLE
Improve Megatron Tokenization: streaming, reasoning_content support, HF in-memory tokenization, etc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Changelog
 - [Security] Changed the default of ``weights_only`` to ``True`` in ``torch.load`` for secure checkpoint loading. If you need to load a checkpoint that requires unpickling arbitrary objects, first register the class in ``torch.serialization.add_safe_globals([cls])`` before loading. Added :meth:`safe_save <modelopt.torch.utils.serialization.safe_save>` and :meth:`safe_load <modelopt.torch.utils.serialization.safe_load>` API to save and load checkpoints securely.
 - Bump minimum required PyTorch version to 2.8.
 - [Experimental] Add support for transformers>=5.0. Unified Hugging Face checkpoint export for quantized checkpoints may not work for MoE models with transformers>=5.0 yet.
+- Improve ``megatron_preprocess_data``: add ``--reasoning_content`` support for Nemotron v3 datasets, eliminate intermediate JSONL for HuggingFace datasets, and return output file prefixes from the Python API to directly pass to Megatron-Bridge or Megatron-LM training or distillation scripts.
 
 0.43 (2026-04-09)
 ^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,7 @@ Changelog
 - [Security] Changed the default of ``weights_only`` to ``True`` in ``torch.load`` for secure checkpoint loading. If you need to load a checkpoint that requires unpickling arbitrary objects, first register the class in ``torch.serialization.add_safe_globals([cls])`` before loading. Added :meth:`safe_save <modelopt.torch.utils.serialization.safe_save>` and :meth:`safe_load <modelopt.torch.utils.serialization.safe_load>` API to save and load checkpoints securely.
 - Bump minimum required PyTorch version to 2.8.
 - [Experimental] Add support for transformers>=5.0. Unified Hugging Face checkpoint export for quantized checkpoints may not work for MoE models with transformers>=5.0 yet.
-- Improve ``megatron_preprocess_data``: add ``--reasoning_content`` support for Nemotron v3 datasets, eliminate intermediate JSONL for HuggingFace datasets, return output file prefixes from the Python API, add gzip input support (``.jsonl.gz``), and add ``--strip_newlines`` flag to replace newlines with spaces for plain-text pretraining data.
+- Improve ``megatron_preprocess_data``: add ``--reasoning_content`` support for Nemotron v3 datasets, eliminate intermediate JSONL for HuggingFace datasets, return output file prefixes from the Python API, add gzip input support (``.jsonl.gz``), add ``--strip_newlines`` flag for plain-text pretraining data, add ``--hf_streaming`` for very large datasets (only consumed rows downloaded), and auto-shuffle when ``--hf_max_samples_per_split`` is set to avoid biased sampling.
 
 0.43 (2026-04-09)
 ^^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,7 @@ Changelog
 - [Security] Changed the default of ``weights_only`` to ``True`` in ``torch.load`` for secure checkpoint loading. If you need to load a checkpoint that requires unpickling arbitrary objects, first register the class in ``torch.serialization.add_safe_globals([cls])`` before loading. Added :meth:`safe_save <modelopt.torch.utils.serialization.safe_save>` and :meth:`safe_load <modelopt.torch.utils.serialization.safe_load>` API to save and load checkpoints securely.
 - Bump minimum required PyTorch version to 2.8.
 - [Experimental] Add support for transformers>=5.0. Unified Hugging Face checkpoint export for quantized checkpoints may not work for MoE models with transformers>=5.0 yet.
-- Improve ``megatron_preprocess_data``: add ``--reasoning_content`` support for Nemotron v3 datasets, eliminate intermediate JSONL for HuggingFace datasets, and return output file prefixes from the Python API to directly pass to Megatron-Bridge or Megatron-LM training or distillation scripts.
+- Improve ``megatron_preprocess_data``: add ``--reasoning_content`` support for Nemotron v3 datasets, eliminate intermediate JSONL for HuggingFace datasets, return output file prefixes from the Python API, add gzip input support (``.jsonl.gz``), and add ``--strip_newlines`` flag to replace newlines with spaces for plain-text pretraining data.
 
 0.43 (2026-04-09)
 ^^^^^^^^^^^^^^^^^

--- a/examples/dataset/README.md
+++ b/examples/dataset/README.md
@@ -140,12 +140,17 @@ In `generate` mode, assistant turns are stripped so the row ends with a user tur
 
 ## Tokenizing for Megatron Frameworks
 
-The distillation and pre-training scripts in Megatron-Bridge or Megatron-LM expect data pre-tokenized in Megatron's binary indexed format (`.bin` / `.idx`).  Use the `megatron_preprocess_data` utility to tokenize any JSONL or Hugging Face dataset. Below tokenization scripts prints the list of output prefixes (e.g. `tokenized_qwen3/data1_text`) that you can use for `data_paths` argument (with relative weights on different files) in megatron training scripts.
+The distillation and pre-training scripts in Megatron-Bridge or Megatron-LM expect data pre-tokenized in Megatron's binary indexed format (`.bin` / `.idx`).
+Use the `megatron_preprocess_data` utility to tokenize any JSONL or Hugging Face dataset.
+The tokenization scripts below prints the list of output prefixes (e.g. `tokenized_qwen3/data1_text`) that you can use for the `data_paths` argument (with relative weights on different files) in Megatron training scripts.
+
+**Important Notes:**
+
+- For Pretraining / raw-text data (`text` key) — use `--append_eod` so Megatron can tell where documents end when concatenating them into long sequences.
+- For Post-training chat data (`messages` key) — omit `--append_eod`; the chat template already appends EOS at the end of each conversation.
+- Set `--max_sequence_length 256_000` to avoid rare OOM errors if some text is very long.
 
 ### From JSONL files
-
-For **Pretraining / raw-text data** (`text` key) — use `--append_eod` so Megatron can tell where
-documents end when concatenating them into long sequences:
 
 ```bash
 python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
@@ -157,9 +162,6 @@ python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
     --append_eod
 ```
 
-For **Post-training chat data** (`messages` key) — omit `--append_eod`; the chat template already
-appends EOS at the end of each conversation:
-
 ```bash
 python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
     --jsonl_paths /path/to/sft_data.jsonl \
@@ -170,9 +172,6 @@ python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
 ```
 
 Instead of `--jsonl_paths`, pass `--input_dir /path/to/dir` to tokenize all JSONL files in a directory (`.jsonl` and `.jsonl.gz` are both supported).
-Set `--max_sequence_length 256_000` to avoid rare OOM errors if some text is very long.
-
-For **plain prose / pretraining text** (non-coding pretraining data) where newlines are not meaningful, add `--strip_newlines` to replace them with spaces before tokenization.
 
 ### From Hugging Face Hub
 
@@ -188,12 +187,17 @@ python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
     --tokenizer Qwen/Qwen3-0.6B \
     --output_dir tokenized_qwen3 \
     --workers 32 \
-    --max_sequence_length 256_000 \
     --append_eod
 ```
 
 Omit `--hf_name` to process all subsets, `--hf_split` for all splits, or `--hf_max_samples_per_split` for all samples.
 To quickly test, use [nvidia/Nemotron-Pretraining-Dataset-sample](https://huggingface.co/datasets/nvidia/Nemotron-Pretraining-Dataset-sample).
+
+For **very large datasets** (tens of millions of documents), add `--hf_streaming --hf_max_samples_per_split <num_samples>` to avoid downloading the full dataset — only the rows actually consumed are fetched.
+
+> **Performance note:** Non-streaming mode downloads all Parquet shards once and caches them as Arrow files on disk.
+> Re-runs read from cache and are much faster.
+> Streaming re-downloads on every run with no cache, so it is slower for full-dataset processing.
 
 ### Nemotron Post-Training v3 (`reasoning_content`)
 

--- a/examples/dataset/README.md
+++ b/examples/dataset/README.md
@@ -1,4 +1,15 @@
-# Dataset Preparation Scripts
+# Dataset Preparation
+
+<div align="center">
+
+| **Section** | **Description** | **Link** |
+| :------------: | :------------: | :------------: |
+| Building Chat Datasets | Scripts to build conversation datasets from Nemotron and other HuggingFace sources | \[[Link](#building-chat-datasets)\] |
+| Tokenizing for Megatron Frameworks | Convert JSONL or HF datasets to Megatron binary format for distillation and pre-training | \[[Link](#tokenizing-for-megatron-frameworks)\] |
+
+</div>
+
+## Building Chat Datasets
 
 Utilities for building conversation datasets from NVIDIA Nemotron Post-Training
 collections and other HuggingFace sources.  These scripts produce datasets in
@@ -6,10 +17,10 @@ collections and other HuggingFace sources.  These scripts produce datasets in
 and can be used for any downstream fine-tuning task — SFT, distillation,
 speculative decoding draft-model training, etc.
 
-## Files
+### Files
 
 | File | Description |
-|---|---|
+| --- | --- |
 | `make_nemotron_ptv3_dataset.py` | Build a dataset from the [Nemotron PT v3 collection](https://huggingface.co/collections/nvidia/nemotron-post-training-v3) using a configurable YAML mix |
 | `make_nemotron_ptv2_dataset.py` | Build a dataset from [Nemotron-Post-Training-Dataset-v2](https://huggingface.co/datasets/nvidia/Nemotron-Post-Training-Dataset-v2) |
 | `make_dataset.py` | General-purpose mixer for arbitrary HuggingFace datasets (mtbench, sharegpt, ultrachat, magpie, etc.) |
@@ -19,16 +30,16 @@ speculative decoding draft-model training, etc.
 | `nemotron_ptv3_datasets.yaml` | Dataset mix config for `make_nemotron_ptv3_dataset.py` |
 | `example_data_config.yaml` | Example YAML config for `make_dataset.py` |
 
-## Quick Start
+### Quick Start
 
-### Install dependencies
+#### Install dependencies
 
 ```bash
-pip install datasets huggingface_hub pyyaml
-huggingface-cli login   # required for gated datasets
-```text
+pip install nvidia-modelopt[hf]
+hf auth login --token <your token> # required for gated datasets
+```
 
-### Build a Nemotron PT v3 dataset
+#### Build a Nemotron PT v3 dataset
 
 ```bash
 # Synthetic data generation inputs (strips last assistant turn so a model can regenerate it)
@@ -39,45 +50,45 @@ python make_nemotron_ptv3_dataset.py --mode train --output-dir /tmp/ptv3_train
 
 # Use a custom dataset mix
 python make_nemotron_ptv3_dataset.py --config my_mix.yaml --output-dir /tmp/ptv3_custom
-```text
+```
 
-### Build a Nemotron PT v2 dataset
+#### Build a Nemotron PT v2 dataset
 
 ```bash
 python make_nemotron_ptv2_dataset.py --output-dir /tmp/ptv2_gen
 python make_nemotron_ptv2_dataset.py --mode train --output-dir /tmp/ptv2_train
-```text
+```
 
-### Build a general-purpose mixed dataset
+#### Build a general-purpose mixed dataset
 
 ```bash
 python make_dataset.py --config example_data_config.yaml --output-dir /tmp/mixed
-```text
+```
 
-## Dataset Modes
+### Dataset Modes
 
 Both `make_nemotron_pt*.py` scripts support two modes:
 
 | Mode | Description | Use case |
-|---|---|---|
+| --- | --- | --- |
 | `generate` (default) | Strips assistant turns, optionally augments prompts | Input data for synthetic generation (query a target model to produce training responses) |
 | `train` | Keeps all turns, normalizes to clean OpenAI format | Direct SFT / distillation training |
 
-## Synthetic Generation Pipeline
+### Synthetic Generation Pipeline
 
 The `generate` mode produces conversation skeletons that are fed to a target model
 via `tools/launcher/common/query.py` (vLLM or TRT-LLM).  The output becomes training
 data for a draft model (e.g. EAGLE3 speculative decoding) or a distilled student:
 
-```text
+```bash
 make_nemotron_ptv3_dataset.py --mode generate  →  skeleton.jsonl
         ↓
 query.py  (target model generates responses turn-by-turn)
         ↓
 training data for draft model / student
-```text
+```
 
-## Augmentations
+### Augmentations
 
 `augmentations.yaml` defines language-redirect and style-hint variants that are
 applied cyclically across the dataset.  Each enabled entry produces one augmented
@@ -95,9 +106,9 @@ augmentations:
   - type: system_prompt
     content: "You are a helpful assistant."
     enabled: false   # disable without deleting
-```text
+```
 
-## Dataset Mix Config (`nemotron_ptv3_datasets.yaml`)
+### Dataset Mix Config (`nemotron_ptv3_datasets.yaml`)
 
 Edit this file to add, remove, or re-weight datasets without touching the script:
 
@@ -111,9 +122,9 @@ datasets:
   - repo_id: nvidia/OpenMathReasoning-mini
     splits: [train]
     augment: false   # multilingual — skip language-redirect augmentation
-```text
+```
 
-## Output Format
+### Output Format
 
 Every output row is a JSONL object with a single `messages` key:
 
@@ -123,6 +134,82 @@ Every output row is a JSONL object with a single `messages` key:
   {"role": "user",      "content": "What is 2+2?"},
   {"role": "assistant", "content": "4"}
 ]}
-```text
+```
 
 In `generate` mode, assistant turns are stripped so the row ends with a user turn.
+
+## Tokenizing for Megatron Frameworks
+
+The distillation and pre-training scripts in Megatron-Bridge or Megatron-LM expect data pre-tokenized in Megatron's binary indexed format (`.bin` / `.idx`).  Use the `megatron_preprocess_data` utility to tokenize any JSONL or Hugging Face dataset. Below tokenization scripts prints the list of output prefixes (e.g. `tokenized_qwen3/data1_text`) that you can use for `data_paths` argument (with relative weights on differnt files) in megatron training scripts.
+
+### From JSONL files
+
+For **Pretraining / raw-text data** (`text` key) — use `--append_eod` so Megatron can tell where
+documents end when concatenating them into long sequences:
+
+```bash
+python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
+    --jsonl_paths /path/to/data1.jsonl /path/to/data2.jsonl ... \
+    --json_keys text \
+    --tokenizer Qwen/Qwen3-0.6B \
+    --output_dir tokenized_qwen3 \
+    --workers 32 \
+    --append_eod
+```
+
+For **Post-training chat data** (`messages` key) — omit `--append_eod`; the chat template already
+appends EOS at the end of each conversation:
+
+```bash
+python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
+    --jsonl_paths /path/to/sft_data.jsonl \
+    --json_keys messages \
+    --tokenizer Qwen/Qwen3-0.6B \
+    --output_dir tokenized_qwen3 \
+    --workers 32
+```
+
+Instead of `--jsonl_paths`, pass `--input_dir /path/to/dir` to tokenize all JSONL files in a directory.
+Set `--max_sequence_length 256_000` to avoid rare OOM errors if some text is very long.
+
+### From Hugging Face Hub
+
+To tokenize a dataset directly from Hugging Face Hub:
+
+```bash
+python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
+    --hf_dataset nvidia/Nemotron-Pretraining-SFT-v1 \
+    --hf_name Nemotron-SFT-Code \
+    --hf_split train \
+    --hf_max_samples_per_split 10_000_000 \
+    --json_keys text \
+    --tokenizer Qwen/Qwen3-0.6B \
+    --output_dir tokenized_qwen3 \
+    --workers 32 \
+    --max_sequence_length 256_000 \
+    --append_eod
+```
+
+Omit `--hf_name` to process all subsets, `--hf_split` for all splits, or `--hf_max_samples_per_split` for all samples.
+To quickly test, use [nvidia/Nemotron-Pretraining-Dataset-sample](https://huggingface.co/datasets/nvidia/Nemotron-Pretraining-Dataset-sample).
+
+### Nemotron Post-Training v3 (`reasoning_content`)
+
+v3 datasets include a `reasoning_content` field in assistant messages (chain-of-thought separate from
+the final answer). Use `--reasoning_content` to control how it is handled:
+
+| Value | Behaviour |
+| --- | --- |
+| `strip` (default) | Field is discarded before `apply_chat_template`. Safe for any tokenizer. |
+| `inline` | Wrapped as `<think>…</think>` and prepended to `content`. Preserves reasoning in a tokenizer-agnostic way. |
+| `native` | Passed unchanged. Requires the tokenizer's chat template to handle the field (e.g. Qwen3). |
+
+```bash
+python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
+    --hf_dataset nvidia/Nemotron-Post-Training-Dataset-v3 \
+    --json_keys messages \
+    --tokenizer Qwen/Qwen3-0.6B \
+    --output_dir tokenized_qwen3 \
+    --workers 32 \
+    --reasoning_content inline
+```

--- a/examples/dataset/README.md
+++ b/examples/dataset/README.md
@@ -140,7 +140,7 @@ In `generate` mode, assistant turns are stripped so the row ends with a user tur
 
 ## Tokenizing for Megatron Frameworks
 
-The distillation and pre-training scripts in Megatron-Bridge or Megatron-LM expect data pre-tokenized in Megatron's binary indexed format (`.bin` / `.idx`).  Use the `megatron_preprocess_data` utility to tokenize any JSONL or Hugging Face dataset. Below tokenization scripts prints the list of output prefixes (e.g. `tokenized_qwen3/data1_text`) that you can use for `data_paths` argument (with relative weights on differnt files) in megatron training scripts.
+The distillation and pre-training scripts in Megatron-Bridge or Megatron-LM expect data pre-tokenized in Megatron's binary indexed format (`.bin` / `.idx`).  Use the `megatron_preprocess_data` utility to tokenize any JSONL or Hugging Face dataset. Below tokenization scripts prints the list of output prefixes (e.g. `tokenized_qwen3/data1_text`) that you can use for `data_paths` argument (with relative weights on different files) in megatron training scripts.
 
 ### From JSONL files
 
@@ -169,8 +169,10 @@ python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
     --workers 32
 ```
 
-Instead of `--jsonl_paths`, pass `--input_dir /path/to/dir` to tokenize all JSONL files in a directory.
+Instead of `--jsonl_paths`, pass `--input_dir /path/to/dir` to tokenize all JSONL files in a directory (`.jsonl` and `.jsonl.gz` are both supported).
 Set `--max_sequence_length 256_000` to avoid rare OOM errors if some text is very long.
+
+For **plain prose / pretraining text** (non-coding pretraining data) where newlines are not meaningful, add `--strip_newlines` to replace them with spaces before tokenization.
 
 ### From Hugging Face Hub
 

--- a/examples/megatron_bridge/README.md
+++ b/examples/megatron_bridge/README.md
@@ -98,44 +98,8 @@ The [distill.py](distill.py) script loads student and teacher models from Huggin
 
 The distillation script expects pre-tokenized data in Megatron's binary format (`.bin` / `.idx` files).
 
-You can tokenize your JSONL datasets using the following command:
-
-```bash
-python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
-    --jsonl_paths /path/to/data1.jsonl /path/to/data2.jsonl ... \
-    --json_keys text \
-    --tokenizer Qwen/Qwen3-0.6B \
-    --output_dir tokenized_qwen3 \
-    --workers 32 \
-    --max_sequence_length 256_000
-```
-
-This will create `tokenized_qwen3/data1_text_document.{bin,idx}` and `tokenized_qwen3/data2_text_document.{bin,idx}` files. We can use these files in the distillation script by passing `--data_paths 1.0 tokenized_qwen3/data1_text_document 1.0 tokenized_qwen3/data2_text_document` (equal weight for both datasets).
-
-Instead of `--jsonl_paths`, you can also pass a directory path to the `--input_dir` argument to tokenize all JSONL files in the directory.
-We are setting a maximum sequence length of 256k to avoid rare OOM errors in tokenization if text is too long.
-
-If you want to download and tokenize a dataset from Hugging Face Hub directly, you can use the following command:
-
-```bash
-python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
-    --hf_dataset nvidia/Nemotron-Pretraining-SFT-v1 \
-    --hf_name Nemotron-SFT-General \
-    --hf_split train \
-    --hf_max_samples_per_split 10_000_000 \
-    --json_keys text \
-    --tokenizer Qwen/Qwen3-0.6B \
-    --output_dir tokenized_qwen3 \
-    --workers 32 \
-    --max_sequence_length 256_000
-```
-
-The [Nemotron-Pretraining-SFT-v1](https://huggingface.co/datasets/nvidia/Nemotron-Pretraining-SFT-v1) dataset is huge, so it will take a few hours to download and tokenize. You can also split the large `.jsonl` into multiple files (e.g. 10M samples per file using `split -l 10000000 -d --additional-suffix=.jsonl <file>.jsonl <file>_part`) and tokenize them parallelly via the `--jsonl_paths` argument.
-To quickly test the script, you can try the [nvidia/Nemotron-Pretraining-Dataset-sample](https://huggingface.co/datasets/nvidia/Nemotron-Pretraining-Dataset-sample) dataset.
-
-If you skip `--hf_name`, it will download and tokenize all subsets for the dataset.
-If you skip `--hf_split`, it will download and tokenize all splits for the subset.
-If you skip `--hf_max_samples_per_split`, it will download and tokenize all samples for the split.
+See the **[Dataset Preparation README](../dataset/README.md#tokenizing-for-megatron-frameworks)**
+for full instructions on tokenizing JSONL files and Hugging Face datasets and get the list of output prefixes that you can use for `--data_paths` argument.
 
 ### Distillation with Real Data
 

--- a/modelopt/torch/utils/dataset_utils.py
+++ b/modelopt/torch/utils/dataset_utils.py
@@ -690,7 +690,7 @@ def download_hf_dataset_as_jsonl(
     output_dir: str | Path,
     json_keys: str | list[str] = ["text"],
     name: str | None = None,
-    split: str | None = "train",
+    split: str | None = None,
     max_samples_per_split: int | None = None,
     num_proc: int | None = None,
 ) -> list[str]:
@@ -701,7 +701,7 @@ def download_hf_dataset_as_jsonl(
         output_dir: Directory to save the JSONL files
         json_keys: Key or list of keys to extract from the dataset. Defaults to ["text"].
         name: Name of the subset to download
-        split: Split of the dataset to download. Defaults to "train".
+        split: Split of the dataset to download. Defaults to None (all splits).
         max_samples_per_split: Maximum number of samples to download per split. Defaults to None.
         num_proc: Number of processes to use for parallel processing. Defaults to None.
 
@@ -744,7 +744,6 @@ def download_hf_dataset_as_jsonl(
         print(f"\t{entry}")
 
     for entry in splits_to_process:
-        skip_processing = False
         path = entry["dataset"]
         name = entry.get("config", None)
         split = entry["split"]
@@ -761,12 +760,9 @@ def download_hf_dataset_as_jsonl(
 
         for key in json_keys:
             if key not in ds.features:
-                warn(f"[SKIP] {key=} not found in {ds.features=}")
-                skip_processing = True
-                break
-
-        if skip_processing:
-            continue
+                raise KeyError(
+                    f"{key=} not found in dataset features. Available: {list(ds.features)}"
+                )
 
         print(f"Saving raw dataset to {jsonl_file_path}")
         ds.to_json(jsonl_file_path, num_proc=num_proc)

--- a/modelopt/torch/utils/plugins/megatron_preprocess_data.py
+++ b/modelopt/torch/utils/plugins/megatron_preprocess_data.py
@@ -72,6 +72,7 @@ If you skip --hf_split, it will download and tokenize all splits for the subset.
 """
 
 import argparse
+import gzip
 import json
 import multiprocessing
 from pathlib import Path
@@ -107,6 +108,7 @@ class _Encoder:
         append_eod: bool,
         max_sequence_length: int | None,
         reasoning_content: str = "strip",
+        strip_newlines: bool = False,
     ):
         self.tokenizer_name_or_path = tokenizer_name_or_path
         self.json_keys = json_keys
@@ -116,6 +118,7 @@ class _Encoder:
             max_sequence_length * 8 if max_sequence_length is not None else None
         )
         self.reasoning_content = reasoning_content
+        self.strip_newlines = strip_newlines
         print(f"Setting max document length: {self.max_document_length}")
         print(f"reasoning_content mode: {self.reasoning_content}")
 
@@ -174,7 +177,7 @@ class _Encoder:
                 # chat template already embeds all special tokens; don't add BOS again
                 add_special_tokens = False
             else:
-                text = value
+                text = value.replace("\n", " ") if self.strip_newlines else value
                 add_special_tokens = True
 
             # Truncate text by character length if specified
@@ -220,11 +223,16 @@ class _Partition:
     def process_json_file(
         self, input_file_name: str | Path, output_dir: str | Path, encoder: _Encoder
     ) -> tuple[int, list[str]]:
-        output_prefix = Path(output_dir) / Path(input_file_name).stem
+        input_path = Path(input_file_name)
+        stem = input_path.stem if input_path.suffix != ".gz" else Path(input_path.stem).stem
+        output_prefix = Path(output_dir) / stem
         prefixes = [f"{output_prefix}_{key}" for key in self.json_keys]
 
         print(f"\nOpening {input_file_name}")
-        fin = open(input_file_name, encoding="utf-8")
+        if input_path.suffix == ".gz":
+            fin = gzip.open(input_path, "rt", encoding="utf-8")
+        else:
+            fin = open(input_path, encoding="utf-8")
 
         pool = multiprocessing.Pool(self.workers, initializer=encoder.initializer)
         encoded_docs = pool.imap(encoder.encode, fin, 32)
@@ -347,7 +355,8 @@ def _enumerate_hf_splits(
     else:
         try:
             configs = get_dataset_config_names(dataset_name)
-        except Exception:
+        except (FileNotFoundError, ConnectionError) as e:
+            print(f"[WARN] Could not find configs for dataset '{dataset_name}': {e}")
             configs = [None]
 
     result: list[tuple[str | None, str]] = []
@@ -377,6 +386,7 @@ def megatron_preprocess_data(
     workers: int = 1,
     log_interval: int = 100000,
     reasoning_content: str = "strip",
+    strip_newlines: bool = False,
 ):
     """Process large data for pretraining.
 
@@ -402,6 +412,9 @@ def megatron_preprocess_data(
             ``"strip"`` (default) — remove before applying chat template (safe for any tokenizer);
             ``"inline"`` — wrap in ``<think>…</think>`` and prepend to ``content``;
             ``"native"`` — pass unchanged, requires the tokenizer chat template to handle it.
+        strip_newlines: Replace newlines with spaces in plain-text values before tokenization.
+            Defaults to False (newlines are preserved, matching prior behaviour). Has no effect
+            on chat-template encoded values.
 
     Returns:
         List of output file prefixes (one per json_key per split/file, without ``.bin``/``.idx``
@@ -419,7 +432,12 @@ def megatron_preprocess_data(
     vocab_size = AutoTokenizer.from_pretrained(tokenizer_name_or_path).vocab_size
 
     encoder = _Encoder(
-        tokenizer_name_or_path, json_keys, append_eod, max_sequence_length, reasoning_content
+        tokenizer_name_or_path,
+        json_keys,
+        append_eod,
+        max_sequence_length,
+        reasoning_content,
+        strip_newlines,
     )
     partition = _Partition(vocab_size, json_keys, log_interval, workers)
 
@@ -435,7 +453,9 @@ def megatron_preprocess_data(
             all_prefixes.extend(prefixes)
     else:
         if input_dir is not None:
-            file_names = sorted(Path(input_dir).glob("*.jsonl"))
+            file_names = sorted(
+                [*Path(input_dir).glob("*.jsonl"), *Path(input_dir).glob("*.jsonl.gz")]
+            )
             if not file_names:
                 raise ValueError(f"No JSONL files found in input directory: {input_dir}")
         elif isinstance(jsonl_paths, (str, Path)):
@@ -512,6 +532,15 @@ def main():
             "'native': pass unchanged (requires tokenizer chat template support, e.g. Qwen3)."
         ),
     )
+    parser.add_argument(
+        "--strip_newlines",
+        action="store_true",
+        help=(
+            "Replace newlines with spaces in plain-text values before tokenization. "
+            "By default, newlines are preserved. "
+            "Has no effect on chat-template encoded values."
+        ),
+    )
     args = parser.parse_args()
 
     print("\n==================== Arguments ====================")
@@ -534,6 +563,7 @@ def main():
         workers=args.workers,
         log_interval=args.log_interval,
         reasoning_content=args.reasoning_content,
+        strip_newlines=args.strip_newlines,
     )
 
 

--- a/modelopt/torch/utils/plugins/megatron_preprocess_data.py
+++ b/modelopt/torch/utils/plugins/megatron_preprocess_data.py
@@ -76,13 +76,24 @@ import json
 import multiprocessing
 from pathlib import Path
 
+from datasets import get_dataset_config_names, get_dataset_split_names, load_dataset
 from megatron.core.datasets import indexed_dataset
 from transformers import AutoTokenizer
 
 from modelopt.torch.utils import num2hrb
-from modelopt.torch.utils.dataset_utils import download_hf_dataset_as_jsonl
 
 __all__ = ["megatron_preprocess_data"]
+
+
+def _is_main_or_first_worker() -> bool:
+    """Return True only for the main process or the first pool worker.
+
+    ``multiprocessing.current_process()._identity`` is ``()`` in the main process
+    and ``(N,)`` in the N-th pool worker.  Gating noisy prints on this prevents
+    the same message from appearing once per worker when using many workers.
+    """
+    identity = multiprocessing.current_process()._identity
+    return not identity or identity[0] == 1
 
 
 class _Encoder:
@@ -95,6 +106,7 @@ class _Encoder:
         json_keys: list[str],
         append_eod: bool,
         max_sequence_length: int | None,
+        reasoning_content: str = "strip",
     ):
         self.tokenizer_name_or_path = tokenizer_name_or_path
         self.json_keys = json_keys
@@ -103,11 +115,41 @@ class _Encoder:
         self.max_document_length = (
             max_sequence_length * 8 if max_sequence_length is not None else None
         )
+        self.reasoning_content = reasoning_content
         print(f"Setting max document length: {self.max_document_length}")
+        print(f"reasoning_content mode: {self.reasoning_content}")
 
     def initializer(self):
         # Use Encoder class as a container for global data
         _Encoder.tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name_or_path)
+
+    def _process_messages(self, messages: list[dict]) -> list[dict]:
+        """Handle reasoning_content field in v3 Nemotron datasets.
+
+        Nemotron Post-Training v3 datasets include a ``reasoning_content`` field
+        in assistant messages alongside ``content``. Behaviour is controlled by
+        ``self.reasoning_content``:
+
+        - ``"strip"``  (default): remove the field before calling apply_chat_template.
+          Safe for any tokenizer; reasoning traces are discarded.
+        - ``"inline"``: prepend ``<think>…</think>`` to ``content`` then strip the
+          field. Preserves the reasoning trace in a tokenizer-agnostic way.
+        - ``"native"``: pass messages unchanged; the tokenizer's chat template must
+          handle ``reasoning_content`` itself (e.g. Qwen3).
+        """
+        if self.reasoning_content == "native":
+            return messages
+        processed = []
+        for msg in messages:
+            if "reasoning_content" not in msg:
+                processed.append(msg)
+                continue
+            msg = dict(msg)  # shallow copy — don't mutate the original
+            rc = msg.pop("reasoning_content")
+            if self.reasoning_content == "inline" and rc:
+                msg["content"] = f"<think>\n{rc}\n</think>\n{msg.get('content', '')}"
+            processed.append(msg)
+        return processed
 
     def encode(self, json_line: str):
         data = json.loads(json_line)
@@ -121,25 +163,30 @@ class _Encoder:
             if isinstance(value, list):
                 if key not in _Encoder._chat_template_logged:
                     _Encoder._chat_template_logged.add(key)
-                    print(f"Applying chat_template to '{key}' key")
+                    if _is_main_or_first_worker():
+                        print(f"Applying chat_template to '{key}' key")
                 kwargs = {}
                 tools = data.get("tools")
                 if tools:
                     kwargs["tools"] = tools
+                value = self._process_messages(value)
                 text = _Encoder.tokenizer.apply_chat_template(value, tokenize=False, **kwargs)
+                # chat template already embeds all special tokens; don't add BOS again
+                add_special_tokens = False
             else:
                 text = value
+                add_special_tokens = True
 
             # Truncate text by character length if specified
             if self.max_document_length is not None:
                 original_length = len(text)
                 text = text[: self.max_document_length]
-                if original_length != len(text):
+                if original_length != len(text) and _is_main_or_first_worker():
                     print(f"Document truncated from {original_length} to {len(text)} characters")
             doc_len += len(text)
 
             # Tokenize the entire text as one document
-            encoded = _Encoder.tokenizer.encode(text)
+            encoded = _Encoder.tokenizer.encode(text, add_special_tokens=add_special_tokens)
 
             if self.max_sequence_length is not None:
                 encoded = encoded[: self.max_sequence_length]
@@ -172,8 +219,9 @@ class _Partition:
 
     def process_json_file(
         self, input_file_name: str | Path, output_dir: str | Path, encoder: _Encoder
-    ):
+    ) -> tuple[int, list[str]]:
         output_prefix = Path(output_dir) / Path(input_file_name).stem
+        prefixes = [f"{output_prefix}_{key}" for key in self.json_keys]
 
         print(f"\nOpening {input_file_name}")
         fin = open(input_file_name, encoding="utf-8")
@@ -184,11 +232,10 @@ class _Partition:
         output_bin_files = {}
         output_idx_files = {}
         builders = {}
-        level = "document"
 
         for key in self.json_keys:
-            output_bin_files[key] = "{}_{}_{}.bin".format(output_prefix, key, level)
-            output_idx_files[key] = "{}_{}_{}.idx".format(output_prefix, key, level)
+            output_bin_files[key] = f"{output_prefix}_{key}.bin"
+            output_idx_files[key] = f"{output_prefix}_{key}.idx"
             if Path(output_bin_files[key]).exists() and Path(output_idx_files[key]).exists():
                 continue
             builders[key] = indexed_dataset.IndexedDatasetBuilder(
@@ -198,7 +245,7 @@ class _Partition:
 
         if not builders:
             print(f"\t[SKIP] Output files corresponding to {input_file_name} already exist")
-            return 0
+            return 0, prefixes
 
         total_doc_len, total_enc_len, final_enc_len = 0, 0, 0
         for i, (doc, sentence_lens, (doc_len, enc_len)) in enumerate(encoded_docs, start=1):
@@ -214,7 +261,102 @@ class _Partition:
         for key in builders:
             builders[key].finalize(output_idx_files[key])
 
-        return final_enc_len
+        return final_enc_len, prefixes
+
+    @staticmethod
+    def _iter_hf_as_json(ds):
+        """Yield each row of a HF Dataset as a JSON string, matching JSONL line format."""
+        for row in ds:
+            yield json.dumps(dict(row))
+
+    def process_hf_split(
+        self,
+        output_dir: str | Path,
+        encoder: "_Encoder",
+        dataset_name: str,
+        config: str | None,
+        split: str,
+        max_samples: int | None = None,
+    ) -> tuple[int, list[str]]:
+        """Load a HF dataset split and tokenize directly without writing an intermediate JSONL."""
+        split_arg = f"{split}[:{max_samples}]" if max_samples is not None else split
+        print(f"\nLoading HF dataset {dataset_name=}, {config=}, {split_arg=}")
+        ds = load_dataset(path=dataset_name, name=config, split=split_arg)
+
+        for key in self.json_keys:
+            if key not in ds.features:
+                raise KeyError(
+                    f"{key=} not found in dataset features. Available: {list(ds.features)}"
+                )
+
+        safe_name = dataset_name.replace("/", "--")
+        output_prefix = Path(output_dir) / f"{safe_name}_{config}_{split}"
+        prefixes = [f"{output_prefix}_{key}" for key in self.json_keys]
+
+        output_bin_files = {}
+        output_idx_files = {}
+        builders = {}
+
+        for key in self.json_keys:
+            output_bin_files[key] = f"{output_prefix}_{key}.bin"
+            output_idx_files[key] = f"{output_prefix}_{key}.idx"
+            if Path(output_bin_files[key]).exists() and Path(output_idx_files[key]).exists():
+                continue
+            builders[key] = indexed_dataset.IndexedDatasetBuilder(
+                output_bin_files[key],
+                dtype=indexed_dataset.DType.optimal_dtype(self.vocab_size),
+            )
+
+        if not builders:
+            print(f"\t[SKIP] Output files for {dataset_name} {config}/{split} already exist")
+            return 0, prefixes
+
+        pool = multiprocessing.Pool(self.workers, initializer=encoder.initializer)
+        encoded_docs = pool.imap(encoder.encode, self._iter_hf_as_json(ds), 32)
+
+        total_doc_len, total_enc_len, final_enc_len = 0, 0, 0
+        i = 0
+        for i, (doc, sentence_lens, (doc_len, enc_len)) in enumerate(encoded_docs, start=1):
+            total_doc_len += doc_len
+            total_enc_len += enc_len
+            final_enc_len += sum(sum(sentence_lens[key]) for key in sentence_lens)
+            for key in doc:
+                builders[key].add_document(doc[key], sentence_lens[key])
+            self._print_processing_stats(i, total_doc_len, total_enc_len)
+
+        if i:
+            self._print_processing_stats(i, total_doc_len, total_enc_len, force_print=True)
+
+        pool.close()
+        pool.join()
+        for key in builders:
+            builders[key].finalize(output_idx_files[key])
+
+        return final_enc_len, prefixes
+
+
+def _enumerate_hf_splits(
+    dataset_name: str,
+    name: str | None,
+    split: str | None,
+) -> list[tuple[str | None, str]]:
+    """Return (config, split) pairs to process for a HuggingFace dataset."""
+    configs: list[str | None]
+    if name is not None:
+        configs = [name]
+    else:
+        try:
+            configs = get_dataset_config_names(dataset_name)
+        except Exception:
+            configs = [None]
+
+    result: list[tuple[str | None, str]] = []
+    for config in configs:
+        if split is not None:
+            result.append((config, split))
+        else:
+            result.extend((config, s) for s in get_dataset_split_names(dataset_name, config))
+    return result
 
 
 def megatron_preprocess_data(
@@ -224,7 +366,7 @@ def megatron_preprocess_data(
     # Hugging Face Hub dataset arguments
     hf_dataset: str | None = None,
     hf_name: str | None = None,
-    hf_split: str | None = "train",
+    hf_split: str | None = None,
     hf_max_samples_per_split: int | None = None,
     # Other arguments
     output_dir: str | Path,
@@ -234,6 +376,7 @@ def megatron_preprocess_data(
     max_sequence_length: int | None = None,
     workers: int = 1,
     log_interval: int = 100000,
+    reasoning_content: str = "strip",
 ):
     """Process large data for pretraining.
 
@@ -244,7 +387,7 @@ def megatron_preprocess_data(
         jsonl_paths: One or more paths to JSONL files.
         hf_dataset: Hugging Face Hub dataset name or path to download and tokenize.
         hf_name: Hugging Face Hub dataset subset name. Downloads all subsets if None.
-        hf_split: Hugging Face Hub dataset split. Defaults to "train".
+        hf_split: Hugging Face Hub dataset split. Defaults to None (all splits).
         hf_max_samples_per_split: Maximum number of samples to download per split from Hugging Face Hub.
             Skip to download all samples.
         output_dir: Path to directory to save binary output files.
@@ -254,6 +397,15 @@ def megatron_preprocess_data(
         max_sequence_length: Maximum tokenized sequence length. Defaults to None.
         workers: Number of worker processes to launch. Defaults to 1.
         log_interval: Interval between progress updates. Defaults to 100000.
+        reasoning_content: How to handle the ``reasoning_content`` field present in many
+            Nemotron Post-Training v3 datasets. One of:
+            ``"strip"`` (default) — remove before applying chat template (safe for any tokenizer);
+            ``"inline"`` — wrap in ``<think>…</think>`` and prepend to ``content``;
+            ``"native"`` — pass unchanged, requires the tokenizer chat template to handle it.
+
+    Returns:
+        List of output file prefixes (one per json_key per split/file, without ``.bin``/``.idx``
+        extension) that can be used directly to build weighted ``data_paths`` argument in megatron training scripts.
     """
     if isinstance(json_keys, str):
         json_keys = [json_keys]
@@ -263,39 +415,47 @@ def megatron_preprocess_data(
             "Exactly one of `input_dir`, `jsonl_paths`, or `hf_dataset` must be provided."
         )
 
-    if hf_dataset is not None:
-        jsonl_paths = download_hf_dataset_as_jsonl(
-            hf_dataset,
-            f"{output_dir}/raw",
-            json_keys,
-            name=hf_name,
-            split=hf_split,
-            max_samples_per_split=hf_max_samples_per_split,
-            num_proc=workers,
-        )
-        print(f"\n\nTokenizing downloaded JSONL files: {jsonl_paths}\n")
-
-    if input_dir is not None:
-        file_names = sorted(Path(input_dir).glob("*.jsonl"))
-        if not file_names:
-            raise ValueError(f"No JSONL files found in input directory: {input_dir}")
-    elif isinstance(jsonl_paths, (str, Path)):
-        file_names = [jsonl_paths]  # type: ignore[list-item]
-    else:
-        file_names = list(jsonl_paths)  # type: ignore[arg-type]
-
     Path(output_dir).mkdir(exist_ok=True)
     vocab_size = AutoTokenizer.from_pretrained(tokenizer_name_or_path).vocab_size
 
-    encoder = _Encoder(tokenizer_name_or_path, json_keys, append_eod, max_sequence_length)
+    encoder = _Encoder(
+        tokenizer_name_or_path, json_keys, append_eod, max_sequence_length, reasoning_content
+    )
     partition = _Partition(vocab_size, json_keys, log_interval, workers)
 
     final_enc_len = 0
-    for name in file_names:
-        num_tokens = partition.process_json_file(name, output_dir, encoder)
-        final_enc_len += num_tokens
+    all_prefixes: list[str] = []
 
-    print(f"\n\n>>> Total number of tokens currently processed: {num2hrb(final_enc_len)}\nDone!")
+    if hf_dataset is not None:
+        for config, split in _enumerate_hf_splits(hf_dataset, hf_name, hf_split):
+            enc_len, prefixes = partition.process_hf_split(
+                output_dir, encoder, hf_dataset, config, split, hf_max_samples_per_split
+            )
+            final_enc_len += enc_len
+            all_prefixes.extend(prefixes)
+    else:
+        if input_dir is not None:
+            file_names = sorted(Path(input_dir).glob("*.jsonl"))
+            if not file_names:
+                raise ValueError(f"No JSONL files found in input directory: {input_dir}")
+        elif isinstance(jsonl_paths, (str, Path)):
+            file_names = [jsonl_paths]  # type: ignore[list-item]
+        else:
+            file_names = list(jsonl_paths)  # type: ignore[arg-type]
+
+        for name in file_names:
+            enc_len, prefixes = partition.process_json_file(name, output_dir, encoder)
+            final_enc_len += enc_len
+            all_prefixes.extend(prefixes)
+
+    print(f"\n\n>>> Total number of tokens currently processed: {num2hrb(final_enc_len)}")
+    print(
+        "\n>>> Output prefixes (Use to build weighted data_paths / blend in megatron training scripts):"
+    )
+    for prefix in all_prefixes:
+        print(f"\t{prefix}")
+    print("Done!")
+    return all_prefixes
 
 
 def main():
@@ -321,7 +481,7 @@ def main():
     parser.add_argument(
         "--hf_split",
         type=str,
-        default="train",
+        default=None,
         help="Hugging Face Hub dataset split. Skip to download and tokenize all splits for the subset.",
     )
     parser.add_argument(
@@ -340,6 +500,18 @@ def main():
     )
     parser.add_argument("--workers", type=int, default=8, help="Number of worker processes")
     parser.add_argument("--log_interval", type=int, default=100000, help="Log interval")
+    parser.add_argument(
+        "--reasoning_content",
+        type=str,
+        default="strip",
+        choices=["strip", "inline", "native"],
+        help=(
+            "How to handle the reasoning_content field in Nemotron v3 datasets. "
+            "'strip': discard (default, safe for any tokenizer). "
+            "'inline': wrap in <think>...</think> and prepend to content. "
+            "'native': pass unchanged (requires tokenizer chat template support, e.g. Qwen3)."
+        ),
+    )
     args = parser.parse_args()
 
     print("\n==================== Arguments ====================")
@@ -361,6 +533,7 @@ def main():
         max_sequence_length=args.max_sequence_length,
         workers=args.workers,
         log_interval=args.log_interval,
+        reasoning_content=args.reasoning_content,
     )
 
 

--- a/modelopt/torch/utils/plugins/megatron_preprocess_data.py
+++ b/modelopt/torch/utils/plugins/megatron_preprocess_data.py
@@ -286,7 +286,7 @@ class _Partition:
         for i, (doc, sentence_lens, (doc_len, enc_len)) in enumerate(encoded_docs, start=1):
             total_doc_len += doc_len
             total_enc_len += enc_len
-            final_enc_len += sum(sentence_lens[key])
+            final_enc_len += sum(sum(sentence_lens[k]) for k in sentence_lens)
             for key in doc:
                 builders[key].add_document(doc[key], sentence_lens[key])
             self._print_processing_stats(i, total_doc_len, total_enc_len, start_time)
@@ -322,16 +322,17 @@ class _Partition:
 
         When ``max_samples`` is set, the dataset is shuffled to avoid sampling from a biased prefix of the dataset.
         """
-        split_arg = (
-            f"{split}[:{max_samples}]" if (max_samples is not None and not streaming) else split
-        )
-        print(f"\nLoading HF dataset {dataset_name=}, {config=}, {split_arg=}, {streaming=}")
-        ds = load_dataset(path=dataset_name, name=config, split=split_arg, streaming=streaming)
+        print(f"\nLoading HF dataset {dataset_name=}, {config=}, {split=}, {streaming=}")
+        ds = load_dataset(path=dataset_name, name=config, split=split, streaming=streaming)
         if max_samples is not None:
-            # Shuffle before capping to avoid biased sampling from the dataset prefix
+            # Shuffle first so the selected subset is random, not a biased prefix.
+            # Non-streaming: global index shuffle (memory-mapped, efficient) then .select(N).
+            # Streaming: buffer shuffle (approximate) then .take(N).
             ds = ds.shuffle(seed=42)
             if streaming:
                 ds = ds.take(max_samples)
+            else:
+                ds = ds.select(range(max_samples))
 
         # features are available from dataset metadata without downloading data
         features = ds.features if ds.features is not None else {}
@@ -343,16 +344,18 @@ class _Partition:
                     )
 
         safe_name = dataset_name.replace("/", "--")
+        sample_tag = f"_max{max_samples}" if max_samples is not None else ""
         output_prefix = Path(output_dir) / f"{safe_name}_{config}_{split}"
-        prefixes = [f"{output_prefix}_{key}" for key in self.json_keys]
 
+        prefixes = []
         output_bin_files = {}
         output_idx_files = {}
         builders = {}
-
         for key in self.json_keys:
-            output_bin_files[key] = f"{output_prefix}_{key}.bin"
-            output_idx_files[key] = f"{output_prefix}_{key}.idx"
+            prefix = f"{output_prefix}_{key}{sample_tag}"
+            prefixes.append(prefix)
+            output_bin_files[key] = f"{prefix}.bin"
+            output_idx_files[key] = f"{prefix}.idx"
             if Path(output_bin_files[key]).exists() and Path(output_idx_files[key]).exists():
                 continue
             builders[key] = indexed_dataset.IndexedDatasetBuilder(

--- a/modelopt/torch/utils/plugins/megatron_preprocess_data.py
+++ b/modelopt/torch/utils/plugins/megatron_preprocess_data.py
@@ -15,32 +15,26 @@
 
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 
-"""Processing large data pretraining and post-training datasets to tokenize for usage in megatron pretraining scripts.
+"""Tokenize pretraining and post-training datasets into Megatron's binary indexed format.
 
-We apply chat_template to the data if the JSON key is a list of message dicts (e.g. Nemotron-Post-Training-Dataset-v2)
-so that we can tokenize the data for usage in megatron pretraining scripts.
+When the value for a JSON key is a list of message dicts, ``tokenizer.apply_chat_template``
+is automatically used (``add_special_tokens=False`` to avoid a duplicate BOS). Plain-text
+values are tokenized directly.
 
-Usage to tokenize one or more JSONL files (pretraining, ``text`` key):
-
-```bash
-python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
-    --jsonl_paths path/to/input/data1.jsonl path/to/input/data2.jsonl ... \
-    --json_keys text \
-    --output_dir /path/to/tokenized/Qwen3/ \
-    --tokenizer Qwen/Qwen3-0.6B
-```
-
-Usage to tokenize all JSONL files in a directory:
+**Tokenize JSONL files — pretraining text** (use ``--append_eod`` so Megatron knows document
+boundaries when concatenating sequences; use ``--strip_newlines`` for prose/web text):
 
 ```bash
 python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
-    --input_dir /path/to/input/data/ \
+    --jsonl_paths path/to/data1.jsonl path/to/data2.jsonl \
     --json_keys text \
     --output_dir /path/to/tokenized/Qwen3/ \
-    --tokenizer Qwen/Qwen3-0.6B
+    --tokenizer Qwen/Qwen3-0.6B \
+    --append_eod \
+    --strip_newlines
 ```
 
-Usage to tokenize a post-training dataset with ``messages`` key (chat format):
+**Tokenize JSONL files — post-training chat data** (omit ``--append_eod``; chat template adds EOS):
 
 ```bash
 python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
@@ -50,31 +44,50 @@ python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
     --tokenizer Qwen/Qwen3-0.6B
 ```
 
-When the value for a JSON key is a list of message dicts (e.g.
-``[{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]``),
-``tokenizer.apply_chat_template`` is automatically used to render the conversation
-into a single text string before tokenization.
+Pass ``--input_dir /path/to/dir`` to tokenize all ``.jsonl`` / ``.jsonl.gz`` files in a directory.
 
-Usage to download and tokenize a dataset from Hugging Face Hub:
+**Download and tokenize from Hugging Face Hub:**
 
 ```bash
 python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
-    --hf_dataset nvidia/Nemotron-Pretraining-Dataset-sample \
-    --hf_name Nemotron-SFT-Code \
+    --hf_dataset nvidia/Nemotron-Pretraining-SFT-v1 \
+    --hf_name Nemotron-SFT-General \
     --hf_split train \
     --json_keys text \
     --tokenizer Qwen/Qwen3-0.6B \
-    --output_dir /path/to/tokenized/Qwen3/
+    --output_dir /path/to/tokenized/Qwen3/ \
+    --append_eod \
+    --strip_newlines
 ```
 
-NOTE: If you skip --hf_name, it will download and tokenize all subsets for the dataset.
-If you skip --hf_split, it will download and tokenize all splits for the subset.
+Omit ``--hf_name`` to process all subsets; omit ``--hf_split`` for all splits. When ``--hf_max_samples_per_split``
+is set, the dataset is automatically shuffled to avoid biased sampling from the prefix.
+
+**Large datasets — streaming mode** (only consumed rows downloaded, no disk cache):
+
+```bash
+python -m modelopt.torch.utils.plugins.megatron_preprocess_data \
+    --hf_dataset nvidia/Nemotron-CC-v2.1 \
+    --hf_name High-Quality \
+    --hf_max_samples_per_split 5000000 \
+    --hf_streaming \
+    --json_keys text \
+    --tokenizer Qwen/Qwen3-0.6B \
+    --output_dir /path/to/tokenized/Qwen3/ \
+    --append_eod \
+    --strip_newlines
+```
+
+Note: ``--hf_streaming`` without ``--hf_max_samples_per_split`` falls back to non-streaming,
+since streaming the full dataset is slower than the cached non-streaming path.
 """
 
 import argparse
 import gzip
 import json
 import multiprocessing
+import time
+import warnings
 from pathlib import Path
 
 from datasets import get_dataset_config_names, get_dataset_split_names, load_dataset
@@ -125,6 +138,11 @@ class _Encoder:
     def initializer(self):
         # Use Encoder class as a container for global data
         _Encoder.tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name_or_path)
+        # Suppress "Token indices sequence length is longer than model_max_length" warnings.
+        # model_max_length is the model's inference limit and irrelevant here — we are only
+        # converting text to token IDs, not running a forward pass. Megatron splits documents
+        # into fixed-length training sequences at training time.
+        _Encoder.tokenizer.model_max_length = int(1e30)
 
     def _process_messages(self, messages: list[dict]) -> list[dict]:
         """Handle reasoning_content field in v3 Nemotron datasets.
@@ -212,11 +230,19 @@ class _Partition:
         self.workers = workers
 
     def _print_processing_stats(
-        self, count: int, total_doc_len: int, total_enc_len: int, *, force_print: bool = False
+        self,
+        count: int,
+        total_doc_len: int,
+        total_enc_len: int,
+        start_time: float,
+        *,
+        force_print: bool = False,
     ):
         if count % self.log_interval == 0 or force_print:
+            elapsed = (time.time() - start_time) / 60
             print(
-                f"\tProcessed {num2hrb(count)} docs = {num2hrb(total_doc_len)} chars = {num2hrb(total_enc_len)} tokens",
+                f"\tProcessed {num2hrb(count)} docs = {num2hrb(total_doc_len)} chars"
+                f" = {num2hrb(total_enc_len)} tokens ({elapsed:.1f}mins)",
                 flush=True,
             )
 
@@ -255,6 +281,7 @@ class _Partition:
             print(f"\t[SKIP] Output files corresponding to {input_file_name} already exist")
             return 0, prefixes
 
+        start_time = time.time()
         total_doc_len, total_enc_len, final_enc_len = 0, 0, 0
         for i, (doc, sentence_lens, (doc_len, enc_len)) in enumerate(encoded_docs, start=1):
             total_doc_len += doc_len
@@ -262,8 +289,8 @@ class _Partition:
             final_enc_len += sum(sentence_lens[key])
             for key in doc:
                 builders[key].add_document(doc[key], sentence_lens[key])
-            self._print_processing_stats(i, total_doc_len, total_enc_len)
-        self._print_processing_stats(i, total_doc_len, total_enc_len, force_print=True)
+            self._print_processing_stats(i, total_doc_len, total_enc_len, start_time)
+        self._print_processing_stats(i, total_doc_len, total_enc_len, start_time, force_print=True)
 
         fin.close()
         for key in builders:
@@ -285,17 +312,35 @@ class _Partition:
         config: str | None,
         split: str,
         max_samples: int | None = None,
+        streaming: bool = False,
     ) -> tuple[int, list[str]]:
-        """Load a HF dataset split and tokenize directly without writing an intermediate JSONL."""
-        split_arg = f"{split}[:{max_samples}]" if max_samples is not None else split
-        print(f"\nLoading HF dataset {dataset_name=}, {config=}, {split_arg=}")
-        ds = load_dataset(path=dataset_name, name=config, split=split_arg)
+        """Load a HF dataset split and tokenize directly without writing an intermediate JSONL.
 
-        for key in self.json_keys:
-            if key not in ds.features:
-                raise KeyError(
-                    f"{key=} not found in dataset features. Available: {list(ds.features)}"
-                )
+        When ``streaming=True``, only consumed rows are downloaded — useful for large pretraining
+        datasets where downloading the full split is impractical. Note that streaming mode does not
+        cache to disk, so re-runs will re-download the data.
+
+        When ``max_samples`` is set, the dataset is shuffled to avoid sampling from a biased prefix of the dataset.
+        """
+        split_arg = (
+            f"{split}[:{max_samples}]" if (max_samples is not None and not streaming) else split
+        )
+        print(f"\nLoading HF dataset {dataset_name=}, {config=}, {split_arg=}, {streaming=}")
+        ds = load_dataset(path=dataset_name, name=config, split=split_arg, streaming=streaming)
+        if max_samples is not None:
+            # Shuffle before capping to avoid biased sampling from the dataset prefix
+            ds = ds.shuffle(seed=42)
+            if streaming:
+                ds = ds.take(max_samples)
+
+        # features are available from dataset metadata without downloading data
+        features = ds.features if ds.features is not None else {}
+        if features:
+            for key in self.json_keys:
+                if key not in features:
+                    raise KeyError(
+                        f"{key=} not found in dataset features. Available: {list(features)}"
+                    )
 
         safe_name = dataset_name.replace("/", "--")
         output_prefix = Path(output_dir) / f"{safe_name}_{config}_{split}"
@@ -322,6 +367,7 @@ class _Partition:
         pool = multiprocessing.Pool(self.workers, initializer=encoder.initializer)
         encoded_docs = pool.imap(encoder.encode, self._iter_hf_as_json(ds), 32)
 
+        start_time = time.time()
         total_doc_len, total_enc_len, final_enc_len = 0, 0, 0
         i = 0
         for i, (doc, sentence_lens, (doc_len, enc_len)) in enumerate(encoded_docs, start=1):
@@ -330,10 +376,12 @@ class _Partition:
             final_enc_len += sum(sum(sentence_lens[key]) for key in sentence_lens)
             for key in doc:
                 builders[key].add_document(doc[key], sentence_lens[key])
-            self._print_processing_stats(i, total_doc_len, total_enc_len)
+            self._print_processing_stats(i, total_doc_len, total_enc_len, start_time)
 
         if i:
-            self._print_processing_stats(i, total_doc_len, total_enc_len, force_print=True)
+            self._print_processing_stats(
+                i, total_doc_len, total_enc_len, start_time, force_print=True
+            )
 
         pool.close()
         pool.join()
@@ -377,6 +425,7 @@ def megatron_preprocess_data(
     hf_name: str | None = None,
     hf_split: str | None = None,
     hf_max_samples_per_split: int | None = None,
+    hf_streaming: bool = False,
     # Other arguments
     output_dir: str | Path,
     tokenizer_name_or_path: str,
@@ -398,8 +447,10 @@ def megatron_preprocess_data(
         hf_dataset: Hugging Face Hub dataset name or path to download and tokenize.
         hf_name: Hugging Face Hub dataset subset name. Downloads all subsets if None.
         hf_split: Hugging Face Hub dataset split. Defaults to None (all splits).
-        hf_max_samples_per_split: Maximum number of samples to download per split from Hugging Face Hub.
-            Skip to download all samples.
+        hf_max_samples_per_split: Maximum number of rows to consume per split.
+        hf_streaming: Load HuggingFace datasets in streaming mode. Only consumed rows are
+            downloaded — useful for very large pretraining datasets. Note: streaming does not
+            cache to disk, so re-runs re-download. Defaults to False.
         output_dir: Path to directory to save binary output files.
         tokenizer_name_or_path: Name or path of the Hugging Face tokenizer to use.
         json_keys: Key or list of keys to extract from json. Defaults to ["text"].
@@ -427,8 +478,16 @@ def megatron_preprocess_data(
         raise ValueError(
             "Exactly one of `input_dir`, `jsonl_paths`, or `hf_dataset` must be provided."
         )
+    if hf_streaming and hf_max_samples_per_split is None and _is_main_or_first_worker():
+        warnings.warn(
+            "--hf_streaming is set but --hf_max_samples_per_split is not. "
+            "Streaming without a sample cap re-downloads the full dataset on every run with no "
+            "disk cache, which is slower than non-streaming mode. Falling back to streaming=False.",
+            stacklevel=2,
+        )
+        hf_streaming = False
 
-    Path(output_dir).mkdir(exist_ok=True)
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
     vocab_size = AutoTokenizer.from_pretrained(tokenizer_name_or_path).vocab_size
 
     encoder = _Encoder(
@@ -443,11 +502,18 @@ def megatron_preprocess_data(
 
     final_enc_len = 0
     all_prefixes: list[str] = []
+    overall_start = time.time()
 
     if hf_dataset is not None:
         for config, split in _enumerate_hf_splits(hf_dataset, hf_name, hf_split):
             enc_len, prefixes = partition.process_hf_split(
-                output_dir, encoder, hf_dataset, config, split, hf_max_samples_per_split
+                output_dir,
+                encoder,
+                hf_dataset,
+                config,
+                split,
+                hf_max_samples_per_split,
+                hf_streaming,
             )
             final_enc_len += enc_len
             all_prefixes.extend(prefixes)
@@ -468,7 +534,11 @@ def megatron_preprocess_data(
             final_enc_len += enc_len
             all_prefixes.extend(prefixes)
 
-    print(f"\n\n>>> Total number of tokens currently processed: {num2hrb(final_enc_len)}")
+    elapsed = (time.time() - overall_start) / 60
+    print(
+        f"\n\n>>> Total number of tokens currently processed: {num2hrb(final_enc_len)}"
+        f" (time: {elapsed:.1f}mins)"
+    )
     print(
         "\n>>> Output prefixes (Use to build weighted data_paths / blend in megatron training scripts):"
     )
@@ -508,7 +578,16 @@ def main():
         "--hf_max_samples_per_split",
         type=int,
         default=None,
-        help="Maximum number of samples to download per split from Hugging Face Hub. Skip to download all samples.",
+        help="Maximum number of rows to consume per split.",
+    )
+    parser.add_argument(
+        "--hf_streaming",
+        action="store_true",
+        help=(
+            "Load HuggingFace datasets in streaming mode. Only consumed rows are downloaded — "
+            "useful for very large pretraining datasets (e.g. Nemotron-CC-v2.1). "
+            "Note: streaming does not cache to disk, so re-runs will re-download the data."
+        ),
     )
     # Other arguments
     parser.add_argument("--output_dir", type=str, required=True, help="Output directory")
@@ -536,8 +615,7 @@ def main():
         "--strip_newlines",
         action="store_true",
         help=(
-            "Replace newlines with spaces in plain-text values before tokenization. "
-            "By default, newlines are preserved. "
+            "Replace newlines with spaces in plain-text values (non-coding pretraining data) before tokenization. "
             "Has no effect on chat-template encoded values."
         ),
     )
@@ -555,6 +633,7 @@ def main():
         hf_name=args.hf_name,
         hf_split=args.hf_split,
         hf_max_samples_per_split=args.hf_max_samples_per_split,
+        hf_streaming=args.hf_streaming,
         output_dir=args.output_dir,
         tokenizer_name_or_path=args.tokenizer,
         json_keys=args.json_keys,

--- a/tests/gpu_megatron/torch/utils/plugins/test_megatron_preprocess_data.py
+++ b/tests/gpu_megatron/torch/utils/plugins/test_megatron_preprocess_data.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -23,15 +22,7 @@ from modelopt.torch.utils.dataset_utils import download_hf_dataset_as_jsonl
 from modelopt.torch.utils.plugins.megatron_preprocess_data import megatron_preprocess_data
 
 
-def test_megatron_preprocess_data_with_minipile_jsonl(tmp_path):
-    """Test megatron_preprocess_data with nanotron/minipile_100_samples dataset.
-
-    This test:
-    1. Downloads the HuggingFace dataset "nanotron/minipile_100_samples"
-    2. Converts it to JSONL format
-    3. Calls megatron_preprocess_data with jsonl_paths
-    4. Verifies that output files are created
-    """
+def test_megatron_preprocess_data_with_jsonl_path(tmp_path):
     input_jsonl = download_hf_dataset_as_jsonl("nanotron/minipile_100_samples", tmp_path / "raw")
     assert len(input_jsonl) == 1, "Expected 1 JSONL file"
     input_jsonl = Path(input_jsonl[0])
@@ -44,7 +35,7 @@ def test_megatron_preprocess_data_with_minipile_jsonl(tmp_path):
         assert "text" in first_item, "Each JSONL item should have a 'text' field"
         assert isinstance(first_item["text"], str), "Text field should be a string"
 
-    megatron_preprocess_data(
+    prefixes = megatron_preprocess_data(
         jsonl_paths=input_jsonl,
         output_dir=tmp_path,
         tokenizer_name_or_path="gpt2",
@@ -52,34 +43,23 @@ def test_megatron_preprocess_data_with_minipile_jsonl(tmp_path):
         workers=1,
     )
 
-    output_prefix = tmp_path / "nanotron--minipile_100_samples_default_train"
-    expected_bin_file = f"{output_prefix}_text_document.bin"
-    expected_idx_file = f"{output_prefix}_text_document.idx"
-
-    assert os.path.exists(expected_bin_file), (
-        f"Expected binary file {expected_bin_file} should exist"
+    assert prefixes == [str(tmp_path / f"{input_jsonl.stem}_text")], (
+        f"Expected prefix based on JSONL stem, got {prefixes}"
     )
-    assert os.path.exists(expected_idx_file), (
-        f"Expected index file {expected_idx_file} should exist"
-    )
-
-    assert os.path.getsize(expected_bin_file) > 0, "Binary file should not be empty"
-    assert os.path.getsize(expected_idx_file) > 0, "Index file should not be empty"
+    assert Path(prefixes[0] + ".bin").exists(), f"Expected binary file {prefixes[0]}.bin"
+    assert Path(prefixes[0] + ".idx").exists(), f"Expected index file {prefixes[0]}.idx"
+    assert Path(prefixes[0] + ".bin").stat().st_size > 0, "Binary file should not be empty"
+    assert Path(prefixes[0] + ".idx").stat().st_size > 0, "Index file should not be empty"
 
 
 @pytest.mark.parametrize(
     ("hf_dataset", "hf_split", "json_keys"),
     [
         ("nanotron/minipile_100_samples", "train", ["text"]),
-        ("HuggingFaceTB/everyday-conversations-llama3.1-2k", "test_sft", ["messages"]),
     ],
 )
 def test_megatron_preprocess_data_with_hf_dataset(tmp_path, hf_dataset, hf_split, json_keys):
-    """Test megatron_preprocess_data with dataset download, --append_eod and --max_sequence_length.
-
-    Downloads nanotron/minipile_100_samples train split from Hugging Face and tokenizes it.
-    """
-    megatron_preprocess_data(
+    prefixes = megatron_preprocess_data(
         hf_dataset=hf_dataset,
         hf_split=hf_split,
         hf_max_samples_per_split=10,
@@ -91,11 +71,57 @@ def test_megatron_preprocess_data_with_hf_dataset(tmp_path, hf_dataset, hf_split
         workers=4,
     )
 
-    bin_files = sorted(tmp_path.glob("*.bin"))
-    idx_files = sorted(tmp_path.glob("*.idx"))
+    jsonl_files = sorted(tmp_path.glob("**/*.jsonl"))
+    assert len(jsonl_files) == 0, (
+        f"No intermediate .jsonl files should be written, found: {jsonl_files}"
+    )
 
-    assert len(bin_files) > 0, f"Expected .bin files in {tmp_path}, found none"
-    assert len(idx_files) > 0, f"Expected .idx files in {tmp_path}, found none"
+    assert len(prefixes) > 0, "Expected at least one output prefix"
+    assert len(prefixes) == len(json_keys), f"Expected one prefix per json_key, got {prefixes}"
+    for prefix in prefixes:
+        assert Path(prefix + ".bin").exists(), f"Expected binary file {prefix}.bin"
+        assert Path(prefix + ".idx").exists(), f"Expected index file {prefix}.idx"
+        assert Path(prefix + ".bin").stat().st_size > 0, f"{prefix}.bin should not be empty"
+        assert Path(prefix + ".idx").stat().st_size > 0, f"{prefix}.idx should not be empty"
 
-    for f in bin_files + idx_files:
-        assert f.stat().st_size > 0, f"{f.name} should not be empty"
+
+def test_megatron_preprocess_data_reasoning_content(tmp_path):
+    sample = {
+        "messages": [
+            {"role": "user", "content": "What is 2 + 2?"},
+            {
+                "role": "assistant",
+                "content": "The answer is 4.",
+                "reasoning_content": "I need to add 2 and 2 together. The result is 4.",
+            },
+        ]
+    }
+    jsonl_path = tmp_path / "test_reasoning.jsonl"
+    jsonl_path.write_text(json.dumps(sample) + "\n", encoding="utf-8")
+
+    for mode in ("strip", "inline"):
+        out_dir = tmp_path / mode
+        out_dir.mkdir()
+        prefixes = megatron_preprocess_data(
+            jsonl_paths=jsonl_path,
+            output_dir=out_dir,
+            tokenizer_name_or_path="Qwen/Qwen3-0.6B",
+            json_keys=["messages"],
+            workers=1,
+            reasoning_content=mode,
+        )
+        assert len(prefixes) == 1, f"[{mode}] Expected 1 prefix, got {prefixes}"
+        assert prefixes[0] == str(out_dir / "test_reasoning_messages"), (
+            f"[{mode}] Unexpected prefix: {prefixes[0]}"
+        )
+        assert Path(prefixes[0] + ".bin").exists(), f"[{mode}] Expected {prefixes[0]}.bin"
+        assert Path(prefixes[0] + ".idx").exists(), f"[{mode}] Expected {prefixes[0]}.idx"
+        assert Path(prefixes[0] + ".bin").stat().st_size > 0, (
+            f"[{mode}] Binary output should not be empty"
+        )
+
+    strip_size = Path(str(tmp_path / "strip" / "test_reasoning_messages") + ".bin").stat().st_size
+    inline_size = Path(str(tmp_path / "inline" / "test_reasoning_messages") + ".bin").stat().st_size
+    assert inline_size > strip_size, (
+        f"inline ({inline_size} bytes) should produce a larger binary than strip ({strip_size} bytes)"
+    )

--- a/tests/gpu_megatron/torch/utils/plugins/test_megatron_preprocess_data.py
+++ b/tests/gpu_megatron/torch/utils/plugins/test_megatron_preprocess_data.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gzip
 import json
 from pathlib import Path
 
@@ -125,3 +126,37 @@ def test_megatron_preprocess_data_reasoning_content(tmp_path):
     assert inline_size > strip_size, (
         f"inline ({inline_size} bytes) should produce a larger binary than strip ({strip_size} bytes)"
     )
+
+
+def test_megatron_preprocess_data_with_gzip_input(tmp_path):
+    gz_path = tmp_path / "data.jsonl.gz"
+    with gzip.open(gz_path, "wt", encoding="utf-8") as f:
+        for i in range(10):
+            f.write(json.dumps({"text": f"Line one.\nLine two.\nSample {i}."}) + "\n")
+
+    prefixes = megatron_preprocess_data(
+        jsonl_paths=gz_path,
+        output_dir=tmp_path,
+        tokenizer_name_or_path="gpt2",
+        json_keys=["text"],
+        workers=1,
+        strip_newlines=True,
+    )
+
+    # .jsonl.gz → stem should be "data", not "data.jsonl"
+    assert prefixes == [str(tmp_path / "data_text")], f"Unexpected prefix: {prefixes}"
+    assert Path(prefixes[0] + ".bin").stat().st_size > 0
+
+
+def test_megatron_preprocess_data_hf_streaming_warning(tmp_path):
+    # hf_streaming without hf_max_samples_per_split should warn and fall back to non-streaming
+    with pytest.warns(UserWarning, match="hf_streaming"):
+        megatron_preprocess_data(
+            hf_dataset="nanotron/minipile_100_samples",
+            hf_split="train",
+            hf_streaming=True,
+            output_dir=tmp_path,
+            tokenizer_name_or_path="gpt2",
+            json_keys=["text"],
+            workers=1,
+        )

--- a/tests/gpu_megatron/torch/utils/plugins/test_megatron_preprocess_data.py
+++ b/tests/gpu_megatron/torch/utils/plugins/test_megatron_preprocess_data.py
@@ -80,6 +80,10 @@ def test_megatron_preprocess_data_with_hf_dataset(tmp_path, hf_dataset, hf_split
     assert len(prefixes) > 0, "Expected at least one output prefix"
     assert len(prefixes) == len(json_keys), f"Expected one prefix per json_key, got {prefixes}"
     for prefix in prefixes:
+        assert "_max10" in prefix, (
+            f"Expected '_max10' in prefix when hf_max_samples_per_split=10, got {prefix}"
+        )
+    for prefix in prefixes:
         assert Path(prefix + ".bin").exists(), f"Expected binary file {prefix}.bin"
         assert Path(prefix + ".idx").exists(), f"Expected index file {prefix}.idx"
         assert Path(prefix + ".bin").stat().st_size > 0, f"{prefix}.bin should not be empty"


### PR DESCRIPTION
### What does this PR do?

Type of change: New feature

Improvements to `megatron_preprocess_data` for Nemotron v3 post-training datasets and Megatron-Bridge distillation workflows:

- **`--reasoning_content`** flag (`strip` / `inline` / `native`) to handle the `reasoning_content` field in Nemotron Post-Training v3 assistant messages
- **No intermediate JSONL** for HuggingFace datasets — load directly from Arrow cache via `_iter_hf_as_json` + `process_hf_split`
- **Return output prefixes** (`list[str]`) from the Python API so callers can build `--data_paths` without hardcoding paths; also printed at end of run
- **Gzip input support** — `.jsonl.gz` files accepted directly; `--input_dir` globs both `*.jsonl` and `*.jsonl.gz`
- **`--strip_newlines`** flag (opt-in) to replace newlines with spaces in plain-text values; default preserves newlines (no breaking change for code/structured-text datasets)
- **`--hf_streaming`** flag for very large datasets — only consumed rows are downloaded; automatically falls back to non-streaming (with a warning) if `--hf_max_samples_per_split` is not set, since streaming without a cap is slower than cached non-streaming
- **Auto-shuffle** when `--hf_max_samples_per_split` is set — reservoir sampling (buffer=10,000, seed=42) applied before capping to avoid biased prefix sampling
- Remove `_document` suffix from output filenames (`_text.bin` instead of `_text_document.bin`)
- Fix duplicate BOS token for chat-template data (`add_special_tokens=False`)
- Fix `TypeError` in `process_hf_split` (`sum(list)` not `sum(int)`)
- Suppress duplicate prints across pool workers via `_is_main_or_first_worker()`
- Raise `KeyError` instead of warning for missing JSON keys
- Default `hf_split=None` (all splits) instead of `"train"`

### Usage

```python
from modelopt.torch.utils.plugins.megatron_preprocess_data import megatron_preprocess_data

# Nemotron v3 with reasoning content preserved inline as <think>...</think>
prefixes = megatron_preprocess_data(
    hf_dataset="nvidia/Nemotron-Post-Training-Dataset-v3",
    json_keys=["messages"],
    tokenizer_name_or_path="Qwen/Qwen3-0.6B",
    output_dir="tokenized/",
    workers=32,
    reasoning_content="inline",
)
# prefixes == ["tokenized/nvidia--Nemotron-Post-Training-Dataset-v3_..._messages"]
data_paths = [x for p in prefixes for x in ("1.0", p)]

# Large pretraining dataset — stream + cap (auto-shuffled before capping)
prefixes = megatron_preprocess_data(
    hf_dataset="nvidia/Nemotron-CC-v2.1",
    hf_name="High-Quality",
    hf_max_samples_per_split=5_000_000,
    hf_streaming=True,
    json_keys=["text"],
    tokenizer_name_or_path="Qwen/Qwen3-0.6B",
    output_dir="tokenized/",
    workers=32,
    append_eod=True,
    strip_newlines=True,
)
```

### Testing

- New unit tests
- Tested tokenization on Nemotron Pretraining and Post-training v3 datasets

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ (output filename changed: `_text_document` → `_text`; existing callers need to re-tokenize or rename files)
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preprocessing tool: configurable reasoning-content modes (strip|inline|native), optional newline stripping, gzip (.jsonl.gz) input support, HF streaming mode, auto-shuffle when per-split max samples set, returns output-file prefixes, and processes all HF splits by default without writing intermediate JSONL.

* **Documentation**
  * Consolidated and reformatted dataset preparation and tokenization guidance; updated install/auth instructions and examples.

* **Tests**
  * Tests updated to validate returned prefixes, reasoning-content behaviors, gzip input handling, HF streaming warnings, and HF output assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->