### PR TITLE
[OMNIML-4507] training_support

### DIFF
--- a/tools/launcher/common/service_utils.sh
+++ b/tools/launcher/common/service_utils.sh
@@ -18,8 +18,8 @@
 native_mpi_rank=$OMPI_COMM_WORLD_RANK
 native_mpi_local_rank=$OMPI_COMM_WORLD_LOCAL_RANK
 # Works with Slurm launching with `--mpi=pmix`
-mpi_rank=${PMIX_RANK:-$native_mpi_rank}
-mpi_local_rank=${PMIX_LOCAL_RANK:-$native_mpi_local_rank}
+mpi_rank=${PMIX_RANK:-${native_mpi_rank:-${SLURM_PROCID:-0}}}
+mpi_local_rank=${PMIX_LOCAL_RANK:-${native_mpi_local_rank:-${SLURM_LOCALID:-0}}}
 
 FAIL=0
 FAIL_EXIT=0
@@ -48,8 +48,23 @@ function report_result {
 }
 
 function util_install_extra_dep {
+    local _marker=/tmp/.nmm_extra_dep_installed
+    if [[ -f "$_marker" ]]; then
+        return 0
+    fi
     if [[ "$mpi_local_rank" -eq 0 ]]; then
         pip install diskcache
+        local _nvrx_dir
+        _nvrx_dir="$(mktemp -d)/nvidia-resiliency-ext"
+        git clone --depth 1 https://github.com/NVIDIA/nvidia-resiliency-ext "${_nvrx_dir}" \
+            && pip install "${_nvrx_dir}"
+        touch "$_marker"
+    else
+        local _waited=0
+        while [[ ! -f "$_marker" && $_waited -lt 600 ]]; do
+            sleep 1
+            _waited=$((_waited + 1))
+        done
     fi
 }
 

--- a/tools/launcher/examples/Qwen/qwen3-v0342a-eagle3/step3_train.yaml
+++ b/tools/launcher/examples/Qwen/qwen3-v0342a-eagle3/step3_train.yaml
@@ -1,0 +1,30 @@
+# EAGLE3 offline draft-head training for qwen3-v0342a-eagle3.
+#
+# Standalone step3_train task extracted from the full EAGLE3 pipeline.
+# Reads hidden states produced by step2_dump_hidden_states.
+
+job_name: qwen3-v0342a-eagle3_EAGLE3_train
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/qwen3-v0342a-eagle3
+
+  task_0:
+    script: common/eagle3/train_eagle.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.offline_data_path=/scratchspace/offline_hidden_states
+      - training.output_dir=/scratchspace/eagle3
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-4507](https://jirasw.nvidia.com/browse/OMNIML-4507).

Stage `training_support` of Epic `OMNIML-4501`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._