### PR TITLE
Pin transformers<5.8 to avoid CI failures

### DIFF
--- a/modelopt/torch/__init__.py
+++ b/modelopt/torch/__init__.py
@@ -44,7 +44,9 @@ if _Version(_torch_version) < _Version("2.9"):
 try:
     from transformers import __version__ as _transformers_version
 
-    if _Version(_transformers_version) < _Version("4.56"):
+    if _Version(_transformers_version) < _Version("4.56") or _Version(
+        _transformers_version
+    ) >= _Version("5.8"):
         _warnings.warn(
             f"transformers {_transformers_version} is not tested with current version of modelopt and may cause issues."
             " Please install recommended version with `pip install -U nvidia-modelopt[hf]` if working with HF models.",

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,7 @@ TORCH_VERSIONS = {
 }
 
 TRANSFORMERS_VERSIONS = {
-    "tf_latest": None,
+    "tf_latest": "transformers~=5.7.0",
     "tf_min": "transformers~=4.56.0",
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ hf = [
     "peft>=0.17.0",
     "sentencepiece>=0.2.1",                                                           # Also implicitly used in test_unified_export_megatron, test_vllm_fakequant_megatron_export
     "tiktoken",
-    "transformers>=4.56",                                                             # Should match modelopt/torch/__init__.py and noxfile.py
+    "transformers>=4.56,<5.8",                                                        # Should match modelopt/torch/__init__.py and noxfile.py
     "wonderwords",
 ]
 


### PR DESCRIPTION
Transformers now releases new versions weekly/biweekly causing frequest breaking changes in our tests (We always pin a max version for release branches so thats unaffected). Hence pinning max version to 5.7 in main branch. We will bump transformers monthly / with torch bump instead of always using latest one