### PR TITLE
[OMNIML-4671] synth_support

### DIFF
--- a/tools/launcher/examples/Qwen/Qwen3-8B/step1_synth.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/step1_synth.yaml
@@ -1,0 +1,35 @@
+# EAGLE3 offline speculative decoding pipeline for Qwen3-8B - Step 1: Synthetic data generation
+# Extracted from hf_offline_eagle3.yaml task_0
+
+job_name: Qwen3-8B_EAGLE3_synth
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3-8B
+
+  # Step 1: Data synthesis via TRT-LLM server
+  # Args before "--" go to trtllm-serve; args after "--" go to tools/query.py.
+  task_0:
+    script: common/tensorrt_llm/query.sh
+    args:
+      - --model <<global_vars.hf_model>>
+      - --tp_size 8
+      - --ep_size 8
+      - --max_num_tokens 32000
+      - --port 8000
+      - --host 0.0.0.0
+      - --trust_remote_code
+      - --
+      - --data /hf-local/modelopt/Speculative-Decoding-Prompt-Samples
+      - --save /scratchspace/data
+    environment:
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 8
+      gpus_per_node: 8
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-4671](https://jirasw.nvidia.com/browse/OMNIML-4671).

Stage `synth_support` of Epic `OMNIML-4666`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an example pipeline for Qwen3-8B that provides a synthetic data generation workflow using TensorRT-LLM in a containerized SLURM execution environment for the EAGLE3 speculative decoding flow. The pipeline is enabled by default, includes model location and resource configuration (TP/EP, tasks, GPUs), and uses an NVIDIA TensorRT-LLM container.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1476)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->