### PR TITLE
Centralize 'trtexec' subprocess runs in ONNX into a single function

### DIFF
--- a/modelopt/onnx/quantization/autotune/benchmark.py
+++ b/modelopt/onnx/quantization/autotune/benchmark.py
@@ -185,7 +185,6 @@ class TrtExecBenchmark(Benchmark):
         self.latency_pattern = r"\[I\]\s+Latency:.*?median\s*=\s*([\d.]+)\s*ms"
 
         self._base_cmd = [
-            self.trtexec_path,
             f"--avgRuns={self.timing_runs}",
             f"--iterations={self.timing_runs}",
             f"--warmUp={self.warmup_runs}",

--- a/modelopt/onnx/quantization/autotune/benchmark.py
+++ b/modelopt/onnx/quantization/autotune/benchmark.py
@@ -31,7 +31,6 @@ import importlib.util
 import os
 import re
 import shutil
-import subprocess  # nosec B404
 import tempfile
 import time
 from abc import ABC, abstractmethod
@@ -42,7 +41,7 @@ import numpy as np
 import torch
 
 from modelopt.onnx.logging_config import logger
-from modelopt.onnx.quantization.ort_utils import _check_for_trtexec
+from modelopt.onnx.quantization.ort_utils import _check_for_trtexec, _run_trtexec
 
 TRT_AVAILABLE = importlib.util.find_spec("tensorrt") is not None
 if TRT_AVAILABLE:
@@ -269,7 +268,7 @@ class TrtExecBenchmark(Benchmark):
 
             cmd = [*self._base_cmd, f"--onnx={model_path}"]
             self.logger.debug(f"Running: {' '.join(cmd)}")
-            result = subprocess.run(cmd, capture_output=True, text=True)  # nosec B603
+            result = _run_trtexec(cmd)
             self._write_log_file(
                 log_file,
                 "\n".join(

--- a/modelopt/onnx/quantization/autotune/benchmark.py
+++ b/modelopt/onnx/quantization/autotune/benchmark.py
@@ -158,7 +158,6 @@ class TrtExecBenchmark(Benchmark):
         warmup_runs: int = 5,
         timing_runs: int = 10,
         plugin_libraries: list[str] | None = None,
-        trtexec_path: str = "trtexec",
         trtexec_args: list[str] | None = None,
     ):
         """Initialize the trtexec benchmark.
@@ -168,14 +167,11 @@ class TrtExecBenchmark(Benchmark):
             warmup_runs: See :meth:`Benchmark.__init__`.
             timing_runs: See :meth:`Benchmark.__init__`.
             plugin_libraries: See :meth:`Benchmark.__init__`.
-            trtexec_path: Path to trtexec binary. Defaults to 'trtexec' which
-                         looks for the binary in PATH.
             trtexec_args: Additional command-line arguments to pass to trtexec.
                          These are appended after the standard arguments.
                          Example: ['--fp16', '--workspace=4096', '--verbose']
         """
         super().__init__(timing_cache_file, warmup_runs, timing_runs, plugin_libraries)
-        self.trtexec_path = trtexec_path
         self.trtexec_args = trtexec_args if trtexec_args is not None else []
         self.temp_dir = tempfile.mkdtemp(prefix="trtexec_benchmark_")
         self.engine_path = os.path.join(self.temp_dir, "engine.trt")
@@ -299,8 +295,9 @@ class TrtExecBenchmark(Benchmark):
             self.logger.info(f"TrtExec benchmark (median): {latency:.2f} ms")
             return latency
         except FileNotFoundError:
-            self.logger.error(f"trtexec binary not found: {self.trtexec_path}")
-            self.logger.error("Please ensure TensorRT is installed and trtexec path is correct")
+            self.logger.error(
+                "'trtexec' binary not found. Please ensure TensorRT is installed and 'trtexec' is in PATH."
+            )
             return float("inf")
         except Exception as e:
             self.logger.error(f"Benchmark failed: {e}")

--- a/modelopt/onnx/quantization/autotune/benchmark.py
+++ b/modelopt/onnx/quantization/autotune/benchmark.py
@@ -262,13 +262,14 @@ class TrtExecBenchmark(Benchmark):
                 self.logger.debug(f"Wrote model bytes to temporary file: {model_path}")
 
             cmd = [*self._base_cmd, f"--onnx={model_path}"]
-            self.logger.debug(f"Running: {' '.join(cmd)}")
+            full_cmd = ["trtexec", *cmd]
+            self.logger.debug(f"Running: {' '.join(full_cmd)}")
             result = _run_trtexec(cmd)
             self._write_log_file(
                 log_file,
                 "\n".join(
                     [
-                        f"Command: {' '.join(cmd)}",
+                        f"Command: {' '.join(full_cmd)}",
                         f"Return code: {result.returncode}",
                         "=" * 80,
                         "STDOUT:",

--- a/modelopt/onnx/quantization/ort_utils.py
+++ b/modelopt/onnx/quantization/ort_utils.py
@@ -46,6 +46,15 @@ def _check_lib_in_ld_library_path(ld_library_path, lib_pattern):
     return False, None
 
 
+def _run_trtexec(cmd, timeout=None):
+    """Run a 'trtexec' command via subprocess."""
+    # Ensure that this command is a trtexec run
+    assert any("trtexec" in c for c in cmd), "Subprocess can only execute 'trtexec' commands"
+
+    # Run trtexec command
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)  # nosec B603
+
+
 def _check_for_trtexec(min_version: str = "10.0") -> str:
     """Check if the `trtexec` CLI tool is available in PATH and is >= min_version.
 
@@ -89,7 +98,7 @@ def _check_for_trtexec(min_version: str = "10.0") -> str:
         )
 
     try:
-        result = subprocess.run([trtexec_path], capture_output=True, text=True, timeout=5)  # nosec B603
+        result = _run_trtexec([trtexec_path], timeout=5)
         banner_output = result.stdout + result.stderr
         parsed_version = _parse_version_from_string(banner_output)
 

--- a/modelopt/onnx/quantization/ort_utils.py
+++ b/modelopt/onnx/quantization/ort_utils.py
@@ -46,12 +46,19 @@ def _check_lib_in_ld_library_path(ld_library_path, lib_pattern):
     return False, None
 
 
-def _run_trtexec(cmd, timeout=None):
-    """Run a 'trtexec' command via subprocess."""
-    # Ensure that this command is a trtexec run
-    assert any("trtexec" in c for c in cmd), "Subprocess can only execute 'trtexec' commands"
+def _run_trtexec(
+    args: list[str] | None = None, timeout: float | None = None
+) -> subprocess.CompletedProcess:
+    """Run a 'trtexec' command via subprocess.
 
-    # Run trtexec command
+    Args:
+        args: Arguments to pass to trtexec (without the 'trtexec' command itself).
+        timeout: Optional subprocess timeout in seconds.
+
+    Returns:
+        The completed subprocess result.
+    """
+    cmd = ["trtexec", *(args or [])]
     return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)  # nosec B603
 
 
@@ -98,7 +105,7 @@ def _check_for_trtexec(min_version: str = "10.0") -> str:
         )
 
     try:
-        result = _run_trtexec([trtexec_path], timeout=5)
+        result = _run_trtexec(timeout=5)
         banner_output = result.stdout + result.stderr
         parsed_version = _parse_version_from_string(banner_output)
 

--- a/modelopt/onnx/quantization/ort_utils.py
+++ b/modelopt/onnx/quantization/ort_utils.py
@@ -57,9 +57,17 @@ def _run_trtexec(
 
     Returns:
         The completed subprocess result.
+
+    Raises:
+        FileNotFoundError: If the 'trtexec' binary is not found in PATH.
     """
     cmd = ["trtexec", *(args or [])]
-    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)  # nosec B603
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)  # nosec B603
+    except FileNotFoundError as e:
+        raise FileNotFoundError(
+            "'trtexec' binary not found. Please ensure TensorRT is installed and 'trtexec' is in PATH."
+        ) from e
 
 
 def _check_for_trtexec(min_version: str = "10.0") -> str:

--- a/modelopt/torch/_deploy/_runtime/tensorrt/constants.py
+++ b/modelopt/torch/_deploy/_runtime/tensorrt/constants.py
@@ -32,10 +32,6 @@ ONE_MEBI_IN_BYTES = 1 << 20
 ONE_GIBI_IN_BYTES = 1 << 30
 
 # TensorRT conversion tool names
-TRTEXEC = "trtexec"
-
-# trtexec path within docker
-TRTEXEC_PATH = "trtexec"
 DEFAULT_ARTIFACT_DIR = "modelopt_build/trt_artifacts"
 
 # Default conversion params

--- a/modelopt/torch/_deploy/_runtime/tensorrt/engine_builder.py
+++ b/modelopt/torch/_deploy/_runtime/tensorrt/engine_builder.py
@@ -28,7 +28,6 @@ from .constants import (
     DEFAULT_NUM_INFERENCE_PER_RUN,
     SHA_256_HASH_LENGTH,
     TRT_MODE_FLAGS,
-    TRTEXEC_PATH,
     WARMUP_TIME_MS,
     TRTMode,
 )
@@ -41,25 +40,29 @@ logging.basicConfig(
 )
 
 
-# TODO: Get rid of this function or get approval for `# nosec` usage if we want to include this
-#   as a non-compiled python file in the release.
-def _run_command(cmd: list[str], cwd: Path | None = None) -> tuple[int, bytes]:
-    """Util function to execute a command.
+def _run_trtexec_streamed(args: list[str], cwd: Path | None = None) -> tuple[int, bytes]:
+    """Run a 'trtexec' command via subprocess, streaming stdout/stderr to a temp file.
 
-    This util will not direct stdout and stderr to console if the cmd succeeds.
+    The 'trtexec' binary is hardcoded as the executable; only its arguments may be supplied
+    by the caller. This restricts the function to trtexec invocations.
+
+    Output handling: stdout and stderr are captured to a temp file and returned as bytes.
+    On failure (non-zero returncode), the captured output is also logged at ERROR level;
+    on success, this function emits nothing to the console.
 
     Args:
-        cmd: the command line list
-        cwd: current working directory
+        args: Arguments to pass to trtexec (without the 'trtexec' command itself).
+        cwd: Optional working directory for the subprocess.
 
     Returns:
-        return code: 0 means successful, otherwise means failed
-        log_string: the stdout and stderr output as a string
-
+        A tuple of (returncode, output) where output is the combined stdout/stderr bytes.
     """
+    cmd = ["trtexec", *args]
     logging.info(" ".join(cmd))
     with NamedTemporaryFile("w+b") as log:
-        p = subprocess.Popen(cmd, stdout=log, stderr=log, cwd=str(cwd) if cwd else None)  # nosec
+        p = subprocess.Popen(  # nosec B603 - cmd[0] is hardcoded "trtexec"
+            cmd, stdout=log, stderr=log, cwd=str(cwd) if cwd else None
+        )
         p.wait()
         log.seek(0)
         output = log.read()
@@ -181,7 +184,7 @@ def build_engine(
         calib_cache_path: Path | None = None,
         timing_cache_path: Path | None = None,
     ) -> list[str]:
-        cmd = [TRTEXEC_PATH, f"--onnx={onnx_path}"]
+        cmd = [f"--onnx={onnx_path}"]
         cmd.extend(TRT_MODE_FLAGS[trt_mode])
 
         if trt_mode == TRTMode.INT8 and calib_cache and calib_cache_path:
@@ -235,7 +238,7 @@ def build_engine(
         cmd = _build_command(onnx_path, engine_path, calib_cache_path, timing_cache_path)
 
         try:
-            ret_code, out = _run_command(cmd)
+            ret_code, out = _run_trtexec_streamed(cmd)
             if ret_code != 0:
                 return None, out
 
@@ -284,7 +287,7 @@ def profile_engine(
     """
 
     def _build_command(engine_path: Path, profile_path: Path, layer_info_path: Path) -> list[str]:
-        cmd = [TRTEXEC_PATH, f"--loadEngine={engine_path}"]
+        cmd = [f"--loadEngine={engine_path}"]
         cmd += _get_profiling_params(profiling_runs)
 
         if enable_layerwise_profiling:
@@ -320,7 +323,7 @@ def profile_engine(
         cmd = _build_command(engine_path, profile_path, layer_info_path)
 
         try:
-            ret_code, out = _run_command(cmd)
+            ret_code, out = _run_trtexec_streamed(cmd)
             if ret_code != 0:
                 return None, out
 

--- a/modelopt/torch/_deploy/_runtime/tensorrt/engine_builder.py
+++ b/modelopt/torch/_deploy/_runtime/tensorrt/engine_builder.py
@@ -17,7 +17,7 @@ import logging
 import shutil
 import sys
 from pathlib import Path
-from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir
+from tempfile import TemporaryDirectory, gettempdir
 
 from ..._runtime.common import read_bytes, timeit, write_bytes, write_string
 from ..._runtime.tensorrt.layerwise_profiling import process_layerwise_result
@@ -39,14 +39,14 @@ logging.basicConfig(
 )
 
 
-def _run_trtexec_streamed(args: list[str], cwd: Path | None = None) -> tuple[int, bytes]:
-    """Run a 'trtexec' command via subprocess, streaming stdout/stderr to a temp file.
+def _run_trtexec_with_logging(args: list[str], cwd: Path | None = None) -> tuple[int, bytes]:
+    """Run a 'trtexec' command via subprocess, logging the cmd and any failure output.
 
     The 'trtexec' binary is hardcoded as the executable; only its arguments may be supplied
     by the caller. This restricts the function to trtexec invocations.
 
-    Output handling: stdout and stderr are captured to a temp file and returned as bytes.
-    On failure (non-zero returncode), the captured output is also logged at ERROR level;
+    Output handling: stdout and stderr are merged and captured in memory.
+    On failure (non-zero returncode) or timeout, the captured output is logged at ERROR level;
     on success, this function emits nothing to the console.
 
     Args:
@@ -55,21 +55,34 @@ def _run_trtexec_streamed(args: list[str], cwd: Path | None = None) -> tuple[int
 
     Returns:
         A tuple of (returncode, output) where output is the combined stdout/stderr bytes.
+
+    Raises:
+        FileNotFoundError: If the 'trtexec' binary is not found in PATH.
+        subprocess.TimeoutExpired: If trtexec does not finish within 60 minutes.
+            The captured output is logged before re-raising.
     """
     import subprocess  # nosec
 
     cmd = ["trtexec", *args]
     logging.info(" ".join(cmd))
-    with NamedTemporaryFile("w+b") as log:
-        p = subprocess.Popen(  # nosec B603 - cmd[0] is hardcoded "trtexec"
-            cmd, stdout=log, stderr=log, cwd=str(cwd) if cwd else None
+    try:
+        result = subprocess.run(  # nosec B603 - cmd[0] is hardcoded "trtexec"
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            cwd=str(cwd) if cwd else None,
+            timeout=3600,
         )
-        p.wait()
-        log.seek(0)
-        output = log.read()
-        if p.returncode != 0:
-            logging.error(output.decode(errors="ignore"))
-        return p.returncode, output
+    except FileNotFoundError as e:
+        raise FileNotFoundError(
+            "'trtexec' binary not found. Please ensure TensorRT is installed and 'trtexec' is in PATH."
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        logging.error((e.stdout or b"").decode(errors="ignore"))
+        raise
+    if result.returncode != 0:
+        logging.error(result.stdout.decode(errors="ignore"))
+    return result.returncode, result.stdout
 
 
 def _get_profiling_params(profiling_runs: int) -> list[str]:
@@ -239,7 +252,7 @@ def build_engine(
         cmd = _build_command(onnx_path, engine_path, calib_cache_path, timing_cache_path)
 
         try:
-            ret_code, out = _run_trtexec_streamed(cmd)
+            ret_code, out = _run_trtexec_with_logging(cmd)
             if ret_code != 0:
                 return None, out
 
@@ -324,7 +337,7 @@ def profile_engine(
         cmd = _build_command(engine_path, profile_path, layer_info_path)
 
         try:
-            ret_code, out = _run_trtexec_streamed(cmd)
+            ret_code, out = _run_trtexec_with_logging(cmd)
             if ret_code != 0:
                 return None, out
 

--- a/modelopt/torch/_deploy/_runtime/tensorrt/engine_builder.py
+++ b/modelopt/torch/_deploy/_runtime/tensorrt/engine_builder.py
@@ -15,7 +15,6 @@
 
 import logging
 import shutil
-import subprocess  # nosec
 import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir
@@ -57,6 +56,8 @@ def _run_trtexec_streamed(args: list[str], cwd: Path | None = None) -> tuple[int
     Returns:
         A tuple of (returncode, output) where output is the combined stdout/stderr bytes.
     """
+    import subprocess  # nosec
+
     cmd = ["trtexec", *args]
     logging.info(" ".join(cmd))
     with NamedTemporaryFile("w+b") as log:

--- a/tests/unit/torch/deploy/_runtime/tensorrt/test_engine_builder.py
+++ b/tests/unit/torch/deploy/_runtime/tensorrt/test_engine_builder.py
@@ -55,7 +55,7 @@ def setup_mocks():
 
     with (
         mock.patch(
-            "modelopt.torch._deploy._runtime.tensorrt.engine_builder._run_command"
+            "modelopt.torch._deploy._runtime.tensorrt.engine_builder._run_trtexec_with_logging"
         ) as mock_run,
         mock.patch(
             "modelopt.torch._deploy._runtime.tensorrt.engine_builder.TemporaryDirectory"


### PR DESCRIPTION
### What does this PR do?

Type of change: code improvement

Subprocess is needed to run `trtexec` commands but those require `nosec` approval. This PR centralizes it into a single function for the ONNX workflow to avoid future approval triggers. The torch workflow has that centralized in `run_command` (renamed to `_run_trtexec_streamed`).

Original request: https://github.com/NVIDIA/Model-Optimizer/pull/1259#issuecomment-4253630765

### Usage

```python
results = _run_trtexec(cmd)
```

### Testing
N/A

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A <!--- Mandatory -->
- Did you write any new necessary tests?: N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified how the app runs and logs the external conversion/benchmarking tool across build, profile, and benchmark flows for consistent behavior and clearer logs.
* **Behavior Change**
  * The tool is now invoked by name from PATH (configurable path option removed).
* **Bug Fixes**
  * Missing-tool errors now instruct to ensure the external tool is available in PATH.
* **Tests**
  * Tests updated to match the new execution/logging entrypoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->