### PR TITLE
[6110209] Patch zero FP16 scales in INT4_AWQ ONNX export

### DIFF
--- a/modelopt/onnx/quantization/qdq_utils.py
+++ b/modelopt/onnx/quantization/qdq_utils.py
@@ -1011,14 +1011,37 @@ def replace_zero_scale_with_smallest_nonzero(onnx_model: onnx.ModelProto) -> onn
     """Replace zero scale values with smallest nonzero fp16 value in the ONNX model."""
     graph = onnx_model.graph
     fp16_smallest_nonzero = np.float16(6e-08)
-    scale_nodes = [node.input[1] for node in graph.node if node.op_type == "QuantizeLinear"]
+    qdq_op_types = {
+        "QuantizeLinear",
+        "DequantizeLinear",
+        "TRT_INT4QuantizeLinear",
+        "TRT_INT4DequantizeLinear",
+    }
+    scale_tensor_names = {
+        node.input[1]
+        for node in graph.node
+        if node.op_type in qdq_op_types and len(node.input) >= 2
+    }
+    # Scales stored as graph initializers (e.g. INT4_AWQ / TRT_INT4DequantizeLinear exports).
+    for init in graph.initializer:
+        if init.name in scale_tensor_names:
+            tensor = numpy_helper.to_array(init)
+            if tensor.dtype.kind == "f":
+                new_tensor = np.where(tensor == 0, fp16_smallest_nonzero, tensor).astype(
+                    tensor.dtype
+                )
+                init.CopyFrom(numpy_helper.from_array(new_tensor, init.name))
+    # Scales emitted by Constant nodes (legacy QDQ export path).
     for node in graph.node:
-        if node.op_type == "Constant" and node.output[0] in scale_nodes:
+        if node.op_type == "Constant" and node.output[0] in scale_tensor_names:
             for attr in node.attribute:
                 if attr.name == "value":
                     tensor = numpy_helper.to_array(attr.t)
-                    new_tensor = np.where(tensor == 0, fp16_smallest_nonzero, tensor)
-                    attr.t.CopyFrom(numpy_helper.from_array(new_tensor, attr.t.name))
+                    if tensor.dtype.kind == "f":
+                        new_tensor = np.where(tensor == 0, fp16_smallest_nonzero, tensor).astype(
+                            tensor.dtype
+                        )
+                        attr.t.CopyFrom(numpy_helper.from_array(new_tensor, attr.t.name))
     return onnx_model
 
 

--- a/tests/unit/onnx/quantization/test_qdq_utils.py
+++ b/tests/unit/onnx/quantization/test_qdq_utils.py
@@ -1021,3 +1021,90 @@ class TestColumnMajorTransformation:
 
         print(f"transB flipped: 1 -> {trans_b_value}")
         print(f"Transpose nodes: {len(transpose_nodes)}")
+
+
+def _build_model_with_zero_scale_initializer(dq_op_type: str):
+    """Build an ONNX model whose scale initializer feeds a (Quantize|Dequantize)Linear node.
+
+    Mirrors the INT4_AWQ failure mode from NVBug 6110209: scales live in graph initializers
+    (not Constant nodes) and feed DequantizeLinear (default or trt:: domain) consumers.
+    """
+    weight_data = np.random.randint(-8, 8, size=(6, 8), dtype=np.int8)
+    weight_tensor = numpy_helper.from_array(weight_data, "weight")
+
+    scale_data = np.array([1e-3, 0.0, 5e-4, 0.0, 0.0, 2e-3], dtype=np.float16).reshape(6, 1)
+    scale_tensor = numpy_helper.from_array(scale_data, "scale")
+
+    input_tensor = helper.make_tensor_value_info("input", TensorProto.FLOAT16, [None, 6])
+    dq_node = helper.make_node(
+        dq_op_type, inputs=["weight", "scale"], outputs=["dq_output"], name="weight_dq"
+    )
+    matmul_node = helper.make_node(
+        "MatMul", inputs=["input", "dq_output"], outputs=["output"], name="matmul"
+    )
+    graph = helper.make_graph(
+        nodes=[dq_node, matmul_node],
+        name="test_graph",
+        inputs=[input_tensor],
+        outputs=[helper.make_tensor_value_info("output", TensorProto.FLOAT16, [None, 8])],
+        initializer=[weight_tensor, scale_tensor],
+    )
+    return helper.make_model(graph)
+
+
+class TestReplaceZeroScaleWithSmallestNonzero:
+    """Regression tests for ``replace_zero_scale_with_smallest_nonzero`` (NVBug 6110209)."""
+
+    @pytest.mark.parametrize("dq_op_type", ["DequantizeLinear", "TRT_INT4DequantizeLinear"])
+    def test_zero_scale_initializer_fed_to_dq_is_patched(self, dq_op_type):
+        from modelopt.onnx.quantization.qdq_utils import replace_zero_scale_with_smallest_nonzero
+
+        model = _build_model_with_zero_scale_initializer(dq_op_type)
+        scale_before = numpy_helper.to_array(
+            next(init for init in model.graph.initializer if init.name == "scale")
+        )
+        assert (scale_before == 0).any(), "fixture must contain zeros to exercise the fix"
+
+        patched = replace_zero_scale_with_smallest_nonzero(model)
+
+        scale_after_init = next(init for init in patched.graph.initializer if init.name == "scale")
+        scale_after = numpy_helper.to_array(scale_after_init)
+        assert not (scale_after == 0).any()
+        assert (scale_after > 0).all()
+        assert scale_after_init.data_type == TensorProto.FLOAT16
+
+    def test_constant_node_scale_path_still_patched(self):
+        """Legacy Constant-node QDQ path must continue to be patched."""
+        from modelopt.onnx.quantization.qdq_utils import replace_zero_scale_with_smallest_nonzero
+
+        scale_data = np.array([1e-3, 0.0, 2e-3], dtype=np.float16)
+        scale_const = helper.make_node(
+            "Constant",
+            inputs=[],
+            outputs=["scale_out"],
+            value=numpy_helper.from_array(scale_data),
+            name="scale_constant",
+        )
+        input_tensor = helper.make_tensor_value_info("input", TensorProto.FLOAT, [3])
+        q_node = helper.make_node(
+            "QuantizeLinear",
+            inputs=["input", "scale_out"],
+            outputs=["q_output"],
+            name="q",
+        )
+        graph = helper.make_graph(
+            nodes=[scale_const, q_node],
+            name="test_graph",
+            inputs=[input_tensor],
+            outputs=[helper.make_tensor_value_info("q_output", TensorProto.INT8, [3])],
+            initializer=[],
+        )
+        model = helper.make_model(graph)
+
+        patched = replace_zero_scale_with_smallest_nonzero(model)
+
+        const = next(n for n in patched.graph.node if n.op_type == "Constant")
+        value_attr = next(a for a in const.attribute if a.name == "value")
+        scale_arr = numpy_helper.to_array(value_attr.t)
+        assert not (scale_arr == 0).any()
+        assert (scale_arr > 0).all()


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fix `replace_zero_scale_with_smallest_nonzero()` in `modelopt/onnx/quantization/qdq_utils.py` so the FP16-scale sanitizer actually runs for INT4_AWQ ONNX exports.

