### PR TITLE
[6034518] Remove return statement preventing remote auto tuning

### DIFF
--- a/modelopt/onnx/quantization/autotune/benchmark.py
+++ b/modelopt/onnx/quantization/autotune/benchmark.py
@@ -220,7 +220,6 @@ class TrtExecBenchmark(Benchmark):
                         "Remote autotuning requires '--skipInference' to be set. Adding it to trtexec arguments."
                     )
                     self.trtexec_args.append("--skipInference")
-                return
             except ImportError:
                 self.logger.warning(
                     "Remote autotuning is not supported with TensorRT version < 10.15. "


### PR DESCRIPTION
### What does this PR do?

Remove return statement from the code checking remote auto tuning config arguments since that results in skipping adding the actual remote tuning config to the trtexec cmd.

**Root cause**: The necessary flags do not get added to `self._base_cmd.extend(trtexec_args)` when remote autotuning is enabled.

**Before fix**:
```
['trtexec', '--avgRuns=100', '--iterations=100', '--warmUp=50', '--stronglyTyped', \
    '--saveEngine=engine.trt', '--timingCacheFile=trtexec_timing.cache', \
    '--onnx=baseline.onnx']
```
**After fix**:
```
['trtexec', '--avgRuns=100', '--iterations=100', '--warmUp=50', '--stronglyTyped', \
    '--saveEngine=engine.trt', '--timingCacheFile=trtexec_timing.cache', \
    '--remoteAutoTuningConfig=$CONFIG', '--safe', '--skipInference', \
    '--onnx=baseline.onnx']
```
Notice that the remote autotuning and related flags are now included in the `trtexec` command.

**Related PR**: https://github.com/NVIDIA/Model-Optimizer/pull/1259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where remote autotuning configuration arguments were not being properly included in benchmark commands, ensuring all remote autotuning settings are now correctly applied during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->