### PR TITLE
Fix hf_ptq mllama path not honoring --calib_seq flag

### DIFF
--- a/examples/llm_ptq/hf_ptq.py
+++ b/examples/llm_ptq/hf_ptq.py
@@ -262,6 +262,7 @@ def make_calib_dataloader(
             processor=processor,
             batch_size=args.batch_size,
             num_samples=args.calib_size[0],
+            max_length=args.calib_seq,
         )
     elif model_type == "whisper":
         assert processor is not None and isinstance(processor, WhisperProcessor), (


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

`examples/llm_ptq/hf_ptq.py` accepts a `--calib_seq` argument to control the max calibration sample length, but the `mllama` branch of `make_calib_dataloader` never forwarded it to `get_vlm_dataset_dataloader`. As a result, mllama VLM calibration silently used the default `max_length` regardless of what the user passed on the command line.

This complements #1311, which landed the analogous fix for the LLM (`get_dataset_dataloader`) branch. After this PR, every branch of `make_calib_dataloader` that has a length concept honors `--calib_seq`:

| Branch | How `calib_seq` flows |
|---|---|
| `specdec_offline_dataset` | `EagleOfflineDataCollator(train_len=args.calib_seq)` (already correct) |
| `calib_with_images` (VLM) | `get_vlm_dataset_dataloader(..., max_length=args.calib_seq)` (already correct) |
| `mllama` (VLM) | `get_vlm_dataset_dataloader(..., max_length=args.calib_seq)` ← **this PR** |
| `whisper` (speech) | N/A — `get_speech_dataset_dataloader` has no length parameter; audio is fixed-shape 80×3000 mel features |
| default (LLM) | `get_dataset_dataloader(..., max_sample_length=args.calib_seq)` (fixed by #1311) |

### Usage

```bash
python examples/llm_ptq/hf_ptq.py \
    --pyt_ckpt_path <mllama-model> \
    --qformat fp8 \
    --calib_seq 2048
```

### Testing

Validated on Qwen3-8B using a two-part script:

1. **Library contract**: directly called `get_dataset_dataloader` with `max_sample_length ∈ {64, 128, 512}` and confirmed every batch had `input_ids.shape[1] ≤ max_sample_length`.
2. **`hf_ptq.py` plumbing**: invoked `make_calib_dataloader` with `args.calib_seq ∈ {128, 1024}` and a mocked inner dataloader — confirmed the spy received `max_sample_length=args.calib_seq` (LLM path) and `max_length=args.calib_seq` (VLM path) verbatim.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ❌ (single-line fix to an example script; no unit test harness for this path)
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A

### Additional Information

Single-line fix in `examples/llm_ptq/hf_ptq.py::make_calib_dataloader` (mllama branch). Builds on #1311.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Calibration dataloader now correctly respects the configured sequence length during calibration runs, ensuring input sequences are truncated/padded to the specified length. This improves consistency and reliability of calibration and quantization results for applicable model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->