### PR TITLE
Add disable_sensitive_layers field to QuantizeConfig

### DIFF
--- a/docs/source/guides/10_recipes.rst
+++ b/docs/source/guides/10_recipes.rst
@@ -69,9 +69,10 @@ The simplest form is a single ``.yml`` or ``.yaml`` file.  Here is a PTQ example
 
    quantize:
      algorithm: max
+     # Auto-prepend a deny-all and auto-append ModelOpt's curated sensitive-layer disables
+     # (lm_head, MoE routers, BatchNorm, Mamba conv1d, ...). See :ref:`disable-sensitive-layers`.
+     disable_sensitive_layers: true
      quant_cfg:
-       - quantizer_name: '*'
-         enable: false
        - quantizer_name: '*input_quantizer'
          cfg:
            num_bits: e4m3
@@ -84,7 +85,6 @@ The simplest form is a single ``.yml`` or ``.yaml`` file.  Here is a PTQ example
          enable: true
          cfg:
            num_bits: e4m3
-       # ... standard exclusions omitted for brevity
 
 Directory format
 ----------------
@@ -112,9 +112,8 @@ example:
 .. code-block:: yaml
 
    algorithm: max
+   disable_sensitive_layers: true
    quant_cfg:
-     - quantizer_name: '*'
-       enable: false
      - quantizer_name: '*weight_quantizer'
        cfg:
          num_bits: e2m1
@@ -175,6 +174,13 @@ PTQ recipes contain a ``quantize`` mapping with:
      - The calibration algorithm: ``"max"`` (default), ``"mse"``, ``"smoothquant"``,
        ``"awq_lite"``, ``"awq_full"``, ``"awq_clip"``, ``"gptq"``, or ``null`` for
        formats that need no calibration (e.g. MX formats).
+   * - ``disable_sensitive_layers``
+     - No
+     - When set, automatically wraps ``quant_cfg`` with a leading deny-all and a trailing
+       set of sensitive-layer disables. ``true`` appends ModelOpt's curated defaults
+       (lm_head, MoE routers, BatchNorm, Mamba conv1d, ...); ``false`` only prepends the
+       deny-all; a list of patterns appends a custom suffix. Defaults to ``null``
+       (passthrough). See :ref:`disable-sensitive-layers`.
 
 
 ExMy floating-point notation
@@ -366,9 +372,10 @@ Example -- creating a custom PTQ recipe (INT8 per-channel):
 
    quantize:
      algorithm: max
+     # Auto-prepend deny-all and auto-append the curated sensitive-layer disables
+     # (which already includes ``*lm_head*`` and ``*output_layer*``).
+     disable_sensitive_layers: true
      quant_cfg:
-       - quantizer_name: '*'
-         enable: false
        - quantizer_name: '*weight_quantizer'
          cfg:
            num_bits: 8
@@ -377,10 +384,6 @@ Example -- creating a custom PTQ recipe (INT8 per-channel):
          cfg:
            num_bits: 8
            axis:
-       - quantizer_name: '*lm_head*'
-         enable: false
-       - quantizer_name: '*output_layer*'
-         enable: false
 
 
 Recipe repository layout

--- a/docs/source/guides/_quant_cfg.rst
+++ b/docs/source/guides/_quant_cfg.rst
@@ -271,6 +271,91 @@ For entirely custom recipes, compose the list directly:
 
     model = mtq.quantize(model, MY_CUSTOM_CFG, forward_loop)
 
