### PR TITLE
[OMNIML-4592] training_support

### DIFF
--- a/tools/launcher/examples/Qwen/qwen3-v0349a-eagle3/step3_train.yaml
+++ b/tools/launcher/examples/Qwen/qwen3-v0349a-eagle3/step3_train.yaml
@@ -1,0 +1,34 @@
+# EAGLE3 offline training (step3_train) for qwen3-v0349a-eagle3.
+#
+# This is a single-task pipeline that trains the EAGLE3 draft head
+# using hidden states produced by the preceding step2_hidden_state stage.
+# It expects /scratchspace/offline_hidden_states to exist (output of step2).
+#
+# Usage:
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/qwen3-v0349a-eagle3/step3_train.yaml --yes
+
+job_name: qwen3-v0349a-eagle3_EAGLE3_train
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/qwen3-v0349a-eagle3
+
+  task_0:
+    script: common/eagle3/train_eagle.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.offline_data_path=/scratchspace/offline_hidden_states
+      - training.output_dir=/scratchspace/eagle3
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-4592](https://jirasw.nvidia.com/browse/OMNIML-4592).

Stage `training_support` of Epic `OMNIML-4586`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._