### PR TITLE
Update codecov.yml

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,5 +9,5 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 2% # Allow atmost 2% coverage drop from main branch.
+        threshold: 1% # Allow atmost 1% coverage drop from main branch.
     patch: false


### PR DESCRIPTION
Dont allow more than 1% overall project coverage drop per PR. 2% was too much for such a large codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage enforcement thresholds for pull requests to maintain stricter quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->