### PR TITLE
Add 7 nvidia/Nemotron-* calibration datasets to SUPPORTED_DATASET_CONFIG

### DIFF
--- a/modelopt/torch/utils/dataset_utils.py
+++ b/modelopt/torch/utils/dataset_utils.py
@@ -32,6 +32,11 @@ from tqdm import tqdm
 if TYPE_CHECKING:
     from transformers import PreTrainedTokenizerBase
 
+
+def _join_messages_content(sample: dict) -> str:
+    return "\n".join(turn["content"] for turn in sample["messages"])
+
+
 # Use dict to store the config for each dataset.
 # If we want to export more options to user like target languages, we need more standardized approach like dataclass.
 SUPPORTED_DATASET_CONFIG: dict[str, Any] = {
@@ -61,7 +66,7 @@ SUPPORTED_DATASET_CONFIG: dict[str, Any] = {
             "path": "nvidia/Nemotron-Post-Training-Dataset-v2",
             "split": ["stem", "chat", "math", "code"],
         },
-        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "preprocess": _join_messages_content,
         "chat_key": "messages",
     },
     "nemotron-post-training-dataset-v1": {
@@ -69,7 +74,7 @@ SUPPORTED_DATASET_CONFIG: dict[str, Any] = {
             "path": "nvidia/Nemotron-Post-Training-Dataset-v1",
             "split": ["stem", "chat", "math", "code", "tool_calling"],
         },
-        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "preprocess": _join_messages_content,
         "chat_key": "messages",
     },
     "nemotron-sft-instruction-following-chat-v2": {
@@ -78,7 +83,7 @@ SUPPORTED_DATASET_CONFIG: dict[str, Any] = {
             "path": "nvidia/Nemotron-SFT-Instruction-Following-Chat-v2",
             "split": ["reasoning_off"],
         },
-        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "preprocess": _join_messages_content,
         "chat_key": "messages",
     },
     "nemotron-science-v1": {
@@ -86,7 +91,7 @@ SUPPORTED_DATASET_CONFIG: dict[str, Any] = {
             "path": "nvidia/Nemotron-Science-v1",
             "split": ["MCQ", "RQA"],
         },
-        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "preprocess": _join_messages_content,
         "chat_key": "messages",
     },
     "nemotron-competitive-programming-v1": {
@@ -100,7 +105,7 @@ SUPPORTED_DATASET_CONFIG: dict[str, Any] = {
                 "competitive_coding_python_part01",
             ],
         },
