### PR TITLE
use typed quantize config instead of a raw dict

### DIFF
--- a/examples/llm_ptq/hf_ptq.py
+++ b/examples/llm_ptq/hf_ptq.py
@@ -1059,7 +1059,7 @@ def quantize_main(
             assert isinstance(recipe, ModelOptPTQRecipe), (
                 f"Expected PTQ recipe, but got {type(recipe).__name__} from {args.recipe}"
             )
-            quant_cfg = recipe.quantize
+            quant_cfg = recipe.quantize.model_dump()
 
         else:
             assert len(args.qformat.split(",")) == 1, (

--- a/modelopt/recipe/config.py
+++ b/modelopt/recipe/config.py
@@ -18,11 +18,11 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any
 
 from pydantic import field_validator
 
 from modelopt.torch.opt.config import ModeloptBaseConfig, ModeloptField
+from modelopt.torch.quantization.config import QuantizeConfig
 
 
 class RecipeType(str, Enum):
@@ -66,8 +66,8 @@ class ModelOptRecipeBase(ModeloptBaseConfig):
 class ModelOptPTQRecipe(ModelOptRecipeBase):
     """Our config class for PTQ recipes."""
 
-    quantize: dict[str, Any] = ModeloptField(
-        default={},
+    quantize: QuantizeConfig = ModeloptField(
+        default_factory=QuantizeConfig,
         title="PTQ config",
         description="PTQ config containing quant_cfg and algorithm.",
         validate_default=True,

--- a/modelopt/recipe/config.py
+++ b/modelopt/recipe/config.py
@@ -67,7 +67,7 @@ class ModelOptPTQRecipe(ModelOptRecipeBase):
     """Our config class for PTQ recipes."""
 
     quantize: QuantizeConfig = ModeloptField(
-        default_factory=QuantizeConfig,
+        default=QuantizeConfig(),
         title="PTQ config",
         description="PTQ config containing quant_cfg and algorithm.",
         validate_default=True,

--- a/tests/unit/recipe/test_loader.py
+++ b/tests/unit/recipe/test_loader.py
@@ -170,7 +170,8 @@ def test_load_recipe_dir(tmp_path):
     recipe = load_recipe(tmp_path)
     assert recipe.recipe_type == RecipeType.PTQ
     assert recipe.description == "Dir test."
-    assert recipe.quantize == {"algorithm": "max", "quant_cfg": []}
+    assert recipe.quantize.algorithm == "max"
+    assert recipe.quantize.quant_cfg == []
 
 
 def test_load_recipe_dir_missing_recipe_raises(tmp_path):


### PR DESCRIPTION
### What does this PR do?

But fix:

Use typed QuantizeConfig instead using raw dict for formal typed ModelOpt configs.

The dict typing was accidental.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Quantization recipe configuration is now implemented with a strongly-typed, structured schema that enforces type safety and provides enhanced validation with comprehensive error detection capabilities.

* **Tests**
  * Updated recipe loading tests to correctly validate quantization configurations when recipes are loaded from directories, fully supporting the new structured object-based configuration format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->