### PR TITLE
Fix debugger server failing to detect editable-installed modelopt

### DIFF
--- a/tools/debugger/server.sh
+++ b/tools/debugger/server.sh
@@ -61,6 +61,8 @@ fi
 CMD_DIR="$RELAY_DIR/cmd"
 RESULT_DIR="$RELAY_DIR/result"
 
+echo "[server] Workdir: $WORKDIR"
+
 cleanup() {
     echo "[server] Shutting down..."
     # Kill any running command (guard all reads with || true to prevent set -e
@@ -97,8 +99,7 @@ mkdir -p "$CMD_DIR" "$RESULT_DIR"
 
 # Ensure modelopt is editable-installed from WORKDIR
 check_modelopt_local() {
-    # Clear PYTHONPATH and use -I to validate actual install state, not source tree
-    PYTHONPATH="" python -I -c "
+    python -c "
 import modelopt, os, sys
 actual = os.path.realpath(modelopt.__path__[0])
 expected = os.path.realpath('$WORKDIR')
@@ -124,7 +125,6 @@ fi
 # Signal that server is ready
 echo "$(hostname):$$:$(date -Iseconds)" > "$RELAY_DIR/server.ready"
 echo "[server] Ready. Relay dir: $RELAY_DIR"
-echo "[server] Workdir: $WORKDIR"
 echo "[server] Waiting for client handshake..."
 
 # Wait for client handshake


### PR DESCRIPTION
## Summary
- Removed `PYTHONPATH="" python -I` override in `check_modelopt_local()` so the PYTHONPATH validation uses the actual environment instead of an isolated one
- Moved the workdir log line earlier in `server.sh` for better debugging visibility

## Test plan
- [x] Start `server.sh` inside a Docker container and verify it correctly detects editable-installed modelopt
- [x] Confirm the workdir is logged before the modelopt check runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Server startup now displays the configured work directory earlier in the initialization process, providing improved visibility of the active directory during server launch.
  * Simplified the modelopt validation check during server initialization while maintaining the same validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->