### PR TITLE
chore: declare contents: read on code_quality workflow

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   code-quality:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`code_quality.yml` runs lint and code-quality checks. Twelve other workflows already declare permissions; this brings the remaining quality-check workflow in line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automation workflow permissions to explicitly grant read access to repository contents, ensuring code-quality processes can access necessary files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->