### PR TITLE
vLLM fakequant export update for AWQ checkpoint

### DIFF
--- a/examples/vllm_serve/README.md
+++ b/examples/vllm_serve/README.md
@@ -98,5 +98,5 @@ QUANT_CFG=<quant_cfg> QUANT_FILE_PATH=<quantizer_state.pth> python vllm_serve_fa
 ## Known Problems
 
 1. **MCore reload does not use `MODELOPT_STATE_PATH`**; use `QUANT_FILE_PATH` and make sure `QUANT_CFG` matches the quantization recipe used for the original MCore model (otherwise quantizer keys/config won’t align).
-3. KV cache quantization export and reload is not supported in MCore yet.
-4. **`NVFP4_KV_CFG` and `NVFP4_AFFINE_KV_CFG` require `--enforce-eager`**; these configs use a dynamic-block Triton kernel for KV-cache quantization that is incompatible with CUDA graph capture (the kernel grid is computed from Python-level tensor shapes, which get baked in at capture time). Without `--enforce-eager`, the captured grid will be wrong for different batch sizes, producing incorrect outputs.
+2. KV cache quantization export and reload is not supported in MCore yet.
+3. **`NVFP4_KV_CFG` and `NVFP4_AFFINE_KV_CFG` require `--enforce-eager`**; these configs use a dynamic-block Triton kernel for KV-cache quantization that is incompatible with CUDA graph capture (the kernel grid is computed from Python-level tensor shapes, which get baked in at capture time). Without `--enforce-eager`, the captured grid will be wrong for different batch sizes, producing incorrect outputs.

--- a/examples/vllm_serve/README.md
+++ b/examples/vllm_serve/README.md
@@ -98,6 +98,5 @@ QUANT_CFG=<quant_cfg> QUANT_FILE_PATH=<quantizer_state.pth> python vllm_serve_fa
 ## Known Problems
 
 1. **MCore reload does not use `MODELOPT_STATE_PATH`**; use `QUANT_FILE_PATH` and make sure `QUANT_CFG` matches the quantization recipe used for the original MCore model (otherwise quantizer keys/config won’t align).
-2. AWQ reload is not supported yet
 3. KV cache quantization export and reload is not supported in MCore yet.
 4. **`NVFP4_KV_CFG` and `NVFP4_AFFINE_KV_CFG` require `--enforce-eager`**; these configs use a dynamic-block Triton kernel for KV-cache quantization that is incompatible with CUDA graph capture (the kernel grid is computed from Python-level tensor shapes, which get baked in at capture time). Without `--enforce-eager`, the captured grid will be wrong for different batch sizes, producing incorrect outputs.

--- a/examples/vllm_serve/fakequant_worker.py
+++ b/examples/vllm_serve/fakequant_worker.py
@@ -31,7 +31,7 @@ from vllm_reload_utils import (
 )
 
 import modelopt.torch.quantization as mtq
-from modelopt.torch.export.hf_vllm_quantizer_merge import is_weight_quantizer_state_key
+from modelopt.torch.export.plugins.vllm_fakequant_hf import is_weight_quantizer_state_key
 from modelopt.torch.quantization.plugins.vllm import (
     disable_compilation,
     post_restore_vllm_parallel_linears,

--- a/examples/vllm_serve/fakequant_worker.py
+++ b/examples/vllm_serve/fakequant_worker.py
@@ -15,6 +15,7 @@
 
 
 import os
+import warnings
 from typing import Any
 
 import torch
@@ -62,8 +63,11 @@ def _fakequant_run_prolog_worker(self) -> None:
         model = model.unwrap()
     if quant_config["modelopt_state_path"]:
         print(f"Loading modelopt state from {quant_config['modelopt_state_path']}")
-        # Load on CPU to avoid failures when the checkpoint was saved from a different
-        # GPU mapping
+        # map_location="cpu": load tensors on CPU so device ids in the file need not match this worker.
+        # weights_only=False: ``vllm_fq_modelopt_state.pth`` is a full ModelOpt pickle (metadata,
+        # nested dicts, dtypes, etc.); PyTorch's ``weights_only=True`` rejects that and only
+        # allows tensor-only checkpoints. Loading arbitrary pickles can execute stored code—use
+        # paths you trust (your own exports or verified checkpoints).
         modelopt_state = torch.load(
             quant_config["modelopt_state_path"], weights_only=False, map_location="cpu"
         )
@@ -73,16 +77,12 @@ def _fakequant_run_prolog_worker(self) -> None:
             if hasattr(self.model_runner.model, "hf_to_vllm_mapper")
             else None
         )
-        # convert modelopt state to vllm format
         modelopt_state = convert_modelopt_state_to_vllm(modelopt_state, map_fun=map_fun)
-        # restore model from modelopt state
         restore_from_modelopt_state_vllm(model, modelopt_state)
 
         if modelopt_weights is not None:
-            # convert quantizer state values to vllm format
             modelopt_weights = convert_dict_to_vllm(modelopt_weights, map_fun=map_fun)
             mtq.utils.set_quantizer_state_dict(model, modelopt_weights)
-            # Log any pqs keys in modelopt_weights that were not loaded (key mismatch).
             if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
                 from modelopt.torch.quantization.nn import TensorQuantizer
                 from modelopt.torch.utils import get_unwrapped_name
@@ -93,22 +93,22 @@ def _fakequant_run_prolog_worker(self) -> None:
                     if isinstance(m, TensorQuantizer)
                 }
                 pqs_in_weights = {
-                    k for k, v in modelopt_weights.items()
+                    k
+                    for k, v in modelopt_weights.items()
                     if isinstance(v, dict) and "_pre_quant_scale" in v
                 }
                 unmatched_pqs = pqs_in_weights - loaded_keys
                 if unmatched_pqs:
-                    print(
-                        f"[fakequant_worker] WARNING: {len(unmatched_pqs)} pqs key(s) in "
-                        f"modelopt_weights have no matching quantizer in the model:\n"
-                        + "\n".join(f"  {k}" for k in sorted(unmatched_pqs)[:20])
+                    sample = sorted(unmatched_pqs)[:20]
+                    warnings.warn(
+                        f"{len(unmatched_pqs)} checkpoint pre_quant_scale key(s) have no "
+                        f"matching TensorQuantizer in the model (showing up to 20): {sample}",
+                        stacklevel=2,
                     )
-            # set_quantizer_state_dict does not invoke modelopt_post_restore (unlike restore_quantizer_state).
+            # set_quantizer_state_dict does not run modelopt_post_restore (unlike restore_quantizer_state).
             post_restore_vllm_parallel_linears(model)
-            # For RowParallelLinear layers, pqs was saved at full H_in width (single-GPU
-            # export). Slice it to [H_in / tp_world_size] so it matches the local shard.
-            _debug_pqs = os.environ.get("MODELOPT_DEBUG_PQS", "0").lower() in ("1", "true")
-            shard_pre_quant_scale_for_tp(model, debug=_debug_pqs)
+            # Row-parallel: slice full-width exported pre_quant_scale to this TP rank.
+            shard_pre_quant_scale_for_tp(model)
 
     else:
         if quant_config["quant_file_path"]:
@@ -127,15 +127,13 @@ def _fakequant_run_prolog_worker(self) -> None:
 
         quant_cfg = get_quant_config(quant_config, model)
 
-        # quantize model
         with disable_compilation(model):
             print("Quantizing model...")
             mtq.quantize(model, quant_cfg, forward_loop=calibrate_loop)
 
         quantizer_file_path = quant_config["quant_file_path"]
         if quantizer_file_path:
-            # Get amax and other quantizer state from the quantizer file
-            # this can be used with Megatron-LM exported model using export_mcore_gpt_to_hf_vllm_fq
+            self.model_runner._dummy_run(1)
             current_state_dict = load_state_dict_from_path(self, quantizer_file_path, model)
             model.load_state_dict(current_state_dict)
 

--- a/examples/vllm_serve/fakequant_worker.py
+++ b/examples/vllm_serve/fakequant_worker.py
@@ -92,8 +92,10 @@ def _fakequant_run_prolog_worker(self) -> None:
                     for n, m in model.named_modules()
                     if isinstance(m, TensorQuantizer)
                 }
+                # Same namespace as ``loaded_keys``: checkpoint keys may include DDP/FSDP
+                # prefixes that ``convert_dict_to_vllm`` does not strip.
                 pqs_in_weights = {
-                    k
+                    get_unwrapped_name(k, model)
                     for k, v in modelopt_weights.items()
                     if isinstance(v, dict) and "_pre_quant_scale" in v
                 }
@@ -107,7 +109,7 @@ def _fakequant_run_prolog_worker(self) -> None:
                     )
             # set_quantizer_state_dict does not run modelopt_post_restore (unlike restore_quantizer_state).
             post_restore_vllm_parallel_linears(model)
-            # Row-parallel: slice full-width exported pre_quant_scale to this TP rank.
+            # Must follow post_restore: shard_pre_quant_scale_for_tp uses weight H_in vs pqs length.
             shard_pre_quant_scale_for_tp(model)
 
     else:

--- a/examples/vllm_serve/fakequant_worker.py
+++ b/examples/vllm_serve/fakequant_worker.py
@@ -31,10 +31,12 @@ from vllm_reload_utils import (
 )
 
 import modelopt.torch.quantization as mtq
+from modelopt.torch.export.hf_vllm_quantizer_merge import is_weight_quantizer_state_key
 from modelopt.torch.quantization.plugins.vllm import (
     disable_compilation,
     post_restore_vllm_parallel_linears,
 )
