### PR TITLE
[OMNIML-4683] hidden_state_dump_support

### DIFF
--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_offline_eagle3.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_offline_eagle3.yaml
@@ -53,7 +53,7 @@ pipeline:
       - --output-dir /scratchspace/offline_hidden_states
       - --max-seq-len 8192
       - --tp 8
-      - --moe-ep 8
+      - --moe-ep 1
     environment:
       - HF_MODEL_CKPT: <<global_vars.hf_model>>
     slurm_config:


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-4683](https://jirasw.nvidia.com/browse/OMNIML-4683).

Stage `hidden_state_dump_support` of Epic `OMNIML-4681`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._