+.. tip::
+
+    The boilerplate ``_base_disable_all`` prepend and ``_default_disabled_quantizer_cfg``
+    suffix can be replaced with the :ref:`disable-sensitive-layers <disable-sensitive-layers>`
+    field, which is friendlier for YAML recipes and Pydantic-validated configs:
+
+    .. code-block:: python
+
+        MY_CUSTOM_CFG = {
+            "quant_cfg": [
+                {"quantizer_name": "*weight_quantizer", "cfg": {"num_bits": 4, "block_sizes": {-1: 128}}},
+                {"quantizer_name": "*input_quantizer", "cfg": {"num_bits": 8, "axis": None}},
+            ],
+            "algorithm": "max",
+            "disable_sensitive_layers": True,
+        }
+
+----------
+
+.. _disable-sensitive-layers:
+
+Auto-Expanding with ``disable_sensitive_layers``
+=================================================
+
+Most PTQ recipes use the same bracket pattern: a leading deny-all, then the user's enable rules,
+then a trailing list of always-disabled "sensitive" layers (``lm_head``, MoE routers, BatchNorm,
+Mamba ``conv1d``, etc.). Writing all three layers by hand is verbose and easy to get wrong,
+especially in YAML.
+
+The :class:`QuantizeConfig <modelopt.torch.quantization.config.QuantizeConfig>` schema accepts a
+top-level ``disable_sensitive_layers`` field that drives a Pydantic
+:func:`model_validator` to wrap the user-provided ``quant_cfg`` automatically:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Value
+     - Behavior
+   * - ``None`` (default)
+     - **Backward-compatible passthrough.** ``quant_cfg`` is left untouched. Use this if you
+       are hand-composing the full bracket (as ``FP8_DEFAULT_CFG`` and other built-in Python
+       constants do).
+   * - ``True``
+     - Auto-prepend ``{quantizer_name: '*', enable: False}`` and auto-append
+       :data:`_default_disabled_quantizer_cfg <modelopt.torch.quantization.config._default_disabled_quantizer_cfg>`
+       (lm_head, MoE routers, BatchNorm, Mamba conv1d, output layers, …).
+   * - ``False``
+     - Auto-prepend the deny-all only. No sensitive-layer suffix. Useful when you want a clean
+       start without ModelOpt's opinionated sensitive-layer set.
+   * - ``list[str]``
+     - Auto-prepend the deny-all and append a custom suffix where each pattern in the list is
+       disabled (``{quantizer_name: <pattern>, enable: False}``).
+
+The expansion is performed by :func:`expand_quant_cfg
+<modelopt.torch.quantization.config.expand_quant_cfg>` once during
+``QuantizeConfig`` validation. After expansion the field is reset to ``None`` so a round-trip
+through ``model_dump()`` does **not** double-expand.
+
+YAML example
+------------
+
+.. code-block:: yaml
+
+    quantize:
+      algorithm: max
+      disable_sensitive_layers: true
+      quant_cfg:
+        - quantizer_name: '*input_quantizer'
+          cfg:
+            num_bits: e4m3
+            axis:
+        - quantizer_name: '*weight_quantizer'
+          cfg:
+            num_bits: e4m3
+            axis:
+        - quantizer_name: '*[kv]_bmm_quantizer'
+          enable: true
+          cfg:
+            num_bits: e4m3
+
+is equivalent to the hand-built form (see ``modelopt.torch.quantization.config.FP8_DEFAULT_CFG``)
+where ``_base_disable_all`` is prepended and ``_default_disabled_quantizer_cfg`` is appended
+explicitly.
+
 ----------
 
 .. _sequential-quantizers:
@@ -390,4 +475,5 @@ Reference
 - :class:`QuantizerCfgEntry <modelopt.torch.quantization.config.QuantizerCfgEntry>`
 - :class:`QuantizerAttributeConfig <modelopt.torch.quantization.config.QuantizerAttributeConfig>`
 - :class:`QuantizeConfig <modelopt.torch.quantization.config.QuantizeConfig>`
+- :func:`expand_quant_cfg <modelopt.torch.quantization.config.expand_quant_cfg>`
 - :func:`set_quantizer_by_cfg <modelopt.torch.quantization.conversion.set_quantizer_by_cfg>`

--- a/modelopt/torch/quantization/config.py
+++ b/modelopt/torch/quantization/config.py
@@ -1723,6 +1723,63 @@ def normalize_quant_cfg_list(v: dict | list) -> list[QuantizerCfgEntry]:
     return result
 
 
