### PR TITLE
fix(launcher): propagate dflash training failures and fast-fail vllm smoke test on missing draft

### DIFF
--- a/tools/launcher/common/specdec/dflash_online_training.sh
+++ b/tools/launcher/common/specdec/dflash_online_training.sh
@@ -45,6 +45,9 @@ export PATH=$PATH:/workspace/.local/bin
 ###################################################################################################
 
 trap 'error_handler $0 $LINENO' ERR
+# Without this, the ERR trap sets FAIL_EXIT=1 but the script still exits 0,
+# masking training failures (e.g. CUDA OOM) as Slurm SUCCEEDED.
+trap 'exit_handler' EXIT
 
 # Auto-detect head node IP for multi-node training
 NUM_NODES=${NUM_NODES:-1}

--- a/tools/launcher/common/specdec/vllm_smoke_test.sh
+++ b/tools/launcher/common/specdec/vllm_smoke_test.sh
@@ -45,6 +45,14 @@ if [ -z "$DRAFT" ] && [ -n "${DRAFT_CKPT_DIR:-}" ]; then
     DRAFT=$(ls -d ${DRAFT_CKPT_DIR}/exported-checkpoint-* 2>/dev/null | sort -t- -k3 -n | tail -1)
     if [ -n "$DRAFT" ]; then
         echo "Auto-detected draft model: ${DRAFT}"
+    else
+        # Fail fast: caller asked for a draft from training output, but training
+        # produced nothing. Without this, we'd fall through to the self-draft
+        # branch and vLLM would reject the config with a confusing
+        # "num_speculative_tokens was provided but without speculative model" error.
+        echo "ERROR: DRAFT_CKPT_DIR=${DRAFT_CKPT_DIR} contains no exported-checkpoint-* directory."
+        echo "       The upstream training task likely failed to produce a draft model."
+        exit 1
     fi
 fi
 METHOD=${SPEC_METHOD:-eagle}


### PR DESCRIPTION
## Summary

Two related fixes to the speculative-decoding launcher scripts that surfaced as silent failures in nmm-sandbox CI pipeline [50509971](https://gitlab-master.nvidia.com/omniml/integration/nmm-sandbox/-/pipelines/50509971):

- **`dflash_online_training.sh`** — install an `EXIT` trap so `error_handler`'s `FAIL_EXIT=1` actually surfaces as a non-zero shell exit. Previously, training failures (e.g. CUDA OOM) emitted `<REPORT>` tags but the script exited 0, and Slurm marked the task `SUCCEEDED`. The orchestrator then proceeded to run dependent tasks against a non-existent checkpoint.

- **`vllm_smoke_test.sh`** — when `DRAFT_CKPT_DIR` is set but contains no `exported-checkpoint-*` (typically because the upstream training task crashed), exit 1 with a clear message instead of falling through to the self-draft branch. The self-draft fallback produced a confusing `num_speculative_tokens was provided but without speculative model` error from vLLM's `SpeculativeConfig` validation that obscured the real cause (the upstream training failure).

## Test plan

- [ ] Re-run `Qwen3-8B_DFlash_online` on Computelab with insufficient GPU memory; verify task_0 surfaces as `FAILED` (not `SUCCEEDED`) and task_1 doesn't bother trying the self-draft path.
- [ ] Re-run on adequate hardware (H200/B200) and verify the trap doesn't fire for the success path (script exits 0 normally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved error handling in training script to properly detect and report training failures (e.g., out-of-memory errors) instead of incorrectly marking them as successful
* Enhanced validation for missing draft checkpoints with clearer error messaging to prevent confusing downstream configuration errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->