### PR TITLE
fix: validate modelopt state file structure on load

### DIFF
--- a/modelopt/torch/opt/conversion.py
+++ b/modelopt/torch/opt/conversion.py
@@ -513,6 +513,9 @@ def save(model: nn.Module, f: str | os.PathLike | BinaryIO, **kwargs) -> None:
     torch.save(ckpt_dict, f, **kwargs)
 
 
+_MODELOPT_STATE_REQUIRED_KEYS = ("modelopt_state_dict", "modelopt_version")
+
+
 def load_modelopt_state(modelopt_state_path: str | os.PathLike, **kwargs) -> dict[str, Any]:
     """Load the modelopt state from a file.
 
@@ -522,9 +525,27 @@ def load_modelopt_state(modelopt_state_path: str | os.PathLike, **kwargs) -> dic
 
     Returns:
         A modelopt state dictionary describing the modifications to the model.
+
+    Raises:
+        ValueError: if the loaded object is not a valid modelopt state dictionary
+            (not a dict or missing required keys).
     """
     kwargs.setdefault("map_location", "cpu")
-    return safe_load(modelopt_state_path, **kwargs)
+    state = safe_load(modelopt_state_path, **kwargs)
+
+    if not isinstance(state, dict):
+        raise ValueError(
+            f"{modelopt_state_path!r} is not a valid modelopt state file: "
+            f"expected a dict, got {type(state).__name__}."
+        )
+    missing = [k for k in _MODELOPT_STATE_REQUIRED_KEYS if k not in state]
+    if missing:
+        raise ValueError(
+            f"{modelopt_state_path!r} is not a valid modelopt state file: "
+            f"missing required keys {missing} "
+            f"(expected {list(_MODELOPT_STATE_REQUIRED_KEYS)})."
+        )
+    return state
 
 
 def restore_from_modelopt_state(

--- a/tests/unit/torch/opt/test_chaining.py
+++ b/tests/unit/torch/opt/test_chaining.py
@@ -337,3 +337,25 @@ def test_chained_modes_preserve_forward_patching_during_quantize():
     assert called["patched_forward"] == 1
     assert called["input_q"] == 1
     assert called["weight_q"] == 1
+
+
+def test_load_modelopt_state_rejects_non_dict(tmp_path):
+    path = tmp_path / "bad_state.pt"
+    torch.save([1, 2, 3], path)
+    with pytest.raises(ValueError, match="not a valid modelopt state file"):
+        mto.load_modelopt_state(path)
+
+
+def test_load_modelopt_state_rejects_missing_keys(tmp_path):
+    path = tmp_path / "incomplete_state.pt"
+    torch.save({"modelopt_state_dict": []}, path)
+    with pytest.raises(ValueError, match="missing required keys"):
+        mto.load_modelopt_state(path)
+
+
+def test_load_modelopt_state_round_trip(tmp_path):
+    model = SimpleLinearModel()
+    path = tmp_path / "good_state.pt"
+    torch.save(mto.modelopt_state(model), path)
+    loaded = mto.load_modelopt_state(path)
+    assert set(loaded) >= {"modelopt_state_dict", "modelopt_version"}


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

`load_modelopt_state()` previously returned whatever `safe_load()` produced, with no schema
check. When users pointed it at a corrupted or unrelated file, the failure surfaced
downstream inside `restore_from_modelopt_state()` as an opaque `KeyError` on
`"modelopt_state_dict"` / `"modelopt_version"`, or a `TypeError` when the loaded object
wasn't a dict at all.

This PR addresses the existing request in NVIDIA/Model-Optimizer#1041 by validating the loaded object at the
entry point and raising a clear `ValueError` that names the offending file and the missing
keys.

### Usage

```python
import modelopt.torch.opt as mto

mto.load_modelopt_state("not_a_modelopt_state.pt")
# ValueError: 'not_a_modelopt_state.pt' is not a valid modelopt state file:
# missing required keys ['modelopt_state_dict', 'modelopt_version']
# (expected ['modelopt_state_dict', 'modelopt_version']).
```

### Testing

Added three unit tests in tests/unit/torch/opt/test_chaining.py:

- test_load_modelopt_state_rejects_non_dict
- test_load_modelopt_state_rejects_missing_keys
- test_load_modelopt_state_round_trip — exercises the happy path against
mto.modelopt_state(model) so the accepted schema stays in sync with the producer side.

Run with:

```bash
python -m pytest tests/unit/torch/opt/test_chaining.py -k load_modelopt_state -v
```

## Checklist

- [x] Is this change backward compatible?: yes 
- [x] Did you write any new necessary tests?: yes
- [x] Did you update https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst?: N/A - minor user-facing improvement, no API change. 

Additional Information

Closes NVIDIA/Model-Optimizer#1041.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation for loading saved state files: malformed or incomplete files are now rejected with clear errors.

* **Documentation**
  * Updated docs to explain validation rules and the specific error conditions when loading state files.

* **Tests**
  * Added tests covering invalid top-level payloads, missing required keys, and a successful save/load round trip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->