### PR TITLE
[OMNIML-4600] hidden_state_dump_support

### DIFF
--- a/tools/launcher/examples/Qwen/qwen3-v0350a-eagle3/step2_hidden.yaml
+++ b/tools/launcher/examples/Qwen/qwen3-v0350a-eagle3/step2_hidden.yaml
@@ -1,0 +1,33 @@
+# Step 2 hidden-state dump for qwen3-v0350a-eagle3 (EAGLE3 offline pipeline).
+#
+# Standalone task that dumps hidden states from the target model.
+# Output goes to /scratchspace/offline_hidden_states for consumption by step 3.
+#
+# Usage:
+#   uv run slurm.py --yaml examples/Qwen/qwen3-v0350a-eagle3/step2_hidden.yaml --dry-run
+
+job_name: qwen3-v0350a-eagle3_EAGLE3_hidden_dump
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/qwen3-v0350a-eagle3
+
+  task_0:
+    script: common/eagle3/dump_offline_data.sh
+    args:
+      - --input-data /scratchspace/data
+      - --output-dir /scratchspace/offline_hidden_states
+      - --max-seq-len 8192
+      - --tp 8
+      - --moe-ep 8
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 8
+      gpus_per_node: 8
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-4600](https://jirasw.nvidia.com/browse/OMNIML-4600).

Stage `hidden_state_dump_support` of Epic `OMNIML-4598`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._