### PR TITLE
llm_sparsity: Set warmup_steps 0 instead of 0.0 for transformers 5.x compat

### DIFF
--- a/examples/llm_sparsity/weight_sparsity/launch_finetune.sh
+++ b/examples/llm_sparsity/weight_sparsity/launch_finetune.sh
@@ -88,7 +88,7 @@ CMD="accelerate launch --multi_gpu --mixed_precision bf16 finetune.py \
     --save_total_limit 10 \
     --learning_rate 2e-5 \
     --weight_decay 0.1 \
-    --warmup_steps 0.0 \
+    --warmup_steps 0 \
     --lr_scheduler_type cosine \
     --logging_steps 1 \
     --fsdp 'full_shard auto_wrap' \


### PR DESCRIPTION
Fix for NVBug 6120631 to fix

```
finetune.py: error: argument --warmup_steps/--warmup-steps: invalid int value: '0.0'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected parameter format in finetuning example script for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->