### PR TITLE
fix(launcher): use afterany dependency for allow_to_fail pipelines

### DIFF
--- a/tools/launcher/core.py
+++ b/tools/launcher/core.py
@@ -471,6 +471,11 @@ def run_jobs(
                     )
                     task_env.update(default_slurm_env)
 
+                # When allow_to_fail is set, use "afterany" so downstream tasks
+                # run even if a predecessor times out or fails.
+                if job.allow_to_fail and hasattr(executor, "dependency_type"):
+                    executor.dependency_type = "afterany"
+
                 task_instance = run.Script(task.script, args=task_args, env=task_env)
                 print(f"job {job_name} task {task_id} slurm_config: {task.slurm_config}")
 


### PR DESCRIPTION
## Summary
- nemo-run's `SlurmExecutor` defaults to `dependency_type="afterok"`, which cancels all downstream Slurm tasks when a predecessor times out (`TIMEOUT`) or fails
- For pipelines with `allow_to_fail=True`, this changes the dependency type to `"afterany"` so subsequent tasks run regardless of predecessor exit status
- This unblocks EAGLE3 multi-step pipelines where task_0 (data generation) may time out but task_1+ should still run on whatever data was produced

## Test plan
- [ ] Verify existing launcher unit tests pass (`uv run python3 -m pytest tests/ -v` in `tools/launcher/`)
- [ ] Submit an EAGLE3 pipeline with `allow_to_fail: true` and confirm task_1 runs after task_0 times out
- [ ] Verify pipelines without `allow_to_fail` still use default `afterok` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experiments can now continue executing downstream tasks even when upstream tasks fail or timeout, improving workflow resilience and enabling more robust experiment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->