### PR TITLE
[OMNIML-4447] training_support

### DIFF
--- a/tools/launcher/examples/Qwen/qwen3-v0348a-demo/step3_train.yaml
+++ b/tools/launcher/examples/Qwen/qwen3-v0348a-demo/step3_train.yaml
@@ -1,0 +1,36 @@
+# EAGLE3 offline draft-head training for qwen3-v0348a-demo (step 3).
+#
+# This is a standalone task extracted from the 4-step offline speculative
+# decoding pipeline.  It consumes hidden states produced by step 2
+# (/scratchspace/offline_hidden_states) and writes the trained draft head
+# to /scratchspace/eagle3.
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/qwen3-v0348a-demo/step3_train.yaml --yes
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/qwen3-v0348a-demo/step3_train.yaml --yes
+
+job_name: qwen3-v0348a-demo_EAGLE3_train
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/qwen3-v0348a-demo
+
+  task_0:
+    script: common/eagle3/train_eagle.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.offline_data_path=/scratchspace/offline_hidden_states
+      - training.output_dir=/scratchspace/eagle3
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-4447](https://jirasw.nvidia.com/browse/OMNIML-4447).

Stage `training_support` of Epic `OMNIML-4441`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._