+from modelopt.torch.utils import safe_load
 from modelopt.torch.utils.dataset_utils import get_dataset_dataloader
 
 quant_config: dict[str, Any] = {
@@ -63,14 +65,8 @@ def _fakequant_run_prolog_worker(self) -> None:
         model = model.unwrap()
     if quant_config["modelopt_state_path"]:
         print(f"Loading modelopt state from {quant_config['modelopt_state_path']}")
-        # map_location="cpu": load tensors on CPU so device ids in the file need not match this worker.
-        # weights_only=False: ``vllm_fq_modelopt_state.pth`` is a full ModelOpt pickle (metadata,
-        # nested dicts, dtypes, etc.); PyTorch's ``weights_only=True`` rejects that and only
-        # allows tensor-only checkpoints. Loading arbitrary pickles can execute stored code—use
-        # paths you trust (your own exports or verified checkpoints).
-        modelopt_state = torch.load(
-            quant_config["modelopt_state_path"], weights_only=False, map_location="cpu"
-        )
+        # Load on CPU to avoid failures when the checkpoint was saved from a different GPU mapping.
+        modelopt_state = safe_load(quant_config["modelopt_state_path"], map_location="cpu")
         modelopt_weights = modelopt_state.pop("modelopt_state_weights", None)
         map_fun = (
             self.model_runner.model.hf_to_vllm_mapper.apply_dict
@@ -148,7 +144,7 @@ def _fakequant_run_prolog_worker(self) -> None:
 
     mtq.fold_weight(model)
     for name, module in model.named_modules():
-        if name.endswith("weight_quantizer"):
+        if is_weight_quantizer_state_key(name):
             assert not module.is_enabled, f"quantizer {name} is still enabled"
 
 

--- a/examples/vllm_serve/fakequant_worker.py
+++ b/examples/vllm_serve/fakequant_worker.py
@@ -26,6 +26,7 @@ from vllm_reload_utils import (
     convert_modelopt_state_to_vllm,
     load_state_dict_from_path,
     restore_from_modelopt_state_vllm,
+    shard_pre_quant_scale_for_tp,
 )
 
 import modelopt.torch.quantization as mtq
@@ -64,7 +65,7 @@ def _fakequant_run_prolog_worker(self) -> None:
         # Load on CPU to avoid failures when the checkpoint was saved from a different
         # GPU mapping
         modelopt_state = torch.load(
-            quant_config["modelopt_state_path"], weights_only=True, map_location="cpu"
+            quant_config["modelopt_state_path"], weights_only=False, map_location="cpu"
         )
         modelopt_weights = modelopt_state.pop("modelopt_state_weights", None)
         map_fun = (
@@ -81,8 +82,33 @@ def _fakequant_run_prolog_worker(self) -> None:
             # convert quantizer state values to vllm format
             modelopt_weights = convert_dict_to_vllm(modelopt_weights, map_fun=map_fun)
             mtq.utils.set_quantizer_state_dict(model, modelopt_weights)
+            # Log any pqs keys in modelopt_weights that were not loaded (key mismatch).
+            if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
+                from modelopt.torch.quantization.nn import TensorQuantizer
+                from modelopt.torch.utils import get_unwrapped_name
+
+                loaded_keys = {
+                    get_unwrapped_name(n, model)
+                    for n, m in model.named_modules()
+                    if isinstance(m, TensorQuantizer)
+                }
+                pqs_in_weights = {
+                    k for k, v in modelopt_weights.items()
+                    if isinstance(v, dict) and "_pre_quant_scale" in v
+                }
+                unmatched_pqs = pqs_in_weights - loaded_keys
+                if unmatched_pqs:
+                    print(
+                        f"[fakequant_worker] WARNING: {len(unmatched_pqs)} pqs key(s) in "
+                        f"modelopt_weights have no matching quantizer in the model:\n"
+                        + "\n".join(f"  {k}" for k in sorted(unmatched_pqs)[:20])
+                    )
             # set_quantizer_state_dict does not invoke modelopt_post_restore (unlike restore_quantizer_state).
             post_restore_vllm_parallel_linears(model)
+            # For RowParallelLinear layers, pqs was saved at full H_in width (single-GPU
+            # export). Slice it to [H_in / tp_world_size] so it matches the local shard.
+            _debug_pqs = os.environ.get("MODELOPT_DEBUG_PQS", "0").lower() in ("1", "true")
+            shard_pre_quant_scale_for_tp(model, debug=_debug_pqs)
 
     else:
         if quant_config["quant_file_path"]:

--- a/examples/vllm_serve/fakequant_worker.py
+++ b/examples/vllm_serve/fakequant_worker.py
@@ -144,8 +144,11 @@ def _fakequant_run_prolog_worker(self) -> None:
 
     mtq.fold_weight(model)
     for name, module in model.named_modules():
-        if is_weight_quantizer_state_key(name):
-            assert not module.is_enabled, f"quantizer {name} is still enabled"
+        if is_weight_quantizer_state_key(name) and module.is_enabled:
+            raise RuntimeError(
+                f"Weight quantizer {name!r} is still enabled after fold_weight — "
+                "double-quantization would corrupt activations."
+            )
 
 
 class FakeQuantWorker(BaseWorker):

--- a/examples/vllm_serve/vllm_reload_utils.py
+++ b/examples/vllm_serve/vllm_reload_utils.py
@@ -23,10 +23,7 @@ from typing import Any
 import torch
 from vllm.distributed.parallel_state import get_tp_group
 
-from modelopt.torch.export.plugins.vllm_fakequant_hf import (
-    is_weight_quantizer_state_key,
-    merge_amax_tensors_for_vllm_group,
-)
+from modelopt.torch.export.plugins.vllm_fakequant_hf import is_weight_quantizer_state_key
 from modelopt.torch.opt.conversion import (
     ModelLikeModule,
     ModeloptStateManager,
@@ -161,6 +158,33 @@ def _group_keys_for_vllm(
         # action == "skip" does nothing
 
     return vllm_state_dict, merge_groups
+
+
+def merge_amax_tensors_for_vllm_group(tensors: list[torch.Tensor]) -> torch.Tensor:
+    """Combine `_amax` buffers from a merge group into a single tensor.
+
+    Used when HuggingFace module names are folded to vLLM names (e.g. q/k/v → qkv_proj).
+
+    - If every tensor has the same shape, take the element-wise maximum over the group
+      (conservative when each branch carried the same axis layout).
+    - If shapes differ (e.g. GQA q vs k), try ``torch.cat(..., dim=0)`` when valid for
+      per-channel amax; otherwise fall back to a scalar max over all elements.
+    """
+    if not tensors:
+        raise ValueError("merge_amax_tensors_for_vllm_group: expected at least one tensor")
+    if len(tensors) == 1:
+        return tensors[0]
+
+    first = tensors[0]
+    if all(t.shape == first.shape for t in tensors):
+        stacked = torch.stack([t.float() for t in tensors], dim=0)
+        return torch.amax(stacked, dim=0).to(dtype=first.dtype, device=first.device)
+
+    try:
+        return torch.cat(tensors, dim=0).to(dtype=first.dtype, device=first.device)
+    except RuntimeError:
+        flat = torch.cat([t.reshape(-1).float() for t in tensors])
+        return torch.max(flat).to(dtype=first.dtype, device=first.device)
 
 
 def _merge_values_by_max_or_concat(merged_key: str, key_value_pairs: list[tuple[str, Any]]) -> Any:

--- a/examples/vllm_serve/vllm_reload_utils.py
+++ b/examples/vllm_serve/vllm_reload_utils.py
@@ -22,6 +22,7 @@ from typing import Any
 import torch
 from vllm.distributed.parallel_state import get_tp_group
 
+from modelopt.torch.export.hf_vllm_quantizer_merge import merge_amax_tensors_for_vllm_group
 from modelopt.torch.opt.conversion import (
     ModelLikeModule,
     ModeloptStateManager,
@@ -173,7 +174,7 @@ def _merge_values_by_max_or_concat(merged_key: str, key_value_pairs: list[tuple[
         for dict_key in values[0]:
             tensors = [v[dict_key] for v in values]
             if "_amax" in dict_key:
-                merged_value[dict_key] = torch.stack(tensors).max(dim=0)[0]
+                merged_value[dict_key] = merge_amax_tensors_for_vllm_group(tensors)
             elif "_pre_quant_scale" in dict_key:
                 # _pre_quant_scale is per-input-channel: identical across q/k/v projections
                 # since they share the same input. Do not concatenate; take the first value.
@@ -184,7 +185,7 @@ def _merge_values_by_max_or_concat(merged_key: str, key_value_pairs: list[tuple[
     else:
         # Values are tensors directly
         if "_amax" in merged_key:
-            merged_value = torch.stack(values).max(dim=0)[0]
+            merged_value = merge_amax_tensors_for_vllm_group(values)
         else:
             merged_value = torch.cat(values, dim=0)
         return merged_value

--- a/examples/vllm_serve/vllm_reload_utils.py
+++ b/examples/vllm_serve/vllm_reload_utils.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import re
 import warnings
 from collections import defaultdict
@@ -248,7 +247,7 @@ def _infer_prefix_remap(
                 if new_first != first_component:
                     prefix_remap[first_component] = new_first
         except Exception as e:
-            logging.getLogger(__name__).debug("prefix-remap probe failed for %r: %s", probe_key, e)
+            warnings.warn(f"prefix-remap probe failed for {probe_key!r}: {e}")
     return prefix_remap
 
 
@@ -401,6 +400,17 @@ def filter_modelopt_state_quantizer_state_for_model(
                 if is_weight_quantizer_state_key(k) and not state.get("_disabled"):
                     state = {**state, "_disabled": True}
                 filtered[k] = state
+
+            # Invariant: weight quantizers absent from export must be _disabled.
+            for wq_k in model_keys:
+                if not is_weight_quantizer_state_key(wq_k):
+                    continue
+                wq_state = filtered[wq_k]
+                assert wq_k in saved or wq_state.get("_disabled"), (
+                    f"Weight quantizer {wq_k!r} is missing from saved quantizer_state but "
+                    f"is not marked _disabled (got _disabled={wq_state.get('_disabled')!r}). "
+                    f"vLLM fakequant export omits weight quantizer keys when weights are folded."
+                )
             metadata["quantizer_state"] = filtered
 
 

--- a/examples/vllm_serve/vllm_reload_utils.py
+++ b/examples/vllm_serve/vllm_reload_utils.py
@@ -84,7 +84,7 @@ def _convert_key_for_vllm(key: str, value: Any) -> tuple[str, str | None, Any]:
     if "quantizer" not in key:
         return ("copy", key, value)
 
-    # Skip softmax_quantizer and lm_head quantizers(not needed in vLLM)
+    # Skip softmax_quantizer and lm_head quantizers (not needed in vLLM).
     if "softmax_quantizer" in key or (key.startswith("lm_head.") and "quantizer" in key):
         return ("skip", None, None)
 
@@ -95,8 +95,7 @@ def _convert_key_for_vllm(key: str, value: Any) -> tuple[str, str | None, Any]:
         group_key = qkv_match.group(1) + "qkv_proj." + qkv_match.group(3) + suffix
         return ("group", group_key, value)
 
-    # Check if this is an expert gate/up projection
-    # if "mixer" not in key:
+    # Expert gate/up (per-expert) → w13 merge
     expert_gate_up_match = re.search(
         r"(.*\.experts)\.\d+\.(gate|up)_proj\.([^.]+_quantizer)(\..+)?$", key
     )
@@ -113,8 +112,6 @@ def _convert_key_for_vllm(key: str, value: Any) -> tuple[str, str | None, Any]:
             group_key = gate_up_match.group(1) + "gate_up_proj." + gate_up_match.group(3) + suffix
             return ("group", group_key, value)
 
-    # Check if this is an expert down_proj
-    # if "mixer" not in key:
     expert_down_match = re.search(r"(.*\.experts)\.\d+\.down_proj\.([^.]+_quantizer)(\..+)?$", key)
     if expert_down_match:
         suffix = expert_down_match.group(3) or ""
@@ -222,37 +219,31 @@ def _infer_prefix_remap(
     quantizer_keys: dict[str, Any],
     map_fun: Callable[[dict[str, Any]], dict[str, Any]],
 ) -> dict[str, str]:
-    """Infer root-prefix renames (e.g. ``backbone`` → ``model``) by probing map_fun.
+    """Map HF root name → vLLM root (e.g. ``backbone`` → ``model``) using ``map_fun`` on ``*.weight`` keys.
 
-    Some HF models use a different top-level module name than vLLM (e.g.
-    NemotronH uses ``backbone.layers`` in HF but ``model.layers`` in vLLM).
-    Quantizer keys are not run through map_fun (which transforms tensor values),
-    so the prefix rename is never applied to them.  This function discovers the
-    rename by sending a synthetic weight key derived from each unseen root prefix
-    through map_fun and comparing the first path component of the result.
+    Quantizer keys skip ``map_fun`` later, so we learn renames by probing with a small 2-D tensor
+    (many mappers assume 2-D weights; 1-D probes can raise).
     """
     prefix_remap: dict[str, str] = {}
-    # Use a 2-D dummy so the mapper can handle ops like transpose/chunk without
-    # shape errors (1-D tensors fail for many weight-transform operations).
-    _DUMMY = torch.empty(16, 16)
     for key in quantizer_keys:
         first_component = key.split(".")[0]
         if first_component in prefix_remap:
-            continue  # already found a mapping for this prefix
+            continue
         last_dot = key.rfind(".")
         if last_dot == -1:
             continue
-        module_path = key[:last_dot]
-        probe_key = module_path + ".weight"
+        probe_key = key[:last_dot] + ".weight"
         try:
-            result = map_fun({probe_key: _DUMMY})
+            result = map_fun({probe_key: torch.empty(16, 16)})
             if result:
                 new_key = next(iter(result))
                 new_first = new_key.split(".")[0]
                 if new_first != first_component:
                     prefix_remap[first_component] = new_first
-        except Exception:
-            pass  # mapper doesn't know this layer type; try the next key
+        except Exception as e:
+            import logging
+
+            logging.getLogger(__name__).debug("prefix-remap probe failed for %r: %s", probe_key, e)
     return prefix_remap
 
 
@@ -440,85 +431,114 @@ def restore_from_modelopt_state_vllm(
     return model
 
 
+def _tp_concat_shard_dims(
+    value_shape: tuple[int, ...],
+    expected_shape: tuple[int, ...],
+    tp_world_size: int,
+) -> list[int]:
+    """Dims ``d`` where checkpoint looks like TP concat: ``value[d] == expected[d] * tp_world_size``."""
+    return [
+        d for d in range(len(expected_shape)) if value_shape[d] == expected_shape[d] * tp_world_size
+    ]
+
+
+def _narrow_tensor_to_tp_local_shard(
+    value: torch.Tensor,
+    expected_shape: tuple[int, ...] | torch.Size,
+    tp_rank: int,
+    tp_world_size: int,
+    *,
+    context: str,
+) -> torch.Tensor:
+    """Slice ``value`` to this TP rank when it is the concat of per-rank shards along one dim."""
+    value_shape = value.shape
+    expected_shape = tuple(expected_shape)
+    if value_shape == expected_shape:
+        return value
+    if len(value_shape) != len(expected_shape):
+        raise ValueError(
+            f"{context}: rank mismatch (checkpoint={tuple(value_shape)}, expected={tuple(expected_shape)})"
+        )
+    shard_dims = _tp_concat_shard_dims(value_shape, expected_shape, tp_world_size)
+    if len(shard_dims) != 1:
+        raise ValueError(
+            f"{context}: cannot infer TP shard dim "
+            f"(expected={tuple(expected_shape)}, checkpoint={tuple(value_shape)}, tp={tp_world_size})"
+        )
+    d = shard_dims[0]
+    shard_size = expected_shape[d]
+    start = tp_rank * shard_size
+    if start + shard_size > value_shape[d]:
+        raise ValueError(
+            f"{context}: TP shard out of bounds "
+            f"(expected={tuple(expected_shape)}, checkpoint={tuple(value_shape)})"
+        )
+    return value.narrow(d, start, shard_size).contiguous()
+
+
+def _pqs_local_expected_shape(pqs: torch.Tensor, expected_in: int) -> tuple[int, ...] | None:
+    """Local per-rank shape for ``_pre_quant_scale`` (1-D ``[H]`` or broadcast 2-D ``[1, H]``)."""
+    if pqs.ndim == 1:
+        return (expected_in,)
+    if pqs.ndim == 2 and pqs.shape[0] == 1:
+        return (1, expected_in)
+    return None
+
+
+def _expected_in_features_for_input_quantizer(parent: Any, input_quantizer_attr: str) -> int | None:
+    """Input feature count for the weight paired with ``*_input_quantizer`` (Linear or FusedMoE)."""
+    stem = input_quantizer_attr[: -len("_input_quantizer")]
+    w = getattr(parent, (stem + "_weight") if stem else "weight", None)
+    if w is None or not isinstance(w, torch.Tensor) or w.is_meta:
+        return None
+    return int(w.shape[-1] if w.ndim == 3 else w.shape[1])
+
+
 def shard_pre_quant_scale_for_tp(model: Any) -> None:
-    """Shard ``_pre_quant_scale`` tensors in-place for the local TP rank.
+    """Shard ``_pre_quant_scale`` in-place for the local TP rank (row-parallel inputs).
 
-    After ``set_quantizer_state_dict`` loads full-size pqs from the HF export
-    (which was saved from a single-GPU run), RowParallelLinear layers need the
-    input-channel pqs sliced down to ``H_in / tp_world_size``.  Column-parallel
-    layers share the full input across ranks and don't need sharding.
+    HF exports often store full (unsharded) scales; after load, row-parallel layers need
+    ``pqs`` narrowed to ``H_in / tp`` when ``len(pqs) == H_in * tp_world_size``.
 
-    The heuristic: compare the pqs channel count against the corresponding
-    weight tensor's input dimension.  If they differ by exactly ``tp_world_size``
-    the tensor is sliced; otherwise it is left unchanged.
+    Args:
+        model: vLLM model with ``TensorQuantizer`` submodules.
     """
     from modelopt.torch.quantization.nn import TensorQuantizer
 
     tp_group = get_tp_group()
-    tp_rank = tp_group.rank_in_group
-    tp_world_size = tp_group.world_size
+    tp_rank, tp_world_size = tp_group.rank_in_group, tp_group.world_size
     if tp_world_size == 1:
         return
 
-    # Iterate over TensorQuantizer modules directly. Submodules live in
-    # module._modules, not in vars(module).__dict__, so iterating vars() misses them.
-    for quantizer_name, quantizer in model.named_modules():
+    for qname, quantizer in model.named_modules():
         if not isinstance(quantizer, TensorQuantizer):
             continue
         pqs = getattr(quantizer, "_pre_quant_scale", None)
         if pqs is None:
             continue
-
-        # Resolve the parent module and quantizer attribute name.
-        # quantizer_name: "model.layers.0.o_proj.input_quantizer"
-        #              or "model.layers.1.mixer.experts.w13_input_quantizer"
-        last_dot = quantizer_name.rfind(".")
-        if last_dot == -1:
+        last = qname.rfind(".")
+        if last == -1 or not qname[last + 1 :].endswith("input_quantizer"):
             continue
-        parent_path = quantizer_name[:last_dot]
-        attr_name = quantizer_name[last_dot + 1 :]  # "input_quantizer" or "w13_input_quantizer"
-
-        if not attr_name.endswith("input_quantizer"):
-            continue
-
         try:
-            parent = model.get_submodule(parent_path)
-        except AttributeError:
+            parent = model.get_submodule(qname[:last])
+        except (AttributeError, LookupError):
             continue
-
-        # Derive the weight attribute name from the quantizer attribute name.
-        #   "input_quantizer"     -> "weight"        (regular QuantLinear)
-        #   "w13_input_quantizer" -> "w13_weight"    (FusedMoE gate+up)
-        #   "w2_input_quantizer"  -> "w2_weight"     (FusedMoE down)
-        stem = attr_name[: -len("_input_quantizer")]  # "" / "w13" / "w2"
-        weight_attr = (stem + "_weight") if stem else "weight"
-        w = getattr(parent, weight_attr, None)
-        if w is None or not isinstance(w, torch.Tensor) or w.is_meta:
+        expected_in = _expected_in_features_for_input_quantizer(parent, qname[last + 1 :])
+        if expected_in is None:
             continue
-
-        # Input dim: last dim for 3D [E, H_out, H_in] (FusedMoE), dim 1 for 2D.
-        expected_size = w.shape[-1] if w.ndim == 3 else w.shape[1]
-
-        # Support both [H_in] (1-D) and [1, H_in] (2-D broadcast) layouts.
-        if pqs.ndim == 1:
-            shard_dim, full_size = 0, pqs.shape[0]
-        elif pqs.ndim == 2 and pqs.shape[0] == 1:
-            shard_dim, full_size = 1, pqs.shape[1]
-        else:
+        expected_shape = _pqs_local_expected_shape(pqs, expected_in)
+        if expected_shape is None:
             continue
-
-        if full_size == expected_size:
-            continue  # already the right size (column-parallel or TP=1)
-        if full_size != expected_size * tp_world_size:
-            warnings.warn(
-                f"{quantizer_name}._pre_quant_scale: "
-                f"size {full_size} does not equal expected_size {expected_size} × "
-                f"tp_world_size {tp_world_size}. Skipping shard."
+        try:
+            quantizer._pre_quant_scale = _narrow_tensor_to_tp_local_shard(
+                pqs,
+                expected_shape,
+                tp_rank,
+                tp_world_size,
+                context=f"{qname}._pre_quant_scale",
             )
-            continue
-
-        start = tp_rank * expected_size
-        quantizer._pre_quant_scale = pqs.narrow(shard_dim, start, expected_size).contiguous()
+        except ValueError as e:
+            warnings.warn(str(e))
 
 
 def process_state_dict_for_tp(saved_qstate_dict, current_state_dict):
@@ -531,42 +551,14 @@ def process_state_dict_for_tp(saved_qstate_dict, current_state_dict):
     for key, value in saved_qstate_dict.items():
         if key in current_state_dict:
             expected = current_state_dict[key]
-            if not hasattr(value, "shape") or not hasattr(expected, "shape"):
-                result[key] = value
-                continue
-            expected_shape = expected.shape
-            value_shape = value.shape
-            if value_shape != expected_shape:
-                # Verify compatible rank before indexing
-                if len(value_shape) != len(expected_shape):
-                    raise ValueError(
-                        f"Cannot infer TP shard dim for {key}: rank mismatch "
-                        f"(checkpoint rank={len(value_shape)}, expected rank={len(expected_shape)})"
-                    )
-                # Find the dimension that was tensor-parallel sharded.
-                # We expect exactly one dimension to satisfy:
-                #   checkpoint_dim == expected_dim * tp_world_size
-                shard_dims = [
-                    d
-                    for d in range(len(expected_shape))
-                    if value_shape[d] == expected_shape[d] * tp_world_size
-                ]
-                if len(shard_dims) != 1:
-                    raise ValueError(
-                        f"Cannot infer TP shard dim for {key}: "
-                        f"expected_shape={tuple(expected_shape)}, checkpoint_shape={tuple(value_shape)}"
-                    )
-
-                shard_dim = shard_dims[0]
-                shard_size = expected_shape[shard_dim]
-                start = tp_rank * shard_size
-                end = start + shard_size
-                if end > value_shape[shard_dim]:
-                    raise ValueError(
-                        f"TP shard out of bounds for {key}: "
-                        f"expected_shape={tuple(expected_shape)}, checkpoint_shape={tuple(value_shape)}"
-                    )
-                value = value.narrow(shard_dim, start, shard_size).contiguous()
+            if hasattr(value, "shape") and hasattr(expected, "shape"):
+                value = _narrow_tensor_to_tp_local_shard(
+                    value,
+                    expected.shape,
+                    tp_rank,
+                    tp_world_size,
+                    context=f"Key {key!r}",
+                )
         result[key] = value
 
     return result
@@ -575,12 +567,8 @@ def process_state_dict_for_tp(saved_qstate_dict, current_state_dict):
 def load_state_dict_from_path(
     fakequant_runner: Any, quantizer_file_path: str, model: Any
 ) -> dict[str, Any]:
-    fakequant_runner.model_runner._dummy_run(1)
-    print(f"Loading quantizer values from {quantizer_file_path}")
-    # Load on CPU to avoid failures when the checkpoint was saved from a different
-    # GPU mapping
+    # Load on CPU to avoid failures when the checkpoint was saved from a different GPU mapping.
     saved_quant_dict = torch.load(quantizer_file_path, weights_only=True, map_location="cpu")
-    # convert quant keys to vLLM format
     if hasattr(fakequant_runner.model_runner.model, "hf_to_vllm_mapper"):
         saved_quant_dict = fakequant_runner.model_runner.model.hf_to_vllm_mapper.apply_dict(
             saved_quant_dict
@@ -593,7 +581,6 @@ def load_state_dict_from_path(
     saved_quant_dict = convert_dict_to_vllm(saved_quant_dict)
 
     current_state_dict = model.state_dict()
-    # Count quant keys in checkpoint and model
     checkpoint_quant_keys = [key for key in saved_quant_dict if "quantizer" in key]
     model_quant_keys = [key for key in current_state_dict if "quantizer" in key]
     ckpt_key_set = set(checkpoint_quant_keys)

--- a/examples/vllm_serve/vllm_reload_utils.py
+++ b/examples/vllm_serve/vllm_reload_utils.py
@@ -221,10 +221,12 @@ def _infer_prefix_remap(
 ) -> dict[str, str]:
     """Map HF root name → vLLM root (e.g. ``backbone`` → ``model``) using ``map_fun`` on ``*.weight`` keys.
 
-    Quantizer keys skip ``map_fun`` later, so we learn renames by probing with a small 2-D tensor
-    (many mappers assume 2-D weights; 1-D probes can raise).
+    Quantizer keys never go through ``map_fun`` later, so we probe with a tiny CPU placeholder.
+    It must be **2-D** (mappers expect matrix weights; 1-D often errors). Only the returned key
+    path is used; values are ignored. A CPU tensor is enough for typical HF↔vLLM name mapping.
     """
     prefix_remap: dict[str, str] = {}
+    probe_weight = torch.empty((1, 1))
     for key in quantizer_keys:
         first_component = key.split(".")[0]
         if first_component in prefix_remap:
@@ -234,7 +236,7 @@ def _infer_prefix_remap(
             continue
         probe_key = key[:last_dot] + ".weight"
         try:
-            result = map_fun({probe_key: torch.empty(16, 16)})
+            result = map_fun({probe_key: probe_weight})
             if result:
                 new_key = next(iter(result))
                 new_first = new_key.split(".")[0]
@@ -388,7 +390,14 @@ def filter_modelopt_state_quantizer_state_for_model(
             }
             # Add state for quantizers in model but not in metadata (e.g. disabled/excluded)
             for k in model_keys - filtered.keys():
-                filtered[k] = model_qstate[k]
+                state = model_qstate[k]
+                # Weight quantizers absent from exported metadata were disabled during export
+                # (weights are already fake-quantized and pre_quant_scale is folded in).
+                # Keep them disabled on reload so fold_weight does not re-quantize the
+                # already-folded weights (re-quantizing distorts the pqs-scaled values).
+                if k.endswith("weight_quantizer") and not state.get("_disabled"):
+                    state = {**state, "_disabled": True}
+                filtered[k] = state
             metadata["quantizer_state"] = filtered
 
 
@@ -499,6 +508,11 @@ def shard_pre_quant_scale_for_tp(model: Any) -> None:
 
     HF exports often store full (unsharded) scales; after load, row-parallel layers need
     ``pqs`` narrowed to ``H_in / tp`` when ``len(pqs) == H_in * tp_world_size``.
+
+    Call after parallel linear modules expose TP-sharded weight shapes (e.g.
+    ``post_restore_vllm_parallel_linears``). If run earlier, ``expected_in`` inferred from
+    weights can match an unsharded checkpoint and a second call becomes a no-op even when
+    pqs should still be narrowed.
 
     Args:
         model: vLLM model with ``TensorQuantizer`` submodules.

--- a/examples/vllm_serve/vllm_reload_utils.py
+++ b/examples/vllm_serve/vllm_reload_utils.py
@@ -218,6 +218,44 @@ def _merge_values_require_identical(merged_key: str, key_value_pairs: list[tuple
     return first_value
 
 
+def _infer_prefix_remap(
+    quantizer_keys: dict[str, Any],
+    map_fun: Callable[[dict[str, Any]], dict[str, Any]],
+) -> dict[str, str]:
+    """Infer root-prefix renames (e.g. ``backbone`` → ``model``) by probing map_fun.
+
+    Some HF models use a different top-level module name than vLLM (e.g.
+    NemotronH uses ``backbone.layers`` in HF but ``model.layers`` in vLLM).
+    Quantizer keys are not run through map_fun (which transforms tensor values),
+    so the prefix rename is never applied to them.  This function discovers the
+    rename by sending a synthetic weight key derived from each unseen root prefix
+    through map_fun and comparing the first path component of the result.
+    """
+    prefix_remap: dict[str, str] = {}
+    # Use a 2-D dummy so the mapper can handle ops like transpose/chunk without
+    # shape errors (1-D tensors fail for many weight-transform operations).
+    _DUMMY = torch.empty(16, 16)
+    for key in quantizer_keys:
+        first_component = key.split(".")[0]
+        if first_component in prefix_remap:
+            continue  # already found a mapping for this prefix
+        last_dot = key.rfind(".")
+        if last_dot == -1:
+            continue
+        module_path = key[:last_dot]
+        probe_key = module_path + ".weight"
+        try:
+            result = map_fun({probe_key: _DUMMY})
+            if result:
+                new_key = next(iter(result))
+                new_first = new_key.split(".")[0]
+                if new_first != first_component:
+                    prefix_remap[first_component] = new_first
+        except Exception:
+            pass  # mapper doesn't know this layer type; try the next key
+    return prefix_remap
+
+
 def convert_dict_to_vllm(
     state_dict: dict[str, Any],
     max_or_concat: bool = True,
@@ -231,6 +269,25 @@ def convert_dict_to_vllm(
         max_or_concat: Whether to merge grouped values by taking max/concatenate or require identical
         map_fun: Function to map the state dict to vLLM format
     """
+    # If map_fun is provided, pre-transform quantizer key module-path prefixes so that
+    # HF→vLLM model renames (e.g. backbone.layers → model.layers) are applied before
+    # key grouping (q/k/v → qkv, experts.N.up_proj → experts.w13, etc.).
+    # This is necessary for models where the HF root module differs from vLLM's (e.g.
+    # NemotronH uses backbone.layers in HF but model.layers in vLLM), and for
+    # modelopt_state_weights where ALL keys are quantizer keys so map_fun is never
+    # invoked on non-quantizer keys.
+    if map_fun is not None:
+        q_only = {k: v for k, v in state_dict.items() if "_quantizer" in k}
+        prefix_remap = _infer_prefix_remap(q_only, map_fun)
+        if prefix_remap:
+            renamed = {}
+            for k, v in state_dict.items():
+                if "_quantizer" in k:
+                    first = k.split(".")[0]
+                    k = prefix_remap.get(first, first) + k[len(first) :]
+                renamed[k] = v
+            state_dict = renamed
+
     vllm_state_dict, merge_groups = _group_keys_for_vllm(state_dict)
 
     merge_fn = _merge_values_by_max_or_concat if max_or_concat else _merge_values_require_identical
@@ -381,6 +438,87 @@ def restore_from_modelopt_state_vllm(
         model = model.init_modellike()
     assert not isinstance(model, ModelLikeModule), "Model must be a regular Module now!"
     return model
+
+
+def shard_pre_quant_scale_for_tp(model: Any) -> None:
+    """Shard ``_pre_quant_scale`` tensors in-place for the local TP rank.
+
+    After ``set_quantizer_state_dict`` loads full-size pqs from the HF export
+    (which was saved from a single-GPU run), RowParallelLinear layers need the
+    input-channel pqs sliced down to ``H_in / tp_world_size``.  Column-parallel
+    layers share the full input across ranks and don't need sharding.
+
+    The heuristic: compare the pqs channel count against the corresponding
+    weight tensor's input dimension.  If they differ by exactly ``tp_world_size``
+    the tensor is sliced; otherwise it is left unchanged.
+    """
+    from modelopt.torch.quantization.nn import TensorQuantizer
+
+    tp_group = get_tp_group()
+    tp_rank = tp_group.rank_in_group
+    tp_world_size = tp_group.world_size
+    if tp_world_size == 1:
+        return
+
+    # Iterate over TensorQuantizer modules directly. Submodules live in
+    # module._modules, not in vars(module).__dict__, so iterating vars() misses them.
+    for quantizer_name, quantizer in model.named_modules():
+        if not isinstance(quantizer, TensorQuantizer):
+            continue
+        pqs = getattr(quantizer, "_pre_quant_scale", None)
+        if pqs is None:
+            continue
+
+        # Resolve the parent module and quantizer attribute name.
+        # quantizer_name: "model.layers.0.o_proj.input_quantizer"
+        #              or "model.layers.1.mixer.experts.w13_input_quantizer"
+        last_dot = quantizer_name.rfind(".")
+        if last_dot == -1:
+            continue
+        parent_path = quantizer_name[:last_dot]
+        attr_name = quantizer_name[last_dot + 1 :]  # "input_quantizer" or "w13_input_quantizer"
+
+        if not attr_name.endswith("input_quantizer"):
+            continue
+
+        try:
+            parent = model.get_submodule(parent_path)
+        except AttributeError:
+            continue
+
+        # Derive the weight attribute name from the quantizer attribute name.
+        #   "input_quantizer"     -> "weight"        (regular QuantLinear)
+        #   "w13_input_quantizer" -> "w13_weight"    (FusedMoE gate+up)
+        #   "w2_input_quantizer"  -> "w2_weight"     (FusedMoE down)
+        stem = attr_name[: -len("_input_quantizer")]  # "" / "w13" / "w2"
+        weight_attr = (stem + "_weight") if stem else "weight"
+        w = getattr(parent, weight_attr, None)
+        if w is None or not isinstance(w, torch.Tensor) or w.is_meta:
+            continue
+
+        # Input dim: last dim for 3D [E, H_out, H_in] (FusedMoE), dim 1 for 2D.
+        expected_size = w.shape[-1] if w.ndim == 3 else w.shape[1]
+
+        # Support both [H_in] (1-D) and [1, H_in] (2-D broadcast) layouts.
+        if pqs.ndim == 1:
+            shard_dim, full_size = 0, pqs.shape[0]
+        elif pqs.ndim == 2 and pqs.shape[0] == 1:
+            shard_dim, full_size = 1, pqs.shape[1]
+        else:
+            continue
+
+        if full_size == expected_size:
+            continue  # already the right size (column-parallel or TP=1)
+        if full_size != expected_size * tp_world_size:
+            warnings.warn(
+                f"{quantizer_name}._pre_quant_scale: "
+                f"size {full_size} does not equal expected_size {expected_size} × "
+                f"tp_world_size {tp_world_size}. Skipping shard."
+            )
+            continue
+
+        start = tp_rank * expected_size
+        quantizer._pre_quant_scale = pqs.narrow(shard_dim, start, expected_size).contiguous()
 
 
 def process_state_dict_for_tp(saved_qstate_dict, current_state_dict):

--- a/examples/vllm_serve/vllm_reload_utils.py
+++ b/examples/vllm_serve/vllm_reload_utils.py
@@ -23,7 +23,10 @@ from typing import Any
 import torch
 from vllm.distributed.parallel_state import get_tp_group
 
-from modelopt.torch.export.plugins.vllm_fakequant_hf import is_weight_quantizer_state_key
+from modelopt.torch.export.plugins.vllm_fakequant_hf import (
+    is_weight_quantizer_state_key,
+    merge_amax_tensors_for_group,
+)
 from modelopt.torch.opt.conversion import (
     ModelLikeModule,
     ModeloptStateManager,
@@ -160,33 +163,6 @@ def _group_keys_for_vllm(
     return vllm_state_dict, merge_groups
 
 
-def merge_amax_tensors_for_vllm_group(tensors: list[torch.Tensor]) -> torch.Tensor:
-    """Combine `_amax` buffers from a merge group into a single tensor.
-
-    Used when HuggingFace module names are folded to vLLM names (e.g. q/k/v → qkv_proj).
-
-    - If every tensor has the same shape, take the element-wise maximum over the group
-      (conservative when each branch carried the same axis layout).
-    - If shapes differ (e.g. GQA q vs k), try ``torch.cat(..., dim=0)`` when valid for
-      per-channel amax; otherwise fall back to a scalar max over all elements.
-    """
-    if not tensors:
-        raise ValueError("merge_amax_tensors_for_vllm_group: expected at least one tensor")
-    if len(tensors) == 1:
-        return tensors[0]
-
-    first = tensors[0]
-    if all(t.shape == first.shape for t in tensors):
-        stacked = torch.stack([t.float() for t in tensors], dim=0)
-        return torch.amax(stacked, dim=0).to(dtype=first.dtype, device=first.device)
-
-    try:
-        return torch.cat(tensors, dim=0).to(dtype=first.dtype, device=first.device)
-    except RuntimeError:
-        flat = torch.cat([t.reshape(-1).float() for t in tensors])
-        return torch.max(flat).to(dtype=first.dtype, device=first.device)
-
-
 def _merge_values_by_max_or_concat(merged_key: str, key_value_pairs: list[tuple[str, Any]]) -> Any:
     """
     Merge values by taking max for amax, concatenating for others.
@@ -202,7 +178,7 @@ def _merge_values_by_max_or_concat(merged_key: str, key_value_pairs: list[tuple[
         for dict_key in values[0]:
             tensors = [v[dict_key] for v in values]
             if "_amax" in dict_key:
-                merged_value[dict_key] = merge_amax_tensors_for_vllm_group(tensors)
+                merged_value[dict_key] = merge_amax_tensors_for_group(tensors)
             elif "_pre_quant_scale" in dict_key:
                 # _pre_quant_scale is per-input-channel: identical across q/k/v projections
                 # since they share the same input. Do not concatenate; take the first value.
@@ -213,7 +189,7 @@ def _merge_values_by_max_or_concat(merged_key: str, key_value_pairs: list[tuple[
     else:
         # Values are tensors directly
         if "_amax" in merged_key:
-            merged_value = merge_amax_tensors_for_vllm_group(values)
+            merged_value = merge_amax_tensors_for_group(values)
         else:
             merged_value = torch.cat(values, dim=0)
         return merged_value

--- a/examples/vllm_serve/vllm_reload_utils.py
+++ b/examples/vllm_serve/vllm_reload_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import re
 import warnings
 from collections import defaultdict
@@ -22,7 +23,10 @@ from typing import Any
 import torch
 from vllm.distributed.parallel_state import get_tp_group
 
-from modelopt.torch.export.hf_vllm_quantizer_merge import merge_amax_tensors_for_vllm_group
+from modelopt.torch.export.hf_vllm_quantizer_merge import (
+    is_weight_quantizer_state_key,
+    merge_amax_tensors_for_vllm_group,
+)
 from modelopt.torch.opt.conversion import (
     ModelLikeModule,
     ModeloptStateManager,
@@ -244,8 +248,6 @@ def _infer_prefix_remap(
                 if new_first != first_component:
                     prefix_remap[first_component] = new_first
         except Exception as e:
-            import logging
-
             logging.getLogger(__name__).debug("prefix-remap probe failed for %r: %s", probe_key, e)
     return prefix_remap
 
@@ -396,7 +398,7 @@ def filter_modelopt_state_quantizer_state_for_model(
                 # (weights are already fake-quantized and pre_quant_scale is folded in).
                 # Keep them disabled on reload so fold_weight does not re-quantize the
                 # already-folded weights (re-quantizing distorts the pqs-scaled values).
-                if k.endswith("weight_quantizer") and not state.get("_disabled"):
+                if is_weight_quantizer_state_key(k) and not state.get("_disabled"):
                     state = {**state, "_disabled": True}
                 filtered[k] = state
             metadata["quantizer_state"] = filtered
@@ -544,16 +546,13 @@ def shard_pre_quant_scale_for_tp(model: Any) -> None:
         expected_shape = _pqs_local_expected_shape(pqs, expected_in)
         if expected_shape is None:
             continue
-        try:
-            quantizer._pre_quant_scale = _narrow_tensor_to_tp_local_shard(
-                pqs,
-                expected_shape,
-                tp_rank,
-                tp_world_size,
-                context=f"{qname}._pre_quant_scale",
-            )
-        except ValueError as e:
-            warnings.warn(str(e))
+        quantizer._pre_quant_scale = _narrow_tensor_to_tp_local_shard(
+            pqs,
+            expected_shape,
+            tp_rank,
+            tp_world_size,
+            context=f"{qname}._pre_quant_scale",
+        )
 
 
 def process_state_dict_for_tp(saved_qstate_dict, current_state_dict):

--- a/examples/vllm_serve/vllm_reload_utils.py
+++ b/examples/vllm_serve/vllm_reload_utils.py
@@ -23,7 +23,7 @@ from typing import Any
 import torch
 from vllm.distributed.parallel_state import get_tp_group
 
-from modelopt.torch.export.hf_vllm_quantizer_merge import (
+from modelopt.torch.export.plugins.vllm_fakequant_hf import (
     is_weight_quantizer_state_key,
     merge_amax_tensors_for_vllm_group,
 )

--- a/examples/vllm_serve/vllm_reload_utils.py
+++ b/examples/vllm_serve/vllm_reload_utils.py
@@ -23,6 +23,7 @@ import torch
 from vllm.distributed.parallel_state import get_tp_group
 
 from modelopt.torch.export.plugins.vllm_fakequant_hf import (
+    infer_quantizer_prefix_remap,
     is_weight_quantizer_state_key,
     merge_amax_tensors_for_group,
 )
@@ -149,9 +150,10 @@ def _group_keys_for_vllm(
     for key, value in state_dict.items():
         action, new_key, new_value = _convert_key_for_vllm(key, value)
         if new_key is None or new_value is None:
-            assert action == "skip", (
-                f"Expected action to be 'skip' for key {key}, value {value}, got {action}"
-            )
+            if action != "skip":
+                raise RuntimeError(
+                    f"Expected action to be 'skip' for key {key}, value {value}, got {action}"
+                )
             continue
         if action == "copy":
             vllm_state_dict[new_key] = new_value
@@ -219,38 +221,6 @@ def _merge_values_require_identical(merged_key: str, key_value_pairs: list[tuple
     return first_value
 
 
-def _infer_prefix_remap(
-    quantizer_keys: dict[str, Any],
-    map_fun: Callable[[dict[str, Any]], dict[str, Any]],
-) -> dict[str, str]:
-    """Map HF root name → vLLM root (e.g. ``backbone`` → ``model``) using ``map_fun`` on ``*.weight`` keys.
-
-    Quantizer keys never go through ``map_fun`` later, so we probe with a tiny CPU placeholder.
-    It must be **2-D** (mappers expect matrix weights; 1-D often errors). Only the returned key
-    path is used; values are ignored. A CPU tensor is enough for typical HF↔vLLM name mapping.
-    """
-    prefix_remap: dict[str, str] = {}
-    probe_weight = torch.empty((1, 1))
-    for key in quantizer_keys:
-        first_component = key.split(".")[0]
-        if first_component in prefix_remap:
-            continue
-        last_dot = key.rfind(".")
-        if last_dot == -1:
-            continue
-        probe_key = key[:last_dot] + ".weight"
-        try:
-            result = map_fun({probe_key: probe_weight})
-            if result:
-                new_key = next(iter(result))
-                new_first = new_key.split(".")[0]
-                if new_first != first_component:
-                    prefix_remap[first_component] = new_first
-        except Exception as e:
-            warnings.warn(f"prefix-remap probe failed for {probe_key!r}: {e}")
-    return prefix_remap
-
-
 def convert_dict_to_vllm(
     state_dict: dict[str, Any],
     max_or_concat: bool = True,
@@ -273,7 +243,7 @@ def convert_dict_to_vllm(
     # invoked on non-quantizer keys.
     if map_fun is not None:
         q_only = {k: v for k, v in state_dict.items() if "_quantizer" in k}
-        prefix_remap = _infer_prefix_remap(q_only, map_fun)
+        prefix_remap = infer_quantizer_prefix_remap(q_only, map_fun)
         if prefix_remap:
             renamed = {}
             for k, v in state_dict.items():
@@ -406,11 +376,12 @@ def filter_modelopt_state_quantizer_state_for_model(
                 if not is_weight_quantizer_state_key(wq_k):
                     continue
                 wq_state = filtered[wq_k]
-                assert wq_k in saved or wq_state.get("_disabled"), (
-                    f"Weight quantizer {wq_k!r} is missing from saved quantizer_state but "
-                    f"is not marked _disabled (got _disabled={wq_state.get('_disabled')!r}). "
-                    f"vLLM fakequant export omits weight quantizer keys when weights are folded."
-                )
+                if wq_k not in saved and not wq_state.get("_disabled"):
+                    raise RuntimeError(
+                        f"Weight quantizer {wq_k!r} is missing from saved quantizer_state but "
+                        f"is not marked _disabled (got _disabled={wq_state.get('_disabled')!r}). "
+                        f"vLLM fakequant export omits weight quantizer keys when weights are folded."
+                    )
             metadata["quantizer_state"] = filtered
 
 
@@ -449,7 +420,8 @@ def restore_from_modelopt_state_vllm(
 
     if not manager.has_state and isinstance(model, ModelLikeModule):
         model = model.init_modellike()
-    assert not isinstance(model, ModelLikeModule), "Model must be a regular Module now!"
+    if isinstance(model, ModelLikeModule):
+        raise RuntimeError("Model must be a regular Module after restore, got ModelLikeModule")
     return model
 
 

--- a/modelopt/torch/export/layer_utils.py
+++ b/modelopt/torch/export/layer_utils.py
@@ -84,19 +84,14 @@ with import_plugin("megatron", verbose=False):
 def get_experts_list(
     module: torch.nn.Module,
     model_type: str,
-    hf_config_model_type: str | None = None,
 ):
     """Returns list of grouped experts by linear name for given module.
 
     Args:
         module: MoE block (e.g. MixtralSparseMoeBlock, NemotronHMOE).
         model_type: `type(root_model).__name__.lower()` (may change after ModelOpt quantize).
-        hf_config_model_type: Optional `model.config.model_type` (e.g. `nemotron_h`) when
-            the root class name no longer contains the HF architecture string after wrapping.
     """
     experts_list = []
-
-    hf_mt = (hf_config_model_type or "").lower()
 
     # Define linear layer names for different model types
     if "mixtralforcausallm" in model_type:
@@ -111,8 +106,7 @@ def get_experts_list(
         ]
     ):
         linear_names = ["gate_proj", "down_proj", "up_proj"]
-    elif hf_mt == "nemotron_h" or "nemotronhforcausallm" in model_type:
-        # Nemotron-3-Nano (NemotronHMOE experts use NemotronHMLP: up_proj, down_proj only)
+    elif "nemotronhforcausallm" in model_type:
         linear_names = ["up_proj", "down_proj"]
     else:
         raise NotImplementedError(f" {model_type} not supported")
@@ -320,7 +314,7 @@ def is_moe(module: nn.Module) -> bool:
     # Auto-detect common MoE patterns
     if name.endswith("sparsemoeblock") or "moelayer" in name:
         return True
-    # Explicit matches for non-standard naming (e.g. Nemotron-3-Nano / nemotron_h uses NemotronHMOE)
+    # Explicit matches for non-standard naming
     return any(key in name for key in ["arcticmoe", "deepseekmoe", "dbrxffn", "nemotronhmoe"])
 
 
@@ -1010,6 +1004,9 @@ def get_expert_linear_names(module: nn.Module) -> list[str]:
         return ["w1_linear", "w2_linear", "v1_linear"]
     elif module_match_name_list(module, ["GptOssMoE"]):
         return ["gate_up_proj", "down_proj"]
+    elif module_match_name_list(module, ["NemotronHMOE"]):
+        # NemotronHMOE experts (NemotronHMLP) use up_proj and down_proj only (no gate).
+        return ["up_proj", "down_proj"]
     else:
         # assuming w1, w2, w3 by default
         return ["w1", "w2", "w3"]

--- a/modelopt/torch/export/layer_utils.py
+++ b/modelopt/torch/export/layer_utils.py
@@ -81,9 +81,22 @@ with import_plugin("megatron", verbose=False):
     has_mcore = True
 
 
-def get_experts_list(module: torch.nn.Module, model_type: str):
-    """Returns list of grouped experts by linear name for given module."""
+def get_experts_list(
+    module: torch.nn.Module,
+    model_type: str,
+    hf_config_model_type: str | None = None,
+):
+    """Returns list of grouped experts by linear name for given module.
+
+    Args:
+        module: MoE block (e.g. MixtralSparseMoeBlock, NemotronHMOE).
+        model_type: `type(root_model).__name__.lower()` (may change after ModelOpt quantize).
+        hf_config_model_type: Optional `model.config.model_type` (e.g. `nemotron_h`) when
+            the root class name no longer contains the HF architecture string after wrapping.
+    """
     experts_list = []
+
+    hf_mt = (hf_config_model_type or "").lower()
 
     # Define linear layer names for different model types
     if "mixtralforcausallm" in model_type:
@@ -98,6 +111,9 @@ def get_experts_list(module: torch.nn.Module, model_type: str):
         ]
     ):
         linear_names = ["gate_proj", "down_proj", "up_proj"]
+    elif hf_mt == "nemotron_h" or "nemotronhforcausallm" in model_type:
+        # Nemotron-3-Nano (NemotronHMOE experts use NemotronHMLP: up_proj, down_proj only)
+        linear_names = ["up_proj", "down_proj"]
     else:
         raise NotImplementedError(f" {model_type} not supported")
 
@@ -304,8 +320,8 @@ def is_moe(module: nn.Module) -> bool:
     # Auto-detect common MoE patterns
     if name.endswith("sparsemoeblock") or "moelayer" in name:
         return True
-    # Explicit matches for non-standard naming
-    return any(key in name for key in ["arcticmoe", "deepseekmoe", "dbrxffn"])
+    # Explicit matches for non-standard naming (e.g. Nemotron-3-Nano / nemotron_h uses NemotronHMOE)
+    return any(key in name for key in ["arcticmoe", "deepseekmoe", "dbrxffn", "nemotronhmoe"])
 
 
 def is_quantlinear(module: nn.Module) -> bool:

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Export HuggingFace model to vLLM fakequant checkpoint."""
 
+import contextlib
 import copy
 import re
 from pathlib import Path
@@ -34,6 +35,7 @@ from modelopt.torch.utils import get_unwrapped_name, safe_save
 
 from ..layer_utils import get_experts_list, is_moe
 from ..quant_utils import get_quantization_format
+from ..unified_export_hf import collect_shared_input_modules
 
 __all__ = [
     "export_hf_vllm_fq_checkpoint",
@@ -189,12 +191,22 @@ def _resmooth_experts_for_export(
     model: nn.Module,
     state_dict: dict[str, Any],
 ) -> tuple[dict[str, tuple[torch.Tensor, torch.Tensor | None]], set[str]]:
-    """Average pqs and unify input amax across MoE experts when AWQ smoothing applies (no-op otherwise).
+    """Average pqs and unify input amax for all groups vLLM collapses to one input quantizer.
 
-    Adjusts expert weights in ``state_dict`` as ``W' = W * old_pqs / avg_pqs`` and returns
-    input-quantizer overrides for ``modelopt_state_weights``. **Does nothing** for weight-only
-    MoE (no ``pre_quant_scale`` on experts) or unsupported MoE layouts — same as skipping the
-    MoE branch in :func:`requantize_resmooth_fused_llm_layers`.
+    Covers two cases that are structurally identical — a set of linears sharing the
+    same input that vLLM fuses behind a single input quantizer:
+
+    * **MoE experts** — vLLM uses one input quantizer per expert group.
+    * **Dense GQA attention** — vLLM fuses q/k/v into ``qkv_proj`` with one input
+      quantizer. AWQ calibration gives each projection a different pqs because they
+      share the same input but have different weight magnitudes; using only q's pqs
+      for k and v at inference corrupts those activations.
+
+    For each group, adjusts weights in ``state_dict`` as ``W' = W * old_pqs / avg_pqs``
+    and returns input-quantizer overrides so every member exports the same ``avg_pqs``.
+    Only runs when input quantizers are **enabled** (``nvfp4_awq_wa`` style); for
+    weight-only AWQ the input quantizer is disabled and pqs is folded into each
+    projection's own weight independently.
     """
     qfmt = get_quantization_format(model)
     if qfmt is None or "awq" not in qfmt.lower():
@@ -204,61 +216,70 @@ def _resmooth_experts_for_export(
     id_to_name: dict[int, str] = {id(m): n for n, m in model.named_modules()}
     out: dict[str, tuple[torch.Tensor, torch.Tensor | None]] = {}
     requant_weights: set[str] = set()
+
+    def _process_group(modules: list[nn.Module]) -> None:
+        pqs_list = _collect_expert_pre_quant_scales(modules)
+        if pqs_list is None:
+            return
+
+        avg_pqs = torch.stack(pqs_list).mean(0)
+        avg_pqs = avg_pqs.clamp(min=torch.finfo(torch.float32).tiny)
+
+        for m in modules:
+            nm = id_to_name.get(id(m))
+            if nm is None or f"{nm}.weight" not in state_dict:
+                continue
+            old_pqs = m.input_quantizer._pre_quant_scale
+            avg_pqs_dev = avg_pqs.to(device=old_pqs.device, dtype=old_pqs.dtype)
+            if torch.equal(old_pqs, avg_pqs_dev):
+                continue
+            weight = state_dict[f"{nm}.weight"]
+            ratio = old_pqs.to(dtype=torch.float32, device=weight.device) / avg_pqs_dev.to(
+                dtype=torch.float32, device=weight.device
+            )
+            state_dict[f"{nm}.weight"] = (weight.to(torch.float32) * ratio).to(weight.dtype)
+            requant_weights.add(f"{nm}.weight")
+
+        synced_amax: torch.Tensor | None = None
+        amaxes = [m.input_quantizer.amax for m in modules]
+        if all(a is not None for a in amaxes):
+            synced_amax = merge_amax_tensors_for_group(amaxes)
+
+        avg_pqs_out = avg_pqs.detach().clone()
+        for m in modules:
+            nm = id_to_name.get(id(m))
+            if nm is None:
+                continue
+            out[get_unwrapped_name(f"{nm}.input_quantizer", model)] = (avg_pqs_out, synced_amax)
+
+    # MoE expert groups — must be enumerated by name because MoE routing sends
+    # different tokens to each expert, so forward hooks cannot detect them as
+    # sharing the same input tensor.
     for _, module in model.named_modules():
-        if not is_moe(module):
-            continue
-        try:
-            expert_groups = get_experts_list(module, model_type)
-        except NotImplementedError:
-            continue
+        if is_moe(module):
+            try:
+                expert_groups = get_experts_list(module, model_type)
+            except NotImplementedError:
+                pass
+            else:
+                for experts in expert_groups:
+                    if experts:
+                        _process_group(experts)
 
-        for experts in expert_groups:
-            if not experts:
-                continue
-            pre_quant_scales_list = _collect_expert_pre_quant_scales(experts)
-            if pre_quant_scales_list is None:
-                continue
+    # Dense shared-input groups (e.g. q/k/v in GQA attention) — detected via forward
+    # hooks so any architecture is covered regardless of projection attribute names.
 
-            avg_pre_quant_scale = torch.stack(pre_quant_scales_list).mean(0)
-            # Guard against degenerate calibration where a channel's scale is zero:
-            # zero avg_pqs would produce inf ratio and corrupt the exported weight.
-            avg_pre_quant_scale = avg_pre_quant_scale.clamp(min=torch.finfo(torch.float32).tiny)
+    dev = next(model.parameters()).device
 
-            for ex in experts:
-                nm = id_to_name.get(id(ex))
-                if nm is None or f"{nm}.weight" not in state_dict:
-                    continue
-                old_pre_quant_scale = ex.input_quantizer._pre_quant_scale
-                avg_pre_quant_scale = avg_pre_quant_scale.to(
-                    device=old_pre_quant_scale.device, dtype=old_pre_quant_scale.dtype
-                )
-                if torch.equal(old_pre_quant_scale, avg_pre_quant_scale):
-                    continue
-                weight = state_dict[f"{nm}.weight"]
-                updated_weight = (
-                    weight.to(torch.float32)
-                    * old_pre_quant_scale.to(dtype=torch.float32, device=weight.device)
-                    / avg_pre_quant_scale.to(dtype=torch.float32, device=weight.device)
-                ).to(weight.dtype)
-                state_dict[f"{nm}.weight"] = updated_weight
-                requant_weights.add(f"{nm}.weight")
+    def _dummy_forward() -> None:
+        # Partial forward is OK: hooks record layers reached before failure (e.g. VLMs).
+        with contextlib.suppress(Exception):
+            model(torch.ones([1, 2], dtype=torch.long, device=dev))
 
-            iq0 = experts[0].input_quantizer
-            synced_amax: torch.Tensor | None = None
-            if iq0.is_enabled:
-                amaxes = [e.input_quantizer.amax for e in experts]
-                if all(a is not None for a in amaxes):
-                    synced_amax = merge_amax_tensors_for_group(amaxes)
-
-            avg_pre_quant_scale_output = avg_pre_quant_scale.detach().clone()
-            for ex in experts:
-                nm = id_to_name.get(id(ex))
-                if nm is None:
-                    continue
-                out[get_unwrapped_name(f"{nm}.input_quantizer", model)] = (
-                    avg_pre_quant_scale_output,
-                    synced_amax,
-                )
+    input_to_linear, _ = collect_shared_input_modules(model, _dummy_forward)
+    for modules in input_to_linear.values():
+        if len(modules) > 1:
+            _process_group(modules)
 
     return out, requant_weights
 
@@ -299,10 +320,10 @@ def export_hf_vllm_fq_checkpoint(
     # to the corresponding weight tensor in the copy.
     state_dict = model.state_dict()
 
-    # Non-mutating MoE expert resmooth: average pqs and adjust state_dict weights.
-    # Must run before the fakequant loop so that the adjusted weights are fakequanted
-    # with the correct per-block scales.
-    expert_pqs_overrides, requant_weights = _resmooth_experts_for_export(model, state_dict)
+    # Non-mutating resmooth: average pqs across all shared-input groups (dense GQA q/k/v
+    # and MoE experts) and adjust state_dict weights. Must run before the fakequant loop
+    # so adjusted weights are fakequanted with the correct per-block scales.
+    pqs_overrides, requant_weights = _resmooth_experts_for_export(model, state_dict)
 
     fakequant_weights: set[str] = set()
     # Input quantizer keys whose _pre_quant_scale was folded into the weight above.
@@ -392,9 +413,9 @@ def export_hf_vllm_fq_checkpoint(
                     qstate_val["_pre_quant_scale"]
                 )
 
-    # Patch expert input quantizers with averaged pqs and unified amax so that
-    # vLLM's single per-group input quantizer sees consistent values across experts.
-    for iq_key, (avg_pqs, max_input_amax) in expert_pqs_overrides.items():
+    # Patch input quantizers with averaged pqs and unified amax so that vLLM's single
+    # per-group input quantizer sees consistent values (covers both dense qkv and MoE experts).
+    for iq_key, (avg_pqs, max_input_amax) in pqs_overrides.items():
         if iq_key in quantizer_state_dict:
             qstate_val = quantizer_state_dict[iq_key]
             if isinstance(qstate_val, dict):

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -15,6 +15,7 @@
 """Export HuggingFace model to vLLM fakequant checkpoint."""
 
 import copy
+import re
 from pathlib import Path
 from typing import Any
 
@@ -31,11 +32,52 @@ from modelopt.torch.quantization.utils.core_utils import enable_weight_access_an
 from modelopt.torch.quantization.utils.layerwise_calib import LayerActivationCollector
 from modelopt.torch.utils import get_unwrapped_name, safe_save
 
-from ..hf_vllm_quantizer_merge import is_weight_quantizer_state_key
 from ..layer_utils import get_experts_list, is_moe
 from ..quant_utils import get_quantization_format
 
-__all__ = ["export_hf_vllm_fq_checkpoint", "is_weight_quantizer_state_key"]
+__all__ = [
+    "export_hf_vllm_fq_checkpoint",
+    "is_weight_quantizer_state_key",
+    "merge_amax_tensors_for_vllm_group",
+]
+
+# Matches ``…weight_quantizer``, ``…weight_quantizer.0``, ``…w13_weight_quantizer.0``, etc.
+_WEIGHT_QUANTIZER_STATE_KEY = re.compile(r"(?:^|\.)(?:\w+_)?weight_quantizer(?:\.\d+)*$")
+
+
+def is_weight_quantizer_state_key(key: str) -> bool:
+    """Return True for weight-quantizer state keys, including SequentialQuantizer entries.
+
+    Matches ``weight_quantizer``, ``w13_weight_quantizer``, ``weight_quantizer.0``, etc.
+    """
+    return bool(_WEIGHT_QUANTIZER_STATE_KEY.search(key))
+
+
+def merge_amax_tensors_for_vllm_group(tensors: list[torch.Tensor]) -> torch.Tensor:
+    """Combine `_amax` buffers from a merge group into a single tensor.
+
+    Used when HuggingFace module names are folded to vLLM names (e.g. q/k/v → qkv_proj).
+
+    - If every tensor has the same shape, take the element-wise maximum over the group
+      (conservative when each branch carried the same axis layout).
+    - If shapes differ (e.g. GQA q vs k), try ``torch.cat(..., dim=0)`` when valid for
+      per-channel amax; otherwise fall back to a scalar max over all elements.
+    """
+    if not tensors:
+        raise ValueError("merge_amax_tensors_for_vllm_group: expected at least one tensor")
+    if len(tensors) == 1:
+        return tensors[0]
+
+    first = tensors[0]
+    if all(t.shape == first.shape for t in tensors):
+        stacked = torch.stack([t.float() for t in tensors], dim=0)
+        return torch.amax(stacked, dim=0).to(dtype=first.dtype, device=first.device)
+
+    try:
+        return torch.cat(tensors, dim=0).to(dtype=first.dtype, device=first.device)
+    except RuntimeError:
+        flat = torch.cat([t.reshape(-1).float() for t in tensors])
+        return torch.max(flat).to(dtype=first.dtype, device=first.device)
 
 
 def disable_rotate(quantizer: TensorQuantizer):

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -15,7 +15,6 @@
 """Export HuggingFace model to vLLM fakequant checkpoint."""
 
 import copy
-import re
 from pathlib import Path
 from typing import Any
 
@@ -30,20 +29,13 @@ from modelopt.torch.quantization.nn import QuantModule, TensorQuantizer
 from modelopt.torch.quantization.utils import get_quantizer_state_dict
 from modelopt.torch.quantization.utils.core_utils import enable_weight_access_and_writeback
 from modelopt.torch.quantization.utils.layerwise_calib import LayerActivationCollector
-from modelopt.torch.utils import get_unwrapped_name
+from modelopt.torch.utils import get_unwrapped_name, safe_save
 
+from ..hf_vllm_quantizer_merge import is_weight_quantizer_state_key
 from ..layer_utils import get_experts_list, is_moe
 from ..quant_utils import get_quantization_format
 
-__all__ = ["export_hf_vllm_fq_checkpoint"]
-
-# Matches ``…weight_quantizer``, ``…weight_quantizer.0``, ``…w13_weight_quantizer.0``, etc.
-_WEIGHT_QUANTIZER_STATE_KEY = re.compile(r"(?:^|\.)(?:\w+_)?weight_quantizer(?:\.\d+)*$")
-
-
-def _is_weight_quantizer_state_key(key: str) -> bool:
-    """True for weight quantizer state keys, including ModuleList entries (``…weight_quantizer.0``)."""
-    return bool(_WEIGHT_QUANTIZER_STATE_KEY.search(key))
+__all__ = ["export_hf_vllm_fq_checkpoint", "is_weight_quantizer_state_key"]
 
 
 def disable_rotate(quantizer: TensorQuantizer):
@@ -131,7 +123,7 @@ def _collect_expert_pre_quant_scales(
     pqs_list: list[torch.Tensor] = []
     for ex in experts:
         iq = getattr(ex, "input_quantizer", None)
-        if iq is None or getattr(iq, "_disabled", False) or iq.pre_quant_scale is None:
+        if iq is None or not iq.is_enabled or iq.pre_quant_scale is None:
             return None
         pqs_list.append(iq.pre_quant_scale)
     return pqs_list
@@ -186,6 +178,9 @@ def _resmooth_experts_for_export(
                 continue
 
             avg_pqs = torch.stack(pqs_list).mean(0)
+            # Guard against degenerate calibration where a channel's scale is zero:
+            # zero avg_pqs would produce inf ratio and corrupt the exported weight.
+            avg_pqs = avg_pqs.clamp(min=torch.finfo(torch.float32).tiny)
 
             for ex in experts:
                 nm = id_to_name.get(id(ex))
@@ -334,7 +329,7 @@ def export_hf_vllm_fq_checkpoint(
 
     quantizer_state_dict = get_quantizer_state_dict(model)
     for key in list(quantizer_state_dict):
-        if _is_weight_quantizer_state_key(key):
+        if is_weight_quantizer_state_key(key):
             # Fakequant amax is folded into HF weights; do not reload weight quantizer tensors.
             quantizer_state_dict.pop(key)
         elif key in input_quantizers_folded_pqs:
@@ -362,7 +357,7 @@ def export_hf_vllm_fq_checkpoint(
     # ``quantizer_state`` and drop disabled weight quantizer entries (weights already folded).
     qstate = quantizer_state(model)
     for key in list(qstate):
-        if _is_weight_quantizer_state_key(key) and qstate[key].get("_disabled"):
+        if is_weight_quantizer_state_key(key) and qstate[key].get("_disabled"):
             qstate.pop(key)
 
     for mode_str, m_state in modelopt_state.get("modelopt_state_dict", []):
@@ -372,7 +367,7 @@ def export_hf_vllm_fq_checkpoint(
 
     # Per-quantizer tensor dict loaded alongside metadata on reload.
     modelopt_state["modelopt_state_weights"] = quantizer_state_dict
-    torch.save(modelopt_state, export_dir / "vllm_fq_modelopt_state.pth")
+    safe_save(modelopt_state, export_dir / "vllm_fq_modelopt_state.pth")
 
     # Step 3: Save HF weights.
     if inplace_mem_efficient:

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -17,6 +17,7 @@
 import copy
 import logging
 import re
+import warnings
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -123,11 +124,12 @@ def _check_all_weight_quantizers_disabled(model: nn.Module) -> None:
             if attr_name.endswith("weight_quantizer") and isinstance(
                 quantizer, (TensorQuantizer, SequentialQuantizer)
             ):
-                assert not quantizer.is_enabled, (
-                    f"vLLM fakequant export: {attr_name!r} must be disabled before saving "
-                    f"quantizer_state (weights already folded). "
-                    f"See filter_modelopt_state_quantizer_state_for_model in vllm_reload_utils."
-                )
+                if quantizer.is_enabled:
+                    raise RuntimeError(
+                        f"vLLM fakequant export: {attr_name!r} must be disabled before saving "
+                        f"quantizer_state (weights already folded). "
+                        f"See filter_modelopt_state_quantizer_state_for_model in vllm_reload_utils."
+                    )
 
 
 def disable_rotate(quantizer: TensorQuantizer):
@@ -238,25 +240,27 @@ def requant_weights_for_export(
     ``w`` (e.g. CPU offload).
     """
     copied = copy.deepcopy(quantizer).to(device=weight.device)
-    sequence_quantizers: list[TensorQuantizer] = (
+    quantizers: list[TensorQuantizer] = (
         list(copied) if isinstance(copied, SequentialQuantizer) else [copied]
     )
 
-    for quantizer_copy in sequence_quantizers:
+    for quantizer_copy in quantizers:
         quantizer_copy.eval()
         quantizer_copy.reset_amax()
         enable_stats_collection(quantizer_copy)
     # Match legacy single-quantizer path: first calib uses ``w`` as-is; chains use float.
-    if len(sequence_quantizers) == 1:
-        weight_quantized = sequence_quantizers[0](weight)
+    if len(quantizers) == 1:
+        weight_quantized = quantizers[0](weight)
     else:
-        weight_quantized = weight.float()
-        for quantizer_copy in sequence_quantizers:
+        weight_quantized = weight
+        for quantizer_copy in quantizers:
             weight_quantized = quantizer_copy(weight_quantized)
-    for quantizer_copy in sequence_quantizers:
+    for quantizer_copy in quantizers:
         finish_stats_collection(quantizer_copy)
-    weight_quantized = weight.float()
-    for quantizer_copy in sequence_quantizers:
+    # Re-run application pass to get the quantized output with the freshly collected amax.
+    # The calibration forward above only collected stats; its output is intentionally discarded.
+    weight_quantized = weight
+    for quantizer_copy in quantizers:
         weight_quantized = quantizer_copy(weight_quantized)
     return weight_quantized.to(weight.dtype)
 
@@ -286,6 +290,12 @@ def merge_amax_tensors_for_group(tensors: list[torch.Tensor]) -> torch.Tensor:
     try:
         return torch.cat(tensors, dim=0).to(dtype=first.dtype, device=first.device)
     except RuntimeError:
+        shapes = [tuple(t.shape) for t in tensors]
+        warnings.warn(
+            f"merge_amax_tensors_for_group: torch.cat failed for shapes {shapes}; "
+            "falling back to scalar max which loses per-channel amax structure.",
+            stacklevel=2,
+        )
         flat = torch.cat([t.reshape(-1).float() for t in tensors])
         return torch.max(flat).to(dtype=first.dtype, device=first.device)
 
@@ -325,7 +335,9 @@ def _resmooth_experts_for_export(
         if pqs_list is None:
             return
 
-        avg_pqs = torch.stack(pqs_list).mean(0)
+        # Mean and clamp in float32: fp16/bf16 would underflow float32.tiny to 0 and divide by zero.
+        pqs_dtype = pqs_list[0].dtype
+        avg_pqs = torch.stack([p.float() for p in pqs_list]).mean(0)
         avg_pqs = avg_pqs.clamp(min=torch.finfo(torch.float32).tiny)
 
         for m in modules:
@@ -337,8 +349,8 @@ def _resmooth_experts_for_export(
             if torch.equal(old_pqs, avg_pqs_dev):
                 continue
             weight = state_dict[f"{nm}.weight"]
-            ratio = old_pqs.to(dtype=torch.float32, device=weight.device) / avg_pqs_dev.to(
-                dtype=torch.float32, device=weight.device
+            ratio = old_pqs.to(dtype=torch.float32, device=weight.device) / avg_pqs.to(
+                device=weight.device
             )
             state_dict[f"{nm}.weight"] = (weight.to(torch.float32) * ratio).to(weight.dtype)
             requant_weights.add(f"{nm}.weight")
@@ -348,7 +360,7 @@ def _resmooth_experts_for_export(
         if all(a is not None for a in amaxes):
             synced_amax = merge_amax_tensors_for_group(amaxes)
 
-        avg_pqs_out = avg_pqs.detach().clone()
+        avg_pqs_out = avg_pqs.detach().to(pqs_dtype).clone()
         for m in modules:
             nm = id_to_name.get(id(m))
             if nm is None:
@@ -376,14 +388,15 @@ def _resmooth_experts_for_export(
 
     def _dummy_forward() -> None:
         # Partial forward is OK: hooks record layers reached before failure.
-        try:
-            model(torch.ones([1, 2], dtype=torch.long, device=dev))
-        except Exception as e:
-            import logging
+        with torch.inference_mode():
+            try:
+                model(torch.ones([1, 2], dtype=torch.long, device=dev))
+            except Exception as e:
+                import logging
 
-            logging.getLogger(__name__).debug(
-                "Dummy forward for shared-input detection failed (expected for VLMs): %s", e
-            )
+                logging.getLogger(__name__).debug(
+                    "Dummy forward for shared-input detection failed (expected for VLMs): %s", e
+                )
 
     input_to_linear, _ = collect_shared_input_modules(model, _dummy_forward)
     for modules in input_to_linear.values():
@@ -494,83 +507,85 @@ def export_hf_vllm_fq_checkpoint(
     # Rotation is also cleared: the weight was already folded with rotation applied,
     # so if fold_weight is called on reload it must not re-rotate the exported weight.
     wqs_to_restore: list[tuple[TensorQuantizer, Any]] = []
-    for _, module in model.named_modules():
-        if isinstance(module, QuantModule):
-            for attr_name, quantizer in module.named_children():
-                if not (attr_name.endswith("weight_quantizer") and quantizer.is_enabled):
-                    continue
-                if isinstance(quantizer, SequentialQuantizer):
-                    quantizer.disable()
-                    for sub in quantizer:
-                        orig_rotate = sub._rotate
-                        if sub.rotate_is_enabled:
-                            sub._rotate = disable_rotate(sub)
-                        wqs_to_restore.append((sub, orig_rotate))
-                elif isinstance(quantizer, TensorQuantizer):
-                    quantizer.disable()
-                    orig_rotate = quantizer._rotate
-                    if quantizer.rotate_is_enabled:
-                        quantizer._rotate = disable_rotate(quantizer)
-                    wqs_to_restore.append((quantizer, orig_rotate))
+    try:
+        for _, module in model.named_modules():
+            if isinstance(module, QuantModule):
+                for attr_name, quantizer in module.named_children():
+                    if not (attr_name.endswith("weight_quantizer") and quantizer.is_enabled):
+                        continue
+                    if isinstance(quantizer, SequentialQuantizer):
+                        quantizer.disable()
+                        for sub in quantizer:
+                            orig_rotate = sub._rotate
+                            if sub.rotate_is_enabled:
+                                sub._rotate = disable_rotate(sub)
+                            wqs_to_restore.append((sub, orig_rotate))
+                    elif isinstance(quantizer, TensorQuantizer):
+                        quantizer.disable()
+                        orig_rotate = quantizer._rotate
+                        if quantizer.rotate_is_enabled:
+                            quantizer._rotate = disable_rotate(quantizer)
+                        wqs_to_restore.append((quantizer, orig_rotate))
 
-    quantizer_state_dict = get_quantizer_state_dict(model)
-    for key in list(quantizer_state_dict):
-        if is_weight_quantizer_state_key(key):
-            # Fakequant amax is folded into HF weights; do not reload weight quantizer tensors.
-            # Reload must force-disable WQs missing from saved state (see
-            # ``filter_modelopt_state_quantizer_state_for_model`` assertion in vllm_reload_utils).
-            quantizer_state_dict.pop(key)
-        elif key in input_quantizers_folded_pqs:
-            # pre_quant_scale was folded into the weight; keep the buffer for strict load but
-            # save identity so activations are not scaled twice.
-            qstate_val = quantizer_state_dict[key]
-            if isinstance(qstate_val, dict) and "_pre_quant_scale" in qstate_val:
-                quantizer_state_dict[key]["_pre_quant_scale"] = torch.ones_like(
-                    qstate_val["_pre_quant_scale"]
-                )
+        quantizer_state_dict = get_quantizer_state_dict(model)
+        for key in list(quantizer_state_dict):
+            if is_weight_quantizer_state_key(key):
+                # Fakequant amax is folded into HF weights; do not reload weight quantizer tensors.
+                # Reload must force-disable WQs missing from saved state (see
+                # ``filter_modelopt_state_quantizer_state_for_model`` assertion in vllm_reload_utils).
+                quantizer_state_dict.pop(key)
+            elif key in input_quantizers_folded_pqs:
+                # pre_quant_scale was folded into the weight; keep the buffer for strict load but
+                # save identity so activations are not scaled twice.
+                qstate_val = quantizer_state_dict[key]
+                if isinstance(qstate_val, dict) and "_pre_quant_scale" in qstate_val:
+                    quantizer_state_dict[key]["_pre_quant_scale"] = torch.ones_like(
+                        qstate_val["_pre_quant_scale"]
+                    )
 
-    # Patch input quantizers with averaged pqs and unified amax so that vLLM's single
-    # per-group input quantizer sees consistent values (covers both dense qkv and MoE experts).
-    for iq_key, (avg_pqs, max_input_amax) in pqs_overrides.items():
-        if iq_key in quantizer_state_dict:
-            qstate_val = quantizer_state_dict[iq_key]
-            if isinstance(qstate_val, dict):
-                if "_pre_quant_scale" in qstate_val:
-                    qstate_val["_pre_quant_scale"] = avg_pqs
-                if max_input_amax is not None and "_amax" in qstate_val:
-                    qstate_val["_amax"] = max_input_amax
+        # Patch input quantizers with averaged pqs and unified amax so that vLLM's single
+        # per-group input quantizer sees consistent values (covers both dense qkv and MoE experts).
+        for iq_key, (avg_pqs, max_input_amax) in pqs_overrides.items():
+            if iq_key in quantizer_state_dict:
+                qstate_val = quantizer_state_dict[iq_key]
+                if isinstance(qstate_val, dict):
+                    if "_pre_quant_scale" in qstate_val:
+                        qstate_val["_pre_quant_scale"] = avg_pqs
+                    if max_input_amax is not None and "_amax" in qstate_val:
+                        qstate_val["_amax"] = max_input_amax
 
-    modelopt_state = mto.modelopt_state(model)
-    # ``modelopt_state`` may be stale if another mode (e.g. calibrate) ran last. Rebuild
-    # ``quantizer_state`` and strip weight-quantizer entries (same policy as
-    # ``modelopt_state_weights``). Reload synthesizes missing WQ rows with ``_disabled``.
-    _check_all_weight_quantizers_disabled(model)
-    qstate = quantizer_state(model)
-    for key in list(qstate):
-        if is_weight_quantizer_state_key(key):
-            qstate.pop(key)
+        modelopt_state = mto.modelopt_state(model)
+        # ``modelopt_state`` may be stale if another mode (e.g. calibrate) ran last. Rebuild
+        # ``quantizer_state`` and strip weight-quantizer entries (same policy as
+        # ``modelopt_state_weights``). Reload synthesizes missing WQ rows with ``_disabled``.
+        _check_all_weight_quantizers_disabled(model)
+        qstate = quantizer_state(model)
+        for key in list(qstate):
+            if is_weight_quantizer_state_key(key):
+                qstate.pop(key)
 
-    for mode_str, m_state in modelopt_state.get("modelopt_state_dict", []):
-        if mode_str == "quantize" and "metadata" in m_state:
-            m_state["metadata"]["quantizer_state"] = qstate
-            break
+        for mode_str, m_state in modelopt_state.get("modelopt_state_dict", []):
+            if mode_str == "quantize" and "metadata" in m_state:
+                m_state["metadata"]["quantizer_state"] = qstate
+                break
 
-    # Per-quantizer tensor dict loaded alongside metadata on reload.
-    modelopt_state["modelopt_state_weights"] = quantizer_state_dict
-    safe_save(modelopt_state, export_dir / "vllm_fq_modelopt_state.pth")
+        # Per-quantizer tensor dict loaded alongside metadata on reload.
+        modelopt_state["modelopt_state_weights"] = quantizer_state_dict
+        safe_save(modelopt_state, export_dir / "vllm_fq_modelopt_state.pth")
 
-    # Step 3: Save HF weights.
-    if inplace_mem_efficient:
-        prev_ignore = getattr(model, "_keys_to_ignore_on_save", None)
-        model._keys_to_ignore_on_save = quantizer_keys
-        try:
-            model.save_pretrained(export_dir, save_modelopt_state=False)
-        finally:
-            model._keys_to_ignore_on_save = prev_ignore
-    else:
-        model.save_pretrained(export_dir, state_dict=clean_sd, save_modelopt_state=False)
+        # Step 3: Save HF weights.
+        if inplace_mem_efficient:
+            prev_ignore = getattr(model, "_keys_to_ignore_on_save", None)
+            model._keys_to_ignore_on_save = quantizer_keys
+            try:
+                model.save_pretrained(export_dir, save_modelopt_state=False)
+            finally:
+                model._keys_to_ignore_on_save = prev_ignore
+        else:
+            model.save_pretrained(export_dir, state_dict=clean_sd, save_modelopt_state=False)
 
-    if not inplace_mem_efficient:
-        for wq, orig_rotate in wqs_to_restore:
-            wq.enable()
-            wq._rotate = orig_rotate
+    finally:
+        if not inplace_mem_efficient:
+            for wq, orig_rotate in wqs_to_restore:
+                wq.enable()
+                wq._rotate = orig_rotate

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -38,7 +38,6 @@ from ..quant_utils import get_quantization_format
 __all__ = [
     "export_hf_vllm_fq_checkpoint",
     "is_weight_quantizer_state_key",
-    "merge_amax_tensors_for_vllm_group",
 ]
 
 # Matches ``…weight_quantizer``, ``…weight_quantizer.0``, ``…w13_weight_quantizer.0``, etc.
@@ -51,33 +50,6 @@ def is_weight_quantizer_state_key(key: str) -> bool:
     Matches ``weight_quantizer``, ``w13_weight_quantizer``, ``weight_quantizer.0``, etc.
     """
     return bool(_WEIGHT_QUANTIZER_STATE_KEY.search(key))
-
-
-def merge_amax_tensors_for_vllm_group(tensors: list[torch.Tensor]) -> torch.Tensor:
-    """Combine `_amax` buffers from a merge group into a single tensor.
-
-    Used when HuggingFace module names are folded to vLLM names (e.g. q/k/v → qkv_proj).
-
-    - If every tensor has the same shape, take the element-wise maximum over the group
-      (conservative when each branch carried the same axis layout).
-    - If shapes differ (e.g. GQA q vs k), try ``torch.cat(..., dim=0)`` when valid for
-      per-channel amax; otherwise fall back to a scalar max over all elements.
-    """
-    if not tensors:
-        raise ValueError("merge_amax_tensors_for_vllm_group: expected at least one tensor")
-    if len(tensors) == 1:
-        return tensors[0]
-
-    first = tensors[0]
-    if all(t.shape == first.shape for t in tensors):
-        stacked = torch.stack([t.float() for t in tensors], dim=0)
-        return torch.amax(stacked, dim=0).to(dtype=first.dtype, device=first.device)
-
-    try:
-        return torch.cat(tensors, dim=0).to(dtype=first.dtype, device=first.device)
-    except RuntimeError:
-        flat = torch.cat([t.reshape(-1).float() for t in tensors])
-        return torch.max(flat).to(dtype=first.dtype, device=first.device)
 
 
 def disable_rotate(quantizer: TensorQuantizer):

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -170,7 +170,8 @@ def _fakequant_module_weights(
         weight_name = attr_name.removesuffix("_quantizer")
         prefix = f"{module_name}." if module_name else ""
         sd_key = f"{prefix}{weight_name}"
-        assert sd_key not in fakequant_weights, f"Weight {sd_key} has already been fakequantized"
+        if sd_key in fakequant_weights:
+            raise RuntimeError(f"Weight {sd_key} has already been fakequantized")
 
         if inplace:
             w = getattr(module, weight_name)
@@ -179,7 +180,8 @@ def _fakequant_module_weights(
             else:
                 w_quant = quantizer(w.float()).to(w.dtype)
         else:
-            assert state_dict is not None
+            if state_dict is None:
+                raise RuntimeError("state_dict is required when inplace=False for fakequant export")
             if sd_key not in state_dict:
                 continue
             w = state_dict[sd_key]
@@ -209,7 +211,8 @@ def _fakequant_module_weights(
         if inplace:
             w.data.copy_(w_quant)
         else:
-            assert state_dict is not None
+            if state_dict is None:
+                raise RuntimeError("state_dict is required when inplace=False for fakequant export")
             state_dict[sd_key] = w_quant.cpu()
         fakequant_weights.add(sd_key)
 
@@ -390,7 +393,10 @@ def _resmooth_experts_for_export(
                 )
                 w_param.data.copy_((w_param.to(torch.float32) * ratio).to(w_param.dtype))
             else:
-                assert state_dict is not None
+                if state_dict is None:
+                    raise RuntimeError(
+                        "state_dict is required when inplace=False in _resmooth_experts_for_export"
+                    )
                 weight = state_dict[w_key]
                 ratio = old_pqs.to(dtype=torch.float32, device=weight.device) / avg_pqs.to(
                     device=weight.device
@@ -424,7 +430,10 @@ def _resmooth_experts_for_export(
             if not experts:
                 continue
             if inplace:
-                assert name_to_module is not None
+                if name_to_module is None:
+                    raise RuntimeError(
+                        "name_to_module is required when inplace=True in _resmooth_experts_for_export"
+                    )
                 with _enable_writeback_for_group(experts, model, name_to_module):
                     _process_group(experts)
             else:
@@ -450,7 +459,10 @@ def _resmooth_experts_for_export(
         if len(modules) <= 1:
             continue
         if inplace:
-            assert name_to_module is not None
+            if name_to_module is None:
+                raise RuntimeError(
+                    "name_to_module is required when inplace=True in _resmooth_experts_for_export"
+                )
             with _enable_writeback_for_group(modules, model, name_to_module):
                 _process_group(modules)
         else:
@@ -499,9 +511,10 @@ def export_hf_vllm_fq_checkpoint(
             pqs_overrides, requant_weights = _resmooth_experts_for_export(model, None, inplace=True)
             # Inplace path: iterate decoder layers, one offload<->onload per layer.
             decoder_layers = LayerActivationCollector.get_decoder_layers(model)
-            assert decoder_layers is not None, (
-                "inplace_mem_efficient=True requires a model with discoverable decoder layers"
-            )
+            if decoder_layers is None:
+                raise RuntimeError(
+                    "inplace_mem_efficient=True requires a model with discoverable decoder layers"
+                )
             for name, module in model.named_modules():
                 if module not in decoder_layers:
                     continue

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -19,6 +19,7 @@ import logging
 import re
 import warnings
 from collections.abc import Callable
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -148,6 +149,7 @@ def _fakequant_module_weights(
     state_dict: dict | None,
     input_quantizers_folded_pqs: set,
     fakequant_weights: set,
+    requant_weights: set[str],
     inplace: bool,
 ):
     """Apply fake-quant to a single QuantModule's weights.
@@ -172,13 +174,19 @@ def _fakequant_module_weights(
 
         if inplace:
             w = getattr(module, weight_name)
-            w_quant = quantizer(w.float()).to(w.dtype)
+            if sd_key in requant_weights:
+                w_quant = requant_weights_for_export(quantizer, w, copy_quantizer=False)
+            else:
+                w_quant = quantizer(w.float()).to(w.dtype)
         else:
             assert state_dict is not None
             if sd_key not in state_dict:
                 continue
             w = state_dict[sd_key]
-            w_quant = quantizer(w.float()).to(w.dtype)
+            if sd_key in requant_weights:
+                w_quant = requant_weights_for_export(quantizer, w)
+            else:
+                w_quant = quantizer(w.float()).to(w.dtype)
 
         # Fold pre_quant_scale: (x*s)@fake_quant(W) = x@(fake_quant(W)*s)
         # Only valid when input_quantizer does NOT fake-quant activations. If it does
@@ -189,7 +197,7 @@ def _fakequant_module_weights(
             if (
                 hasattr(inp_q, "_pre_quant_scale")
                 and inp_q._pre_quant_scale is not None
-                and inp_q._disabled
+                and not inp_q.is_enabled
             ):
                 scale = inp_q._pre_quant_scale.squeeze().to(device=w_quant.device)
                 w_quant = (w_quant * scale[None, :]).to(w_quant.dtype)
@@ -230,6 +238,7 @@ def _collect_group_pre_quant_scales(
 def requant_weights_for_export(
     quantizer: TensorQuantizer | SequentialQuantizer,
     weight: torch.Tensor,
+    copy_quantizer: bool = True,
 ) -> torch.Tensor:
     """Requantize folded weights after resmooth (``TensorQuantizer`` or ``SequentialQuantizer``).
 
@@ -239,7 +248,10 @@ def requant_weights_for_export(
     Deepcopy may leave buffers on the original device; ``.to(device=w.device)`` aligns with
     ``w`` (e.g. CPU offload).
     """
-    copied = copy.deepcopy(quantizer).to(device=weight.device)
+    if copy_quantizer:
+        copied = copy.deepcopy(quantizer).to(device=weight.device)
+    else:
+        copied = quantizer
     quantizers: list[TensorQuantizer] = (
         list(copied) if isinstance(copied, SequentialQuantizer) else [copied]
     )
@@ -296,30 +308,56 @@ def merge_amax_tensors_for_group(tensors: list[torch.Tensor]) -> torch.Tensor:
         return torch.max(flat).to(dtype=first.dtype, device=first.device)
 
 
+@contextmanager
+def _enable_writeback_for_group(
+    group: list[nn.Module],
+    root_model: nn.Module,
+    name_to_module: dict[str, nn.Module],
+):
+    """Nest ``enable_weight_access_and_writeback`` for every module in ``group`` (one ``with``).
+
+    The stdlib pattern for a *variable* number of context managers is :class:`ExitStack`;
+    wrapping it here keeps call sites readable.
+    """
+    with ExitStack() as stack:
+        for m in group:
+            stack.enter_context(enable_weight_access_and_writeback(m, root_model, name_to_module))
+        yield
+
+
 def _resmooth_experts_for_export(
     model: nn.Module,
-    state_dict: dict[str, Any],
+    state_dict: dict[str, Any] | None,
+    *,
+    inplace: bool = False,
 ) -> tuple[dict[str, tuple[torch.Tensor, torch.Tensor | None]], set[str]]:
-    """Average pqs and unify input amax for all groups vLLM collapses to one input quantizer.
+    """Prepare AWQ weights for vLLM fakequant export when several linears share one input quantizer.
 
-    Covers two cases that are structurally identical — a set of linears sharing the
-    same input that vLLM fuses behind a single input quantizer:
+    PTQ can assign a different ``pre_quant_scale`` per branch (per expert, or per
+    q/k/v projection) even though they see the same activation. vLLM’s fused kernels expose a
+    **single** input quantizer for that fused group, so reload must use one scale — otherwise
+    activations are scaled wrong for k/v or non-primary experts.
 
-    * **MoE experts** — vLLM uses one input quantizer per expert group.
-    * **Dense GQA attention** — vLLM fuses q/k/v into ``qkv_proj`` with one input
-      quantizer. AWQ calibration gives each projection a different pqs because they
-      share the same input but have different weight magnitudes; using only q's pqs
-      for k and v at inference corrupts those activations.
+    For each group (MoE experts via ``get_experts_list``; dense shared-input linears
+    via ``collect_shared_input_modules`` / hooks), average ``pre_quant_scale``, set weights to
+    ``W' = W * old_pqs / avg_pqs`` so the net is unchanged, merge input ``amax`` where needed,
+    and return per-``input_quantizer`` tensor overrides for ``modelopt_state_weights``.
 
-    For each group, adjusts weights in ``state_dict`` as ``W' = W * old_pqs / avg_pqs``
-    and returns input-quantizer overrides so every member exports the same ``avg_pqs``.
-    Only runs when input quantizers are **enabled** (``nvfp4_awq_wa`` style); for
-    weight-only AWQ the input quantizer is disabled and pqs is folded into each
-    projection's own weight independently.
+    Runs only for AWQ with **enabled** input quantizers (e.g. activation-aware); if inputs are
+    disabled and PQS was folded into weights only, there is nothing to unify.
+
+    ``inplace=False`` — adjust a detached ``state_dict`` copy (``state_dict`` required).
+    ``inplace=True`` — pass ``state_dict=None``; update live ``nn.Parameter`` data under
+    ``_enable_writeback_for_group`` (nested writeback per module so offloaded/meta weights
+    materialize before ``copy_``).
     """
+    if not inplace and state_dict is None:
+        raise ValueError("state_dict is required when inplace=False")
     qfmt = get_quantization_format(model)
     if qfmt is None or "awq" not in qfmt.lower():
         return {}, set()
+
+    name_to_module = dict(model.named_modules()) if inplace else None
 
     model_type = type(model).__name__.lower()
     id_to_name: dict[int, str] = {id(m): n for n, m in model.named_modules()}
@@ -338,18 +376,27 @@ def _resmooth_experts_for_export(
 
         for m in modules:
             nm = id_to_name.get(id(m))
-            if nm is None or f"{nm}.weight" not in state_dict:
+            if nm is None or not hasattr(m, "weight"):
                 continue
+            w_key = f"{nm}.weight"
             old_pqs = m.input_quantizer._pre_quant_scale
             avg_pqs_dev = avg_pqs.to(device=old_pqs.device, dtype=old_pqs.dtype)
             if torch.equal(old_pqs, avg_pqs_dev):
                 continue
-            weight = state_dict[f"{nm}.weight"]
-            ratio = old_pqs.to(dtype=torch.float32, device=weight.device) / avg_pqs.to(
-                device=weight.device
-            )
-            state_dict[f"{nm}.weight"] = (weight.to(torch.float32) * ratio).to(weight.dtype)
-            requant_weights.add(f"{nm}.weight")
+            if inplace:
+                w_param = m.weight
+                ratio = old_pqs.to(dtype=torch.float32, device=w_param.device) / avg_pqs.to(
+                    device=w_param.device
+                )
+                w_param.data.copy_((w_param.to(torch.float32) * ratio).to(w_param.dtype))
+            else:
+                assert state_dict is not None
+                weight = state_dict[w_key]
+                ratio = old_pqs.to(dtype=torch.float32, device=weight.device) / avg_pqs.to(
+                    device=weight.device
+                )
+                state_dict[w_key] = (weight.to(torch.float32) * ratio).to(weight.dtype)
+            requant_weights.add(w_key)
 
         synced_amax: torch.Tensor | None = None
         amaxes = [m.input_quantizer.amax for m in modules]
@@ -367,15 +414,21 @@ def _resmooth_experts_for_export(
     # different tokens to each expert, so forward hooks cannot detect them as
     # sharing the same input tensor.
     for _, module in model.named_modules():
-        if is_moe(module):
-            try:
-                expert_groups = get_experts_list(module, model_type)
-            except NotImplementedError:
-                pass
+        if not is_moe(module):
+            continue
+        try:
+            expert_groups = get_experts_list(module, model_type)
+        except NotImplementedError:
+            continue
+        for experts in expert_groups:
+            if not experts:
+                continue
+            if inplace:
+                assert name_to_module is not None
+                with _enable_writeback_for_group(experts, model, name_to_module):
+                    _process_group(experts)
             else:
-                for experts in expert_groups:
-                    if experts:
-                        _process_group(experts)
+                _process_group(experts)
 
     # Dense shared-input groups (e.g. q/k/v in GQA attention) — detected via forward
     # hooks so any architecture is covered regardless of projection attribute names.
@@ -388,15 +441,19 @@ def _resmooth_experts_for_export(
             try:
                 model(torch.ones([1, 2], dtype=torch.long, device=dev))
             except Exception as e:
-                import logging
-
                 logging.getLogger(__name__).debug(
                     "Dummy forward for shared-input detection failed (expected for VLMs): %s", e
                 )
 
     input_to_linear, _ = collect_shared_input_modules(model, _dummy_forward)
     for modules in input_to_linear.values():
-        if len(modules) > 1:
+        if len(modules) <= 1:
+            continue
+        if inplace:
+            assert name_to_module is not None
+            with _enable_writeback_for_group(modules, model, name_to_module):
+                _process_group(modules)
+        else:
             _process_group(modules)
 
     return out, requant_weights
@@ -418,8 +475,9 @@ def export_hf_vllm_fq_checkpoint(
 
     For MoE models with AWQ quantization, pre_quant_scale is averaged across experts
     and input amax is unified — required because vLLM uses a single input quantizer
-    per expert group. This averaging is performed without mutating the model; only a
-    detached ``state_dict`` copy is updated.
+    per expert group. By default this updates only a detached ``state_dict`` copy.
+    With ``inplace_mem_efficient=True``, resmooth runs **in place** on materialized
+    weight parameters only (no ``state_dict``), before the inplace fakequant loop.
 
     Args:
         model: In-memory quantized model.
@@ -432,22 +490,13 @@ def export_hf_vllm_fq_checkpoint(
     export_dir = Path(export_dir)
     export_dir.mkdir(parents=True, exist_ok=True)
 
-    # Step 1: Build the folded HF state dict.
-    # model.state_dict() returns detached copies of all tensors, so model
-    # parameters are never modified. Apply each weight quantizer's fake-quant
-    # to the corresponding weight tensor in the copy.
-    state_dict = model.state_dict()
-
-    # Non-mutating resmooth: average pqs across all shared-input groups (dense GQA q/k/v
-    # and MoE experts) and adjust state_dict weights. Must run before the fakequant loop
-    # so adjusted weights are fakequanted with the correct per-block scales.
-    pqs_overrides, requant_weights = _resmooth_experts_for_export(model, state_dict)
-
     fakequant_weights: set[str] = set()
     # Input quantizer keys whose _pre_quant_scale was folded into the weight above.
     input_quantizers_folded_pqs: set[str] = set()
     with torch.inference_mode():
         if inplace_mem_efficient:
+            # Resmooth shared-input groups, then fakequant (state dict and/or params).
+            pqs_overrides, requant_weights = _resmooth_experts_for_export(model, None, inplace=True)
             # Inplace path: iterate decoder layers, one offload<->onload per layer.
             decoder_layers = LayerActivationCollector.get_decoder_layers(model)
             assert decoder_layers is not None, (
@@ -466,14 +515,21 @@ def export_hf_vllm_fq_checkpoint(
                             None,
                             input_quantizers_folded_pqs,
                             fakequant_weights,
+                            requant_weights,
                             inplace=True,
                         )
             # Meta tensors for offloaded weights (free); offload maps now have
             # fakequanted values via writeback.
             state_dict = model.state_dict()
         else:
-            # Default path: full state_dict copy, fakequant into the copy.
             state_dict = model.state_dict()
+            # Resmooth shared-input groups, then fakequant (state dict and/or params).
+            pqs_overrides, requant_weights = _resmooth_experts_for_export(
+                model, state_dict, inplace=False
+            )
+
+            # Default path: fakequant into the resmoothed state_dict copy (do not refresh
+            # from model.state_dict() or resmooth is lost).
             for module_name, module in model.named_modules():
                 with enable_weight_access_and_writeback(module, model):
                     _fakequant_module_weights(
@@ -483,6 +539,7 @@ def export_hf_vllm_fq_checkpoint(
                         state_dict,
                         input_quantizers_folded_pqs,
                         fakequant_weights,
+                        requant_weights,
                         inplace=False,
                     )
 

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 """Export HuggingFace model to vLLM fakequant checkpoint."""
 
-import contextlib
 import copy
+import logging
 import re
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -27,7 +28,7 @@ import modelopt.torch.opt as mto
 from modelopt.torch.quantization.config import RotateConfig
 from modelopt.torch.quantization.conversion import quantizer_state
 from modelopt.torch.quantization.model_calib import enable_stats_collection, finish_stats_collection
-from modelopt.torch.quantization.nn import QuantModule, TensorQuantizer
+from modelopt.torch.quantization.nn import QuantModule, SequentialQuantizer, TensorQuantizer
 from modelopt.torch.quantization.utils import get_quantizer_state_dict
 from modelopt.torch.quantization.utils.core_utils import enable_weight_access_and_writeback
 from modelopt.torch.quantization.utils.layerwise_calib import LayerActivationCollector
@@ -39,6 +40,7 @@ from ..unified_export_hf import collect_shared_input_modules
 
 __all__ = [
     "export_hf_vllm_fq_checkpoint",
+    "infer_quantizer_prefix_remap",
     "is_weight_quantizer_state_key",
     "merge_amax_tensors_for_group",
 ]
@@ -53,6 +55,79 @@ def is_weight_quantizer_state_key(key: str) -> bool:
     Matches ``weight_quantizer``, ``w13_weight_quantizer``, ``weight_quantizer.0``, etc.
     """
     return bool(_WEIGHT_QUANTIZER_STATE_KEY.search(key))
+
+
+def infer_quantizer_prefix_remap(
+    quantizer_keys: dict[str, Any],
+    map_fun: Callable[[dict[str, Any]], dict[str, Any]],
+) -> dict[str, str]:
+    """Infer HF root name → vLLM root (e.g. ``backbone`` → ``model``) for reload/export.
+
+    Map HF root → vLLM root (e.g. ``backbone`` → ``model``) by probing ``map_fun`` with
+    synthetic ``<module>.weight`` keys and a 2-D placeholder (quantizer paths are not weight
+    keys). Keys under the same HF root must agree on the target root or :exc:`ValueError` is
+    raised; failed probes are skipped. Returns ``{hf_root: vllm_root}`` only where the root
+    renames; not for arbitrary layer rewrites.
+
+    Args:
+        quantizer_keys: HF quantizer state paths as keys (values unused).
+        map_fun: HF→vLLM weight ``state_dict`` mapper, same as for ``convert_dict_to_vllm``.
+
+    Returns:
+        ``{hf_root: vllm_root}`` for roots that rename; omits identity pairs.
+    """
+    logger = logging.getLogger(__name__)
+    probe_weight = torch.empty((1, 1))
+    observed_vllm_root: dict[str, str] = {}
+
+    for key in quantizer_keys:
+        first_component = key.split(".")[0]
+        last_dot = key.rfind(".")
+        if last_dot == -1:
+            continue
+        probe_key = key[:last_dot] + ".weight"
+        try:
+            result = map_fun({probe_key: probe_weight})
+            if not result:
+                continue
+            new_key = next(iter(result))
+            new_first = new_key.split(".")[0]
+        except Exception as e:
+            logger.debug("prefix-remap probe failed for %r: %s", probe_key, e)
+            continue
+
+        if first_component not in observed_vllm_root:
+            observed_vllm_root[first_component] = new_first
+        elif observed_vllm_root[first_component] != new_first:
+            raise ValueError(
+                "Inconsistent HF→vLLM prefix remap for "
+                f"{first_component!r}: probes implied "
+                f"{observed_vllm_root[first_component]!r} and {new_first!r}. "
+                "map_fun must apply one target root per HF root, or use explicit quantizer "
+                "key remapping."
+            )
+
+    return {
+        hf_root: vllm_root
+        for hf_root, vllm_root in observed_vllm_root.items()
+        if hf_root != vllm_root
+    }
+
+
+def _check_all_weight_quantizers_disabled(model: nn.Module) -> None:
+    """Export invariant before writing metadata: every weight quantizer must be off."""
+    for _, module in model.named_modules():
+        if not isinstance(module, QuantModule):
+            continue
+        for attr_name, quantizer in module.named_children():
+            if attr_name.endswith("weight_quantizer") and isinstance(
+                quantizer, (TensorQuantizer, SequentialQuantizer)
+            ):
+                assert not quantizer.is_enabled, (
+                    f"vLLM fakequant export: {attr_name!r} must be disabled before saving "
+                    f"quantizer_state (weights already folded). "
+                    f"See filter_modelopt_state_quantizer_state_for_model in vllm_reload_utils."
+                )
 
 
 def disable_rotate(quantizer: TensorQuantizer):
@@ -129,7 +204,7 @@ def _fakequant_module_weights(
         fakequant_weights.add(sd_key)
 
 
-def _collect_expert_pre_quant_scales(
+def _collect_group_pre_quant_scales(
     experts: list[nn.Module],
 ) -> list[torch.Tensor] | None:
     """Return per-expert ``pre_quant_scale`` tensors if every expert can be averaged; else None.
@@ -137,27 +212,53 @@ def _collect_expert_pre_quant_scales(
     Skips groups where any expert has no input quantizer, no pqs (e.g. weight-only AWQ INT4),
     or a disabled input quantizer (pqs already folded / not used).
     """
-    pqs_list: list[torch.Tensor] = []
-    for ex in experts:
-        iq = getattr(ex, "input_quantizer", None)
-        if iq is None or not iq.is_enabled or iq.pre_quant_scale is None:
+    pre_quant_scales: list[torch.Tensor] = []
+    for expert_module in experts:
+        input_quantizer = getattr(expert_module, "input_quantizer", None)
+        if (
+            input_quantizer is None
+            or not input_quantizer.is_enabled
+            or input_quantizer.pre_quant_scale is None
+        ):
             return None
-        pqs_list.append(iq.pre_quant_scale)
-    return pqs_list
+        pre_quant_scales.append(input_quantizer.pre_quant_scale)
+    return pre_quant_scales
 
 
 def requant_weights_for_export(
-    quantizer: TensorQuantizer,
-    w: torch.Tensor,
+    quantizer: TensorQuantizer | SequentialQuantizer,
+    weight: torch.Tensor,
 ) -> torch.Tensor:
-    """Requantize weights for export."""
-    quantizer_copy = copy.deepcopy(quantizer)
-    quantizer_copy.eval()
-    quantizer_copy.reset_amax()
-    enable_stats_collection(quantizer_copy)
-    quantizer_copy(w)
-    finish_stats_collection(quantizer_copy)
-    return quantizer_copy(w.float()).to(w.dtype)
+    """Requantize folded weights after resmooth (``TensorQuantizer`` or ``SequentialQuantizer``).
+
+    A single ``TensorQuantizer`` is treated as a one-stage chain so the same
+    calibrate-then-apply steps cover W4A8-style sequential weights (e.g. INT4→FP8).
+
+    Deepcopy may leave buffers on the original device; ``.to(device=w.device)`` aligns with
+    ``w`` (e.g. CPU offload).
+    """
+    copied = copy.deepcopy(quantizer).to(device=weight.device)
+    sequence_quantizers: list[TensorQuantizer] = (
+        list(copied) if isinstance(copied, SequentialQuantizer) else [copied]
+    )
+
+    for quantizer_copy in sequence_quantizers:
+        quantizer_copy.eval()
+        quantizer_copy.reset_amax()
+        enable_stats_collection(quantizer_copy)
+    # Match legacy single-quantizer path: first calib uses ``w`` as-is; chains use float.
+    if len(sequence_quantizers) == 1:
+        weight_quantized = sequence_quantizers[0](weight)
+    else:
+        weight_quantized = weight.float()
+        for quantizer_copy in sequence_quantizers:
+            weight_quantized = quantizer_copy(weight_quantized)
+    for quantizer_copy in sequence_quantizers:
+        finish_stats_collection(quantizer_copy)
+    weight_quantized = weight.float()
+    for quantizer_copy in sequence_quantizers:
+        weight_quantized = quantizer_copy(weight_quantized)
+    return weight_quantized.to(weight.dtype)
 
 
 def merge_amax_tensors_for_group(tensors: list[torch.Tensor]) -> torch.Tensor:
@@ -167,8 +268,10 @@ def merge_amax_tensors_for_group(tensors: list[torch.Tensor]) -> torch.Tensor:
 
     - If every tensor has the same shape, take the element-wise maximum over the group
       (conservative when each branch carried the same axis layout).
-    - If shapes differ (e.g. GQA q vs k), try ``torch.cat(..., dim=0)`` when valid for
-      per-channel amax; otherwise fall back to a scalar max over all elements.
+    - If shapes differ: ``torch.cat(..., dim=0)`` assumes **1D per-channel** amaxes in
+      fused order (e.g. GQA q/k/v → ``[N_q]`` + ``[N_kv]`` + ``[N_kv]``), matching vLLM’s
+      grouped quantizer. Not valid for 2D blockwise amax; on failure, **scalar**
+      max (drops channel structure).
     """
     if not tensors:
         raise ValueError("merge_amax_tensors_for_group: expected at least one tensor")
@@ -218,7 +321,7 @@ def _resmooth_experts_for_export(
     requant_weights: set[str] = set()
 
     def _process_group(modules: list[nn.Module]) -> None:
-        pqs_list = _collect_expert_pre_quant_scales(modules)
+        pqs_list = _collect_group_pre_quant_scales(modules)
         if pqs_list is None:
             return
 
@@ -272,9 +375,15 @@ def _resmooth_experts_for_export(
     dev = next(model.parameters()).device
 
     def _dummy_forward() -> None:
-        # Partial forward is OK: hooks record layers reached before failure (e.g. VLMs).
-        with contextlib.suppress(Exception):
+        # Partial forward is OK: hooks record layers reached before failure.
+        try:
             model(torch.ones([1, 2], dtype=torch.long, device=dev))
+        except Exception as e:
+            import logging
+
+            logging.getLogger(__name__).debug(
+                "Dummy forward for shared-input detection failed (expected for VLMs): %s", e
+            )
 
     input_to_linear, _ = collect_shared_input_modules(model, _dummy_forward)
     for modules in input_to_linear.values():
@@ -388,11 +497,16 @@ def export_hf_vllm_fq_checkpoint(
     for _, module in model.named_modules():
         if isinstance(module, QuantModule):
             for attr_name, quantizer in module.named_children():
-                if (
-                    attr_name.endswith("weight_quantizer")
-                    and isinstance(quantizer, TensorQuantizer)
-                    and quantizer.is_enabled
-                ):
+                if not (attr_name.endswith("weight_quantizer") and quantizer.is_enabled):
+                    continue
+                if isinstance(quantizer, SequentialQuantizer):
+                    quantizer.disable()
+                    for sub in quantizer:
+                        orig_rotate = sub._rotate
+                        if sub.rotate_is_enabled:
+                            sub._rotate = disable_rotate(sub)
+                        wqs_to_restore.append((sub, orig_rotate))
+                elif isinstance(quantizer, TensorQuantizer):
                     quantizer.disable()
                     orig_rotate = quantizer._rotate
                     if quantizer.rotate_is_enabled:
@@ -403,6 +517,8 @@ def export_hf_vllm_fq_checkpoint(
     for key in list(quantizer_state_dict):
         if is_weight_quantizer_state_key(key):
             # Fakequant amax is folded into HF weights; do not reload weight quantizer tensors.
+            # Reload must force-disable WQs missing from saved state (see
+            # ``filter_modelopt_state_quantizer_state_for_model`` assertion in vllm_reload_utils).
             quantizer_state_dict.pop(key)
         elif key in input_quantizers_folded_pqs:
             # pre_quant_scale was folded into the weight; keep the buffer for strict load but
@@ -426,10 +542,12 @@ def export_hf_vllm_fq_checkpoint(
 
     modelopt_state = mto.modelopt_state(model)
     # ``modelopt_state`` may be stale if another mode (e.g. calibrate) ran last. Rebuild
-    # ``quantizer_state`` and drop disabled weight quantizer entries (weights already folded).
+    # ``quantizer_state`` and strip weight-quantizer entries (same policy as
+    # ``modelopt_state_weights``). Reload synthesizes missing WQ rows with ``_disabled``.
+    _check_all_weight_quantizers_disabled(model)
     qstate = quantizer_state(model)
     for key in list(qstate):
-        if is_weight_quantizer_state_key(key) and qstate[key].get("_disabled"):
+        if is_weight_quantizer_state_key(key):
             qstate.pop(key)
 
     for mode_str, m_state in modelopt_state.get("modelopt_state_dict", []):

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -621,19 +621,20 @@ def export_hf_vllm_fq_checkpoint(
                         qstate_val["_amax"] = max_input_amax
 
         modelopt_state = mto.modelopt_state(model)
-        # ``modelopt_state`` may be stale if another mode (e.g. calibrate) ran last. Rebuild
-        # ``quantizer_state`` and strip weight-quantizer entries (same policy as
-        # ``modelopt_state_weights``). Reload synthesizes missing WQ rows with ``_disabled``.
         _check_all_weight_quantizers_disabled(model)
+        # Rebuild quantizer_state from the live model (post-disable) and strip weight-quantizer
+        # entries. Apply to every mode that carries quantizer_state so that stale entries from
+        # a calibrate pass (which also stores quantizer_state in its metadata) are cleaned up.
+        # Reload synthesizes missing WQ rows with ``_disabled`` via
+        # ``filter_modelopt_state_quantizer_state_for_model``.
         qstate = quantizer_state(model)
         for key in list(qstate):
             if is_weight_quantizer_state_key(key):
                 qstate.pop(key)
-
-        for mode_str, m_state in modelopt_state.get("modelopt_state_dict", []):
-            if mode_str == "quantize" and "metadata" in m_state:
-                m_state["metadata"]["quantizer_state"] = qstate
-                break
+        for _mode_str, m_state in modelopt_state.get("modelopt_state_dict", []):
+            md = m_state.get("metadata", {})
+            if "quantizer_state" in md:
+                md["quantizer_state"] = qstate
 
         # Per-quantizer tensor dict loaded alongside metadata on reload.
         modelopt_state["modelopt_state_weights"] = quantizer_state_dict

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -38,6 +38,7 @@ from ..quant_utils import get_quantization_format
 __all__ = [
     "export_hf_vllm_fq_checkpoint",
     "is_weight_quantizer_state_key",
+    "merge_amax_tensors_for_group",
 ]
 
 # Matches ``…weight_quantizer``, ``…weight_quantizer.0``, ``…w13_weight_quantizer.0``, etc.
@@ -157,6 +158,33 @@ def requant_weights_for_export(
     return quantizer_copy(w.float()).to(w.dtype)
 
 
+def merge_amax_tensors_for_group(tensors: list[torch.Tensor]) -> torch.Tensor:
+    """Combine `_amax` buffers from a merge group into a single tensor.
+
+    Used when HuggingFace module names are folded to vLLM names (e.g. q/k/v → qkv_proj).
+
+    - If every tensor has the same shape, take the element-wise maximum over the group
+      (conservative when each branch carried the same axis layout).
+    - If shapes differ (e.g. GQA q vs k), try ``torch.cat(..., dim=0)`` when valid for
+      per-channel amax; otherwise fall back to a scalar max over all elements.
+    """
+    if not tensors:
+        raise ValueError("merge_amax_tensors_for_group: expected at least one tensor")
+    if len(tensors) == 1:
+        return tensors[0]
+
+    first = tensors[0]
+    if all(t.shape == first.shape for t in tensors):
+        stacked = torch.stack([t.float() for t in tensors], dim=0)
+        return torch.amax(stacked, dim=0).to(dtype=first.dtype, device=first.device)
+
+    try:
+        return torch.cat(tensors, dim=0).to(dtype=first.dtype, device=first.device)
+    except RuntimeError:
+        flat = torch.cat([t.reshape(-1).float() for t in tensors])
+        return torch.max(flat).to(dtype=first.dtype, device=first.device)
+
+
 def _resmooth_experts_for_export(
     model: nn.Module,
     state_dict: dict[str, Any],
@@ -214,7 +242,7 @@ def _resmooth_experts_for_export(
             if iq0.is_enabled:
                 amaxes = [e.input_quantizer.amax for e in experts]
                 if all(a is not None for a in amaxes):
-                    max_in_amax = torch.stack(amaxes).max()
+                    max_in_amax = merge_amax_tensors_for_group(amaxes)
 
             avg_out = avg_pqs.detach().clone()
             for ex in experts:

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -215,41 +215,50 @@ def _resmooth_experts_for_export(
         for experts in expert_groups:
             if not experts:
                 continue
-            pqs_list = _collect_expert_pre_quant_scales(experts)
-            if pqs_list is None:
+            pre_quant_scales_list = _collect_expert_pre_quant_scales(experts)
+            if pre_quant_scales_list is None:
                 continue
 
-            avg_pqs = torch.stack(pqs_list).mean(0)
+            avg_pre_quant_scale = torch.stack(pre_quant_scales_list).mean(0)
             # Guard against degenerate calibration where a channel's scale is zero:
             # zero avg_pqs would produce inf ratio and corrupt the exported weight.
-            avg_pqs = avg_pqs.clamp(min=torch.finfo(torch.float32).tiny)
+            avg_pre_quant_scale = avg_pre_quant_scale.clamp(min=torch.finfo(torch.float32).tiny)
 
             for ex in experts:
                 nm = id_to_name.get(id(ex))
                 if nm is None or f"{nm}.weight" not in state_dict:
                     continue
-                old_pqs = ex.input_quantizer._pre_quant_scale
-                avg_on_dev = avg_pqs.to(device=old_pqs.device, dtype=old_pqs.dtype)
-                if torch.equal(old_pqs, avg_on_dev):
+                old_pre_quant_scale = ex.input_quantizer._pre_quant_scale
+                avg_pre_quant_scale = avg_pre_quant_scale.to(
+                    device=old_pre_quant_scale.device, dtype=old_pre_quant_scale.dtype
+                )
+                if torch.equal(old_pre_quant_scale, avg_pre_quant_scale):
                     continue
-                w = state_dict[f"{nm}.weight"]
-                ratio = (old_pqs / avg_pqs).to(dtype=torch.float32, device=w.device)
-                state_dict[f"{nm}.weight"] = (w.float() * ratio[None, :]).to(w.dtype)
+                weight = state_dict[f"{nm}.weight"]
+                updated_weight = (
+                    weight.to(torch.float32)
+                    * old_pre_quant_scale.to(dtype=torch.float32, device=weight.device)
+                    / avg_pre_quant_scale.to(dtype=torch.float32, device=weight.device)
+                ).to(weight.dtype)
+                state_dict[f"{nm}.weight"] = updated_weight
                 requant_weights.add(f"{nm}.weight")
 
             iq0 = experts[0].input_quantizer
-            max_in_amax: torch.Tensor | None = None
+            synced_amax: torch.Tensor | None = None
             if iq0.is_enabled:
                 amaxes = [e.input_quantizer.amax for e in experts]
                 if all(a is not None for a in amaxes):
-                    max_in_amax = merge_amax_tensors_for_group(amaxes)
+                    synced_amax = merge_amax_tensors_for_group(amaxes)
 
-            avg_out = avg_pqs.detach().clone()
+            avg_pre_quant_scale_output = avg_pre_quant_scale.detach().clone()
             for ex in experts:
                 nm = id_to_name.get(id(ex))
                 if nm is None:
                     continue
-                out[get_unwrapped_name(f"{nm}.input_quantizer", model)] = (avg_out, max_in_amax)
+                out[get_unwrapped_name(f"{nm}.input_quantizer", model)] = (
+                    avg_pre_quant_scale_output,
+                    synced_amax,
+                )
 
     return out, requant_weights
 

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Export HuggingFace model to vLLM fakequant checkpoint."""
 
+import copy
+import re
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +25,7 @@ import torch.nn as nn
 import modelopt.torch.opt as mto
 from modelopt.torch.quantization.config import RotateConfig
 from modelopt.torch.quantization.conversion import quantizer_state
+from modelopt.torch.quantization.model_calib import enable_stats_collection, finish_stats_collection
 from modelopt.torch.quantization.nn import QuantModule, TensorQuantizer
 from modelopt.torch.quantization.utils import get_quantizer_state_dict
 from modelopt.torch.quantization.utils.core_utils import enable_weight_access_and_writeback
@@ -33,6 +36,14 @@ from ..layer_utils import get_experts_list, is_moe
 from ..quant_utils import get_quantization_format
 
 __all__ = ["export_hf_vllm_fq_checkpoint"]
+
+# Matches ``…weight_quantizer``, ``…weight_quantizer.0``, ``…w13_weight_quantizer.0``, etc.
+_WEIGHT_QUANTIZER_STATE_KEY = re.compile(r"(?:^|\.)(?:\w+_)?weight_quantizer(?:\.\d+)*$")
+
+
+def _is_weight_quantizer_state_key(key: str) -> bool:
+    """True for weight quantizer state keys, including ModuleList entries (``…weight_quantizer.0``)."""
+    return bool(_WEIGHT_QUANTIZER_STATE_KEY.search(key))
 
 
 def disable_rotate(quantizer: TensorQuantizer):
@@ -126,10 +137,24 @@ def _collect_expert_pre_quant_scales(
     return pqs_list
 
 
+def requant_weights_for_export(
+    quantizer: TensorQuantizer,
+    w: torch.Tensor,
+) -> torch.Tensor:
+    """Requantize weights for export."""
+    quantizer_copy = copy.deepcopy(quantizer)
+    quantizer_copy.eval()
+    quantizer_copy.reset_amax()
+    enable_stats_collection(quantizer_copy)
+    quantizer_copy(w)
+    finish_stats_collection(quantizer_copy)
+    return quantizer_copy(w.float()).to(w.dtype)
+
+
 def _resmooth_experts_for_export(
     model: nn.Module,
     state_dict: dict[str, Any],
-) -> dict[str, tuple[torch.Tensor, torch.Tensor | None]]:
+) -> tuple[dict[str, tuple[torch.Tensor, torch.Tensor | None]], set[str]]:
     """Average pqs and unify input amax across MoE experts when AWQ smoothing applies (no-op otherwise).
 
     Adjusts expert weights in ``state_dict`` as ``W' = W * old_pqs / avg_pqs`` and returns
@@ -139,14 +164,14 @@ def _resmooth_experts_for_export(
     """
     qfmt = get_quantization_format(model)
     if qfmt is None or "awq" not in qfmt.lower():
-        return {}
+        return {}, set()
 
     model_type = type(model).__name__.lower()
     id_to_name: dict[int, str] = {id(m): n for n, m in model.named_modules()}
     out: dict[str, tuple[torch.Tensor, torch.Tensor | None]] = {}
-
+    requant_weights: set[str] = set()
     for _, module in model.named_modules():
-        if not (is_moe(module) or "nemotronhmoe" in model_type):
+        if not is_moe(module):
             continue
         try:
             expert_groups = get_experts_list(module, model_type)
@@ -173,6 +198,7 @@ def _resmooth_experts_for_export(
                 w = state_dict[f"{nm}.weight"]
                 ratio = (old_pqs / avg_pqs).to(dtype=torch.float32, device=w.device)
                 state_dict[f"{nm}.weight"] = (w.float() * ratio[None, :]).to(w.dtype)
+                requant_weights.add(f"{nm}.weight")
 
             iq0 = experts[0].input_quantizer
             max_in_amax: torch.Tensor | None = None
@@ -188,7 +214,7 @@ def _resmooth_experts_for_export(
                     continue
                 out[get_unwrapped_name(f"{nm}.input_quantizer", model)] = (avg_out, max_in_amax)
 
-    return out
+    return out, requant_weights
 
 
 def export_hf_vllm_fq_checkpoint(
@@ -207,8 +233,8 @@ def export_hf_vllm_fq_checkpoint(
 
     For MoE models with AWQ quantization, pre_quant_scale is averaged across experts
     and input amax is unified — required because vLLM uses a single input quantizer
-    per expert group. This averaging is performed non-mutingly on a detached state_dict
-    copy; the original model is never modified.
+    per expert group. This averaging is performed without mutating the model; only a
+    detached ``state_dict`` copy is updated.
 
     Args:
         model: In-memory quantized model.
@@ -230,9 +256,9 @@ def export_hf_vllm_fq_checkpoint(
     # Non-mutating MoE expert resmooth: average pqs and adjust state_dict weights.
     # Must run before the fakequant loop so that the adjusted weights are fakequanted
     # with the correct per-block scales.
-    expert_pqs_overrides = _resmooth_experts_for_export(model, state_dict)
+    expert_pqs_overrides, requant_weights = _resmooth_experts_for_export(model, state_dict)
 
-    fakequant_weights = set()
+    fakequant_weights: set[str] = set()
     # Input quantizer keys whose _pre_quant_scale was folded into the weight above.
     input_quantizers_folded_pqs: set[str] = set()
     with torch.inference_mode():
@@ -291,7 +317,7 @@ def export_hf_vllm_fq_checkpoint(
     # attention quantizers remain active.
     # Rotation is also cleared: the weight was already folded with rotation applied,
     # so if fold_weight is called on reload it must not re-rotate the exported weight.
-    wqs_to_restore = []
+    wqs_to_restore: list[tuple[TensorQuantizer, Any]] = []
     for _, module in model.named_modules():
         if isinstance(module, QuantModule):
             for attr_name, quantizer in module.named_children():
@@ -308,7 +334,7 @@ def export_hf_vllm_fq_checkpoint(
 
     quantizer_state_dict = get_quantizer_state_dict(model)
     for key in list(quantizer_state_dict):
-        if key.endswith("weight_quantizer"):
+        if _is_weight_quantizer_state_key(key):
             # Fakequant amax is folded into HF weights; do not reload weight quantizer tensors.
             quantizer_state_dict.pop(key)
         elif key in input_quantizers_folded_pqs:
@@ -336,7 +362,7 @@ def export_hf_vllm_fq_checkpoint(
     # ``quantizer_state`` and drop disabled weight quantizer entries (weights already folded).
     qstate = quantizer_state(model)
     for key in list(qstate):
-        if key.endswith("weight_quantizer") and qstate[key].get("_disabled"):
+        if _is_weight_quantizer_state_key(key) and qstate[key].get("_disabled"):
             qstate.pop(key)
 
     for mode_str, m_state in modelopt_state.get("modelopt_state_dict", []):

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -107,66 +107,86 @@ def _fakequant_module_weights(
             assert state_dict is not None
             state_dict[sd_key] = w_quant.cpu()
         fakequant_weights.add(sd_key)
+
+
+def _collect_expert_pre_quant_scales(
+    experts: list[nn.Module],
+) -> list[torch.Tensor] | None:
+    """Return per-expert ``pre_quant_scale`` tensors if every expert can be averaged; else None.
+
+    Skips groups where any expert has no input quantizer, no pqs (e.g. weight-only AWQ INT4),
+    or a disabled input quantizer (pqs already folded / not used).
+    """
+    pqs_list: list[torch.Tensor] = []
+    for ex in experts:
+        iq = getattr(ex, "input_quantizer", None)
+        if iq is None or getattr(iq, "_disabled", False) or iq.pre_quant_scale is None:
+            return None
+        pqs_list.append(iq.pre_quant_scale)
+    return pqs_list
+
+
 def _resmooth_experts_for_export(
     model: nn.Module,
     state_dict: dict[str, Any],
 ) -> dict[str, tuple[torch.Tensor, torch.Tensor | None]]:
-    """Average pqs and unify input amax across MoE experts for AWQ formats (no-op otherwise).
+    """Average pqs and unify input amax across MoE experts when AWQ smoothing applies (no-op otherwise).
 
-    Adjusts expert weights in ``state_dict`` to preserve correctness under the new averaged pqs
-    (W' = W * old_pqs / avg_pqs), without touching the model. Returns input-quantizer overrides
-    for patching ``modelopt_state_weights`` on save.
+    Adjusts expert weights in ``state_dict`` as ``W' = W * old_pqs / avg_pqs`` and returns
+    input-quantizer overrides for ``modelopt_state_weights``. **Does nothing** for weight-only
+    MoE (no ``pre_quant_scale`` on experts) or unsupported MoE layouts — same as skipping the
+    MoE branch in :func:`requantize_resmooth_fused_llm_layers`.
     """
     qfmt = get_quantization_format(model)
     if qfmt is None or "awq" not in qfmt.lower():
         return {}
 
     model_type = type(model).__name__.lower()
-    hf_mt = getattr(getattr(model, "config", None), "model_type", None)
     id_to_name: dict[int, str] = {id(m): n for n, m in model.named_modules()}
     out: dict[str, tuple[torch.Tensor, torch.Tensor | None]] = {}
 
     for _, module in model.named_modules():
-        if not is_moe(module):
+        if not (is_moe(module) or "nemotronhmoe" in model_type):
             continue
-        # get_experts_list raises NotImplementedError for MoE types it does not support
-        # (e.g. DBRX, ArcticMoE). is_moe detects those, but only AWQ-quantized variants
-        # would reach here, so a loud failure is the right behavior.
-        expert_groups = get_experts_list(module, model_type, hf_config_model_type=hf_mt)
+        try:
+            expert_groups = get_experts_list(module, model_type)
+        except NotImplementedError:
+            continue
 
         for experts in expert_groups:
             if not experts:
                 continue
-            iq0 = getattr(experts[0], "input_quantizer", None)
-            # Skip when pqs is absent or the input quantizer is disabled (pqs already folded
-            # into the weight by the export loop; overwriting it here would undo that fold).
-            if iq0 is None or iq0.pre_quant_scale is None or iq0._disabled:
+            pqs_list = _collect_expert_pre_quant_scales(experts)
+            if pqs_list is None:
                 continue
 
-            avg_pqs = torch.stack([e.input_quantizer.pre_quant_scale for e in experts]).mean(0)
+            avg_pqs = torch.stack(pqs_list).mean(0)
 
-            # Rescale each expert weight: W' = W * (old_pqs / avg_pqs) per output column.
             for ex in experts:
                 nm = id_to_name.get(id(ex))
                 if nm is None or f"{nm}.weight" not in state_dict:
                     continue
                 old_pqs = ex.input_quantizer._pre_quant_scale
-                if torch.equal(old_pqs, avg_pqs):
+                avg_on_dev = avg_pqs.to(device=old_pqs.device, dtype=old_pqs.dtype)
+                if torch.equal(old_pqs, avg_on_dev):
                     continue
                 w = state_dict[f"{nm}.weight"]
                 ratio = (old_pqs / avg_pqs).to(dtype=torch.float32, device=w.device)
                 state_dict[f"{nm}.weight"] = (w.float() * ratio[None, :]).to(w.dtype)
 
-            # Max amax across experts; vLLM uses a single input quantizer per expert group.
+            iq0 = experts[0].input_quantizer
             max_in_amax: torch.Tensor | None = None
-            if iq0.amax is not None:
-                max_in_amax = torch.stack([e.input_quantizer.amax for e in experts]).max()
+            if iq0.is_enabled:
+                amaxes = [e.input_quantizer.amax for e in experts]
+                if all(a is not None for a in amaxes):
+                    max_in_amax = torch.stack(amaxes).max()
 
+            avg_out = avg_pqs.detach().clone()
             for ex in experts:
                 nm = id_to_name.get(id(ex))
                 if nm is None:
                     continue
-                out[get_unwrapped_name(f"{nm}.input_quantizer", model)] = (avg_pqs, max_in_amax)
+                out[get_unwrapped_name(f"{nm}.input_quantizer", model)] = (avg_out, max_in_amax)
 
     return out
 

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -15,12 +15,12 @@
 """Export HuggingFace model to vLLM fakequant checkpoint."""
 
 from pathlib import Path
+from typing import Any
 
 import torch
 import torch.nn as nn
 
 import modelopt.torch.opt as mto
-from modelopt.torch.export.unified_export_hf import requantize_resmooth_fused_llm_layers
 from modelopt.torch.quantization.config import RotateConfig
 from modelopt.torch.quantization.conversion import quantizer_state
 from modelopt.torch.quantization.nn import QuantModule, TensorQuantizer
@@ -28,6 +28,9 @@ from modelopt.torch.quantization.utils import get_quantizer_state_dict
 from modelopt.torch.quantization.utils.core_utils import enable_weight_access_and_writeback
 from modelopt.torch.quantization.utils.layerwise_calib import LayerActivationCollector
 from modelopt.torch.utils import get_unwrapped_name
+
+from ..layer_utils import get_experts_list, is_moe
+from ..quant_utils import get_quantization_format
 
 __all__ = ["export_hf_vllm_fq_checkpoint"]
 
@@ -104,6 +107,68 @@ def _fakequant_module_weights(
             assert state_dict is not None
             state_dict[sd_key] = w_quant.cpu()
         fakequant_weights.add(sd_key)
+def _resmooth_experts_for_export(
+    model: nn.Module,
+    state_dict: dict[str, Any],
+) -> dict[str, tuple[torch.Tensor, torch.Tensor | None]]:
+    """Average pqs and unify input amax across MoE experts for AWQ formats (no-op otherwise).
+
+    Adjusts expert weights in ``state_dict`` to preserve correctness under the new averaged pqs
+    (W' = W * old_pqs / avg_pqs), without touching the model. Returns input-quantizer overrides
+    for patching ``modelopt_state_weights`` on save.
+    """
+    qfmt = get_quantization_format(model)
+    if qfmt is None or "awq" not in qfmt.lower():
+        return {}
+
+    model_type = type(model).__name__.lower()
+    hf_mt = getattr(getattr(model, "config", None), "model_type", None)
+    id_to_name: dict[int, str] = {id(m): n for n, m in model.named_modules()}
+    out: dict[str, tuple[torch.Tensor, torch.Tensor | None]] = {}
+
+    for _, module in model.named_modules():
+        if not is_moe(module):
+            continue
+        # get_experts_list raises NotImplementedError for MoE types it does not support
+        # (e.g. DBRX, ArcticMoE). is_moe detects those, but only AWQ-quantized variants
+        # would reach here, so a loud failure is the right behavior.
+        expert_groups = get_experts_list(module, model_type, hf_config_model_type=hf_mt)
+
+        for experts in expert_groups:
+            if not experts:
+                continue
+            iq0 = getattr(experts[0], "input_quantizer", None)
+            # Skip when pqs is absent or the input quantizer is disabled (pqs already folded
+            # into the weight by the export loop; overwriting it here would undo that fold).
+            if iq0 is None or iq0.pre_quant_scale is None or iq0._disabled:
+                continue
+
+            avg_pqs = torch.stack([e.input_quantizer.pre_quant_scale for e in experts]).mean(0)
+
+            # Rescale each expert weight: W' = W * (old_pqs / avg_pqs) per output column.
+            for ex in experts:
+                nm = id_to_name.get(id(ex))
+                if nm is None or f"{nm}.weight" not in state_dict:
+                    continue
+                old_pqs = ex.input_quantizer._pre_quant_scale
+                if torch.equal(old_pqs, avg_pqs):
+                    continue
+                w = state_dict[f"{nm}.weight"]
+                ratio = (old_pqs / avg_pqs).to(dtype=torch.float32, device=w.device)
+                state_dict[f"{nm}.weight"] = (w.float() * ratio[None, :]).to(w.dtype)
+
+            # Max amax across experts; vLLM uses a single input quantizer per expert group.
+            max_in_amax: torch.Tensor | None = None
+            if iq0.amax is not None:
+                max_in_amax = torch.stack([e.input_quantizer.amax for e in experts]).max()
+
+            for ex in experts:
+                nm = id_to_name.get(id(ex))
+                if nm is None:
+                    continue
+                out[get_unwrapped_name(f"{nm}.input_quantizer", model)] = (avg_pqs, max_in_amax)
+
+    return out
 
 
 def export_hf_vllm_fq_checkpoint(
@@ -116,8 +181,14 @@ def export_hf_vllm_fq_checkpoint(
     Folds fake-quant weights into a ``state_dict()`` copy (optional
     ``pre_quant_scale`` into weight when input fake-quant is off), drops quantizer
     keys from the HF save, briefly disables weight quantizers to snapshot
-    ModelOpt/quantizer state, then re-enables them. Writes ``export_dir`` via
-    ``save_pretrained(..., save_modelopt_state=False)``.
+    ModelOpt/quantizer state, then re-enables them. Weight files are written with an
+    explicit ``state_dict`` (and ``hf_quantizer`` cleared during save) so safetensors
+    do not pick up live quantizer buffers.
+
+    For MoE models with AWQ quantization, pre_quant_scale is averaged across experts
+    and input amax is unified — required because vLLM uses a single input quantizer
+    per expert group. This averaging is performed non-mutingly on a detached state_dict
+    copy; the original model is never modified.
 
     Args:
         model: In-memory quantized model.
@@ -130,11 +201,20 @@ def export_hf_vllm_fq_checkpoint(
     export_dir = Path(export_dir)
     export_dir.mkdir(parents=True, exist_ok=True)
 
-    requantize_resmooth_fused_llm_layers(model)
-
     # Step 1: Build the folded HF state dict.
+    # model.state_dict() returns detached copies of all tensors, so model
+    # parameters are never modified. Apply each weight quantizer's fake-quant
+    # to the corresponding weight tensor in the copy.
+    state_dict = model.state_dict()
+
+    # Non-mutating MoE expert resmooth: average pqs and adjust state_dict weights.
+    # Must run before the fakequant loop so that the adjusted weights are fakequanted
+    # with the correct per-block scales.
+    expert_pqs_overrides = _resmooth_experts_for_export(model, state_dict)
+
     fakequant_weights = set()
-    input_quantizers_folded_pqs = set()
+    # Input quantizer keys whose _pre_quant_scale was folded into the weight above.
+    input_quantizers_folded_pqs: set[str] = set()
     with torch.inference_mode():
         if inplace_mem_efficient:
             # Inplace path: iterate decoder layers, one offload<->onload per layer.
@@ -219,6 +299,18 @@ def export_hf_vllm_fq_checkpoint(
                 quantizer_state_dict[key]["_pre_quant_scale"] = torch.ones_like(
                     qstate_val["_pre_quant_scale"]
                 )
+
+    # Patch expert input quantizers with averaged pqs and unified amax so that
+    # vLLM's single per-group input quantizer sees consistent values across experts.
+    for iq_key, (avg_pqs, max_input_amax) in expert_pqs_overrides.items():
+        if iq_key in quantizer_state_dict:
+            qstate_val = quantizer_state_dict[iq_key]
+            if isinstance(qstate_val, dict):
+                if "_pre_quant_scale" in qstate_val:
+                    qstate_val["_pre_quant_scale"] = avg_pqs
+                if max_input_amax is not None and "_amax" in qstate_val:
+                    qstate_val["_amax"] = max_input_amax
+
     modelopt_state = mto.modelopt_state(model)
     # ``modelopt_state`` may be stale if another mode (e.g. calibrate) ran last. Rebuild
     # ``quantizer_state`` and drop disabled weight quantizer entries (weights already folded).

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -20,6 +20,7 @@ import torch
 import torch.nn as nn
 
 import modelopt.torch.opt as mto
+from modelopt.torch.export.unified_export_hf import requantize_resmooth_fused_llm_layers
 from modelopt.torch.quantization.config import RotateConfig
 from modelopt.torch.quantization.conversion import quantizer_state
 from modelopt.torch.quantization.nn import QuantModule, TensorQuantizer
@@ -128,6 +129,8 @@ def export_hf_vllm_fq_checkpoint(
     """
     export_dir = Path(export_dir)
     export_dir.mkdir(parents=True, exist_ok=True)
+
+    requantize_resmooth_fused_llm_layers(model)
 
     # Step 1: Build the folded HF state dict.
     fakequant_weights = set()

--- a/modelopt/torch/export/plugins/vllm_fakequant_hf.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_hf.py
@@ -248,13 +248,9 @@ def requant_weights_for_export(
         quantizer_copy.eval()
         quantizer_copy.reset_amax()
         enable_stats_collection(quantizer_copy)
-    # Match legacy single-quantizer path: first calib uses ``w`` as-is; chains use float.
-    if len(quantizers) == 1:
-        weight_quantized = quantizers[0](weight)
-    else:
-        weight_quantized = weight
-        for quantizer_copy in quantizers:
-            weight_quantized = quantizer_copy(weight_quantized)
+    weight_quantized = weight
+    for quantizer_copy in quantizers:
+        weight_quantized = quantizer_copy(weight_quantized)
     for quantizer_copy in quantizers:
         finish_stats_collection(quantizer_copy)
     # Re-run application pass to get the quantized output with the freshly collected amax.

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -163,7 +163,7 @@ def _save_component_state_dict_safetensors(
         json.dump(metadata, f, indent=4)
 
 
-def _collect_shared_input_modules(
+def collect_shared_input_modules(
     model: nn.Module,
     dummy_forward_fn: Callable[[], None],
     collect_layernorms: bool = False,
@@ -387,7 +387,7 @@ def requantize_resmooth_fused_llm_layers(model: torch.nn.Module):
         else:
             model(fake_input)
 
-    input_to_linear, output_to_layernorm = _collect_shared_input_modules(
+    input_to_linear, output_to_layernorm = collect_shared_input_modules(
         model, llm_dummy_forward, collect_layernorms=True
     )
 
@@ -862,7 +862,7 @@ def _fuse_qkv_linears_diffusion(
 
     # Collect modules sharing the same input
     try:
-        input_to_linear, _ = _collect_shared_input_modules(
+        input_to_linear, _ = collect_shared_input_modules(
             model, dummy_forward_fn, collect_layernorms=False
         )
     except Exception as e:

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -353,6 +353,15 @@ class _QuantFusedMoEBase(QuantModule):
         )
         self.parallel_state = create_parallel_state()
 
+        if getattr(self, "invoke_fused_moe_kernel_func", None) is None:  # pragma: no cover
+            for name in ("invoke_fused_moe_kernel", "invoke_fused_moe_triton_kernel"):
+                if hasattr(vllm_fused_moe_package, name):
+                    self.invoke_fused_moe_kernel_func = name
+                    break
+        assert (  # pragma: no cover
+            getattr(self, "invoke_fused_moe_kernel_func", None) is not None
+        ), "fused_moe_kernel is not found"
+
     def invoke_fused_moe_quantized(
         self,
         A: torch.Tensor,  # noqa: N803

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -354,7 +354,7 @@ class _QuantFusedMoEBase(QuantModule):
         self.parallel_state = create_parallel_state()
 
         if getattr(self, "invoke_fused_moe_kernel_func", None) is None:  # pragma: no cover
-            for name in ("invoke_fused_moe_kernel", "invoke_fused_moe_triton_kernel"):
+            for name in ("invoke_fused_moe_kernel", "dispatch_fused_moe_kernel"):
                 if hasattr(vllm_fused_moe_package, name):
                     self.invoke_fused_moe_kernel_func = name
                     break

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -36,6 +36,7 @@ from vllm.distributed.parallel_state import get_dp_group, get_ep_group, get_tp_g
 
 from ...utils.distributed import ParallelState
 from ..nn import QuantLinearConvBase, QuantModule, QuantModuleRegistry, TensorQuantizer
+from ..utils import replace_function
 from .custom import CUSTOM_MODEL_PLUGINS
 
 # Try multiple import paths for vLLM compatibility across versions

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -36,7 +36,7 @@ from vllm.distributed.parallel_state import get_dp_group, get_ep_group, get_tp_g
 
 from ...utils.distributed import ParallelState
 from ..nn import QuantLinearConvBase, QuantModule, QuantModuleRegistry, TensorQuantizer
-from ..utils import replace_function
+from ..utils import replace_function  # pragma: no cover
 from .custom import CUSTOM_MODEL_PLUGINS
 
 # Try multiple import paths for vLLM compatibility across versions

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -36,7 +36,6 @@ from vllm.distributed.parallel_state import get_dp_group, get_ep_group, get_tp_g
 
 from ...utils.distributed import ParallelState
 from ..nn import QuantLinearConvBase, QuantModule, QuantModuleRegistry, TensorQuantizer
-from ..utils import replace_function  # pragma: no cover
 from .custom import CUSTOM_MODEL_PLUGINS
 
 # Try multiple import paths for vLLM compatibility across versions
@@ -352,15 +351,6 @@ class _QuantFusedMoEBase(QuantModule):
             f"quant_method is {type(self.quant_method)}"
         )
         self.parallel_state = create_parallel_state()
-
-        if getattr(self, "invoke_fused_moe_kernel_func", None) is None:  # pragma: no cover
-            for name in ("invoke_fused_moe_kernel", "dispatch_fused_moe_kernel"):
-                if hasattr(vllm_fused_moe_package, name):
-                    self.invoke_fused_moe_kernel_func = name
-                    break
-        assert (  # pragma: no cover
-            getattr(self, "invoke_fused_moe_kernel_func", None) is not None
-        ), "fused_moe_kernel is not found"
 
     def invoke_fused_moe_quantized(
         self,

--- a/tests/gpu/torch/export/test_vllm_fakequant_hf_export.py
+++ b/tests/gpu/torch/export/test_vllm_fakequant_hf_export.py
@@ -28,7 +28,15 @@ from modelopt.torch.quantization.utils import enable_weight_access_and_writeback
 from modelopt.torch.utils import safe_load
 
 
-@pytest.mark.parametrize("quant_cfg", [mtq.FP8_DEFAULT_CFG])
+@pytest.mark.parametrize(
+    "quant_cfg",
+    [
+        mtq.FP8_DEFAULT_CFG,
+        # INT4_AWQ_CFG: exercises the AWQ detection path in _resmooth_experts_for_export and the
+        # pre_quant_scale-folded-into-weight path (disabled input quantizer with pqs → identity saved).
+        mtq.INT4_AWQ_CFG,
+    ],
+)
 def test_hf_vllm_export(tmp_path, quant_cfg):
     """Test HuggingFace model export for vLLM with fake quantization.
 

--- a/tests/gpu/torch/export/test_vllm_fakequant_hf_export.py
+++ b/tests/gpu/torch/export/test_vllm_fakequant_hf_export.py
@@ -17,10 +17,10 @@ from copy import deepcopy
 
 import pytest
 import torch
-from accelerate import init_empty_weights, load_checkpoint_and_dispatch
-from transformers import AutoConfig, AutoModelForCausalLM
 import transformers
 from _test_utils.torch.transformers_models import create_tiny_llama_dir, create_tiny_qwen3_moe_dir
+from accelerate import init_empty_weights, load_checkpoint_and_dispatch
+from transformers import AutoConfig, AutoModelForCausalLM
 
 import modelopt.torch.quantization as mtq
 from modelopt.torch.export import export_hf_vllm_fq_checkpoint
@@ -245,6 +245,8 @@ def test_hf_vllm_export_offload(tmp_path, quant_cfg):
             "_amax" in k for k in quantizer_state_dict_before[name]
         ):
             assert any("_amax" in k for k in state), f"input quantizer {name} should preserve _amax"
+
+
 @pytest.mark.parametrize("quant_cfg", [mtq.FP8_DEFAULT_CFG, mtq.INT4_AWQ_CFG])
 def test_hf_vllm_export_tiny_llama(tmp_path, quant_cfg):
     tiny_model_dir = create_tiny_llama_dir(tmp_path, num_hidden_layers=2)

--- a/tests/gpu/torch/export/test_vllm_fakequant_hf_export.py
+++ b/tests/gpu/torch/export/test_vllm_fakequant_hf_export.py
@@ -17,9 +17,10 @@ from copy import deepcopy
 
 import pytest
 import torch
-from _test_utils.torch.transformers_models import create_tiny_llama_dir
 from accelerate import init_empty_weights, load_checkpoint_and_dispatch
 from transformers import AutoConfig, AutoModelForCausalLM
+import transformers
+from _test_utils.torch.transformers_models import create_tiny_llama_dir, create_tiny_qwen3_moe_dir
 
 import modelopt.torch.quantization as mtq
 from modelopt.torch.export import export_hf_vllm_fq_checkpoint
@@ -28,16 +29,7 @@ from modelopt.torch.quantization.utils import enable_weight_access_and_writeback
 from modelopt.torch.utils import safe_load
 
 
-@pytest.mark.parametrize(
-    "quant_cfg",
-    [
-        mtq.FP8_DEFAULT_CFG,
-        # INT4_AWQ_CFG: exercises the AWQ detection path in _resmooth_experts_for_export and the
-        # pre_quant_scale-folded-into-weight path (disabled input quantizer with pqs → identity saved).
-        mtq.INT4_AWQ_CFG,
-    ],
-)
-def test_hf_vllm_export(tmp_path, quant_cfg):
+def _test_hf_vllm_export(tmp_path, quant_cfg, model_dir):
     """Test HuggingFace model export for vLLM with fake quantization.
 
     This test verifies:
@@ -47,11 +39,8 @@ def test_hf_vllm_export(tmp_path, quant_cfg):
     4. Weight quantizer states are empty in saved state dict; input quantizer amaxes preserved
     """
 
-    # Create a tiny LLaMA model for testing
-    tiny_model_dir = create_tiny_llama_dir(tmp_path, num_hidden_layers=2)
-
     # Load the model
-    model = AutoModelForCausalLM.from_pretrained(tiny_model_dir)
+    model = AutoModelForCausalLM.from_pretrained(model_dir)
     model = model.cuda()
     model.eval()
 
@@ -256,3 +245,15 @@ def test_hf_vllm_export_offload(tmp_path, quant_cfg):
             "_amax" in k for k in quantizer_state_dict_before[name]
         ):
             assert any("_amax" in k for k in state), f"input quantizer {name} should preserve _amax"
+@pytest.mark.parametrize("quant_cfg", [mtq.FP8_DEFAULT_CFG, mtq.INT4_AWQ_CFG])
+def test_hf_vllm_export_tiny_llama(tmp_path, quant_cfg):
+    tiny_model_dir = create_tiny_llama_dir(tmp_path, num_hidden_layers=2)
+    _test_hf_vllm_export(tmp_path, quant_cfg, tiny_model_dir)
+
+
+@pytest.mark.parametrize("quant_cfg", [mtq.FP8_DEFAULT_CFG, mtq.INT4_AWQ_CFG])
+def test_hf_vllm_export_tiny_qwen3_moe(tmp_path, quant_cfg):
+    if quant_cfg == mtq.INT4_AWQ_CFG and transformers.__version__.startswith("5."):
+        pytest.skip("INT4_AWQ_CFG is not supported for Qwen3 MoE in transformers > 5.x")
+    tiny_model_dir = create_tiny_qwen3_moe_dir(tmp_path, num_hidden_layers=2)
+    _test_hf_vllm_export(tmp_path, quant_cfg, tiny_model_dir)

--- a/tests/gpu/torch/export/test_vllm_fakequant_hf_export.py
+++ b/tests/gpu/torch/export/test_vllm_fakequant_hf_export.py
@@ -68,6 +68,23 @@ def test_hf_vllm_export(tmp_path, quant_cfg):
     folded_model = deepcopy(model)
     fold_weight(folded_model)
     expected_weights = {k: v for k, v in folded_model.state_dict().items() if "quantizer" not in k}
+    # fold_weight only applies the weight quantizer's fake-quant; it does NOT fold
+    # input_quantizer.pre_quant_scale into the weight. The export path does:
+    #   w_exported = fake_quant(W) * pqs[None, :]
+    # for modules where input_quantizer is disabled but has pqs (AWQ weight-only).
+    # Apply the same pqs fold here so expected_weights matches the export output.
+    for module_name, module in folded_model.named_modules():
+        inp_q = getattr(module, "input_quantizer", None)
+        if (
+            inp_q is not None
+            and not inp_q.is_enabled
+            and getattr(inp_q, "_pre_quant_scale", None) is not None
+        ):
+            w_key = f"{module_name}.weight" if module_name else "weight"
+            if w_key in expected_weights:
+                w = expected_weights[w_key]
+                scale = inp_q._pre_quant_scale.squeeze().to(device=w.device)
+                expected_weights[w_key] = (w * scale[None, :]).to(w.dtype)
     del folded_model
 
     # Snapshot model state before export to verify it is not mutated

--- a/tests/unit/torch/export/test_vllm_quantizer_reload.py
+++ b/tests/unit/torch/export/test_vllm_quantizer_reload.py
@@ -16,8 +16,10 @@
 import pytest
 import torch
 
-from modelopt.torch.export.plugins.vllm_fakequant_hf import merge_amax_tensors_for_group
-from modelopt.torch.export.plugins.vllm_fakequant_hf import infer_quantizer_prefix_remap
+from modelopt.torch.export.plugins.vllm_fakequant_hf import (
+    infer_quantizer_prefix_remap,
+    merge_amax_tensors_for_group,
+)
 
 
 def _map_backbone_to_model(sd: dict) -> dict:
@@ -53,6 +55,7 @@ def test_infer_prefix_remap_multiple_probes_same_root_agree():
 
 def test_infer_prefix_remap_raises_on_inconsistent_root():
     """If ``map_fun`` maps the same HF root to different vLLM roots, raise with a clear error."""
+
     def bad_map(sd: dict) -> dict:
         out = {}
         for k, v in sd.items():
@@ -110,6 +113,7 @@ def test_infer_prefix_remap_no_quantizer_segment_still_probes_weight_path():
 
 def test_infer_prefix_remap_complex_mapper_not_one_root_raises_or_wrong():
     """Same HF root ``x`` mapping to different first components (``va.*`` vs ``vb.*``) must error."""
+
     def split_map(sd: dict) -> dict:
         k = next(iter(sd))
         v = sd[k]

--- a/tests/unit/torch/export/test_vllm_quantizer_reload.py
+++ b/tests/unit/torch/export/test_vllm_quantizer_reload.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from modelopt.torch.export.plugins.vllm_fakequant_hf import merge_amax_tensors_for_group
+from modelopt.torch.export.plugins.vllm_fakequant_hf import infer_quantizer_prefix_remap
+
+
+def _map_backbone_to_model(sd: dict) -> dict:
+    """Test mapper: rename top-level ``backbone.`` to ``model.`` (typical HF vs vLLM)."""
+    out = {}
+    for k, v in sd.items():
+        if k.startswith("backbone."):
+            out["model." + k[len("backbone.") :]] = v
+        else:
+            out[k] = v
+    return out
+
+
+def test_infer_prefix_remap_simple_root_rename():
+    """``infer_quantizer_prefix_remap`` infers one HF root → vLLM root from ``*.weight`` probes."""
+    q = {
+        "backbone.layers.0.mlp.gate_proj.input_quantizer": {},
+        "backbone.layers.1.self_attn.q_proj.weight_quantizer": {},
+    }
+    rem = infer_quantizer_prefix_remap(q, _map_backbone_to_model)
+    assert rem == {"backbone": "model"}
+
+
+def test_infer_prefix_remap_multiple_probes_same_root_agree():
+    """Regression: every quantizer key under the same HF root must agree on the mapped vLLM root."""
+    q = {
+        "backbone.a.w.input_quantizer": {},
+        "backbone.b.w.weight_quantizer": {},
+    }
+    rem = infer_quantizer_prefix_remap(q, _map_backbone_to_model)
+    assert rem == {"backbone": "model"}
+
+
+def test_infer_prefix_remap_raises_on_inconsistent_root():
+    """If ``map_fun`` maps the same HF root to different vLLM roots, raise with a clear error."""
+    def bad_map(sd: dict) -> dict:
+        out = {}
+        for k, v in sd.items():
+            if "layers.0" in k:
+                out[k.replace("backbone.", "model.")] = v
+            elif "head" in k:
+                out[k.replace("backbone.", "encoder.")] = v
+            else:
+                out[k] = v
+        return out
+
+    q = {
+        "backbone.layers.0.mlp.gate_proj.input_quantizer": {},
+        "backbone.head.proj.input_quantizer": {},
+    }
+    with pytest.raises(ValueError, match="Inconsistent HF→vLLM prefix remap"):
+        infer_quantizer_prefix_remap(q, bad_map)
+
+
+def test_infer_prefix_remap_identity_empty():
+    """When keys already match the mapper output, the inferred remap is empty (no rename)."""
+    q = {"model.layers.0.foo.input_quantizer": {}}
+    rem = infer_quantizer_prefix_remap(q, lambda d: dict(d))
+    assert rem == {}
+
+
+def test_infer_prefix_remap_probe_failure_skipped():
+    """A probe that raises does not block remap if another key under the same root succeeds."""
+
+    def map_drop_layers0(sd: dict) -> dict:
+        out = {}
+        for k, v in sd.items():
+            if "layers.0" in k:
+                raise RuntimeError("simulate missing layer")
+            if k.startswith("backbone."):
+                out["model." + k[len("backbone.") :]] = v
+            else:
+                out[k] = v
+        return out
+
+    q = {
+        "backbone.layers.0.mlp.gate_proj.input_quantizer": {},
+        "backbone.layers.1.mlp.gate_proj.input_quantizer": {},
+    }
+    rem = infer_quantizer_prefix_remap(q, map_drop_layers0)
+    assert rem == {"backbone": "model"}
+
+
+def test_infer_prefix_remap_no_quantizer_segment_still_probes_weight_path():
+    """Short paths (e.g. ``embed.weight_quantizer``) still build a ``.weight`` probe path."""
+    q = {"backbone.embed.weight_quantizer": {}}
+    rem = infer_quantizer_prefix_remap(q, _map_backbone_to_model)
+    assert rem == {"backbone": "model"}
+
+
+def test_infer_prefix_remap_complex_mapper_not_one_root_raises_or_wrong():
+    """Same HF root ``x`` mapping to different first components (``va.*`` vs ``vb.*``) must error."""
+    def split_map(sd: dict) -> dict:
+        k = next(iter(sd))
+        v = sd[k]
+        if "branch_a" in k:
+            return {"va." + k[2:]: v}  # x.branch_a... -> va.branch_a...
+        return {"vb." + k[2:]: v}
+
+    q = {
+        "x.branch_a.mlp.w.input_quantizer": {},
+        "x.branch_b.mlp.w.input_quantizer": {},
+    }
+    with pytest.raises(ValueError, match="Inconsistent HF→vLLM prefix remap"):
+        infer_quantizer_prefix_remap(q, split_map)
+
+
+def test_merge_amax_same_shape_elementwise_max():
+    """``merge_amax_tensors_for_group``: identical shapes → element-wise max (stack then amax)."""
+    a = torch.tensor([1.0, 4.0, 2.0])
+    b = torch.tensor([2.0, 3.0, 5.0])
+    out = merge_amax_tensors_for_group([a, b])
+    assert torch.allclose(out, torch.tensor([2.0, 4.0, 5.0]))
+
+
+def test_merge_amax_different_1d_lengths_uses_cat():
+    """``merge_amax_tensors_for_group``: mismatched 1-D lengths (e.g. GQA q/k/v) → ``cat`` on dim 0."""
+    q = torch.tensor([1.0, 2.0, 3.0])  # e.g. 3 heads
+    k = torch.tensor([0.5, 0.5])  # 2 KV heads
+    v = torch.tensor([0.5, 0.5])
+    out = merge_amax_tensors_for_group([q, k, v])
+    assert out.shape == (7,)
+    assert torch.allclose(out, torch.cat([q, k, v]))
+
+
+def test_merge_amax_incompatible_shapes_scalar_fallback():
+    """``merge_amax_tensors_for_group``: when ``cat`` fails, fall back to a scalar global max."""
+    a = torch.ones(2, 3)
+    b = torch.ones(2, 2)  # cannot cat along dim=0 with matching trailing dims
+    out = merge_amax_tensors_for_group([a, b])
+    assert out.shape == ()
+    assert out.item() == 1.0


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug

Enables end-to-end AWQ checkpoint export and reload in the vLLM fake-quant serving path (`MODELOPT_STATE_PATH`). Previously, the `input_quantizer` was using incorrect `pre_quant_scale` especially with grouped quantizers like `qkv_proj`, using simply the first `input_quantizer.pre_quant_scale`. This MR adds `_resmooth_experts_for_export` that non-mutatively averages `pre_quant_scale` across MoE experts and unifies input `_amax`, required because vLLM uses a single input quantizer per expert group. Adds `merge_amax_tensors_for_group` (element-wise max for same-shape, `cat` for GQA, scalar-max fallback) replacing the scalar-collapsing `torch.stack().max()` that  dropped per-channel `_amax` structure. 

### Usage

```python
# Export AWQ checkpoint from HF model
  from modelopt.torch.export.plugins.vllm_fakequant_hf import export_hf_vllm_fq_checkpoint
  export_hf_vllm_fq_checkpoint(model, export_dir="./awq_vllm_checkpoint")      
```

### Testing
 **Step 1 — Export the quantized checkpoint:**                                                                                                                                                                
  ```bash                    
  python examples/llm_ptq/hf_ptq.py \
    --pyt_ckpt_path <MODEL_PATH> \                                                                                                                                                                             
    --recipe <AWQ_RECIPE> \
    --calib_size 512 \                                                                                                                                                                                         
    --export_path <EXPORT_DIR> \                                                                                                                                                                               
    --vllm_fakequant_export
```
  This produces `<EXPORT_DIR>/vllm_fq_modelopt_state.pth` with the averaged per-expert                                                                                                                           
  pre_quant_scale and unified _amax now included.                                                                                                                                                              
   

 Step 2 — Serve via vLLM fakequant worker:                                                                                                                                                                    
```bash
  MODELOPT_STATE_PATH=<EXPORT_DIR>/vllm_fq_modelopt_state.pth \
    python examples/vllm_serve/vllm_serve_fakequant.py \                                                                                                                                                       
      <EXPORT_DIR> --tensor-parallel-size <TP>   
```

Tested for quantization configurations:
```
FP8_DEFAULT_CFG
FP8_DEFAULT_CFG (input_q disabled)
INT8_SMOOTHQUANT_CFG
INT8_WEIGHT_ONLY_CFG
NVFP4_DEFAULT_CFG
NVFP4_AWQ_LITE_CFG
INT4_AWQ_CFG
NVFP4_AWQ_CFG
NVFP4_DEFAULT_CFG (input_q disabled)
```

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ 
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A 
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A 

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nemotron-style MoE export support and group-aware AWQ resmoothing with optional requantization during export.
  * Improved handling for shared-input / expert groups and tensor-parallel sharding of pre-quantization scales.

* **Bug Fixes**
  * Removed AWQ reload limitation from known issues; improved checkpoint validation and safer save/load behavior.
  * Better detection and handling of enabled weight-quantizers and clearer warnings for mismatched checkpoint keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->