### PR TITLE
[NVBug 6061382] Fix PTQ for VLMs with image calibration

### DIFF
--- a/examples/llm_ptq/hf_ptq.py
+++ b/examples/llm_ptq/hf_ptq.py
@@ -487,8 +487,8 @@ def load_model(args: argparse.Namespace):
             device,
             trust_remote_code=args.trust_remote_code,
         )
-    elif is_nemotron_vl_model and args.calib_with_images:
-        # For Nemotron VL image calibration, we need an AutoProcessor to build multimodal inputs.
+    elif args.calib_with_images:
+        # For VLM image calibration, we need an AutoProcessor to build multimodal inputs.
         processor = AutoProcessor.from_pretrained(
             args.pyt_ckpt_path,
             trust_remote_code=args.trust_remote_code,

--- a/modelopt/torch/utils/vlm_dataset_utils.py
+++ b/modelopt/torch/utils/vlm_dataset_utils.py
@@ -457,7 +457,7 @@ def get_vlm_dataset_dataloader(
             "return_tensors": "pt",
             "padding": True,
         }
-        if max_length is not None:
+        if max_length is not None and "images" not in kwargs:
             kwargs.update({"truncation": True, "max_length": max_length})
 
         enc = processor(**kwargs)


### PR DESCRIPTION
### What does this PR do?

This PR fixes PTQ with image claibration for VLMs (NVBug 6061382)

### Usage

```python
python3 examples/llm_ptq/hf_ptq.py --pyt_ckpt_path Qwen/Qwen3-VL-8B-Instruct --qformat fp8 --export_path Qwen3-VL-8B-Instruct-fp8 --trust_remote_code --kv_cache_qformat none --calib_with_images --calib_size 512
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image-text calibration now extends support to additional model architectures when image calibration is enabled.
  * Improved tokenizer truncation handling in multimodal dataset processing to prevent configuration conflicts when image inputs are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->