+def expand_quant_cfg(
+    quant_cfg: list[QuantizerCfgEntry],
+    disable_sensitive_layers: bool | list[str],
+) -> list[QuantizerCfgEntry]:
+    """Wrap a user ``quant_cfg`` with the standard PTQ defaults.
+
+    This produces the well-known "managed" PTQ ordering:
+
+    1. **Disable everything** (``{quantizer_name: '*', enable: False}``) — auto-prepended.
+    2. **User entries** — applied verbatim.
+    3. **Re-disable sensitive layers** — appended only when
+       ``disable_sensitive_layers`` is truthy.
+
+    Because :func:`set_quantizer_by_cfg` applies entries in list order with
+    last-match-wins semantics per quantizer, the bracket pattern (disable →
+    enable specific → re-disable sensitive) is what protects ``lm_head``,
+    BatchNorm, MoE routers, etc. from the broad enable wildcards in the
+    middle.
+
+    Args:
+        quant_cfg: The user-provided list of :class:`QuantizerCfgEntry` dicts
+            (already normalized via :func:`normalize_quant_cfg_list`).
+        disable_sensitive_layers: Controls the appended suffix.
+
+            * ``True`` — append the curated ModelOpt sensitive-layer disables
+              (:data:`_default_disabled_quantizer_cfg`).
+            * ``False`` — append nothing; only the leading disable-all entry
+              is added. Useful when the user wants the "start clean" behavior
+              without ModelOpt's opinionated sensitive-layer set.
+            * ``list[str]`` — append a custom set of quantizer-name patterns,
+              each disabled.
+
+    Returns:
+        The expanded list, re-normalized via :func:`normalize_quant_cfg_list`
+        so every returned entry is in canonical form regardless of the input
+        shape of the splice constants.
+    """
+    out: list[QuantizerCfgEntry] = list(_base_disable_all)
+    out.extend(quant_cfg)
+    if disable_sensitive_layers is True:
+        out.extend(_default_disabled_quantizer_cfg)
+    elif isinstance(disable_sensitive_layers, list):
+        invalid = [p for p in disable_sensitive_layers if not isinstance(p, str)]
+        if invalid:
+            raise TypeError(
+                "disable_sensitive_layers list entries must all be strings (quantizer-name "
+                f"patterns); got non-str values {invalid!r}."
+            )
+        out.extend({"quantizer_name": p, "enable": False} for p in disable_sensitive_layers)
+    elif disable_sensitive_layers is not False:
+        raise TypeError(
+            "disable_sensitive_layers must be a bool or a list of quantizer-name "
+            f"patterns; got {type(disable_sensitive_layers).__name__}."
+        )
+    return normalize_quant_cfg_list(out)
+
+
 class QuantizeConfig(ModeloptBaseConfig):
     """Default configuration for ``quantize`` mode."""
 
@@ -1737,6 +1794,25 @@ class QuantizeConfig(ModeloptBaseConfig):
         title="Calibration algorithm, see :meth:`calibrate <modelopt.torch.quantization.model_quant.calibrate>` "
         "for more details.",
         validate_default=True,
+    )
+
+    disable_sensitive_layers: bool | list[str] | None = ModeloptField(
+        default=None,
+        title="Auto-expand quant_cfg with the standard PTQ defaults.",
+        description=(
+            "When set (any non-``None`` value), :func:`expand_quant_cfg` is invoked to "
+            "rewrite ``quant_cfg`` into "
+            "``[{'quantizer_name': '*', 'enable': False}] + quant_cfg + suffix`` "
+            "before quantization runs. The value controls the suffix:\n\n"
+            "* ``True`` — append ModelOpt's curated sensitive-layer disables "
+            "(:data:`_default_disabled_quantizer_cfg`: ``lm_head``, BatchNorm, MoE "
+            "routers, Mamba conv1d, etc.).\n"
+            "* ``False`` — append nothing; only the leading disable-all is added.\n"
+            "* ``list[str]`` — append the given quantizer-name patterns, each disabled.\n\n"
+            "When unset (``None``, the default), ``quant_cfg`` is passed through verbatim "
+            "for backward compatibility with hand-built configs that already include their "
+            "own disable-all and sensitive-layer entries (e.g. ``FP8_DEFAULT_CFG``)."
+        ),
     )
 
     @field_validator("quant_cfg", mode="before")
@@ -1761,6 +1837,29 @@ class QuantizeConfig(ModeloptBaseConfig):
                 if isinstance(c, dict) and qac_fields & set(c.keys()):
                     QuantizerAttributeConfig.model_validate(c)
         return v
