### PR TITLE
fix: guard against None chat_template in _post_process_chat_template

### DIFF
--- a/modelopt/torch/utils/plugins/transformers_dataset.py
+++ b/modelopt/torch/utils/plugins/transformers_dataset.py
@@ -181,6 +181,8 @@ class LanguageDataCollator:
     def _post_process_chat_template(self):
         # [WAR]: For DeepSeek-V3/R1 tokenizer, we modify the chat_template such that the <think>
         # tokens are preserved for supervised learning.
+        if self.tokenizer.chat_template is None:
+            return
         self.tokenizer.chat_template = self.tokenizer.chat_template.replace(
             REMOVE_THINK_CHAT_TEMPLATE, ""
         )


### PR DESCRIPTION
## Problem
When training with a model that has no `chat_template` in its tokenizer (e.g. base Llama-3.2 models), `_post_process_chat_template()` crashes:
```
AttributeError: 'NoneType' object has no attribute 'replace'
```
The DeepSeek WAR at the top of `_post_process_chat_template` called `.replace()` directly on `self.tokenizer.chat_template` without checking for `None` first.

Fixes NVBug 6120958

## Fix
Add an early return when `chat_template is None`. The existing check at line 164 (`if self.tokenizer.chat_template is None: raise ValueError`) still provides a clear error message if no valid template is available after post-processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in chat template processing that occurred when a chat template configuration was not set, improving system stability and reliability during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->