### PR TITLE
[OMNIML-4604] training_support

### DIFF
--- a/tools/launcher/examples/Qwen/qwen3-v0350a-eagle3/step3_train.yaml
+++ b/tools/launcher/examples/Qwen/qwen3-v0350a-eagle3/step3_train.yaml
@@ -1,0 +1,33 @@
+# EAGLE3 offline draft-head training (step3) for qwen3-v0350a-eagle3.
+#
+# Standalone step3_train launcher extracted from the monolithic pipeline.
+# Reads hidden states produced by step2 from /scratchspace/offline_hidden_states.
+#
+# Usage:
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/qwen3-v0350a-eagle3/step3_train.yaml --dry-run
+
+job_name: qwen3-v0350a-eagle3_EAGLE3_train
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/qwen3-v0350a-eagle3
+
+  task_0:
+    script: common/eagle3/train_eagle.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.offline_data_path=/scratchspace/offline_hidden_states
+      - training.output_dir=/scratchspace/eagle3
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-4604](https://jirasw.nvidia.com/browse/OMNIML-4604).

Stage `training_support` of Epic `OMNIML-4598`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._