+
+    @model_validator(mode="after")
+    def expand_quant_cfg_with_defaults(self):
+        """Expand ``quant_cfg`` with PTQ defaults when ``disable_sensitive_layers`` is set.
+
+        After this validator runs ``disable_sensitive_layers`` is reset to ``None`` so that a
+        round-trip through ``model_dump()`` -> ``QuantizeConfig(**dump)`` does **not**
+        re-prepend / re-append the defaults a second time.
+
+        Note: we use ``object.__setattr__`` to bypass ``validate_assignment=True`` on
+        :class:`ModeloptBaseConfig`. The expanded list returned by :func:`expand_quant_cfg`
+        is already in canonical form (it calls :func:`normalize_quant_cfg_list` internally),
+        so re-running the field validators on assignment would just be wasted work.
+        """
+        if self.disable_sensitive_layers is None:
+            return self
+        object.__setattr__(
+            self,
+            "quant_cfg",
+            expand_quant_cfg(self.quant_cfg, self.disable_sensitive_layers),
+        )
+        object.__setattr__(self, "disable_sensitive_layers", None)
+        return self
 
 
 class CompressConfig(ModeloptBaseConfig):

--- a/modelopt_recipes/general/ptq/fp8_default-fp8_kv.yaml
+++ b/modelopt_recipes/general/ptq/fp8_default-fp8_kv.yaml
@@ -13,14 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# `disable_sensitive_layers: true` auto-prepends a leading
+# `{quantizer_name: '*', enable: false}` and auto-appends ModelOpt's curated
+# sensitive-layer disables (lm_head, MoE routers, BatchNorm, Mamba conv1d,
+# etc.). See `QuantizeConfig.disable_sensitive_layers` for the contract.
 metadata:
   recipe_type: ptq
   description: FP8 per-tensor weight and activation (W8A8), FP8 KV cache, max calibration.
 quantize:
   algorithm: max
+  disable_sensitive_layers: true
   quant_cfg:
-    - quantizer_name: '*'
-      enable: false
     - quantizer_name: '*input_quantizer'
       cfg:
         num_bits: e4m3
@@ -33,35 +36,3 @@ quantize:
       enable: true
       cfg:
         num_bits: e4m3
-    - quantizer_name: '*block_sparse_moe.gate*'
-      enable: false
-    - quantizer_name: '*linear_attn.conv1d*'
-      enable: false
-    - quantizer_name: '*lm_head*'
-      enable: false
-    - quantizer_name: '*mixer.conv1d*'
-      enable: false
-    - quantizer_name: '*mlp.gate.*'
-      enable: false
-    - quantizer_name: '*mlp.shared_expert_gate.*'
-      enable: false
-    - quantizer_name: '*output_layer*'
-      enable: false
-    - quantizer_name: '*proj_out.*'
-      enable: false
-    - quantizer_name: '*router*'
-      enable: false
-    - quantizer_name: 'output.*'
-      enable: false
-    - parent_class: 'nn.BatchNorm1d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm2d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm3d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.LeakyReLU'
-      quantizer_name: '*'
-      enable: false

--- a/modelopt_recipes/general/ptq/nvfp4_default-fp8_kv.yaml
+++ b/modelopt_recipes/general/ptq/nvfp4_default-fp8_kv.yaml
@@ -12,15 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 metadata:
   recipe_type: ptq
   description: NVFP4 W4A4, FP8 KV cache, max calibration.
 quantize:
   algorithm: max
+  disable_sensitive_layers: true
   quant_cfg:
-    - quantizer_name: '*'
-      enable: false
     - quantizer_name: '*weight_quantizer'
       enable: true
       cfg:
@@ -41,35 +39,3 @@ quantize:
       enable: true
       cfg:
         num_bits: e4m3
-    - quantizer_name: '*block_sparse_moe.gate*'
-      enable: false
-    - quantizer_name: '*linear_attn.conv1d*'
-      enable: false
-    - quantizer_name: '*lm_head*'
-      enable: false
-    - quantizer_name: '*mixer.conv1d*'
-      enable: false
-    - quantizer_name: '*mlp.gate.*'
-      enable: false
-    - quantizer_name: '*mlp.shared_expert_gate.*'
-      enable: false
-    - quantizer_name: '*output_layer*'
-      enable: false
-    - quantizer_name: '*proj_out.*'
-      enable: false
-    - quantizer_name: '*router*'
-      enable: false
-    - quantizer_name: 'output.*'
-      enable: false
-    - parent_class: 'nn.BatchNorm1d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm2d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm3d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.LeakyReLU'
-      quantizer_name: '*'
-      enable: false

--- a/modelopt_recipes/general/ptq/nvfp4_default-none_kv_gptq.yaml
+++ b/modelopt_recipes/general/ptq/nvfp4_default-none_kv_gptq.yaml
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 metadata:
   recipe_type: ptq
   description: NVFP4 weight and activation (W4A4), gptq layerwise calibration.
