### PR TITLE
Update llm_ptq requirements.txt

### DIFF
--- a/examples/llm_ptq/requirements.txt
+++ b/examples/llm_ptq/requirements.txt
@@ -1,7 +1,5 @@
-compressed-tensors==0.12.0
+compressed-tensors<0.15.0
 fire
 flash-attn>=2.6.0
-rouge_score>=0.1.2
-transformers<5.0
 transformers_stream_generator
 zstandard

--- a/examples/llm_ptq/requirements.txt
+++ b/examples/llm_ptq/requirements.txt
@@ -1,5 +1,6 @@
 compressed-tensors<0.15.0
 fire
 flash-attn>=2.6.0
+transformers<5.0
 transformers_stream_generator
 zstandard


### PR DESCRIPTION
### What does this PR do?

Type of change: Dependency update

compressed_tensors 0.15 is not compatible with our current quant implementation for Kimi K2.5, K2.6 

### Testing
Unittest

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened the `compressed-tensors` dependency constraint to allow a wider range of compatible versions.
  * Removed the `rouge_score` dependency from the example requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->