### PR TITLE
Temporarily disable latest pulp and mcore until we fix its nvidia-resiliency-ext dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     # modelopt.torch
     "PyYAML>=6.0",
     "omegaconf>=2.3.0",
-    "pulp",
+    "pulp<4.0",         # breaking changes in upcoming 4.0 release
     "pydantic>=2.0",
     "regex",
     "rich",

--- a/tox.ini
+++ b/tox.ini
@@ -82,7 +82,8 @@ commands =
 [testenv:cuda13-gpu-megatron]
 commands_pre =
     # Install deps here so that it gets installed even in --current-env
-    pip install -U megatron-core
+    # Temporarily disable latest mcore until we fix its nvidia-resiliency-ext dependency
+    pip install 'megatron-core<0.17.0'
     pip install --no-build-isolation git+https://github.com/state-spaces/mamba.git
     pip install --no-build-isolation git+https://github.com/Dao-AILab/causal-conv1d.git
     pip install -e .[hf,dev-test]


### PR DESCRIPTION
- `megatron-core==0.17.0` released yesterday which requires nightly version of `nvidia-resiliency-ext` for an import. Pre-installed version in DLFW Pytorch container is `nvidia-resiliency-ext==0.5.0`
  - Temporarily pin `mcore<0.17.0` to unblock PR from merging. 
- Pin `pulp<4.0` as it has some breaking changes and release imminent

Correct fix is to just use `nemo:26.04` container instead of PyTorch container for megatron-based tests since it always has correct combination of all packages needed for the megatron ecosystem - Done in #1286