### PR TITLE
Fix vLLM fakequant MoE megatron export bug

### DIFF
--- a/examples/vllm_serve/vllm_reload_utils.py
+++ b/examples/vllm_serve/vllm_reload_utils.py
@@ -572,7 +572,7 @@ def load_state_dict_from_path(
         saved_quant_dict = {
             key.replace("quantizer_", "quantizer._"): value
             for key, value in saved_quant_dict.items()
-            if "quantizer_" in key
+            if "quantizer" in key
         }
     saved_quant_dict = convert_dict_to_vllm(saved_quant_dict)
 

--- a/modelopt/torch/export/plugins/vllm_fakequant_megatron.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_megatron.py
@@ -137,7 +137,9 @@ class VllmFqGPTModelExporter(GPTModelExporter):
         block_size = 0
         name_to_value = self._get_weight_bias(module, dtype, name_to_value)
         if "weight" in name_to_value:
-            weight = name_to_value["weight"]
+            # Use the original device (avoid the CPU round-trip introduced by _get_weight_bias;
+            # fake-quantization runs on CUDA and the result is moved to CPU below).
+            weight = module.weight.to(dtype)
             # Fold the weight_quantizer into the weight by applying fake-quantization
             # (quantize then dequantize). The weight_quantizer amax is not exported;
             # the vLLM fakequant reload path disables the weight quantizer when absent.

--- a/modelopt/torch/export/plugins/vllm_fakequant_megatron.py
+++ b/modelopt/torch/export/plugins/vllm_fakequant_megatron.py
@@ -135,9 +135,9 @@ class VllmFqGPTModelExporter(GPTModelExporter):
             # string then it usually ends with "." which needs to be removed.
             self.exclude_modules.append(prefix.removesuffix("."))
         block_size = 0
-
-        if hasattr(module, "weight") and module.weight is not None:
-            weight = module.weight.to(dtype)
+        name_to_value = self._get_weight_bias(module, dtype, name_to_value)
+        if "weight" in name_to_value:
+            weight = name_to_value["weight"]
             # Fold the weight_quantizer into the weight by applying fake-quantization
             # (quantize then dequantize). The weight_quantizer amax is not exported;
             # the vLLM fakequant reload path disables the weight quantizer when absent.
@@ -170,9 +170,6 @@ class VllmFqGPTModelExporter(GPTModelExporter):
             name_to_value["weight"] = weight.cpu()
         else:
             return name_to_value, qformat, block_size
-
-        if hasattr(module, "bias") and module.bias is not None:
-            name_to_value["bias"] = module.bias.to(dtype).cpu()
 
         # Only save input/output quantizer state; weight_quantizer amax is not exported
         # since it has been folded into the weight above.

--- a/modelopt/torch/export/unified_export_megatron.py
+++ b/modelopt/torch/export/unified_export_megatron.py
@@ -743,6 +743,38 @@ class GPTModelExporter:
 
         return all_rules
 
+    def _get_weight_bias(
+        self,
+        module: torch.nn.Module,
+        dtype: torch.dtype = torch.float16,
+        name_to_value: dict[str, torch.Tensor] = {},
+    ) -> dict[str, torch.Tensor]:
+        """Get the weight and bias of the module.
+
+        Args:
+            module: The target module to get the weight and bias.
+            dtype: The data type of the weight and bias.
+            name_to_value: The dictionary to store the weight and bias.
+
+        Returns:
+            The dictionary containing the weight and bias.
+        """
+        if hasattr(module, "weight") and module.weight is not None and module.weight.numel() > 0:
+            weight = module.weight.to(dtype).cpu()
+            name_to_value["weight"] = weight
+
+        if hasattr(module, "bias") and module.bias is not None and module.bias.numel() > 0:
+            name_to_value["bias"] = module.bias.to(dtype).cpu()
+
+        if (
+            hasattr(module, "expert_bias")
+            and module.expert_bias is not None
+            and module.expert_bias.numel() > 0
+        ):
+            name_to_value["expert_bias"] = module.expert_bias.to(dtype).cpu()
+
+        return name_to_value
+
     def _get_quantized_state(
         self,
         module: torch.nn.Module,
@@ -767,21 +799,12 @@ class GPTModelExporter:
             self.exclude_modules.append(prefix.removesuffix("."))
         block_size = get_weight_block_size(module)
 
-        if hasattr(module, "weight") and module.weight is not None and module.weight.numel() > 0:
-            weight = module.weight.to(dtype).cpu()
-            name_to_value["weight"] = weight
-        else:
-            return name_to_value, qformat, block_size
+        name_to_value = self._get_weight_bias(module, dtype, name_to_value)
 
-        if hasattr(module, "bias") and module.bias is not None and module.bias.numel() > 0:
-            name_to_value["bias"] = module.bias.to(dtype).cpu()
-
-        if (
-            hasattr(module, "expert_bias")
-            and module.expert_bias is not None
-            and module.expert_bias.numel() > 0
+        if not (
+            hasattr(module, "weight") and module.weight is not None and module.weight.numel() > 0
         ):
-            name_to_value["expert_bias"] = module.expert_bias.to(dtype).cpu()
+            return name_to_value, qformat, block_size
 
         if qformat == QUANTIZATION_NONE:
             return name_to_value, qformat, block_size

--- a/modelopt/torch/export/unified_export_megatron.py
+++ b/modelopt/torch/export/unified_export_megatron.py
@@ -747,18 +747,24 @@ class GPTModelExporter:
         self,
         module: torch.nn.Module,
         dtype: torch.dtype = torch.float16,
-        name_to_value: dict[str, torch.Tensor] = {},
+        name_to_value: dict[str, torch.Tensor] | None = None,
     ) -> dict[str, torch.Tensor]:
         """Get the weight and bias of the module.
 
         Args:
             module: The target module to get the weight and bias.
             dtype: The data type of the weight and bias.
-            name_to_value: The dictionary to store the weight and bias.
+            name_to_value: The dictionary to store the weight and bias. A new dict is created
+                if not provided.
 
         Returns:
             The dictionary containing the weight and bias.
         """
+        if name_to_value is None:
+            name_to_value = {}
+        # numel() > 0 intentionally excludes zero-element weight tensors (e.g. MoE routing
+        # layers whose weight is a placeholder) so callers can use "weight" in name_to_value
+        # as a reliable guard without re-inspecting module.weight.
         if hasattr(module, "weight") and module.weight is not None and module.weight.numel() > 0:
             weight = module.weight.to(dtype).cpu()
             name_to_value["weight"] = weight
@@ -801,9 +807,7 @@ class GPTModelExporter:
 
         name_to_value = self._get_weight_bias(module, dtype, name_to_value)
 
-        if not (
-            hasattr(module, "weight") and module.weight is not None and module.weight.numel() > 0
-        ):
+        if "weight" not in name_to_value:
             return name_to_value, qformat, block_size
 
         if qformat == QUANTIZATION_NONE:

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -387,10 +387,7 @@ class _QuantFusedMoEBase(QuantModule):
             if self.w13_weight_quantizer.is_enabled:  # pragma: no cover
                 original_weight = self.w13_weight
                 B = self.w13_weight_quantizer(original_weight)  # noqa: N806
-                try:
-                    original_kernel(A, B, C, *args, **kwargs)
-                finally:
-                    self.w13_weight = original_weight
+                original_kernel(A, B, C, *args, **kwargs)
             else:
                 original_kernel(A, B, C, *args, **kwargs)
             if self.w13_output_quantizer.is_enabled:
@@ -400,10 +397,7 @@ class _QuantFusedMoEBase(QuantModule):
             if self.w2_weight_quantizer.is_enabled:  # pragma: no cover
                 original_weight = self.w2_weight
                 B = self.w2_weight_quantizer(original_weight)  # noqa: N806
-                try:
-                    original_kernel(A, B, C, *args, **kwargs)
-                finally:
-                    self.w2_weight = original_weight
+                original_kernel(A, B, C, *args, **kwargs)
             else:
                 original_kernel(A, B, C, *args, **kwargs)
             if self.w2_output_quantizer.is_enabled:

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -385,13 +385,8 @@ class _QuantFusedMoEBase(QuantModule):
             # First layer of expert
             A = self.w13_input_quantizer(A)  # noqa: N806
             if self.w13_weight_quantizer.is_enabled:  # pragma: no cover
-                original_weight, self.w13_weight = (
-                    self.w13_weight,
-                    self.w13_weight_quantizer(self.w13_weight),
-                )
-                # In case the weight quantizer isn't folded yet in vllm_serve_fakequant, pass the
-                # quantized weight to the kernel.
-                B = self.w13_weight  # noqa: N806
+                original_weight = self.w13_weight
+                B = self.w13_weight_quantizer(original_weight)  # noqa: N806
                 try:
                     original_kernel(A, B, C, *args, **kwargs)
                 finally:
@@ -403,13 +398,8 @@ class _QuantFusedMoEBase(QuantModule):
         elif B is self.w2_weight:
             A = self.w2_input_quantizer(A)  # noqa: N806
             if self.w2_weight_quantizer.is_enabled:  # pragma: no cover
-                original_weight, self.w2_weight = (
-                    self.w2_weight,
-                    self.w2_weight_quantizer(self.w2_weight),
-                )
-                # In case the weight quantizer isn't folded yet in vllm_serve_fakequant, pass the
-                # quantized weight to the kernel.
-                B = self.w2_weight  # noqa: N806
+                original_weight = self.w2_weight
+                B = self.w2_weight_quantizer(original_weight)  # noqa: N806
                 try:
                     original_kernel(A, B, C, *args, **kwargs)
                 finally:

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -385,9 +385,22 @@ class _QuantFusedMoEBase(QuantModule):
             # First layer of expert
             A = self.w13_input_quantizer(A)  # noqa: N806
             if self.w13_weight_quantizer.is_enabled:  # pragma: no cover
+                # Same pattern as FakeQuantMethod.apply: wrap as nn.Parameter if needed, swap
+                # w13_weight, call kernel, restore (tensor cannot stay assigned to nn.Parameter slot).
                 original_weight = self.w13_weight
-                B = self.w13_weight_quantizer(original_weight)  # noqa: N806
-                original_kernel(A, B, C, *args, **kwargs)
+                quantized_tensor = self.w13_weight_quantizer(original_weight)
+                try:
+                    if isinstance(original_weight, torch.nn.Parameter) and not isinstance(
+                        quantized_tensor, torch.nn.Parameter
+                    ):
+                        quantized_tensor = torch.nn.Parameter(
+                            quantized_tensor, requires_grad=original_weight.requires_grad
+                        )
+                    self.w13_weight = quantized_tensor
+                    B = quantized_tensor  # noqa: N806
+                    original_kernel(A, B, C, *args, **kwargs)
+                finally:
+                    self.w13_weight = original_weight
             else:
                 original_kernel(A, B, C, *args, **kwargs)
             if self.w13_output_quantizer.is_enabled:
@@ -396,8 +409,19 @@ class _QuantFusedMoEBase(QuantModule):
             A = self.w2_input_quantizer(A)  # noqa: N806
             if self.w2_weight_quantizer.is_enabled:  # pragma: no cover
                 original_weight = self.w2_weight
-                B = self.w2_weight_quantizer(original_weight)  # noqa: N806
-                original_kernel(A, B, C, *args, **kwargs)
+                quantized_tensor = self.w2_weight_quantizer(original_weight)
+                try:
+                    if isinstance(original_weight, torch.nn.Parameter) and not isinstance(
+                        quantized_tensor, torch.nn.Parameter
+                    ):
+                        quantized_tensor = torch.nn.Parameter(
+                            quantized_tensor, requires_grad=original_weight.requires_grad
+                        )
+                    self.w2_weight = quantized_tensor
+                    B = quantized_tensor  # noqa: N806
+                    original_kernel(A, B, C, *args, **kwargs)
+                finally:
+                    self.w2_weight = original_weight
             else:
                 original_kernel(A, B, C, *args, **kwargs)
             if self.w2_output_quantizer.is_enabled:


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix                     
                                                                                                                                                                                        
  Fixes two bugs in the vLLM + Megatron-Core MoE export path and cleans up the related weight-collection helper:                                                                        
    
  1. **`_QuantFusedMoEBase` (vllm.py)**: The weight-quantizer path in `_invoke_fused_moe_quantized_function` was temporarily mutating `self.w13_weight` / `self.w2_weight` to the quantized tensor, then restoring them via `finally`. This exposed a stale quantized tensor on `self` between the mutation and the kernel call. Fixed by computing the quantized weight directly into a local `B` without touching `self.*` attributes.                          
                                                                                                                                                                                        
  2. **`GPTModelExporter` / `VllmFqGPTModelExporter` (unified_export_megatron.py / vllm_fakequant_megatron.py)**: `expert_bias` (present in grouped MoE layers) was silently dropped during export because the bias collection ran after the early-return on missing `weight`. Extracted a `_get_weight_bias` helper that collects weight, bias, and expert_bias together, so bias/expert_bias are captured even when weight is absent or zero-element.                                                                                                          
                                                                                                                                                                                        

### Usage

```python
# No API change; export pipelines pick this up automatically.
# export_mcore_gpt_to_hf_vllm_fq / export_mcore_gpt_to_hf now correctly                   
# export expert_bias for grouped-MoE checkpoints.    
```

### Testing
Step 1 — Quantize (run from Megatron-LM examples/post_training/modelopt):
```
HF_MODEL_CKPT=<path/to/hf/weights> MLM_MODEL_SAVE=<quant-ckpt-name> \
bash quantize.sh <hf-model-id> NVFP4_DEFAULT_CFG
```
Step 2 — Export for vLLM fakequant:
```
MLM_EXTRA_ARGS=--export-vllm-fq \ 
HF_MODEL_CKPT=<path/to/hf/weights> \ 
MLM_MODEL_CKPT=<quant-ckpt-name> \ 
EXPORT_DIR=<export-dir> \ 
bash export.sh <hf-model-id> 
```
Step 3 — Serve (run from examples/vllm_serve):
```
 QUANT_CFG=NVFP4_DEFAULT_CFG \ 
 QUANT_FILE_PATH=<export-dir>/quantizer_state.pth \ 
 python3 vllm_serve_fakequant.py <export-dir> \ 
 -tp 1 --served-model-name <model-name> \ 
 --host 0.0.0.0 --port 8000 \ 
--trust-remote-code --enforce-eager \ 
 --disable-custom-all-reduce \ 
--gpu-memory-utilization 0.8          
```
### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ 
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A 
- Did you write any new necessary tests?: ❌
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized weight/bias/expert-bias extraction and export to a single helper for consistent handling.
  * Standardized quantized-weight flow to temporarily swap and restore parameter tensors during computation.

* **Bug Fixes**
  * Prevented missing or incorrect weight/bias exports by unifying extraction logic.
  * Broadened checkpoint key matching to preserve more quantizer state during reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->