The function is supposed to ensure all FP16 scales are strictly positive before the model reaches TensorRT, since `trtexec --stronglyTyped` asserts `scaleAllPositive`. It had two latent bugs that made it a complete no-op for INT4_AWQ:

1. It only collected scales from `QuantizeLinear` consumers — but INT4_AWQ exports use `DequantizeLinear` (default domain) and `TRT_INT4DequantizeLinear` (trt:: domain). There are zero `QuantizeLinear` nodes in such graphs, so the collected set was empty.
2. It only patched scales emitted by `Constant` nodes — but INT4_AWQ stores scales as graph initializers.

When the FP32→FP16 cast in `_convert_fp32_init_to_fp16()` underflowed small amax values to `0.0` (FP16 min subnormal is 5.96e-8), those zeros sailed through into the exported ONNX. TRT then rejected the model with:

```
Assertion failed: (scaleAllPositive || allowNegativeScale): Scale coefficients must all be positive
```

This PR extends the sanitizer to:
- Walk `QuantizeLinear` / `DequantizeLinear` / `TRT_INT4QuantizeLinear` / `TRT_INT4DequantizeLinear` nodes when collecting scale tensor names.
- Patch zero entries in float-typed graph initializers in addition to `Constant`-node values, preserving the original dtype.

Files modified:
- `modelopt/onnx/quantization/qdq_utils.py` — fix.
- `tests/unit/onnx/quantization/test_qdq_utils.py` — `TestReplaceZeroScaleWithSmallestNonzero` regression tests.
- `CHANGELOG.rst` — bug-fix entry under 0.45.

### Usage

```bash
# Repro that previously failed and now succeeds:
python torch_quant_to_onnx.py \
    --quantize_mode=int4_awq \
    --timm_model_name=vit_base_patch16_224 \
    --onnx_save_path=/tmp/vit_base_patch16_224.int4_awq.onnx \
    --calibration_data_size=32

trtexec --onnx=/tmp/vit_base_patch16_224.int4_awq.onnx --stronglyTyped --skipInference
```

### Testing

- New tests pass: `pytest tests/unit/onnx/quantization/test_qdq_utils.py::TestReplaceZeroScaleWithSmallestNonzero -v` (3 passed).
- Full file: `pytest tests/unit/onnx/quantization/test_qdq_utils.py` (25 passed).
- Broader sanity: `pytest tests/unit/onnx/quantization/` (288 passed).
- Smoke test on a synthetic model with explicit zero scales: 3 zeros → 0 zeros, all positive, FP16 dtype preserved.
- `pre-commit run --files <changed>` clean.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅

### Additional Information

- NVBug: 6110209
- Reproduces with `nvidia-modelopt==0.44.0rc1`, TensorRT 10.15.1.29, on B200 / H20.
- Root cause introduced when the `TRT_INT4DequantizeLinear` export path was added (PR #575, commit `0a4f0a8b`); that PR didn't update the sanitizer to handle the new node type or scale storage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zero scale values in quantization/dequantization ops (including additional operator variants) are now replaced with the smallest nonzero fp16 scale for matching tensors; replacements preserve the original tensor data type and handle scales provided via initializers or constant nodes.

* **Tests**
  * Added regression tests covering initializer- and constant-backed scale tensors across multiple operator configurations to ensure zeros are eliminated and dtype is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->