### PR TITLE
[CI] Update PR Template with claude review details

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@ Make sure you read and follow the [Security Best Practices](https://github.com/N
 - If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
 - Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
 - Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
+- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->
 
 ### Additional Information
 <!-- E.g. related issue. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ Primarily Python codebase with optional C++/CUDA extensions supporting PyTorch, 
   sign-off line
 - `pre-commit` hooks run on commit — if files are modified by hooks, re-stage and commit again
 - PRs require CODEOWNERS review (auto-assigned based on `.github/CODEOWNERS`)
+- When creating PRs (`gh pr create`), fill in `.github/PULL_REQUEST_TEMPLATE.md` verbatim — do NOT substitute the harness's default `## Summary` / `## Test plan` format
+- For non-trivial PRs, run `/claude review` to get Claude approval before merging (NVIDIA org members can self-trigger; orthogonal to CodeRabbit)
 - After rebasing, always re-run tests locally before pushing
 - All code must follow the security guidelines in `SECURITY.md` — violations are blocked as pre-merge errors
 - For contribution guidelines, commit conventions, and PR requirements, see `CONTRIBUTING.md`


### PR DESCRIPTION
### What does this PR do?

Type of change: documentation

Adds a `Did you get Claude approval on this PR?` bullet to the pre-review checklist in `.github/PULL_REQUEST_TEMPLATE.md`. Also adds two CRITICAL rules to `CLAUDE.md` so Claude Code (and contributors using it) follow the project's PR conventions:

- Use `.github/PULL_REQUEST_TEMPLATE.md` verbatim instead of the harness's default `## Summary` / `## Test plan` format
- Run `/claude review` on non-trivial PRs before merging

Builds on #1400 (workflows added) and #1401 (proxy compat fixes).

### Usage

N/A — documentation only.

### Testing

- Verified the new checklist bullet renders under "Before your PR is *Ready for review*" in this PR's description
- Plan to run `/claude review` on this PR as a smoke-test of the integration on a docs-only diff

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌ (will run after PR is open)

### Additional Information

Related: #1400, #1401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new checklist item asking for Claude approval on pull requests.
  * Added guidance requiring the PR template be used verbatim when creating PRs via the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->