### PR TITLE
fix: include medusa in data_module assignment in main.py

### DIFF
--- a/examples/speculative_decoding/main.py
+++ b/examples/speculative_decoding/main.py
@@ -341,7 +341,7 @@ def train():
 
     print_rank_0("Loading dataset...")
     is_dflash = training_args.mode == "dflash"
-    if training_args.mode in ("eagle3", "dflash"):
+    if training_args.mode in ("eagle3", "medusa", "dflash"):
         data_module = make_speculative_data_module(
             tokenizer,
             data_args,


### PR DESCRIPTION
## Problem
When `training.mode == "medusa"` is used in `main.py`, the `data_module` variable is never assigned because line 344 only covered `eagle3` and `dflash` modes. This causes an `UnboundLocalError` when the trainer is constructed with `**data_module`.

Fixes OMNIML-4147

## Fix
Add `"medusa"` to the `training_args.mode in ("eagle3", "dflash")` condition so `data_module` is correctly populated for medusa training.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed speculative decoding example to properly handle "medusa" mode alongside existing "eagle3" and "dflash" modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->