-        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "preprocess": _join_messages_content,
         "chat_key": "messages",
     },
     "nemotron-sft-agentic-v2": {
@@ -109,7 +114,7 @@ SUPPORTED_DATASET_CONFIG: dict[str, Any] = {
             "path": "nvidia/Nemotron-SFT-Agentic-v2",
             "split": ["interactive_agent", "tool_calling"],
         },
-        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "preprocess": _join_messages_content,
         "chat_key": "messages",
     },
     "nemotron-math-v2": {
@@ -117,7 +122,7 @@ SUPPORTED_DATASET_CONFIG: dict[str, Any] = {
             "path": "nvidia/Nemotron-Math-v2",
             "split": ["high_part00", "high_part01", "high_part02", "medium", "low"],
         },
-        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "preprocess": _join_messages_content,
         "chat_key": "messages",
     },
     "nemotron-sft-swe-v2": {
@@ -126,19 +131,34 @@ SUPPORTED_DATASET_CONFIG: dict[str, Any] = {
             "path": "nvidia/Nemotron-SFT-SWE-v2",
             "split": ["agentless"],
         },
-        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "preprocess": _join_messages_content,
         "chat_key": "messages",
     },
     "nemotron-sft-multilingual-v1": {
         "config": {
             "path": "nvidia/Nemotron-SFT-Multilingual-v1",
             "split": [
-                "code_de", "code_es", "code_fr", "code_it", "code_ja", "code_zh",
-                "math_de", "math_es", "math_fr", "math_it", "math_ja", "math_zh",
-                "stem_de", "stem_es", "stem_fr", "stem_it", "stem_ja", "stem_zh",
+                "code_de",
+                "code_es",
+                "code_fr",
+                "code_it",
+                "code_ja",
+                "code_zh",
+                "math_de",
+                "math_es",
+                "math_fr",
+                "math_it",
+                "math_ja",
+                "math_zh",
+                "stem_de",
+                "stem_es",
+                "stem_fr",
+                "stem_it",
+                "stem_ja",
+                "stem_zh",
             ],
         },
-        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "preprocess": _join_messages_content,
         "chat_key": "messages",
     },
     "magpie": {

--- a/modelopt/torch/utils/dataset_utils.py
+++ b/modelopt/torch/utils/dataset_utils.py
@@ -72,6 +72,75 @@ SUPPORTED_DATASET_CONFIG: dict[str, Any] = {
         "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
         "chat_key": "messages",
     },
+    "nemotron-sft-instruction-following-chat-v2": {
+        # Skips ``reasoning_on`` split: heterogeneous messages schema fails streaming cast.
+        "config": {
+            "path": "nvidia/Nemotron-SFT-Instruction-Following-Chat-v2",
+            "split": ["reasoning_off"],
+        },
+        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "chat_key": "messages",
+    },
+    "nemotron-science-v1": {
+        "config": {
+            "path": "nvidia/Nemotron-Science-v1",
+            "split": ["MCQ", "RQA"],
+        },
+        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "chat_key": "messages",
+    },
+    "nemotron-competitive-programming-v1": {
+        # Skips ``infinibyte_part0[0|1]``: heterogeneous schema fails streaming cast.
+        "config": {
+            "path": "nvidia/Nemotron-Competitive-Programming-v1",
+            "split": [
+                "competitive_coding_cpp_part00",
+                "competitive_coding_cpp_part01",
+                "competitive_coding_python_part00",
+                "competitive_coding_python_part01",
+            ],
+        },
+        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "chat_key": "messages",
+    },
+    "nemotron-sft-agentic-v2": {
+        # Skips ``search`` split: heterogeneous messages schema fails streaming cast.
+        "config": {
+            "path": "nvidia/Nemotron-SFT-Agentic-v2",
+            "split": ["interactive_agent", "tool_calling"],
+        },
+        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "chat_key": "messages",
+    },
+    "nemotron-math-v2": {
+        "config": {
+            "path": "nvidia/Nemotron-Math-v2",
+            "split": ["high_part00", "high_part01", "high_part02", "medium", "low"],
+        },
+        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "chat_key": "messages",
+    },
+    "nemotron-sft-swe-v2": {
+        # Skips ``openhands_swe`` split: heterogeneous schema fails streaming cast.
+        "config": {
+            "path": "nvidia/Nemotron-SFT-SWE-v2",
+            "split": ["agentless"],
+        },
+        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "chat_key": "messages",
+    },
+    "nemotron-sft-multilingual-v1": {
+        "config": {
+            "path": "nvidia/Nemotron-SFT-Multilingual-v1",
+            "split": [
+                "code_de", "code_es", "code_fr", "code_it", "code_ja", "code_zh",
+                "math_de", "math_es", "math_fr", "math_it", "math_ja", "math_zh",
+                "stem_de", "stem_es", "stem_fr", "stem_it", "stem_ja", "stem_zh",
+            ],
+        },
+        "preprocess": lambda sample: "\n".join(turn["content"] for turn in sample["messages"]),
+        "chat_key": "messages",
+    },
     "magpie": {
         "config": {
             "path": "Magpie-Align/Magpie-Pro-MT-300K-v0.1",

--- a/tests/unit/torch/utils/test_dataset_utils.py
+++ b/tests/unit/torch/utils/test_dataset_utils.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from unittest.mock import Mock, patch
 
 import pytest
 import torch
+from huggingface_hub import get_token
 from torch.utils.data import DataLoader
 
 from modelopt.torch.utils.dataset_utils import (
@@ -692,28 +692,52 @@ class TestHfTinyDataset:
         assert sum(b["input_ids"].shape[0] for b in batches) == 5
 
 
-@pytest.mark.parametrize(
-    "dataset_key",
-    [
-        "nemotron-sft-instruction-following-chat-v2",
-        "nemotron-science-v1",
-        "nemotron-competitive-programming-v1",
-        "nemotron-sft-agentic-v2",
-        "nemotron-math-v2",
-        "nemotron-sft-swe-v2",
-        "nemotron-sft-multilingual-v1",
-    ],
-)
+_NEW_NEMOTRON_KEYS = [
+    "nemotron-sft-instruction-following-chat-v2",
+    "nemotron-science-v1",
+    "nemotron-competitive-programming-v1",
+    "nemotron-sft-agentic-v2",
+    "nemotron-math-v2",
+    "nemotron-sft-swe-v2",
+    "nemotron-sft-multilingual-v1",
+]
+
+
+@pytest.mark.parametrize("dataset_key", _NEW_NEMOTRON_KEYS)
+def test_new_nemotron_registry_shape(dataset_key):
+    """Always-on shape check on the 7 newly registered nvidia/Nemotron-* entries.
+
+    Complements the gated smoke test below — catches typos in dataset paths or
+    split names even when the runner has no HF credentials.
+    """
+    from modelopt.torch.utils.dataset_utils import SUPPORTED_DATASET_CONFIG
+
+    assert dataset_key in SUPPORTED_DATASET_CONFIG
+    entry = SUPPORTED_DATASET_CONFIG[dataset_key]
+    config = entry["config"]
+    assert config["path"].startswith("nvidia/Nemotron-")
+    splits = config["split"]
+    assert isinstance(splits, list) and splits
+    assert all(isinstance(s, str) and s for s in splits)
+    assert len(set(splits)) == len(splits)
+    assert callable(entry["preprocess"])
+    assert entry["chat_key"] == "messages"
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("dataset_key", _NEW_NEMOTRON_KEYS)
 def test_get_dataset_samples_new_nemotron(dataset_key):
     """Smoke-test the 7 newly registered nvidia/Nemotron-* calibration datasets.
 
-    Skipped when ``HF_TOKEN`` is unset because these datasets live behind the HF Hub
-    and the CI runner may not have credentials.
+    Skipped when no HF token is available because these datasets live behind the HF Hub.
+    ``huggingface_hub.get_token()`` covers both the ``HF_TOKEN`` env var and tokens
+    cached by ``hf auth login``.
     """
     pytest.importorskip("datasets")
-    pytest.importorskip("huggingface_hub")
-    if not os.environ.get("HF_TOKEN"):
-        pytest.skip("HF_TOKEN not set; skipping nvidia/Nemotron-* dataset smoke test")
+    if not get_token():
+        pytest.skip(
+            "No HF token (env HF_TOKEN or `hf auth login`); skipping gated Nemotron smoke test"
+        )
 
     samples = get_dataset_samples(dataset_key, num_samples=2)
 

--- a/tests/unit/torch/utils/test_dataset_utils.py
+++ b/tests/unit/torch/utils/test_dataset_utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from unittest.mock import Mock, patch
 
 import pytest
@@ -689,3 +690,33 @@ class TestHfTinyDataset:
         )
         batches = list(loader)
         assert sum(b["input_ids"].shape[0] for b in batches) == 5
+
+
+@pytest.mark.parametrize(
+    "dataset_key",
+    [
+        "nemotron-sft-instruction-following-chat-v2",
+        "nemotron-science-v1",
+        "nemotron-competitive-programming-v1",
+        "nemotron-sft-agentic-v2",
+        "nemotron-math-v2",
+        "nemotron-sft-swe-v2",
+        "nemotron-sft-multilingual-v1",
+    ],
+)
+def test_get_dataset_samples_new_nemotron(dataset_key):
+    """Smoke-test the 7 newly registered nvidia/Nemotron-* calibration datasets.
+
+    Skipped when ``HF_TOKEN`` is unset because these datasets live behind the HF Hub
+    and the CI runner may not have credentials.
+    """
+    pytest.importorskip("datasets")
+    pytest.importorskip("huggingface_hub")
+    if not os.environ.get("HF_TOKEN"):
+        pytest.skip("HF_TOKEN not set; skipping nvidia/Nemotron-* dataset smoke test")
+
+    samples = get_dataset_samples(dataset_key, num_samples=2)
+
+    assert isinstance(samples, list)
+    assert len(samples) == 2
+    assert all(isinstance(s, str) and len(s) > 0 for s in samples)


### PR DESCRIPTION
Registers nemotron-{sft-instruction-following-chat-v2, science-v1, competitive-programming-v1, sft-agentic-v2, math-v2, sft-swe-v2, sft-multilingual-v1} so hf_ptq.py's --dataset flag (which enumerates get_supported_datasets() automatically) can select these for PTQ calibration. Splits with heterogeneous parquet schemas that crash streaming CastError mid-iteration are excluded per inline comments.

Adds a parametrized smoke test that skips when HF_TOKEN is unset since the nvidia/Nemotron-* datasets are gated.

### What does this PR do?

Type of change: ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

<!-- Details about the change. -->

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized chat-style preprocessing (joining message contents) and normalized chat key to "messages" across seven Nemotron dataset variants, with explicit dataset paths and curated splits.
* **Tests**
  * Added registry-shape unit checks for each new dataset entry.
  * Added a gated integration smoke test that fetches sample data when a Hugging Face Hub token is present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->