### PR TITLE
fix puzzletron container test path; add NeMo setup docs

### DIFF
--- a/examples/puzzletron/README.md
+++ b/examples/puzzletron/README.md
@@ -22,9 +22,9 @@ The recommended way to run puzzletron is inside an NVIDIA NeMo container (e.g. `
 Once inside the container with the repo available, install dependencies from the repo root:
 
 ```bash
-pip uninstall nvidia-modelopt nvidia-lm-eval -y 2>/dev/null
-pip install -e ".[hf,puzzletron]"
-pip install -r examples/puzzletron/requirements.txt
+python -m pip uninstall nvidia-lm-eval -y 2>/dev/null
+python -m pip install -e ".[hf,puzzletron]"
+python -m pip install -r examples/puzzletron/requirements.txt
 ```
 
 To verify the install, you can run the GPU tests as a smoke check:

--- a/examples/puzzletron/README.md
+++ b/examples/puzzletron/README.md
@@ -15,7 +15,27 @@ In this example, we compress the [Llama-3.1-8B-Instruct](https://huggingface.co/
 
 ## Environment
 
-- Install Model-Optimizer in editable mode with the corresponding dependencies (run from the repo root):
+### Container setup (NeMo)
+
+The recommended way to run puzzletron is inside an NVIDIA NeMo container (e.g. `nvcr.io/nvidia/nemo:26.02`). NeMo containers ship a pre-installed `nvidia-modelopt` that does not include the puzzletron extras so you need to replace it with an editable install from this repo.
+
+Once inside the container with the repo available, install dependencies from the repo root:
+
+```bash
+pip uninstall nvidia-modelopt nvidia-lm-eval -y 2>/dev/null
+pip install -e ".[hf,puzzletron]"
+pip install -r examples/puzzletron/requirements.txt
+```
+
+To verify the install, you can run the GPU tests as a smoke check:
+
+```bash
+python -m pytest -s -v tests/gpu/torch/puzzletron/test_puzzletron.py -o addopts="" -k "mistral"
+```
+
+### Bare-metal / other containers
+
+If you are not using a NeMo container, install Model-Optimizer in editable mode with the corresponding dependencies (run from the repo root):
 
 ```bash
 pip install -e .[hf,puzzletron]
@@ -24,6 +44,8 @@ pip install -r examples/puzzletron/requirements.txt
 
 > **Note:** NeMo containers may ship `nvidia-lm-eval` which may conflict with `lm-eval` that is used for evaluation.
 > If so, run `pip uninstall nvidia-lm-eval -y` before installing requirements.
+
+### Hardware
 
 - For this example we are using 2x NVIDIA H100 80GB HBM3 to show multi-GPU steps. You can use also use a single GPU.
 

--- a/modelopt/torch/puzzletron/anymodel/README.md
+++ b/modelopt/torch/puzzletron/anymodel/README.md
@@ -96,7 +96,7 @@ Update pruning YAML files (`ffn_pruning.yaml`, `expert_pruning.yaml`, etc.):
 
 ## End-to-end example
 
-See [test_puzzletron.py](../../../../tests/gpu/torch/puzzletron/test_puzzletron.py) for a complete example that runs both convert and compression steps.
+See [test_puzzletron.py](../../../../tests/gpu/torch/puzzletron/test_puzzletron.py) for a complete example that runs both convert and compression steps. For container setup and dependencies needed to run this test, see the [Puzzletron README environment section](../../../../examples/puzzletron/README.md#environment).
 
 ---
 

--- a/tests/gpu/torch/puzzletron/test_puzzletron.py
+++ b/tests/gpu/torch/puzzletron/test_puzzletron.py
@@ -26,6 +26,11 @@ from _test_utils.torch.misc import set_seed
 from _test_utils.torch.puzzletron.utils import setup_test_model_and_data
 from packaging.version import Version
 
+# The puzzletron pipeline imports mip unconditionally at module level. In NeMo containers
+# the [puzzletron] extras are not pre-installed, so importing the test file fails with a
+# deep ModuleNotFoundError. Skip early with an actionable message instead.
+pytest.importorskip("mip", reason="pip install -e '.[puzzletron]' to install MIP solver")
+
 import modelopt.torch.utils.distributed as dist
 from modelopt.torch.puzzletron import puzzletron
 from modelopt.torch.puzzletron.anymodel import convert_model


### PR DESCRIPTION
## Issue
the NeMo 26.02 container that is currently used in puzzletron tutorials ships nvidia-modelopt without puzzletron extras, so running `pytest -k "mistral"` on `test_puzzletron.py` fails with `ModuleNotFoundError: No module named 'mip'` at collection time. the container setup instructions for installing the extras were missing from the docs.

## changes:
- add container setup section 
- add pytest.importorskip("mip") guard so missing deps produce a clean skip 
- add cross-reference to environment setup next to existing test link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured Puzzletron environment setup with separate container and bare-metal workflows, added container-specific setup steps and a Hardware section; linked end-to-end example guidance to the Puzzletron environment docs.

* **Tests**
  * Made Puzzletron GPU test module skip early when optional dependencies are missing to avoid import failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->