### PR TITLE
[CI] Bump test containers to latest

### DIFF
--- a/.github/workflows/bump_uv_lock.yml
+++ b/.github/workflows/bump_uv_lock.yml
@@ -30,7 +30,10 @@ jobs:
           t['tool']['uv']['override-dependencies'] = ['torch; sys_platform == \"never\"']
           toml.dump(t, open('pyproject.toml', 'w'))
           "
-      - run: uv lock --upgrade
+      - name: Run uv lock upgrade
+        run: |
+          set -o pipefail
+          uv lock --upgrade 2>&1 | tee /tmp/uv_lock_output.txt
       - name: Check for changes
         id: changes
         run: |
@@ -53,12 +56,22 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -s -m "[chore]: bump uv.lock"
           git push origin "$BRANCH"
+          UV_OUTPUT=$(cat /tmp/uv_lock_output.txt)
           gh pr create \
             --title "[chore]: weekly bump of uv.lock on ${BASE} ($(date +%Y-%m-%d))" \
-            --body "$(cat <<'EOF'
+            --body "$(cat <<EOF
           ## Summary
           Automated weekly update of uv.lock file for nSpect Scanning:
-          - `uv.lock` — upgraded all transitive dependencies to latest compatible versions
+          - \`uv.lock\` — upgraded all transitive dependencies to latest compatible versions
+
+          <details>
+          <summary>uv lock --upgrade output</summary>
+
+          \`\`\`
+          ${UV_OUTPUT}
+          \`\`\`
+
+          </details>
           EOF
           )" \
             --base "$BASE"

--- a/.github/workflows/example_tests.yml
+++ b/.github/workflows/example_tests.yml
@@ -60,7 +60,7 @@ jobs:
     uses: ./.github/workflows/_example_tests_runner.yml
     secrets: inherit
     with:
-      docker_image: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10"
+      docker_image: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc12"
       example: ${{ matrix.example }}
       pip_install_extras: "[hf,dev-test]"
       runner: linux-amd64-gpu-rtxpro6000-latest-1
@@ -74,7 +74,7 @@ jobs:
     uses: ./.github/workflows/_example_tests_runner.yml
     secrets: inherit
     with:
-      docker_image: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10"
+      docker_image: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc12"
       example: ${{ matrix.example }}
       pip_install_extras: "[hf,dev-test]"
       runner: linux-amd64-gpu-rtxpro6000-latest-2

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -40,14 +40,13 @@ jobs:
         include:
           - example: gpu
             timeout: 60
-            container_image: pytorch:26.01-py3
-            # tests/gpu/_extensions/test_onnx_extensions.py fails for newer containers until https://github.com/tbenthompson/cppimport/pull/98
+            container_image: pytorch:26.03-py3
           - example: gpu_megatron
             timeout: 45
             container_image: nemo:26.04
           - example: gpu_trtllm
             timeout: 30
-            container_image: tensorrt-llm/release:1.3.0rc10
+            container_image: tensorrt-llm/release:1.3.0rc12
     runs-on: ${{ startsWith(github.ref, 'refs/heads/pull-request/') && 'linux-amd64-gpu-rtxpro6000-latest-1' || 'linux-amd64-gpu-rtxpro6000-latest-2' }}
     timeout-minutes: ${{ matrix.timeout }}
     container:

--- a/modelopt/onnx/quantization/extensions.py
+++ b/modelopt/onnx/quantization/extensions.py
@@ -18,7 +18,7 @@
 import os
 import sys
 
-# TODO: cppimport is no longer maintained, switch to a different library
+# TODO: cppimport is not actively maintained, consider a better alternative library
 import cppimport
 
 from modelopt.onnx.logging_config import logger
@@ -32,7 +32,5 @@ try:
 except Exception as e:
     logger.warning(
         f"{e}\nUnable to load `modelopt_round_and_pack_ext', falling back to python based optimized version. "
-        "If you see `copy_file() got an unexpected keyword argument 'dry_run'`, you will need "
-        "https://github.com/tbenthompson/cppimport/pull/98 or downgrade setuptools until we have a workaround"
     )
     round_and_pack_ext = None


### PR DESCRIPTION
- Use latest containers for testing in CICD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped TensorRT-LLM Docker images to 1.3.0rc12 in example and GPU test workflows.
  * Updated PyTorch container image from 26.01 to 26.03 for GPU tests.
  * Captured uv lock upgrade output to a temp file, inlined it into PR bodies, and adjusted workflow heredoc/templating and step behavior.

* **Documentation**
  * Clarified an inline comment and simplified a warning message for an ONNX quantization extension.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->