@@ -21,9 +20,8 @@ quantize:
     method: gptq
     layerwise: true
     layerwise_checkpoint_dir: output/layerwise_ckpts/
+  disable_sensitive_layers: true
   quant_cfg:
-    - quantizer_name: '*'
-      enable: false
     - quantizer_name: '*weight_quantizer'
       cfg:
         block_sizes:
@@ -38,37 +36,7 @@ quantize:
           type: dynamic
           scale_bits: e4m3
         num_bits: e2m1
+    # KV-cache quantization is intentionally disabled in this recipe (overrides any
+    # downstream FP8/NVFP4 KV merge).
     - quantizer_name: '*[kv]_bmm_quantizer'
-      enable: false
-    - quantizer_name: '*block_sparse_moe.gate*'
-      enable: false
-    - quantizer_name: '*linear_attn.conv1d*'
-      enable: false
-    - quantizer_name: '*lm_head*'
-      enable: false
-    - quantizer_name: '*mixer.conv1d*'
-      enable: false
-    - quantizer_name: '*mlp.gate.*'
-      enable: false
-    - quantizer_name: '*mlp.shared_expert_gate.*'
-      enable: false
-    - quantizer_name: '*output_layer*'
-      enable: false
-    - quantizer_name: '*proj_out.*'
-      enable: false
-    - quantizer_name: '*router*'
-      enable: false
-    - quantizer_name: 'output.*'
-      enable: false
-    - parent_class: 'nn.BatchNorm1d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm2d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm3d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.LeakyReLU'
-      quantizer_name: '*'
       enable: false

--- a/modelopt_recipes/general/ptq/nvfp4_experts_only-fp8_kv.yaml
+++ b/modelopt_recipes/general/ptq/nvfp4_experts_only-fp8_kv.yaml
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 metadata:
   recipe_type: ptq
   description: NVFP4 static weight and dynamic activation for expert layers only (W4A4), FP8 KV cache, max layerwise calibration.
@@ -21,9 +20,8 @@ quantize:
     method: max
     # Max calibration is fast and does not typically need checkpointing.
     layerwise: true
+  disable_sensitive_layers: true
   quant_cfg:
-    - quantizer_name: '*'
-      enable: false
     - quantizer_name: '*mlp.experts*weight_quantizer'
       enable: true
       cfg:
@@ -60,35 +58,3 @@ quantize:
       enable: true
       cfg:
         num_bits: e4m3
-    - quantizer_name: '*block_sparse_moe.gate*'
-      enable: false
-    - quantizer_name: '*linear_attn.conv1d*'
-      enable: false
-    - quantizer_name: '*lm_head*'
-      enable: false
-    - quantizer_name: '*mixer.conv1d*'
-      enable: false
-    - quantizer_name: '*mlp.gate.*'
-      enable: false
-    - quantizer_name: '*mlp.shared_expert_gate.*'
-      enable: false
-    - quantizer_name: '*output_layer*'
-      enable: false
-    - quantizer_name: '*proj_out.*'
-      enable: false
-    - quantizer_name: '*router*'
-      enable: false
-    - quantizer_name: 'output.*'
-      enable: false
-    - parent_class: 'nn.BatchNorm1d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm2d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm3d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.LeakyReLU'
-      quantizer_name: '*'
-      enable: false

--- a/modelopt_recipes/general/ptq/nvfp4_mlp_only-fp8_kv.yaml
+++ b/modelopt_recipes/general/ptq/nvfp4_mlp_only-fp8_kv.yaml
@@ -12,15 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 metadata:
   recipe_type: ptq
   description: NVFP4 static weight and dynamic activation for all linear layers (W4A4), FP8 KV cache, max calibration.
 quantize:
   algorithm: max
+  disable_sensitive_layers: true
   quant_cfg:
-    - quantizer_name: '*'
-      enable: false
     - quantizer_name: '*mlp*weight_quantizer'
       enable: true
       cfg:
@@ -57,35 +55,3 @@ quantize:
       enable: true
       cfg:
         num_bits: e4m3
