### PR TITLE
Register SyncBatchNorm as quantization module

### DIFF
--- a/modelopt/torch/quantization/nn/modules/quant_batchnorm.py
+++ b/modelopt/torch/quantization/nn/modules/quant_batchnorm.py
@@ -22,3 +22,4 @@ from .quant_module import QuantInputBase, QuantModuleRegistry
 QuantModuleRegistry.register({nn.BatchNorm1d: "nn.BatchNorm1d"})(QuantInputBase)
 QuantModuleRegistry.register({nn.BatchNorm2d: "nn.BatchNorm2d"})(QuantInputBase)
 QuantModuleRegistry.register({nn.BatchNorm3d: "nn.BatchNorm3d"})(QuantInputBase)
+QuantModuleRegistry.register({nn.SyncBatchNorm: "nn.SyncBatchNorm"})(QuantInputBase)

--- a/modelopt_recipes/configs/ptq/units/default_disabled_quantizers.yaml
+++ b/modelopt_recipes/configs/ptq/units/default_disabled_quantizers.yaml
@@ -45,6 +45,9 @@
   - parent_class: 'nn.BatchNorm3d'
     quantizer_name: '*'
     enable: false
+  - parent_class: 'nn.SyncBatchNorm'
+    quantizer_name: '*'
+    enable: false
   - parent_class: 'nn.LeakyReLU'
     quantizer_name: '*'
     enable: false

--- a/modelopt_recipes/general/ptq/int4_blockwise_weight_only.yaml
+++ b/modelopt_recipes/general/ptq/int4_blockwise_weight_only.yaml
@@ -57,6 +57,9 @@ quantize:
     - parent_class: 'nn.BatchNorm3d'
       quantizer_name: '*'
       enable: false
+    - parent_class: 'nn.SyncBatchNorm'
+      quantizer_name: '*'
+      enable: false
     - parent_class: 'nn.LeakyReLU'
       quantizer_name: '*'
       enable: false

--- a/modelopt_recipes/huggingface/step3p5/Step3.5-Flash/ptq/nvfp4-mlp-only.yaml
+++ b/modelopt_recipes/huggingface/step3p5/Step3.5-Flash/ptq/nvfp4-mlp-only.yaml
@@ -71,6 +71,9 @@ quantize:
     - parent_class: 'nn.BatchNorm3d'
       quantizer_name: '*'
       enable: false
+    - parent_class: 'nn.SyncBatchNorm'
+      quantizer_name: '*'
+      enable: false
     - parent_class: 'nn.LeakyReLU'
       quantizer_name: '*'
       enable: false

--- a/modelopt_recipes/models/Step3.5-Flash/nvfp4-mlp-only.yaml
+++ b/modelopt_recipes/models/Step3.5-Flash/nvfp4-mlp-only.yaml
@@ -84,6 +84,9 @@ quantize:
     - parent_class: 'nn.BatchNorm3d'
       quantizer_name: '*'
       enable: false
+    - parent_class: 'nn.SyncBatchNorm'
+      quantizer_name: '*'
+      enable: false
     - parent_class: 'nn.LeakyReLU'
       quantizer_name: '*'
       enable: false

--- a/tests/unit/torch/quantization/test_quant_batchnorm.py
+++ b/tests/unit/torch/quantization/test_quant_batchnorm.py
@@ -34,6 +34,7 @@ class TestQuantBatchNormND:
             (nn.BatchNorm1d, (2, NUM_CHANNELS, 8)),
             (nn.BatchNorm2d, (2, NUM_CHANNELS, 8, 8)),
             (nn.BatchNorm3d, (2, NUM_CHANNELS, 8, 8, 8)),
+            (nn.SyncBatchNorm, (2, NUM_CHANNELS, 8, 8)),
         ],
     )
     def test_no_quant(self, original_cls, input_shape):
@@ -60,6 +61,7 @@ class TestQuantBatchNormND:
             (nn.BatchNorm1d, (2, NUM_CHANNELS, 8)),
             (nn.BatchNorm2d, (2, NUM_CHANNELS, 8, 8)),
             (nn.BatchNorm3d, (2, NUM_CHANNELS, 8, 8, 8)),
+            (nn.SyncBatchNorm, (2, NUM_CHANNELS, 8, 8)),
         ],
     )
     def test_fake_quant_per_tensor(self, original_cls, input_shape):
@@ -86,6 +88,7 @@ class TestQuantBatchNormND:
             (nn.BatchNorm1d, (2, NUM_CHANNELS, 8)),
             (nn.BatchNorm2d, (2, NUM_CHANNELS, 8, 8)),
             (nn.BatchNorm3d, (2, NUM_CHANNELS, 8, 8, 8)),
