### PR TITLE
[OMNIML-4697] training_support

### DIFF
--- a/INTERN_SPEC.md
+++ b/INTERN_SPEC.md
@@ -1,0 +1,5 @@
+# Evolved Spec for OMNIML-4697
+
+During execution, it was discovered that the file `tools/launcher/examples/<Family>/Kimi-K2.5-DFlash/hf_offline_eagle3.yaml` does not exist in the repository. The repository only contains a `Qwen` directory under `tools/launcher/examples`. According to the spec, if the file is absent for this model, the task is blocked on `synth_support` (initial-file author). No further verification of `task_2` can be performed until the file is created.
+
+This refinement should be added to the spec: a precondition that the file must exist for the given model; if not, the task is blocked awaiting initial file creation.


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-4697](https://jirasw.nvidia.com/browse/OMNIML-4697).

Stage `training_support` of Epic `OMNIML-4691`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._