-    - quantizer_name: '*block_sparse_moe.gate*'
-      enable: false
-    - quantizer_name: '*linear_attn.conv1d*'
-      enable: false
-    - quantizer_name: '*lm_head*'
-      enable: false
-    - quantizer_name: '*mixer.conv1d*'
-      enable: false
-    - quantizer_name: '*mlp.gate.*'
-      enable: false
-    - quantizer_name: '*mlp.shared_expert_gate.*'
-      enable: false
-    - quantizer_name: '*output_layer*'
-      enable: false
-    - quantizer_name: '*proj_out.*'
-      enable: false
-    - quantizer_name: '*router*'
-      enable: false
-    - quantizer_name: 'output.*'
-      enable: false
-    - parent_class: 'nn.BatchNorm1d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm2d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm3d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.LeakyReLU'
-      quantizer_name: '*'
-      enable: false

--- a/modelopt_recipes/general/ptq/nvfp4_omlp_only-fp8_kv.yaml
+++ b/modelopt_recipes/general/ptq/nvfp4_omlp_only-fp8_kv.yaml
@@ -12,15 +12,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 metadata:
   recipe_type: ptq
   description: NVFP4 static weight and dynamic activation for all linear layers including output projections, FP8 KV cache, max calibration.
 quantize:
   algorithm: max
+  disable_sensitive_layers: true
   quant_cfg:
-    - quantizer_name: '*'
-      enable: false
     - quantizer_name: '*mlp*weight_quantizer'
       enable: true
       cfg:
@@ -73,35 +71,3 @@ quantize:
       enable: true
       cfg:
         num_bits: e4m3
-    - quantizer_name: '*block_sparse_moe.gate*'
-      enable: false
-    - quantizer_name: '*linear_attn.conv1d*'
-      enable: false
-    - quantizer_name: '*lm_head*'
-      enable: false
-    - quantizer_name: '*mixer.conv1d*'
-      enable: false
-    - quantizer_name: '*mlp.gate.*'
-      enable: false
-    - quantizer_name: '*mlp.shared_expert_gate.*'
-      enable: false
-    - quantizer_name: '*output_layer*'
-      enable: false
-    - quantizer_name: '*proj_out.*'
-      enable: false
-    - quantizer_name: '*router*'
-      enable: false
-    - quantizer_name: 'output.*'
-      enable: false
-    - parent_class: 'nn.BatchNorm1d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm2d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm3d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.LeakyReLU'
-      quantizer_name: '*'
-      enable: false

--- a/tests/unit/recipe/test_loader.py
+++ b/tests/unit/recipe/test_loader.py
@@ -109,6 +109,8 @@ _BUILTIN_PTQ_RECIPES = [
     "general/ptq/nvfp4_default-fp8_kv",
     "general/ptq/nvfp4_mlp_only-fp8_kv",
     "general/ptq/nvfp4_omlp_only-fp8_kv",
+    "general/ptq/nvfp4_experts_only-fp8_kv",
+    "general/ptq/nvfp4_default-none_kv_gptq",
 ]
 
 
@@ -203,7 +205,15 @@ def test_load_recipe_dir_missing_quantize_raises(tmp_path):
     ],
 )
 def test_general_ptq_yaml_matches_config_dicts(yaml_path, model_cfg_name, kv_cfg_name):
-    """Each general/ptq YAML's quant_cfg list matches the merged Python config dicts."""
+    """Each general/ptq YAML's expanded quant_cfg matches the merged Python config dicts.
+
+    The YAML side is loaded through ``load_recipe`` so that
+    ``QuantizeConfig.disable_sensitive_layers`` triggers the same disable-all-prepend +
+    sensitive-layer-suffix expansion that ``mtq.quantize`` will see at runtime. The
+    Python side is the historical hand-built form (``_base_disable_all`` + user entries +
+    ``_default_disabled_quantizer_cfg``) which has the same shape post-normalize, so the
+    two should be set-equivalent.
+    """
     import json
 
     import modelopt.torch.quantization.config as qcfg
