### PR TITLE
Fix regex capture for Megatron KD PP layer renaming

### DIFF
--- a/modelopt/torch/distill/plugins/megatron.py
+++ b/modelopt/torch/distill/plugins/megatron.py
@@ -172,7 +172,7 @@ def _adjust_layer_index_for_pp(submodule_name, model_cfg):
     if new_layer_idx < 0:
         raise ValueError(f"Layer {submodule_name} does not fall on final PP rank.")
 
-    new_submodule_name = submodule_name.replace(match.group(0), str(new_layer_idx))
+    new_submodule_name = submodule_name.replace(f".{match.group(0)}", f".{new_layer_idx}")
     if parallel_state.get_tensor_and_context_parallel_rank() == 0:
         logger.info(
             f'Distillation: Renamed layer "{submodule_name}" on final PP rank to "{new_submodule_name}"'

--- a/modelopt/torch/distill/plugins/megatron.py
+++ b/modelopt/torch/distill/plugins/megatron.py
@@ -163,7 +163,7 @@ def setup_distillation_config(
 
 def _adjust_layer_index_for_pp(submodule_name, model_cfg):
     """Adjust any sequence-based layer indices found in a submodule name for Pipeline Parallelism."""
-    match = re.search(r"(?<=\.)\d+(?=\.)", submodule_name)
+    match = re.search(r"(?<=\.)\d+(?=\.|$)", submodule_name)
     if not match:
         return submodule_name
 


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Previously the regex we had looked for a dot after the integer layer number, but it might not exist sometimes.

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of pipeline-parallel layer indices in model submodule names so numeric layer identifiers at the end of names are recognized and safely replaced. This reduces accidental renaming of other numeric sequences and improves compatibility with varied naming conventions in distillation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->