+            (nn.SyncBatchNorm, (2, NUM_CHANNELS, 8, 8)),
         ],
     )
     def test_fake_quant_per_channel(self, original_cls, input_shape):


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

<!-- Details about the change. -->

Registers `nn.SyncBatchNorm` layer for quantization. If a model is setup for distributed training before PTQ, none of the SyncBatchNorm layers are recognised and quantized. On loading of a checkpoint there is now a mismatch between the modelopt state of a model that hasn't had DDP/SyncBN applied to it and the checkpoint trained with DDP/SyncBN.

Performing PTQ and then applying DDP/SyncBN for QAT works fine, but considering that unwrapping DDP is handled properly for either ordering of the steps, SyncBN conversion should be able to be performed in either order as well.

### Usage

```python
## train.py
model = get_model()
# DDP Setup
nn.SyncBatchNorm.convert_sync_batchnorm(model)
model = nn.parallel.DistributedDataParallel(
    model, device_ids=[dist.get_rank()], output_device=dist.get_rank()
)
# PTQ
mtq.quantize(model, mtq.INT8_DEFAULT_CFG, calib)
mtq.print_quant_summary(model) # Missing SyncBN layers
# QAT
train(model)
# Save Checkpoint
torch.save(mto.modelopt_state(model), "modelopt.pt")
torch.save(model.module.state_dict(), "params.pt")

## inference.py
model = get_model()
# Below fails as nn.BatchNorm2d in current model state does not have state in checkpoint since 
# nn.SyncBatchNorm modules were skipped over.
model = restore_model_from_modelopt_state(model, torch.load("modelopt.pt", weights_only=False))
mode.load_state_dict(torch.load("params.pt")
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

Added `nn.SyncBatchNorm` to the quantization tests where other BatchNorm layers appear..

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?:  ❌ - Models trained with missing norm from their modelopt state dict will now have this depending on initialization order. <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌ - lmk if you want this
- Did you get Claude approval on this PR?:  ❌ 
 
### Additional Information
<!-- E.g. related issue. -->

Code for testing issue, run with `python3 script.py` or `torchrun --nproc-per-node=2 script.py`.

```python
from pathlib import Path
import torch
import os
from torch import nn
import torch.distributed as dist
from torchvision.models import resnet18, ResNet18_Weights
from torchvision.datasets.cifar import CIFAR10
from torch.utils.data import DataLoader, DistributedSampler
from torchvision.transforms.v2 import ToTensor
import modelopt.torch.quantization as mtq
import modelopt.torch.opt as mto
from rich.progress import track

assert torch.cuda.is_available(), "NVIDIA GPUs required for distributed training"

torch.cuda.set_device(f"cuda:{os.environ.get('LOCAL_RANK', 0)}")
if dist.is_available() and int(os.environ.get("WORLD_SIZE", 1)) > 1:
    dist.init_process_group(backend="nccl")

model = resnet18(weights=ResNet18_Weights.DEFAULT).cuda()

if dist.is_initialized():  # SyncBN and DDP for training
    nn.SyncBatchNorm.convert_sync_batchnorm(model)
    model = nn.parallel.DistributedDataParallel(
        model, device_ids=[dist.get_rank()], output_device=dist.get_rank()
    )


def calib(m: nn.Module):
    datapath = Path.cwd() / "data"
    datapath.mkdir(exist_ok=True)
    dataset = CIFAR10(datapath, train=False, download=True, transform=ToTensor())
    if dist.is_initialized():
        sampler = DistributedSampler(dataset)
    else:
        sampler = None
    dataloader = DataLoader(dataset, sampler=sampler, num_workers=4, batch_size=8)
    for img, tgt in track(dataloader):
        m(img.cuda())


# PTQ
mtq.quantize(model, mtq.INT8_DEFAULT_CFG, calib)
if not dist.is_initialized() or dist.get_rank() == 0:
    mtq.print_quant_summary(model)

# Do training

mto_ckpt = Path.cwd() / "opt.pt"
torch.save(mto.modelopt_state(model), mto_ckpt)
param_ckpt = Path.cwd() / "params.pt"
if isinstance(model, nn.parallel.DistributedDataParallel):
    params = model.module.state_dict()
else:
    params = model.state_dict()
torch.save(params, param_ckpt)

# Load 'single' GPU for inference
model = resnet18(weights=ResNet18_Weights.DEFAULT).cuda()
model = mto.restore_from_modelopt_state(
    model, torch.load(mto_ckpt, map_location="cuda", weights_only=False)
)
model.load_state_dict(torch.load(param_ckpt))

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for synchronized batch normalization layers in quantization workflows.

* **Tests**
  * Extended quantization test coverage for synchronized batch normalization module types.

* **Chores**
  * Updated quantization configurations to handle synchronized batch normalization layers consistently with other batch norm types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1491)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->