### PR TITLE
[CI] Fix Claude GitHub Actions setup

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -68,6 +68,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          # The NVIDIA inference proxy (LiteLLM-based) rejects the
+          # `context_management` field that Claude Code's SDK sends by
+          # default. Disabling experimental betas drops this field so
+          # the proxy accepts the request.
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -68,11 +68,13 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-          # The NVIDIA inference proxy (LiteLLM-based) rejects the
-          # `context_management` field that Claude Code's SDK sends by
-          # default. Disabling experimental betas drops this field so
-          # the proxy accepts the request.
+          # NVIDIA inference proxy (LiteLLM-based) rejects two fields
+          # the Claude Code SDK sends by default. Set per NVIDIA/OSMO's
+          # workflow which has hit and solved both issues:
+          #   - `context_management` → disable experimental betas
+          #   - `cache_control.ephemeral.scope` → disable prompt caching
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,6 +52,7 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -23,6 +23,7 @@ jobs:
       contains(github.event.comment.body, '/claude review') &&
       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -60,11 +60,13 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-          # The NVIDIA inference proxy (LiteLLM-based) rejects the
-          # `context_management` field that Claude Code's SDK sends by
-          # default. Disabling experimental betas drops this field so
-          # the proxy accepts the request.
+          # NVIDIA inference proxy (LiteLLM-based) rejects two fields
+          # the Claude Code SDK sends by default. Set per NVIDIA/OSMO's
+          # workflow which has hit and solved both issues:
+          #   - `context_management` → disable experimental betas
+          #   - `cache_control.ephemeral.scope` → disable prompt caching
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "/claude review"

--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -60,6 +60,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          # The NVIDIA inference proxy (LiteLLM-based) rejects the
+          # `context_management` field that Claude Code's SDK sends by
+          # default. Disabling experimental betas drops this field so
+          # the proxy accepts the request.
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "/claude review"


### PR DESCRIPTION
## Summary

Fix Claude GitHub Actions setup added in #1400 

## Test plan

- [ ] Comment `/claude review` on this PR and verify the deep-review job runs (this is also serving as the smoke-test for the workflows merged in #1400)
- [ ] Comment `@claude any thoughts on this change?` and verify the interactive job runs
- [ ] Check that both jobs respect the new 10-minute cap if they ever stall

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow timeouts for job execution management.
  * Disabled experimental AI beta features in CI runs to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->