### PR TITLE
[specdec_bench] Stratify --num_requests across categories

### DIFF
--- a/examples/specdec_bench/specdec_bench/datasets/speed.py
+++ b/examples/specdec_bench/specdec_bench/datasets/speed.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 # mypy: disable-error-code="index"
-import math
 import random
 import re
 from enum import Enum
@@ -746,35 +745,31 @@ her fear and anger)."""
     def _stratified_select(dataset: "Dataset", n: int) -> "Dataset":
         """Select ``n`` samples uniformly across the ``category`` column.
 
-        When ``category`` is present, each category contributes
-        ``ceil(n / num_categories)`` rows (capped by category size); the
-        result is truncated to exactly ``n`` rows by interleaving the
-        per-category samples round-robin so any further prefix slice
-        remains balanced. Falls back to ``range(n)`` when ``category`` is
-        absent. Indices come from ``range(category_size)`` (not random)
-        so behavior is deterministic.
+        Round-robin across categories until ``n`` rows are collected. The
+        resulting prefix is balanced; once a smaller category is exhausted
+        the remaining categories continue contributing, so exactly ``n``
+        rows are returned whenever ``n`` does not exceed the dataset size.
+        Falls back to ``range(n)`` when ``category`` is absent or there is
+        only one category. Indices come from ``range(category_size)`` (not
+        random) so behavior is deterministic.
         """
         if "category" not in dataset.column_names:
             return dataset.select(range(n))
         cat_to_rows: dict[str, list[int]] = {}
         for i, c in enumerate(dataset["category"]):
             cat_to_rows.setdefault(c, []).append(i)
-        num_cats = len(cat_to_rows)
-        if num_cats <= 1:
+        if len(cat_to_rows) <= 1:
             return dataset.select(range(n))
-        per_cat = math.ceil(n / num_cats)
-        # Take the first ``per_cat`` rows from each category (parquet order
-        # within a category is treated as the canonical sample order).
-        cat_samples = [
-            rows[: min(per_cat, len(rows))] for rows in cat_to_rows.values()
-        ]
-        # Round-robin interleave so the first N rows are balanced.
+        cat_lists = list(cat_to_rows.values())
         interleaved: list[int] = []
-        for i in range(per_cat):
-            for samples in cat_samples:
-                if i < len(samples):
-                    interleaved.append(samples[i])
-        return dataset.select(interleaved[:n])
+        max_len = max(len(c) for c in cat_lists)
+        for i in range(max_len):
+            for c in cat_lists:
+                if i < len(c):
+                    interleaved.append(c[i])
+                    if len(interleaved) == n:
+                        return dataset.select(interleaved)
+        return dataset.select(interleaved)
 
     def _resolve_external_data(
         self, dataset: "Dataset", speed_config: config_type | str

--- a/examples/specdec_bench/specdec_bench/datasets/speed.py
+++ b/examples/specdec_bench/specdec_bench/datasets/speed.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 # mypy: disable-error-code="index"
+import math
 import random
 import re
 from enum import Enum
@@ -737,9 +738,43 @@ her fear and anger)."""
                     }
                     table = table.replace_schema_metadata(new_meta or None)
                 dataset = HFDataset(table)
-        if self.num_samples is not None:
-            dataset = dataset.select(range(self.num_samples))
+        if self.num_samples is not None and self.num_samples < len(dataset):
+            dataset = self._stratified_select(dataset, self.num_samples)
         return dataset
+
+    @staticmethod
+    def _stratified_select(dataset: "Dataset", n: int) -> "Dataset":
+        """Select ``n`` samples uniformly across the ``category`` column.
+
+        When ``category`` is present, each category contributes
+        ``ceil(n / num_categories)`` rows (capped by category size); the
+        result is truncated to exactly ``n`` rows by interleaving the
+        per-category samples round-robin so any further prefix slice
+        remains balanced. Falls back to ``range(n)`` when ``category`` is
+        absent. Indices come from ``range(category_size)`` (not random)
+        so behavior is deterministic.
+        """
+        if "category" not in dataset.column_names:
+            return dataset.select(range(n))
+        cat_to_rows: dict[str, list[int]] = {}
+        for i, c in enumerate(dataset["category"]):
+            cat_to_rows.setdefault(c, []).append(i)
+        num_cats = len(cat_to_rows)
+        if num_cats <= 1:
+            return dataset.select(range(n))
+        per_cat = math.ceil(n / num_cats)
+        # Take the first ``per_cat`` rows from each category (parquet order
+        # within a category is treated as the canonical sample order).
+        cat_samples = [
+            rows[: min(per_cat, len(rows))] for rows in cat_to_rows.values()
+        ]
+        # Round-robin interleave so the first N rows are balanced.
+        interleaved: list[int] = []
+        for i in range(per_cat):
+            for samples in cat_samples:
+                if i < len(samples):
+                    interleaved.append(samples[i])
+        return dataset.select(interleaved[:n])
 
     def _resolve_external_data(
         self, dataset: "Dataset", speed_config: config_type | str


### PR DESCRIPTION
When the dataset has a `category` column with >1 distinct categories and ``--num_requests N`` is below the dataset size, take ceil(N / num_categories) rows from each category and round-robin interleave them so any prefix is balanced. Falls back to the existing ``range(N)`` slice when category metadata is absent or there's only one category.

Fixes a sampling bug where SPEED-Bench parquet files are sorted by category, so e.g. ``--num_requests 64`` on throughput_8k pulls 64 high_entropy prompts and zero from low_entropy / mixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SPEEDBench dataset truncation now performs deterministic, balanced stratified sampling across categories (round-robin) when multiple categories exist and a smaller sample size is requested.
  * Falls back to simple prefix selection when no category or only one category is present, preserving prior behavior in that case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->