### PR TITLE
Add unit test for checking any leak of temporary augmented onnx files, on exception during ONNX INT4 AWQ quantization

### DIFF
--- a/tests/unit/onnx/quantization/test_quantize_zint4.py
+++ b/tests/unit/onnx/quantization/test_quantize_zint4.py
@@ -14,11 +14,13 @@
 # limitations under the License.
 
 import os
+import tempfile as _tempfile
 from collections.abc import Sequence
 
 import numpy as np
 import onnx
 import onnx_graphsurgeon as gs
+import pytest
 from _test_utils.onnx.lib_test_models import find_init
 
 import modelopt.onnx.quantization as moq
@@ -225,3 +227,57 @@ def test_int4_gather(tmp_path):
     )
 
     # Ensure above tests pass.
+
+
+@pytest.mark.parametrize("calibration_method", ["awq_lite", "awq_clip"])
+@pytest.mark.parametrize("use_external_data_format", [True, False])
+def test_awq_no_temp_file_leak(tmp_path, monkeypatch, calibration_method, use_external_data_format):
+    """Test that tmp*.onnx and tmp*.onnx_data are written to the
+    system temp directory must be removed even when quantization fails mid-run.
+
+    Simulates the real-world failure window (OOM, bad EP, driver error) by injecting
+    a RuntimeError at ORT session creation — which happens after the augmented ONNX
+    has already been written to disk but before the original cleanup code was reached.
+
+    Thread-safe: tracks the exact paths created by mkstemp during this test rather
+    than glob-snapshotting the temp directory, so parallel test runs cannot interfere.
+    """
+    onnx_path = _matmul_model(
+        w=np.random.rand(288, 16).astype(np.float32),
+        in_shape=(96, 288),
+        out_shape=(96, 16),
+        tmp_path=tmp_path,
+    )
+
+    # Intercept mkstemp to record the exact augmented-model temp path(s) created.
+    created_paths = []
+    real_mkstemp = _tempfile.mkstemp
+
+    def _tracking_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        created_paths.append(path)
+        return fd, path
+
+    monkeypatch.setattr("modelopt.onnx.quantization.int4.tempfile.mkstemp", _tracking_mkstemp)
+
+    def _raise_session_error(*args, **kwargs):
+        raise RuntimeError("injected ORT session failure")
+
+    monkeypatch.setattr(
+        "modelopt.onnx.quantization.int4.create_inference_session",
+        _raise_session_error,
+    )
+
+    with pytest.raises(RuntimeError, match="injected ORT session failure"):
+        quantize_int4(
+            onnx_path,
+            calibration_method=calibration_method,
+            use_external_data_format=use_external_data_format,
+            block_size=8,
+        )
+
+    assert created_paths, "Expected mkstemp to be called but it was not"
+    for augmented_path in created_paths:
+        assert not os.path.exists(augmented_path), f"Leaked: {augmented_path}"
+        if use_external_data_format:
+            assert not os.path.exists(augmented_path + "_data"), f"Leaked: {augmented_path}_data"


### PR DESCRIPTION
### What does this PR do?

Type of change: New unit test

- Adding a unit test for checking whether ONNX INT4 AWQ quantization, on exception, leaks temporary augmented ONNX files it created during quantization process.

- Monkey patches create-inference-session to raise / simulate exception. Monkey patches temp-filep-creation utility to track temp files created during quantization process.

- It is a follow up to fix made in to https://github.com/NVIDIA/Model-Optimizer/pull/1359 - [here](https://github.com/NVIDIA/Model-Optimizer/pull/1359#issuecomment-4349540073).

### Testing

- Local test run.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to verify temporary files are properly cleaned up during ONNX quantization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->