### PR TITLE
[OMNIML-4312] training_support

### DIFF
--- a/tools/launcher/examples/Qwen/qwen3-v0336-demo/step1_synth.yaml
+++ b/tools/launcher/examples/Qwen/qwen3-v0336-demo/step1_synth.yaml
@@ -1,0 +1,41 @@
+# EAGLE3 speculative decoding pipeline Step 1: Synthetic data generation
+#
+# Step 1 of 4-step spec_decoding_release pipeline:
+#   task_0: Data synthesis — query TRT-LLM server to generate prompt samples
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/qwen3-v0336-demo/step1_synth.yaml --yes
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/qwen3-v0336-demo/step1_synth.yaml --dry-run
+
+job_name: qwen3-v0336-demo_step1_synth
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/qwen3-v0336-demo
+
+  # Step 1: Data synthesis via TRT-LLM server
+  # Args before "--" go to trtllm-serve; args after "--" go to tools/query.py.
+  task_0:
+    script: common/tensorrt_llm/query.sh
+    args:
+      - --model <<global_vars.hf_model>>
+      - --tp_size 8
+      - --ep_size 8
+      - --max_num_tokens 32000
+      - --port 8000
+      - --host 0.0.0.0
+      - --trust_remote_code
+      - --
+      - --data /hf-local/modelopt/Speculative-Decoding-Prompt-Samples
+      - --save /scratchspace/data
+    environment:
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 8
+      gpus_per_node: 8
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0

--- a/tools/launcher/examples/Qwen/qwen3-v0336-demo/step2_hidden.yaml
+++ b/tools/launcher/examples/Qwen/qwen3-v0336-demo/step2_hidden.yaml
@@ -1,0 +1,35 @@
+# EAGLE3 speculative decoding pipeline Step 2: Hidden-state dump
+#
+# Step 2 of 4-step spec_decoding_release pipeline:
+#   task_0: Dump hidden states — run target model to capture hidden states
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/qwen3-v0336-demo/step2_hidden.yaml --yes
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/qwen3-v0336-demo/step2_hidden.yaml --dry-run
+
+job_name: qwen3-v0336-demo_step2_hidden
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/qwen3-v0336-demo
+
+  # Step 2: Dump hidden states from target model
+  task_0:
+    script: common/eagle3/dump_offline_data.sh
+    args:
+      - --input-data /scratchspace/data
+      - --output-dir /scratchspace/offline_hidden_states
+      - --max-seq-len 8192
+      - --tp 8
+      - --moe-ep 8
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 8
+      gpus_per_node: 8
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0

--- a/tools/launcher/examples/Qwen/qwen3-v0336-demo/step3_train.yaml
+++ b/tools/launcher/examples/Qwen/qwen3-v0336-demo/step3_train.yaml
@@ -1,0 +1,35 @@
+# EAGLE3 speculative decoding pipeline Step 3: Offline training
+#
+# Step 3 of 4-step spec_decoding_release pipeline:
+#   task_0: Offline training — train the EAGLE3 draft head
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/qwen3-v0336-demo/step3_train.yaml --yes
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/qwen3-v0336-demo/step3_train.yaml --dry-run
+
+job_name: qwen3-v0336-demo_step3_train
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/qwen3-v0336-demo
+
+  # Step 3: Train EAGLE3 draft head (offline, single task)
+  task_0:
+    script: common/eagle3/train_eagle.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.offline_data_path=/scratchspace/offline_hidden_states
+      - training.output_dir=/scratchspace/eagle3
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0

--- a/tools/launcher/examples/Qwen/qwen3-v0336-demo/step4_speed_eval.yaml
+++ b/tools/launcher/examples/Qwen/qwen3-v0336-demo/step4_speed_eval.yaml
@@ -1,0 +1,39 @@
+# EAGLE3 speculative decoding pipeline Step 4: SPEED Evaluation
+#
+# Step 4 of 4-step spec_decoding_release pipeline:
+#   task_0: Benchmark — evaluate speculative decoding speedup via VLLM
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/qwen3-v0336-demo/step4_speed_eval.yaml --yes
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/qwen3-v0336-demo/step4_speed_eval.yaml --dry-run
+
+job_name: qwen3-v0336-demo_step4_speed_eval
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/qwen3-v0336-demo
+
+  # Step 4: Benchmark speculative decoding (VLLM backend)
+  task_0:
+    script: common/specdec_bench/quick_check.sh
+    args:
+      - --draft_model_dir /scratchspace/export
+      - --draft_length 3
+      - --output_length 4096
+      - --engine VLLM
+      - --tp_size 8
+      - --ep_size 1
+      - --speculative_algorithm EAGLE3
+      - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
+      - --concurrency 1
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      container: vllm/vllm-openai:latest


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-4312](https://jirasw.nvidia.com/browse/OMNIML-4312).

Stage `training_support` of Epic `OMNIML-4309`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._