@@ -211,7 +221,7 @@ def test_general_ptq_yaml_matches_config_dicts(yaml_path, model_cfg_name, kv_cfg
 
     model_cfg = getattr(qcfg, model_cfg_name)
     kv_cfg = getattr(qcfg, kv_cfg_name)
-    yaml_data = load_config(yaml_path)
+    recipe = load_recipe(yaml_path)
 
     def _normalize_fpx(val):
         """Normalize FPx representations to a canonical ``[E, M]`` list.
@@ -245,7 +255,9 @@ def test_general_ptq_yaml_matches_config_dicts(yaml_path, model_cfg_name, kv_cfg
         return json.dumps(entry, sort_keys=True, default=str)
 
     python_entries = _normalize_entries(model_cfg["quant_cfg"] + kv_cfg["quant_cfg"])
-    yaml_entries = _normalize_entries(yaml_data["quantize"]["quant_cfg"])
+    yaml_entries = _normalize_entries(recipe.quantize.quant_cfg)
 
     assert sorted(python_entries, key=_sort_key) == sorted(yaml_entries, key=_sort_key)
-    assert model_cfg["algorithm"] == yaml_data["quantize"]["algorithm"]
+    assert model_cfg["algorithm"] == recipe.quantize.algorithm
+    # disable_sensitive_layers is consumed by the model_validator and reset to None.
+    assert recipe.quantize.disable_sensitive_layers is None

--- a/tests/unit/torch/quantization/test_config_validation.py
+++ b/tests/unit/torch/quantization/test_config_validation.py
@@ -26,6 +26,9 @@ from modelopt.torch.quantization.config import (
     NVFP4_DEFAULT_CFG,
     W4A8_AWQ_BETA_CFG,
     QuantizeConfig,
+    _base_disable_all,
+    _default_disabled_quantizer_cfg,
+    expand_quant_cfg,
     find_quant_cfg_entry_by_path,
     need_calibration,
     normalize_quant_cfg_list,
@@ -525,3 +528,119 @@ class TestQuantizeConfigValidators:
             algorithm="max",
         )
         assert len(cfg.quant_cfg) == 2
+
+
+class TestExpandQuantCfg:
+    """Tests for ``expand_quant_cfg`` and the ``disable_sensitive_layers`` field."""
+
+    USER_ENTRIES = [
+        {"quantizer_name": "*weight_quantizer", "cfg": {"num_bits": (4, 3), "axis": None}},
+        {"quantizer_name": "*input_quantizer", "cfg": {"num_bits": (4, 3), "axis": None}},
+    ]
+
+    def test_expand_true_prepends_disable_all_and_appends_defaults(self):
+        out = expand_quant_cfg(normalize_quant_cfg_list(self.USER_ENTRIES), True)
+        assert out[0] == {"quantizer_name": "*", "enable": False, "cfg": None}
+        # User entries follow the disable-all
+        assert out[1]["quantizer_name"] == "*weight_quantizer"
+        assert out[2]["quantizer_name"] == "*input_quantizer"
+        # Sensitive disables follow user entries
+        names = {e["quantizer_name"] for e in out[3:]}
+        assert "*lm_head*" in names
+        assert "*router*" in names
+        assert len(out) == len(_base_disable_all) + 2 + len(_default_disabled_quantizer_cfg)
+
+    def test_expand_false_prepends_disable_all_only(self):
+        out = expand_quant_cfg(normalize_quant_cfg_list(self.USER_ENTRIES), False)
+        assert out[0] == {"quantizer_name": "*", "enable": False, "cfg": None}
+        assert len(out) == 1 + 2  # only the prepend, no sensitive-disabled suffix
+
+    def test_expand_list_appends_custom_disables(self):
+        out = expand_quant_cfg(
+            normalize_quant_cfg_list(self.USER_ENTRIES), ["*custom*", "*another*"]
+        )
+        assert {"quantizer_name": "*custom*", "enable": False, "cfg": None} in out
+        assert {"quantizer_name": "*another*", "enable": False, "cfg": None} in out
+        # No ModelOpt sensitive-defaults appended in list mode.
+        assert not any(e.get("quantizer_name") == "*lm_head*" for e in out)
+        assert len(out) == 1 + 2 + 2
+
+    def test_expand_invalid_type_raises(self):
+        with pytest.raises(TypeError, match="disable_sensitive_layers must be"):
+            expand_quant_cfg(normalize_quant_cfg_list(self.USER_ENTRIES), 42)  # type: ignore[arg-type]
+
+    def test_expand_returns_canonical_normalized_entries(self):
+        """Every entry returned by expand_quant_cfg has both ``enable`` and ``cfg`` keys."""
+        out = expand_quant_cfg(normalize_quant_cfg_list(self.USER_ENTRIES), True)
+        for entry in out:
+            assert "enable" in entry
+            assert "cfg" in entry
+            assert "quantizer_name" in entry
+
+
+class TestQuantizeConfigDisableSensitiveLayers:
+    """Tests for the ``disable_sensitive_layers`` field on ``QuantizeConfig``."""
+
+    USER_ENTRIES = [
+        {"quantizer_name": "*weight_quantizer", "cfg": {"num_bits": (4, 3), "axis": None}},
+        {"quantizer_name": "*input_quantizer", "cfg": {"num_bits": (4, 3), "axis": None}},
+    ]
+
+    def test_default_passthrough(self):
+        """When unset, quant_cfg is passed through verbatim (backward compat)."""
+        cfg = QuantizeConfig(quant_cfg=list(self.USER_ENTRIES), algorithm="max")
+        assert cfg.disable_sensitive_layers is None
+        assert len(cfg.quant_cfg) == 2
+
+    def test_true_matches_legacy_fp8_default(self):
+        """``disable_sensitive_layers=True`` reproduces FP8_DEFAULT_CFG semantics.
+
+        Compares ``quant_cfg`` order-sensitively: ``set_quantizer_by_cfg`` applies
+        entries in list order with last-match-wins per quantizer, so the bracket
+        ordering (disable-all → user entries → sensitive-layer disables) is
+        semantically meaningful and must be preserved exactly.
+        """
+        legacy = QuantizeConfig(**FP8_DEFAULT_CFG)
+        managed = QuantizeConfig(
+            quant_cfg=list(self.USER_ENTRIES),
+            algorithm="max",
+            disable_sensitive_layers=True,
+        )
+        # Field is consumed by the model_validator and reset to None.
+        assert managed.disable_sensitive_layers is None
+        assert legacy.quant_cfg == managed.quant_cfg
+
+    def test_false_only_prepends_disable_all(self):
+        cfg = QuantizeConfig(
+            quant_cfg=list(self.USER_ENTRIES),
+            algorithm="max",
+            disable_sensitive_layers=False,
+        )
+        assert cfg.disable_sensitive_layers is None
+        assert cfg.quant_cfg[0] == {"quantizer_name": "*", "enable": False, "cfg": None}
+        # No lm_head/BatchNorm appended.
+        assert not any(e.get("quantizer_name") == "*lm_head*" for e in cfg.quant_cfg)
+
+    def test_list_appends_custom_patterns(self):
+        cfg = QuantizeConfig(
+            quant_cfg=list(self.USER_ENTRIES),
+            algorithm="max",
+            disable_sensitive_layers=["*custom*"],
+        )
+        assert any(
+            e.get("quantizer_name") == "*custom*" and e.get("enable") is False
+            for e in cfg.quant_cfg
+        )
+
+    def test_round_trip_through_model_dump_is_idempotent(self):
+        """A round-trip through ``model_dump()`` -> ``QuantizeConfig(**dump)`` must not double-expand."""
+        cfg = QuantizeConfig(
+            quant_cfg=list(self.USER_ENTRIES),
+            algorithm="max",
+            disable_sensitive_layers=True,
+        )
+        dump = cfg.model_dump()
+        # The field is dumped (as None now) but re-validation is a no-op since it's None.
+        assert dump.get("disable_sensitive_layers") is None
+        cfg2 = QuantizeConfig(**dump)
+        assert len(cfg2.quant_cfg) == len(cfg.quant_cfg)


### PR DESCRIPTION
### What does this PR do?

Type of change: bug gix <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

Currently we need to add the default disabled quantizers in every yaml, and also for user customized quant recipe. We can replace it with a single arg.

* the quant cfg start from `{quantizer_name: '*', enable: false}` by default.
* adding `disable_sensitive_layers`, which if true, append the default disabled quantizers. It can also be a list of matching  patterns, if user want to customize.
* backward compatibility, if `disable_sensitive_layers` is not set, do nothing to existing config.

### Usage

```yaml
quantize:
  algorithm: max
  disable_sensitive_layers: true     # the added
  quant_cfg:
    - quantizer_name: '*input_quantizer'
      cfg:
        num_bits: e4m3
        axis:
    - quantizer_name: '*weight_quantizer'
      cfg:
        num_bits: e4m3
        axis:
    - quantizer_name: '*[kv]_bmm_quantizer'
      enable: true
      cfg:
        num_bits: e4m3
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `disable_sensitive_layers` configuration option for quantization with three modes: automatic sensitive-layer exclusion, explicit disable-all, or custom exclusion patterns.

* **Documentation**
  * Updated quantization guides with documentation and examples for the new configuration field. Simplified recipe configurations by replacing manual exclusion lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->