### PR TITLE
Update excluded modules for Qwen3.5 dense PTQ

### DIFF
--- a/modelopt/torch/quantization/config.py
+++ b/modelopt/torch/quantization/config.py
@@ -228,6 +228,8 @@ _default_disabled_quantizer_cfg: list[QuantizerCfgEntry] = [
         "enable": False,
     },  # Skip the MOE router
     {"quantizer_name": "*linear_attn.conv1d*", "enable": False},
+    {"quantizer_name": "*linear_attn.in_proj_a*", "enable": False},
+    {"quantizer_name": "*linear_attn.in_proj_b*", "enable": False},
     {"quantizer_name": "*mixer.conv1d*", "enable": False},  # Skip mamba conv1d
     {"quantizer_name": "*output_layer*", "enable": False},
     {"quantizer_name": "output.*", "enable": False},


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

<!-- Details about the change. -->

For Qwen3.5 dense models, in_proj modules in linear attention are to be left unquantized.
Example in Qwen3.5-27B-FP8: https://huggingface.co/Qwen/Qwen3.5-27B-FP8/blob/main/config.json#L148
This PR updates `_default_disabled_quantizer_config` so that all Qwen3.5 dense models are quantized with the same exclusion pattern.

### Usage

```python
bash examples/llm_ptq/scripts/huggingface_example.sh --model Qwen/Qwen3.5-4B  --quant fp8 --tasks quant
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅  <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅  <!--- Mandatory -->
- Did you write any new necessary tests?: ❌ <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌ <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default quantization settings to explicitly disable quantization for certain linear attention projection components, preventing unintended quantization and improving model accuracy and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->