### PR TITLE
[Feat]: Streaming Hidden-states Dataset

### DIFF
--- a/examples/speculative_decoding/eagle_utils.py
+++ b/examples/speculative_decoding/eagle_utils.py
@@ -59,6 +59,7 @@ def make_speculative_data_module(
     train_len=None,
     answer_only_loss=False,
     shift_labels=True,
+    seed: int = 0,
 ) -> dict:
     """Create data module for speculative decoding training.
 
@@ -74,7 +75,36 @@ def make_speculative_data_module(
             chat_template = f.read()
         print_rank_0(f"Loaded chat template from {template_path}")
 
-    if data_args.offline_data_path is None:
+    mode = getattr(data_args, "mode", "online")
+    if mode == "streaming":
+        # ``train_len`` right-truncates during tokenization and is also the collator's
+        # pad target; caller must ensure ``train_len <= vllm.max_model_len``.
+        print_rank_0(f"Streaming hidden states from {data_args.streaming_server_url}")
+        from modelopt.torch.speculative.plugins.hf_streaming_dataset import (
+            EagleVllmStreamingConfig,
+            EagleVllmStreamingDataset,
+        )
+
+        ds = load_dataset("json", data_files=data_args.data_path, split="train")
+        if data_args.sample_size > 0:
+            ds = ds.select(range(data_args.sample_size))
+        streaming_cfg = EagleVllmStreamingConfig(
+            server_url=data_args.streaming_server_url,
+            model=data_args.streaming_model_name,
+            shared_storage_root=data_args.streaming_shared_storage_path,
+            max_seq_len=train_len,
+            answer_only_loss=answer_only_loss,
+            prefetch=data_args.streaming_prefetch,
+            seed=seed,
+        )
+        train_dataset = EagleVllmStreamingDataset(
+            entries=ds,
+            tokenizer=tokenizer,
+            config=streaming_cfg,
+        )
+        data_collator = EagleOfflineDataCollator(train_len=train_len)
+
+    elif mode == "online":
         train_dataset = ShardedDataset("json", data_files=data_args.data_path)
 
         if not data_args.vlm_processor:

--- a/examples/speculative_decoding/main.py
+++ b/examples/speculative_decoding/main.py
@@ -159,10 +159,8 @@ def train():
     training_args = HfTrainingArguments(**recipe.training.model_dump())
     init_distributed_env(training_args)
 
-    if not dry_run and not recipe.data.data_path and not recipe.data.offline_data_path:
-        raise ValueError(
-            "Either data.data_path or data.offline_data_path must be set in the config."
-        )
+    if not dry_run and recipe.data.mode in ("online", "streaming") and not recipe.data.data_path:
+        raise ValueError(f"data.mode={recipe.data.mode!r} requires data.data_path.")
     if training_args.cp_size > 1:
         patch_ring_attention_for_ttt()
         # Specific patch to accelerate 1.12.0. Removable after move to 1.13.0
@@ -181,7 +179,7 @@ def train():
 
     checkpoint = training_args.resume_from_checkpoint or last_checkpoint
 
-    use_offline_training = recipe.data.offline_data_path is not None
+    use_offline_training = recipe.data.mode != "online"
 
     if checkpoint:
         with patch_transformers5_params_loading():
@@ -269,6 +267,7 @@ def train():
         train_len=training_args.training_seq_len,
         answer_only_loss=training_args.answer_only_loss,
         shift_labels=not is_dflash,
+        seed=training_args.seed,
     )
 
     callbacks = [EagleTrainingPlot(training_args.ar_validate_steps, training_args.estimate_ar)]
@@ -278,6 +277,13 @@ def train():
         and recipe.eagle.eagle_base_lora_warmup_steps > 0
     ):
         callbacks.append(LoRAWarmupCallback(recipe.eagle.eagle_base_lora_warmup_steps))
+    if recipe.data.mode == "streaming":
+        # Skip-on-resume happens inside the dataset (no re-fetch from server);
+        # disable HF Trainer's own data skip so the offset isn't applied twice.
+        from modelopt.torch.speculative.plugins.hf_streaming_dataset import StreamingResumeCallback
+
+        training_args.ignore_data_skip = True
+        callbacks.append(StreamingResumeCallback())
 
     trainer = EagleTrainerWithAccLog(
         model=model,

--- a/modelopt/recipe/config.py
+++ b/modelopt/recipe/config.py
@@ -149,7 +149,7 @@ class ModelOptEagleRecipe(ModelOptSpeculativeRecipeBase):
 
     @model_validator(mode="after")
     def _derive_eagle_offline(self) -> ModelOptEagleRecipe:
-        self.eagle.eagle_offline = self.data.offline_data_path is not None
+        self.eagle.eagle_offline = self.data.mode != "online"
         return self
 
     @model_validator(mode="after")

--- a/modelopt/torch/speculative/config.py
+++ b/modelopt/torch/speculative/config.py
@@ -139,8 +139,9 @@ class EagleConfig(ModeloptBaseConfig):
     eagle_offline: bool = ModeloptField(
         default=False,
         description=(
-            "Whether to use detached Eagle. Derived by ModelOptEagleRecipe from "
-            "data.offline_data_path; not user-configurable."
+            "Whether the Eagle module consumes pre-computed hidden states (offline or streaming) "
+            "instead of running the base model in-process. Derived by ModelOptEagleRecipe from "
+            "``data.mode``; not user-configurable."
         ),
     )
 

--- a/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
+++ b/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
@@ -76,6 +76,7 @@ def _tokenize_with_loss_mask(
     """
     out = tokenizer.apply_chat_template(
         conversations,
+        tokenize=True,
         return_tensors="pt",
         return_dict=True,
         return_assistant_tokens_mask=answer_only_loss,

--- a/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
+++ b/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
@@ -1,0 +1,607 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Streaming datasets that fetch per-sample hidden states from a running inference server.
+
+The base class :class:`StreamingDataset` owns all the backend-/algorithm-
+agnostic plumbing: threading, queue, tokenization, the bounded sliding-window
+producer, loss_mask alignment, and HTTP-client lifecycle. Concrete subclasses
+specialize along two axes:
+
+- **Backend** (how to talk to the server, how to decode the response): override
+  :meth:`_fetch`.
+- **Algorithm** (how to shape the per-sample dict for the trainer): override
+  :meth:`_format`.
+
+:class:`EagleVllmStreamingDataset` is currently the only concrete
+combination (Eagle algorithm × vLLM backend); future combinations live as
+sibling subclasses.
+
+Requires ``dataloader_num_workers=0``: multiple workers would each spawn their
+own asyncio loop and issue duplicate requests against the server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import queue
+import random
+import threading
+from pathlib import Path
+from typing import TypedDict
+
+import httpx
+import torch
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from safetensors import safe_open
+from torch.utils.data import IterableDataset, get_worker_info
+from transformers import TrainerCallback
+from transformers.trainer_pt_utils import LabelSmoother
+
+from modelopt.torch.utils import distributed as dist_utils
+from modelopt.torch.utils import print_rank_0, warn_rank_0
+
+IGNORE_TOKEN_ID = LabelSmoother.ignore_index
+
+_SENTINEL = object()
+
+
+def _tokenize_with_loss_mask(
+    tokenizer,
+    conversations: list,
+    answer_only_loss: bool,
+    max_seq_len: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Tokenize one conversation and derive its loss mask in the same call.
+
+    Single ``apply_chat_template`` invocation so ``input_ids`` and ``loss_mask`` cannot
+    drift. When ``answer_only_loss=True`` the chat template must carry ``{% generation %}``
+    tags so the tokenizer can return ``assistant_masks``. When ``max_seq_len`` is set,
+    truncation is delegated to the tokenizer so ids and assistant_masks are truncated
+    in lockstep.
+    """
+    out = tokenizer.apply_chat_template(
+        conversations,
+        return_tensors="pt",
+        return_dict=True,
+        return_assistant_tokens_mask=answer_only_loss,
+        add_generation_prompt=False,
+        truncation=max_seq_len is not None,
+        max_length=max_seq_len,
+    )
+    input_ids = out["input_ids"]
+    seq_len = input_ids.shape[-1]
+    if answer_only_loss:
+        mask = out["assistant_masks"]
+        if not isinstance(mask, torch.Tensor):
+            mask = torch.tensor(mask, dtype=torch.long)
+        loss_mask = mask.squeeze(0).to(torch.long)
+        if loss_mask.shape[0] != seq_len:
+            raise RuntimeError(
+                f"assistant_masks length {loss_mask.shape[0]} does not match "
+                f"input_ids length {seq_len}"
+            )
+    else:
+        loss_mask = torch.ones(seq_len, dtype=torch.long)
+    return input_ids, loss_mask
+
+
+class StreamingConfig(BaseModel):
+    """Static tuning knobs for :class:`StreamingDataset`.
+
+    Bundles the rarely-changing settings (loss masking, concurrency, HTTP timeout)
+    so the dataset ctor takes only ``entries`` + ``tokenizer`` + this config.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    answer_only_loss: bool = False
+    prefetch: int = Field(default=64, ge=1)
+    request_timeout: float = Field(default=600.0, gt=0)
+    # Token-level cap applied during tokenization (right-truncation). Must hold
+    # ``max_seq_len <= vllm.max_model_len``. ``None`` disables truncation.
+    max_seq_len: int | None = None
+    # Must be identical on every rank — the dataset shuffles with this seed then
+    # stripes by rank, so equal seeds are required for the partition to be disjoint.
+    seed: int = 0
+    # Circuit breaker: raise after this many consecutive _fetch failures so a dead
+    # server doesn't silently drain the corpus.
+    fail_after_consecutive_skips: int = Field(default=16, ge=1)
+
+
+class StreamingDataset(IterableDataset):
+    """Base class: stream per-sample hidden states from a running inference server.
+
+    Backend- and algorithm-agnostic; subclasses implement :meth:`_fetch` (backend) and
+    :meth:`_format` (algorithm). The dict shape exchanged between them is the
+    algorithm-level contract, declared as a ``TypedDict`` in :attr:`fetch_payload_cls`
+    and validated against the actual ``_fetch`` output on every sample.
+    """
+
+    config_cls: type[StreamingConfig] = StreamingConfig
+    # Algorithm subclasses set this to a TypedDict declaring the keys their _format
+    # reads from the _fetch output. When set, base class validates _fetch's return
+    # value carries all required keys (fail-loud on the first sample).
+    fetch_payload_cls: type | None = None
+
+    def __init__(
+        self,
+        entries: list[dict],
+        tokenizer,
+        config: StreamingConfig | None = None,
+    ):
+        """Hold the *full* corpus on every rank; fetch lazily, rank 0 only.
+
+        DDP sharding is delegated to Accelerate's ``DataLoaderDispatcher``: rank 0
+        consumes the dataset and broadcasts each batch; non-zero ranks rely on
+        :meth:`__iter__`'s rank guard. The corpus is held in full on every rank --
+        the dispatcher reads only rank 0's stream, so sharding here would just
+        shrink that view. Shuffling with ``config.seed`` runs on every rank so
+        the order is reproducible regardless of which rank ends up fetching.
+
+        Args:
+            entries: Untokenized per-sample dicts from the input jsonl. Schema is
+                subclass-defined (see :meth:`_tokenize_entry`); passed through to :meth:`_fetch`.
+            tokenizer: HF tokenizer; used for client-side tokenization and the
+                server/client loss-mask alignment in :meth:`_fetch`.
+            config: Tuning knobs (prefetch, timeout, seed, ...); defaults to
+                ``self.config_cls()``. See :class:`StreamingConfig`.
+        """
+        if not entries:
+            raise ValueError("entries is empty")
+        self.tokenizer = tokenizer
+        self.config = config if config is not None else self.config_cls()
+        # One-shot, consumed by the next __iter__.
+        self._resume_skip = 0
+
+        indices = list(range(len(entries)))
+        random.Random(self.config.seed).shuffle(indices)
+        self.entries = [entries[i] for i in indices]
+        rank, world = dist_utils.rank(), dist_utils.size()
+        print_rank_0(
+            f"[{type(self).__name__}] rank {rank}/{world}: "
+            f"holds {len(self.entries)} entries (full corpus; rank 0 fetches)"
+        )
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+    def set_resume_position(self, skip: int) -> None:
+        """Drop the first ``skip`` entries on the next ``__iter__`` without fetching.
+
+        One-shot; cleared once iteration starts. Used by
+        :class:`StreamingResumeCallback` on HF Trainer checkpoint resume so the
+        server is not re-queried for already-consumed samples.
+        """
+        self._resume_skip = skip
+
+    @staticmethod
+    def _verify_accelerate_dispatcher() -> None:
+        """Raise if Accelerate is initialized for DDP with ``dispatch_batches=False``.
+
+        Best-effort: no-op when Accelerate isn't installed/initialized or in single-process.
+        """
+        try:
+            from accelerate.state import AcceleratorState
+        except ImportError:
+            return
+        if not AcceleratorState._shared_state:
+            return
+        state = AcceleratorState()
+        if getattr(state, "num_processes", 1) <= 1:
+            return
+        # Field moved to ``dataloader_config`` in newer Accelerate; check both.
+        dispatch = getattr(state, "dispatch_batches", None)
+        if dispatch is None:
+            dl_cfg = getattr(state, "dataloader_config", None)
+            if dl_cfg is not None:
+                dispatch = getattr(dl_cfg, "dispatch_batches", None)
+        if dispatch is False:
+            raise RuntimeError(
+                "StreamingDataset requires Accelerate's DataLoaderDispatcher "
+                "(dispatch_batches=True); got False — non-zero ranks would receive no data."
+            )
+
+    def __iter__(self):
+        # IterableDataset with DataLoader workers > 0 would spawn one asyncio loop
+        # per worker, each issuing the full request set — silent Nx duplication
+        # against the server. Fail loud instead.
+        if get_worker_info() is not None:
+            raise RuntimeError(
+                f"{type(self).__name__} requires dataloader_num_workers=0; "
+                "multiple workers would each spawn an asyncio loop and duplicate requests."
+            )
+        # Without dispatch_batches the rank-0 guard below would silently starve
+        # non-zero ranks; fail loud instead.
+        self._verify_accelerate_dispatcher()
+        # Only rank 0 fetches; non-zero ranks receive batches via the dispatcher's broadcast.
+        if dist_utils.rank() != 0:
+            return
+        # Fresh producer per __iter__ call so re-iteration (which shouldn't
+        # happen in 1-epoch streaming) at least doesn't deadlock.
+        q: queue.Queue = queue.Queue(maxsize=self.config.prefetch)
+        stop = threading.Event()
+        skip = self._resume_skip
+        self._resume_skip = 0  # one-shot
+        entries = self.entries[skip:] if skip else self.entries
+
+        def run():
+            try:
+                asyncio.run(self._produce(q, stop, entries))
+            except Exception as e:
+                q.put(e)  # surface to consumer
+            finally:
+                q.put(_SENTINEL)
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+
+        try:
+            while True:
+                item = q.get()
+                if item is _SENTINEL:
+                    break
+                if isinstance(item, Exception):
+                    raise item
+                yield item
+        finally:
+            stop.set()
+            # Drain any leftover items so producer can exit
+            with contextlib.suppress(queue.Empty):
+                while True:
+                    q.get_nowait()
+
+    async def _produce(self, q: queue.Queue, stop: threading.Event, entries):
+        """Stream ``entries`` through a sliding window of at most ``prefetch`` in-flight tasks.
+
+        Counter is local (single writer); ``_process`` tasks report outcome via return value.
+        The circuit breaker has *batch-level* (not per-task) granularity: when
+        ``asyncio.wait(FIRST_COMPLETED)`` returns several tasks in the same loop turn,
+        ``consecutive_skips`` reflects set-iteration order over ``done`` -- sufficient
+        for "detect a dead server" but not strict temporal ordering.
+
+        Args:
+            q: Bounded queue drained by :meth:`__iter__`; full queue backpressures fetching.
+            stop: Set by the consumer to request shutdown; checked between samples.
+            entries: Resume-adjusted slice of ``self.entries`` to fetch this iteration.
+        """
+        timeout = httpx.Timeout(self.config.request_timeout, connect=10.0)
+        threshold = self.config.fail_after_consecutive_skips
+        consecutive_skips = 0
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            pending: set[asyncio.Task] = set()
+            entries_iter = iter(entries)
+            exhausted = False
+            try:
+                while not stop.is_set():
+                    while len(pending) < self.config.prefetch and not exhausted:
+                        try:
+                            entry = next(entries_iter)
+                        except StopIteration:
+                            exhausted = True
+                            break
+                        pending.add(asyncio.create_task(self._process(client, entry, q, stop)))
+                    if not pending:
+                        break
+                    done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+                    for task in done:
+                        outcome = task.result()  # re-raises unexpected errors
+                        if outcome is True:
+                            consecutive_skips = 0
+                        elif outcome is False:
+                            consecutive_skips += 1
+                        # None -> entry unfit pre-fetch; server not at fault
+                    if consecutive_skips >= threshold:
+                        raise RuntimeError(
+                            f"{consecutive_skips} consecutive _fetch failures "
+                            f"in {type(self).__name__}; server likely down."
+                        )
+            finally:
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    await asyncio.gather(*pending, return_exceptions=True)
+
+    async def _process(
+        self,
+        client: httpx.AsyncClient,
+        entry: dict,
+        q: queue.Queue,
+        stop: threading.Event,
+    ) -> bool | None:
+        """Tokenize -> fetch -> format -> enqueue.
+
+        Returns True on enqueue, False on fetch failure (bumps breaker), None
+        when the entry is unfit pre-fetch (no breaker effect).
+        """
+        if stop.is_set():
+            return None
+        sample = await asyncio.to_thread(self._tokenize_entry, entry)
+        if sample is None:
+            return None
+        try:
+            fetched = await self._fetch(client, sample)
+        except Exception as e:
+            warn_rank_0(f"[streaming] error for {sample['cid']}: {e!r}")
+            return False
+        if fetched is None:
+            return False
+        if self.fetch_payload_cls is not None:
+            # ``__required_keys__`` is a TypedDict runtime attribute mypy doesn't
+            # track on ``type``; the assignment site guarantees it's a TypedDict.
+            required: frozenset[str] = self.fetch_payload_cls.__required_keys__  # type: ignore[attr-defined]
+            missing = required - set(fetched)
+            if missing:
+                raise RuntimeError(
+                    f"{type(self).__name__}._fetch missing required keys {missing}; "
+                    f"{self.fetch_payload_cls.__name__} requires "
+                    f"{set(required)}, got {set(fetched)}"
+                )
+        data = self._format(fetched)
+        # Blocking put -> backpressure when trainer is slow.
+        await asyncio.to_thread(q.put, data)
+        return True
+
+    def _tokenize_entry(self, entry: dict) -> dict | None:
+        """Tokenize a single entry.
+
+        Returns ``None`` for entries missing ``cid`` / ``messages``, or when
+        right-truncation to ``max_seq_len`` drops the entire supervised span
+        (``answer_only_loss`` mode with the assistant turn at the tail).
+        """
+        cid = entry.get("conversation_id") or entry.get("uuid")
+        convs = entry.get("messages") or entry.get("conversations")
+        if cid is None or not convs or not isinstance(convs, list):
+            return None
+        input_ids, loss_mask = _tokenize_with_loss_mask(
+            self.tokenizer,
+            convs,
+            self.config.answer_only_loss,
+            max_seq_len=self.config.max_seq_len,
+        )
+        if int(loss_mask.sum()) == 0:
+            return None
+        return {
+            "cid": str(cid),
+            "token_ids": input_ids.squeeze(0).tolist(),
+            "loss_mask": loss_mask,
+        }
+
+    async def _fetch(self, client: httpx.AsyncClient, sample: dict) -> dict | None:
+        """Backend hook: send the request and decode the server's response.
+
+        Override in subclass. Any scratch resources (per-request files, mmap'd
+        buffers) must be released before returning.
+
+        Args:
+            client: Shared async HTTP client owned by :meth:`_produce`.
+            sample: :meth:`_tokenize_entry` output:
+                ``{"cid": str, "token_ids": list[int], "loss_mask": LongTensor[seq]}``.
+
+        Returns:
+            Dict carrying at least the keys declared by :attr:`fetch_payload_cls`,
+            or ``None`` to skip this sample (counts toward the circuit breaker).
+        """
+        raise NotImplementedError("Subclasses must implement _fetch")
+
+    def _format(self, fetched: dict) -> dict[str, torch.Tensor]:
+        """Algorithm hook: shape the fetched dict into the trainer's per-sample batch.
+
+        Override in subclass.
+
+        Args:
+            fetched: :meth:`_fetch` output; the keys declared by
+                :attr:`fetch_payload_cls` are guaranteed to be present.
+
+        Returns:
+            Tensor dict consumed directly by the trainer's ``model.forward(**batch)``.
+        """
+        raise NotImplementedError("Subclasses must implement _format")
+
+
+class EagleFetchPayload(TypedDict):
+    """The dict shape every Eagle backend must produce in :meth:`_fetch`.
+
+    Fields:
+        token_ids:     ``LongTensor`` of shape ``(seq,)`` — what the server tokenized.
+        hidden_states: tensor of shape ``(seq, n_captured_layers, hidden)``.
+        loss_mask:     ``LongTensor`` of shape ``(seq,)``, aligned to ``token_ids``.
+    """
+
+    token_ids: torch.Tensor
+    hidden_states: torch.Tensor
+    loss_mask: torch.Tensor
+
+
+class EagleVllmStreamingConfig(StreamingConfig):
+    """Adds vLLM endpoint info on top of :class:`StreamingConfig`."""
+
+    server_url: str
+    model: str
+    # Allowlist for ``hidden_states_path`` returned by the server. Must match the
+    # connector's ``shared_storage_path``; out-of-tree paths are rejected.
+    shared_storage_root: str
+
+    @field_validator("server_url")
+    @classmethod
+    def _strip_trailing_slash(cls, v: str) -> str:
+        return v.rstrip("/")
+
+    @field_validator("shared_storage_root")
+    @classmethod
+    def _resolve_root(cls, v: str) -> str:
+        return str(Path(v).resolve())
+
+
+class EagleVllmStreamingDataset(StreamingDataset):
+    """Eagle (algorithm) × vLLM (backend).
+
+    Talks to a ``vllm serve`` instance configured with the
+    ``ExampleHiddenStatesConnector`` KV-transfer connector (the server dumps captured
+    layers to a per-request safetensors file under ``shared_storage_path`` and
+    returns the path via ``kv_transfer_params.hidden_states_path``). Expects vLLM
+    to capture ``aux_layers + [final_layer]`` along ``hidden_states.shape[1]``.
+    """
+
+    config_cls = EagleVllmStreamingConfig
+    fetch_payload_cls = EagleFetchPayload
+
+    def __init__(
+        self,
+        entries: list[dict],
+        tokenizer,
+        config: EagleVllmStreamingConfig,
+    ):
+        """Same as the base; ``config`` must include ``server_url`` and ``model``."""
+        super().__init__(entries=entries, tokenizer=tokenizer, config=config)
+        self.config: EagleVllmStreamingConfig = config
+
+    async def _fetch(self, client: httpx.AsyncClient, sample: dict) -> EagleFetchPayload | None:
+        r = await client.post(
+            f"{self.config.server_url}/v1/completions",
+            json={
+                "model": self.config.model,
+                "prompt": sample["token_ids"],
+                "max_tokens": 1,
+                "temperature": 0,
+            },
+        )
+        r.raise_for_status()
+        body = r.json()
+        path = (body.get("kv_transfer_params") or {}).get("hidden_states_path")
+        if path is None:
+            warn_rank_0(f"[streaming] no hidden_states_path for {sample['cid']}")
+            return None
+        if not self._path_under_root(path):
+            warn_rank_0(
+                f"[streaming] path outside shared_storage_root for {sample['cid']}: {path!r}"
+            )
+            return None
+        token_ids, hidden_states = await asyncio.to_thread(self._load_safetensors, path)
+        # Contract: the server tokenization is the client's pre-tokenized prompt
+        # verbatim, plus at most one decode-step token at the tail (from
+        # ``max_tokens=1``). Anything else (e.g. server-side BOS prepend, chat
+        # templating, tokenizer drift) means ``loss_mask`` no longer aligns to
+        # the supervised positions, so fail loudly rather than silently train
+        # on misaligned tokens.
+        client_ids = torch.as_tensor(sample["token_ids"], dtype=token_ids.dtype)
+        n = client_ids.shape[0]
+        if token_ids.shape[0] not in (n, n + 1) or not torch.equal(token_ids[:n], client_ids):
+            raise RuntimeError(
+                f"server token_ids drift for {sample['cid']}: "
+                f"client_len={n}, server_len={token_ids.shape[0]}; "
+                "the server must consume the pre-tokenized prompt verbatim "
+                "(no BOS prepend or chat templating)"
+            )
+        loss_mask = self._align_loss_mask(sample["loss_mask"], token_ids.shape[0])
+        return {
+            "token_ids": token_ids,
+            "hidden_states": hidden_states,
+            "loss_mask": loss_mask,
+        }
+
+    def _path_under_root(self, path: str) -> bool:
+        try:
+            resolved = Path(path).resolve()
+        except (OSError, ValueError):
+            return False
+        return resolved.is_relative_to(self.config.shared_storage_root)
+
+    @staticmethod
+    def _load_safetensors(path: str) -> tuple[torch.Tensor, torch.Tensor]:
+        """Read tensors into CPU memory then unlink the scratch file.
+
+        ``safe_open(..., framework="pt").get_tensor`` materializes an independent
+        torch Tensor (not a view into the mmap'd file), so it is safe to unlink
+        right after the ``with`` block exits.
+        """
+        with safe_open(path, framework="pt") as f:
+            token_ids = f.get_tensor("token_ids")
+            hidden_states = f.get_tensor("hidden_states")  # [seq, n_layers, hidden]
+        with contextlib.suppress(OSError):
+            os.unlink(path)
+        return token_ids, hidden_states
+
+    @staticmethod
+    def _align_loss_mask(loss_mask: torch.Tensor, n: int) -> torch.Tensor:
+        """Trim or right-pad ``loss_mask`` to length ``n``.
+
+        Caller guarantees the server-side token sequence is a strict prefix of
+        the client-side sequence (or the same length), so the only realignment
+        ever needed is at the tail — pad the optional decode-step position
+        with 0 (no client-side label).
+        """
+        if loss_mask.shape[0] > n:
+            return loss_mask[:n]
+        if loss_mask.shape[0] < n:
+            pad = torch.zeros(n - loss_mask.shape[0], dtype=loss_mask.dtype)
+            return torch.cat([loss_mask, pad], dim=0)
+        return loss_mask
+
+    def _format(self, fetched: EagleFetchPayload) -> dict[str, torch.Tensor]:
+        token_ids = fetched["token_ids"]
+        hidden_states = fetched["hidden_states"]
+        loss_mask = fetched["loss_mask"]
+
+        base_model_hidden_states = hidden_states[:, -1, :]
+        aux_hidden_states = hidden_states[:, :-1, :].reshape(hidden_states.shape[0], -1)
+
+        input_ids = token_ids.to(torch.int64)
+        labels = torch.full_like(input_ids, IGNORE_TOKEN_ID)
+        labels[..., :-1] = input_ids[..., 1:]
+
+        return {
+            "input_ids": input_ids,
+            "base_model_hidden_states": base_model_hidden_states,
+            "aux_hidden_states": aux_hidden_states,
+            "attention_mask": torch.ones_like(input_ids),
+            "loss_mask": loss_mask,
+            "labels": labels,
+        }
+
+
+class StreamingResumeCallback(TrainerCallback):
+    """Fast-forward :class:`StreamingDataset` past consumed samples on resume.
+
+    Dispatcher pulls a *global* batch per micro-step, hence the ``world_size`` factor.
+    Requires ``training_args.ignore_data_skip=True``; round-trips only when
+    ``world_size`` and ``config.seed`` match the original run.
+    """
+
+    def on_train_begin(self, args, state, control, train_dataloader=None, **kwargs):
+        """Push the skip count into the dataset when resuming mid-training."""
+        if state.global_step <= 0 or train_dataloader is None:
+            return
+        ds = train_dataloader.dataset
+        if not hasattr(ds, "set_resume_position"):
+            return
+        if not getattr(args, "ignore_data_skip", False):
+            raise RuntimeError(
+                "StreamingResumeCallback requires ignore_data_skip=True to avoid "
+                "double-skipping on resume."
+            )
+        consumed = (
+            state.global_step
+            * args.per_device_train_batch_size
+            * dist_utils.size()
+            * args.gradient_accumulation_steps
+        )
+        ds.set_resume_position(consumed)
+        print_rank_0(
+            f"[StreamingResumeCallback] resuming at global_step={state.global_step}; "
+            f"skipping {consumed} entries"
+        )

--- a/modelopt/torch/speculative/plugins/hf_training_args.py
+++ b/modelopt/torch/speculative/plugins/hf_training_args.py
@@ -49,10 +49,8 @@ class DataArguments(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    # ``None`` is the sentinel "user did not set mode"; auto-promoted from
-    # offline_data_path / streaming_server_url. An explicit value (including ``"online"``)
-    # is always respected, even with stale mode-specific fields present. Always resolved
-    # to one of the three string literals by ``_check_mode_requirements`` before use.
+    # Derived in ``_check_mode_requirements`` from the data-source fields; accepted as input
+    # only for backward compatibility (existing ``mode:`` keys / overrides), then overwritten.
     mode: Literal["online", "offline", "streaming"] | None = None
     data_path: str | None = None
     offline_data_path: str | None = None
@@ -77,24 +75,18 @@ class DataArguments(BaseModel):
 
     @model_validator(mode="after")
     def _check_mode_requirements(self) -> DataArguments:
-        # Auto-promote only when ``mode`` is unset by the user (sentinel ``None``). An
-        # explicit ``mode`` — including ``"online"`` — is always respected so stale
-        # ``streaming_server_url`` / ``offline_data_path`` leftovers can't silently flip it.
-        if self.mode is None:
-            has_offline = self.offline_data_path is not None
-            has_streaming = self.streaming_server_url is not None
-            if has_offline and has_streaming:
-                raise ValueError(
-                    "ambiguous: set data.mode explicitly when both offline_data_path "
-                    "and streaming_server_url are set"
-                )
-            self.mode = "offline" if has_offline else "streaming" if has_streaming else "online"
-        if self.mode == "offline" and not self.offline_data_path:
-            raise ValueError("data.mode='offline' requires data.offline_data_path")
+        # Always recompute from the data-source fields, never trust an incoming ``mode``: a
+        # value stored by an earlier validation can go stale across a recipe dump/reload +
+        # override round-trip and silently select the wrong training path.
+        has_offline = self.offline_data_path is not None
+        has_streaming = self.streaming_server_url is not None
+        if has_offline and has_streaming:
+            raise ValueError(
+                "ambiguous: set only one of data.offline_data_path / data.streaming_server_url"
+            )
+        self.mode = "offline" if has_offline else "streaming" if has_streaming else "online"
         if self.mode == "streaming" and not (
-            self.streaming_server_url
-            and self.streaming_model_name
-            and self.streaming_shared_storage_path
+            self.streaming_model_name and self.streaming_shared_storage_path
         ):
             raise ValueError(
                 "data.mode='streaming' requires data.streaming_server_url, "

--- a/modelopt/torch/speculative/plugins/hf_training_args.py
+++ b/modelopt/torch/speculative/plugins/hf_training_args.py
@@ -29,7 +29,9 @@ The module is pure Pydantic schema with no runtime dependencies on ``transformer
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class ModelArguments(BaseModel):
@@ -47,6 +49,11 @@ class DataArguments(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    # ``None`` is the sentinel "user did not set mode"; auto-promoted from
+    # offline_data_path / streaming_server_url. An explicit value (including ``"online"``)
+    # is always respected, even with stale mode-specific fields present. Always resolved
+    # to one of the three string literals by ``_check_mode_requirements`` before use.
+    mode: Literal["online", "offline", "streaming"] | None = None
     data_path: str | None = None
     offline_data_path: str | None = None
     lazy_preprocess: bool = True
@@ -55,6 +62,11 @@ class DataArguments(BaseModel):
     vlm_img_dir: str | None = None
     vlm_processor: str | None = None
     sample_size: int = -1
+    streaming_server_url: str | None = None
+    streaming_model_name: str | None = None
+    streaming_prefetch: int = Field(default=64, ge=1)
+    # Mirror of the vLLM connector's ``shared_storage_path``; trainer-side allowlist.
+    streaming_shared_storage_path: str | None = None
 
     @field_validator("sample_size")
     @classmethod
@@ -62,6 +74,34 @@ class DataArguments(BaseModel):
         if v == 0 or v < -1:
             raise ValueError("sample_size must be -1 (use all samples) or a positive integer")
         return v
+
+    @model_validator(mode="after")
+    def _check_mode_requirements(self) -> DataArguments:
+        # Auto-promote only when ``mode`` is unset by the user (sentinel ``None``). An
+        # explicit ``mode`` — including ``"online"`` — is always respected so stale
+        # ``streaming_server_url`` / ``offline_data_path`` leftovers can't silently flip it.
+        if self.mode is None:
+            has_offline = self.offline_data_path is not None
+            has_streaming = self.streaming_server_url is not None
+            if has_offline and has_streaming:
+                raise ValueError(
+                    "ambiguous: set data.mode explicitly when both offline_data_path "
+                    "and streaming_server_url are set"
+                )
+            self.mode = "offline" if has_offline else "streaming" if has_streaming else "online"
+        if self.mode == "offline" and not self.offline_data_path:
+            raise ValueError("data.mode='offline' requires data.offline_data_path")
+        if self.mode == "streaming" and not (
+            self.streaming_server_url
+            and self.streaming_model_name
+            and self.streaming_shared_storage_path
+        ):
+            raise ValueError(
+                "data.mode='streaming' requires data.streaming_server_url, "
+                "data.streaming_model_name, and data.streaming_shared_storage_path "
+                "(the trainer-side allowlist for paths returned by the vLLM server)"
+            )
+        return self
 
 
 class TrainingArguments(BaseModel):

--- a/modelopt/torch/speculative/plugins/modeling_fakebase.py
+++ b/modelopt/torch/speculative/plugins/modeling_fakebase.py
@@ -67,14 +67,35 @@ class FakeBaseConfig(PretrainedConfig):
         max_position_embeddings=None,
         dtype=torch.bfloat16,
         tie_word_embeddings=False,
+        num_orig_hidden_layers=None,
+        num_attention_heads=None,
+        num_key_value_heads=None,
+        intermediate_size=None,
         **kwargs,
     ):
         """Initialize FakeBaseConfig with minimal model configuration parameters."""
         super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
         self.num_hidden_layers = num_hidden_layers
+        # Mirror the original base layer count. The non-fake offline path loads with
+        # num_hidden_layers=0 and stashes the real count here (see utils.load_vlm_or_llm);
+        # the fake base keeps num_hidden_layers as the real count, so default to it. DFlash's
+        # offline modify() reads num_orig_hidden_layers directly (hf_dflash.py), so it must
+        # always be present on the base config.
+        self.num_orig_hidden_layers = (
+            num_orig_hidden_layers if num_orig_hidden_layers is not None else num_hidden_layers
+        )
         self.hidden_size = hidden_size
         self.vocab_size = vocab_size
         self.max_position_embeddings = max_position_embeddings
+        # Attention/MLP dims needed when exporting a draft head built on a fake base: the
+        # DFlash exporter (hf_spec_export._export_config) references base_config.{num_attention_heads,
+        # num_key_value_heads, intermediate_size} as getattr fallbacks, which Python evaluates
+        # eagerly, so they must exist even though the fake base has no real layers.
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = (
+            num_key_value_heads if num_key_value_heads is not None else num_attention_heads
+        )
+        self.intermediate_size = intermediate_size
         if isinstance(dtype, str):
             dtype = getattr(torch, dtype)
         self.dtype = dtype
@@ -141,6 +162,9 @@ class FakeBaseModel(PreTrainedModel):
             max_position_embeddings=getattr(base_cfg, "max_position_embeddings", None),
             dtype=getattr(base_cfg, "dtype", torch.bfloat16),
             tie_word_embeddings=getattr(base_cfg, "tie_word_embeddings", False),
+            num_attention_heads=getattr(base_cfg, "num_attention_heads", None),
+            num_key_value_heads=getattr(base_cfg, "num_key_value_heads", None),
+            intermediate_size=getattr(base_cfg, "intermediate_size", None),
         )
         model = cls(config)
         # Load lm_head and embed_tokens only from checkpoint

--- a/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+++ b/modelopt_recipes/general/speculative_decoding/eagle3.yaml
@@ -12,6 +12,10 @@ model:
 
 # maps to DataArguments (main.py)
 data:
+  # online | offline | streaming. Leave unset to auto-derive: offline_data_path
+  # -> offline; streaming_server_url -> streaming; otherwise online. Set
+  # explicitly only to force a specific mode.
+  mode:
   data_path: input_conversations/train.jsonl
   offline_data_path:
   draft_vocab_cache:
@@ -47,7 +51,7 @@ training:
 
 # maps to EagleConfig (modelopt/torch/speculative/config.py).
 eagle:
-  # eagle_offline is derived from data.offline_data_path; do not set here.
+  # eagle_offline is derived from data.mode; do not set here.
   eagle_decoder_type: llama
   eagle_ttt_steps: 3
   eagle_mix_hidden_states: false

--- a/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+++ b/modelopt_recipes/general/speculative_decoding/eagle3.yaml
@@ -12,9 +12,9 @@ model:
 
 # maps to DataArguments (main.py)
 data:
-  # online | offline | streaming. Leave unset to auto-derive: offline_data_path
-  # -> offline; streaming_server_url -> streaming; otherwise online. Set
-  # explicitly only to force a specific mode.
+  # Auto-derived from the data-source fields below (offline_data_path -> offline;
+  # streaming_server_url -> streaming; otherwise online); any value set here is
+  # recomputed from those fields, so leave it unset.
   mode:
   data_path: input_conversations/train.jsonl
   offline_data_path:

--- a/tests/examples/speculative_decoding/test_eagle_streaming.py
+++ b/tests/examples/speculative_decoding/test_eagle_streaming.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end CI test for the streaming speculative-decoding workflow.
+
+Drives ``launch_train.sh`` in ``data.mode=streaming`` against an in-process
+HTTP server that mimics ``vllm serve`` with ``ExampleHiddenStatesConnector``,
+so the full mode-dispatch → dataset → collator → Trainer chain runs without
+needing a real vLLM instance.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+import safetensors.torch
+import torch
+from _test_utils.examples.run_command import MODELOPT_ROOT, run_example_command
+
+EAGLE3_YAML = str(
+    MODELOPT_ROOT / "modelopt_recipes" / "general" / "speculative_decoding" / "eagle3.yaml"
+)
+
+# tiny_llama_path fixture builds num_hidden_layers=2 + hidden_size=512;
+# default_eagle_aux_layer_ids(2) = [0, 1] -> 2 aux + 1 final = 3 captured layers.
+_HIDDEN_SIZE = 512
+_N_CAPTURED_LAYERS = 3
+
+# Tiny EAGLE architecture overrides (dotlist entries) — same as offline test.
+_TINY_EAGLE_ARCH = [
+    "eagle.eagle_architecture_config.max_position_embeddings=128",
+    "eagle.eagle_architecture_config.num_hidden_layers=1",
+    "eagle.eagle_architecture_config.intermediate_size=64",
+    "eagle.eagle_architecture_config.num_attention_heads=2",
+    "eagle.eagle_architecture_config.num_key_value_heads=2",
+    "eagle.eagle_architecture_config.head_dim=64",
+]
+
+
+def _make_handler(scratch_dir: Path):
+    """Stdlib HTTP handler that mimics vLLM's ExampleHiddenStatesConnector.
+
+    Per request, writes a safetensors file and replies with its path.
+    """
+    counter = {"n": 0}
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            body = json.loads(self.rfile.read(length))
+            prompt = body["prompt"]
+            seq = len(prompt)
+            counter["n"] += 1
+            path = scratch_dir / f"req_{counter['n']}.safetensors"
+            safetensors.torch.save_file(
+                {
+                    "token_ids": torch.tensor(prompt, dtype=torch.int64),
+                    "hidden_states": torch.randn(seq, _N_CAPTURED_LAYERS, _HIDDEN_SIZE),
+                },
+                str(path),
+            )
+            payload = json.dumps({"kv_transfer_params": {"hidden_states_path": str(path)}}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args, **kwargs):
+            pass  # keep test output quiet
+
+    return _Handler
+
+
+@pytest.fixture
+def mock_vllm_server(tmp_path_factory):
+    """Stdlib HTTPServer mimicking a vLLM hidden-states endpoint.
+
+    Yields ``(base_url, scratch_dir)`` — scratch_dir is the trainer's
+    ``shared_storage_root`` allowlist.
+    """
+    scratch = tmp_path_factory.mktemp("vllm_scratch")
+    server = HTTPServer(("127.0.0.1", 0), _make_handler(scratch))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", scratch
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+def test_streaming_eagle_training(
+    tiny_llama_path, tiny_conversations_path, mock_vllm_server, tmp_path_factory
+):
+    """Train EAGLE3 in streaming mode end-to-end against the mocked server."""
+    output_dir = tmp_path_factory.mktemp("eagle_streaming_ckpt")
+    server_url, scratch = mock_vllm_server
+
+    overrides = [
+        f"model.model_name_or_path={tiny_llama_path}",
+        f"data.data_path={tiny_conversations_path}",
+        "data.mode=streaming",
+        f"data.streaming_server_url={server_url}",
+        f"data.streaming_model_name={tiny_llama_path}",
+        f"data.streaming_shared_storage_path={scratch}",
+        "data.streaming_prefetch=2",
+        f"training.output_dir={output_dir}",
+        "training.num_train_epochs=1",
+        "training.learning_rate=1e-5",
+        "training.training_seq_len=32",
+        "training.save_steps=1",
+        "training.dataloader_num_workers=0",  # enforced by StreamingDataset
+        *_TINY_EAGLE_ARCH,
+    ]
+
+    run_example_command(
+        ["./launch_train.sh", "--config", EAGLE3_YAML, *overrides],
+        "speculative_decoding",
+        setup_free_port=True,
+    )
+
+    ckpts = list(output_dir.rglob("checkpoint-*"))
+    assert ckpts, f"no checkpoint produced in {output_dir}"

--- a/tests/unit/torch/speculative/plugins/test_hf_speculative_offline.py
+++ b/tests/unit/torch/speculative/plugins/test_hf_speculative_offline.py
@@ -67,6 +67,7 @@ def _make_data_args(sample_size, tmp_path, n_files=5):
     for i in range(n_files):
         torch.save({}, tmp_path / f"sample_{i}.pt")
     return argparse.Namespace(
+        mode="offline",
         vlm_processor=None,
         vlm_img_dir=None,
         offline_data_path=str(tmp_path),
@@ -110,6 +111,7 @@ def test_sample_size_larger_than_dataset_uses_all(tmp_path):
 def test_sample_size_no_pt_files_raises(tmp_path):
     """Empty directory should raise ValueError."""
     data_args = argparse.Namespace(
+        mode="offline",
         vlm_processor=None,
         vlm_img_dir=None,
         offline_data_path=str(tmp_path),

--- a/tests/unit/torch/speculative/plugins/test_hf_streaming_dataset.py
+++ b/tests/unit/torch/speculative/plugins/test_hf_streaming_dataset.py
@@ -1,0 +1,317 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for StreamingDataset's DDP contract.
+
+We do not spin up real torch.distributed; instead we monkeypatch the helper that
+reads rank/world_size. Sharding itself is delegated to Accelerate's
+``DataLoaderDispatcher`` (every rank holds the full corpus; only rank 0 iterates).
+These tests check the corpus-handling and rank-0-only-iter properties on which
+that delegation relies.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import safetensors.torch
+import torch
+
+# hf_streaming_dataset imports TrainerCallback / LabelSmoother at module scope.
+pytest.importorskip("transformers")
+
+from modelopt.torch.speculative.plugins import hf_streaming_dataset
+from modelopt.torch.speculative.plugins.hf_streaming_dataset import (
+    EagleVllmStreamingConfig,
+    EagleVllmStreamingDataset,
+    StreamingConfig,
+    StreamingDataset,
+)
+
+
+def _entries(n: int) -> list[dict]:
+    """Minimal entry shape; ``id`` is the only field tests read back."""
+    return [{"id": i} for i in range(n)]
+
+
+@pytest.fixture
+def patch_dist(monkeypatch):
+    """Return a setter; tests call it with (rank, world) to simulate a DDP rank.
+
+    Patches ``modelopt.torch.utils.distributed.rank/size`` as imported into the
+    streaming dataset module (``dist_utils``). The dataset reads these in
+    ``__init__`` for logging and in ``__iter__`` for the rank-0-only gate.
+    """
+
+    def _set(rank: int, world: int):
+        # ``is_master`` etc. call ``rank(group=...)`` / ``size(group=...)`` — match the signature.
+        monkeypatch.setattr(hf_streaming_dataset.dist_utils, "rank", lambda group=None: rank)
+        monkeypatch.setattr(hf_streaming_dataset.dist_utils, "size", lambda group=None: world)
+
+    return _set
+
+
+def _entry_ids(ds: StreamingDataset) -> list[int]:
+    return [e["id"] for e in ds.entries]
+
+
+@pytest.mark.parametrize("world", [1, 2, 3, 8])
+def test_every_rank_holds_full_corpus(patch_dist, world):
+    """Each rank must see all entries — Accelerate's dispatcher does the sharding,
+    so any per-rank pre-shard here would shrink rank 0's view to 1/N and break
+    ``max_steps``.
+    """
+    corpus = _entries(100)
+    for rank in range(world):
+        patch_dist(rank, world)
+        ds = StreamingDataset(corpus, tokenizer=MagicMock(), config=StreamingConfig(seed=42))
+        assert sorted(_entry_ids(ds)) == list(range(100))
+
+
+def test_same_seed_same_order(patch_dist):
+    """The shuffle is what makes rank 0's fetch order deterministic across reruns."""
+    corpus = _entries(50)
+    patch_dist(0, 1)
+    a = _entry_ids(StreamingDataset(corpus, tokenizer=MagicMock(), config=StreamingConfig(seed=7)))
+    b = _entry_ids(StreamingDataset(corpus, tokenizer=MagicMock(), config=StreamingConfig(seed=7)))
+    assert a == b
+
+
+def test_different_seed_different_order(patch_dist):
+    """Sanity: changing the seed actually reshuffles (else seed is vacuous)."""
+    corpus = _entries(50)
+    patch_dist(0, 1)
+    a = _entry_ids(StreamingDataset(corpus, tokenizer=MagicMock(), config=StreamingConfig(seed=1)))
+    b = _entry_ids(StreamingDataset(corpus, tokenizer=MagicMock(), config=StreamingConfig(seed=2)))
+    assert a != b
+    assert sorted(a) == sorted(b)
+
+
+def test_non_rank_zero_iter_is_empty(patch_dist):
+    """Non-zero ranks must yield nothing on ``__iter__`` — their producer would burn
+    server requests that ``DataLoaderDispatcher`` would discard."""
+    corpus = _entries(8)
+    patch_dist(2, 4)
+    ds = StreamingDataset(corpus, tokenizer=MagicMock(), config=StreamingConfig(seed=0))
+    assert list(iter(ds)) == []
+
+
+def test_iter_rejects_dataloader_workers(patch_dist, monkeypatch):
+    """Iterating from within a DataLoader worker must raise — multiple workers would
+    each spawn an asyncio loop and N× the request load on the server."""
+    patch_dist(0, 1)
+    ds = StreamingDataset(_entries(4), tokenizer=MagicMock(), config=StreamingConfig(seed=0))
+    # Pretend we're inside a DataLoader worker.
+    monkeypatch.setattr(hf_streaming_dataset, "get_worker_info", lambda: MagicMock())
+    with pytest.raises(RuntimeError, match="dataloader_num_workers=0"):
+        next(iter(ds))
+
+
+def test_empty_corpus_raises(patch_dist):
+    patch_dist(0, 1)
+    with pytest.raises(ValueError, match="entries is empty"):
+        StreamingDataset([], tokenizer=MagicMock(), config=StreamingConfig())
+
+
+def test_set_resume_position_skips_entries_without_fetching(patch_dist):
+    """Resume should fast-forward inside the dataset without invoking _fetch.
+
+    Verifies the contract relied on by StreamingResumeCallback: skipped entries
+    are not sent to the server, so resume costs nothing on the inference side.
+    """
+    patch_dist(0, 1)
+    fetched_ids: list[int] = []
+
+    class _Track(StreamingDataset):
+        def _tokenize_entry(self, entry):
+            return {"cid": str(entry["id"]), "token_ids": [1], "loss_mask": None}
+
+        async def _fetch(self, client, sample):
+            fetched_ids.append(int(sample["cid"]))
+
+    corpus = _entries(10)
+    ds = _Track(corpus, tokenizer=MagicMock(), config=StreamingConfig(seed=0, prefetch=2))
+    ds.set_resume_position(5)
+    list(ds)
+
+    expected = {e["id"] for e in ds.entries[5:]}
+    assert set(fetched_ids) == expected
+    # _resume_skip is one-shot
+    assert ds._resume_skip == 0
+
+
+def test_circuit_breaker_trips_on_consecutive_fetch_failures(patch_dist):
+    """When _fetch keeps failing, the producer raises after the threshold so the
+    trainer sees a clear error instead of a silent empty epoch."""
+    patch_dist(0, 1)
+    threshold = 3
+
+    class _AlwaysFails(StreamingDataset):
+        # Bypass tokenization so we don't need a real tokenizer.
+        def _tokenize_entry(self, entry):
+            return {"cid": str(entry["id"]), "token_ids": [1], "loss_mask": None}
+
+        async def _fetch(self, client, sample):
+            raise RuntimeError("simulated server failure")
+
+    ds = _AlwaysFails(
+        _entries(20),
+        tokenizer=MagicMock(),
+        config=StreamingConfig(seed=0, prefetch=2, fail_after_consecutive_skips=threshold),
+    )
+    with pytest.raises(RuntimeError, match="consecutive _fetch failures"):
+        list(ds)
+
+
+def _write_canned_safetensors(path: Path, seq: int, n_layers: int, hidden: int) -> None:
+    """Mimic what vLLM's ExampleHiddenStatesConnector writes per request."""
+    safetensors.torch.save_file(
+        {
+            "token_ids": torch.arange(seq, dtype=torch.int64),
+            "hidden_states": torch.randn(seq, n_layers, hidden),
+        },
+        str(path),
+    )
+
+
+def _tokenizer_returning(seq: int) -> MagicMock:
+    """Tokenizer mock whose apply_chat_template yields a fixed seq-len output."""
+    tok = MagicMock()
+    tok.apply_chat_template.return_value = {
+        "input_ids": torch.arange(seq, dtype=torch.long).unsqueeze(0),
+    }
+    return tok
+
+
+def test_eagle_vllm_dataset_end_to_end(tmp_path, patch_dist, monkeypatch):
+    """Drive EagleVllmStreamingDataset against an in-process mocked server.
+
+    Verifies that the wire-format → tensor → batch-dict chain produces dicts
+    matching what EagleOfflineDataCollator expects, and that scratch files
+    are cleaned up after each fetch.
+    """
+    patch_dist(0, 1)
+    seq, n_layers, hidden = 8, 3, 16  # n_layers = 1 final + 2 aux
+    scratch = tmp_path / "vllm_scratch"
+    scratch.mkdir()
+
+    counter = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        counter["n"] += 1
+        path = scratch / f"req_{counter['n']}.safetensors"
+        _write_canned_safetensors(path, seq, n_layers, hidden)
+        return httpx.Response(
+            200,
+            json={"kv_transfer_params": {"hidden_states_path": str(path)}},
+        )
+
+    real_async_client = httpx.AsyncClient
+
+    def mock_async_client(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(hf_streaming_dataset.httpx, "AsyncClient", mock_async_client)
+
+    n_entries = 4
+    entries = [
+        {
+            "conversation_id": f"c-{i}",
+            "messages": [{"role": "user", "content": "x"}],
+        }
+        for i in range(n_entries)
+    ]
+    ds = EagleVllmStreamingDataset(
+        entries=entries,
+        tokenizer=_tokenizer_returning(seq),
+        config=EagleVllmStreamingConfig(
+            server_url="http://mock:8000",
+            model="mock-model",
+            shared_storage_root=str(scratch),
+            prefetch=2,
+            seed=0,
+        ),
+    )
+
+    batches = list(ds)
+
+    assert len(batches) == n_entries
+    expected_keys = {
+        "input_ids",
+        "base_model_hidden_states",
+        "aux_hidden_states",
+        "attention_mask",
+        "loss_mask",
+        "labels",
+    }
+    for b in batches:
+        assert set(b) == expected_keys
+        assert b["input_ids"].shape == (seq,)
+        assert b["input_ids"].dtype == torch.int64
+        assert b["base_model_hidden_states"].shape == (seq, hidden)
+        # 2 aux layers * hidden, flattened
+        assert b["aux_hidden_states"].shape == (seq, 2 * hidden)
+        assert b["attention_mask"].shape == (seq,)
+        assert b["loss_mask"].shape == (seq,)
+        assert b["labels"].shape == (seq,)
+        # labels are input_ids shifted by 1, last position is IGNORE
+        assert torch.equal(b["labels"][:-1], b["input_ids"][1:])
+        assert b["labels"][-1].item() == hf_streaming_dataset.IGNORE_TOKEN_ID
+
+    assert list(scratch.iterdir()) == [], "scratch files must be unlinked after fetch"
+
+
+def test_path_outside_shared_storage_root_is_rejected(tmp_path, patch_dist, monkeypatch):
+    """Out-of-root path from server is not opened or unlinked."""
+    patch_dist(0, 1)
+    seq, n_layers, hidden = 8, 3, 16
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    forbidden = outside / "secret.safetensors"
+    _write_canned_safetensors(forbidden, seq, n_layers, hidden)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"kv_transfer_params": {"hidden_states_path": str(forbidden)}},
+        )
+
+    real_async_client = httpx.AsyncClient
+
+    def mock_async_client(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(hf_streaming_dataset.httpx, "AsyncClient", mock_async_client)
+
+    ds = EagleVllmStreamingDataset(
+        entries=[{"conversation_id": "c-0", "messages": [{"role": "user", "content": "x"}]}],
+        tokenizer=_tokenizer_returning(seq),
+        config=EagleVllmStreamingConfig(
+            server_url="http://mock:8000",
+            model="mock-model",
+            shared_storage_root=str(allowed),
+            fail_after_consecutive_skips=100,
+            prefetch=1,
+            seed=0,
+        ),
+    )
+
+    assert list(ds) == []
+    assert forbidden.exists(), "rejected path must not be unlinked"

--- a/tools/launcher/common/eagle3/train_eagle_streaming.sh
+++ b/tools/launcher/common/eagle3/train_eagle_streaming.sh
@@ -15,9 +15,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# EAGLE3 streaming training: co-locates `vllm serve` (KV-transfer producer of
-# hidden states) with the trainer on the same node, and routes hidden states
-# over HTTP rather than dumping to disk. Sibling of train_eagle.sh.
+# EAGLE3 streaming training: runs a `vllm serve` (KV-transfer producer of hidden
+# states) alongside the trainer and routes hidden states over HTTP rather than
+# dumping to disk. Sibling of train_eagle.sh.
+#
+# Topology is chosen automatically from the Slurm allocation (the launcher yaml's
+# `nodes:` field); nemo_run runs this script once per node, so it branches on
+# $SLURM_NODEID:
+#   nodes == 1  -> co-located: vllm serve on $SERVE_GPU, trainer on the rest of
+#                  the local GPUs (original single-node behavior).
+#   nodes >= 2  -> split across nodes: node 0 runs vllm serve on all its GPUs,
+#                  node 1 runs the trainer on all its GPUs. The two roles
+#                  rendezvous through the shared /scratchspace mount (node 0
+#                  publishes its address; node 1 signals completion). For large
+#                  models whose serve needs a whole node (e.g. Kimi-K2.5 TP=8),
+#                  allocate exactly 2 nodes.
 #
 # Env vars (required):
 #   HF_MODEL_CKPT       Target model path. Used by both vllm serve (as the
@@ -29,16 +41,25 @@
 #                       default = [1,17,32] -> capture = [2,18,33,36].
 #
 # Env vars (optional):
-#   SERVE_HOST          default 127.0.0.1
 #   SERVE_PORT          default 8765
-#   SERVE_GPU           CUDA_VISIBLE_DEVICES for vllm serve. default "0"
-#   SERVE_TP            tensor-parallel-size for vllm serve. default 1
-#   SERVE_GPU_MEM_UTIL  default 0.4
-#   TRAIN_GPUS          CUDA_VISIBLE_DEVICES for the trainer. default = all
-#                       local GPUs except SERVE_GPU.
+#   SERVE_GPU_MEM_UTIL  default 0.4 (single-node) / 0.9 (multi-node serve node)
+#   SERVE_READY_TIMEOUT seconds to wait for the server to come up. default 900
+#   SERVE_EXTRA_ARGS    extra flags appended to `vllm serve` (e.g. --trust-remote-code)
+#   SERVE_CPU_OFFLOAD_GB  GB of weights/GPU to offload to host RAM (fits big models
+#                         on too-few GPUs; slower). e.g. "10"
+#   SERVE_MAX_MODEL_LEN   cap vllm context length (trims KV/activation). e.g. "4096"
+#   SERVE_MAX_NUM_SEQS    cap concurrent sequences (trims KV/activation). e.g. "8"
+#   SERVE_HOST          single-node only: bind/connect host. default 127.0.0.1
+#   SERVE_GPU           single-node only: CUDA_VISIBLE_DEVICES for vllm. default "0"
+#   SERVE_TP            tensor-parallel size. default 1 (single-node) / all GPUs
+#                       on the serve node (multi-node)
+#   TRAIN_GPUS          single-node only: CUDA_VISIBLE_DEVICES for the trainer.
+#                       default = all local GPUs except SERVE_GPU.
+#   SERVE_ADVERTISE_IP  multi-node only: address node 1 should dial. default is
+#                       node 0's first `hostname -I` IP.
 #
-# All script args after the env-var setup are forwarded to launch_train.sh
-# (typically: --config <yaml> plus OmegaConf dotlist overrides).
+# All script args are forwarded to launch_train.sh (typically: --config <yaml>
+# plus OmegaConf dotlist overrides).
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "${SCRIPT_DIR}/../service_utils.sh"
@@ -100,88 +121,206 @@ if [ -z "$EAGLE_CAPTURE_IDS" ]; then
     echo "ERROR: EAGLE_CAPTURE_IDS must be set (e.g. '[2, 18, 33, 36]' for Qwen3-8B)." >&2; exit 1
 fi
 
-SERVE_HOST="${SERVE_HOST:-127.0.0.1}"
-SERVE_PORT="${SERVE_PORT:-8765}"
-SERVE_GPU="${SERVE_GPU:-0}"
-SERVE_TP="${SERVE_TP:-1}"
-SERVE_GPU_MEM_UTIL="${SERVE_GPU_MEM_UTIL:-0.4}"
+# Everything passed to this script (--config <yaml> + OmegaConf dotlist) is
+# forwarded verbatim to the trainer. Capture it before the helpers below run.
+SCRIPT_ARGS=("$@")
 
-if [ -z "$TRAIN_GPUS" ]; then
-    TRAIN_GPUS=$(python3 - <<PY
-total = int("$(nvidia-smi --query-gpu=count --format=csv,noheader,nounits | head -n1)")
+SERVE_PORT="${SERVE_PORT:-8765}"
+SERVE_READY_TIMEOUT="${SERVE_READY_TIMEOUT:-900}"
+SERVE_SCRATCH="/scratchspace/streaming_serve_scratch"
+SERVE_LOG="/scratchspace/vllm_serve.log"
+# Multi-node rendezvous over the shared /scratchspace mount (lustre, visible on
+# every node): node 0 publishes its address here, node 1 signals completion here.
+SERVE_ADDR_FILE="/scratchspace/.serve_addr"
+DONE_FILE="/scratchspace/.training_done"
+SERVE_PID=""
+mkdir -p "$SERVE_SCRATCH"
+
+cleanup() {
+    [ -n "$SERVE_PID" ] || return 0
+    echo "Cleaning up vllm serve (PID=$SERVE_PID)..."
+    kill "$SERVE_PID" 2>/dev/null || true
+    wait "$SERVE_PID" 2>/dev/null || true
+}
+
+gpus_on_node() { nvidia-smi --query-gpu=count --format=csv,noheader,nounits | head -n1; }
+
+# Start vllm serve in the background. Sets SERVE_PID.
+#   $1 = bind host   $2 = tensor-parallel size   $3 = CUDA_VISIBLE_DEVICES ("" -> all)
+launch_vllm() {
+    local bind_host="$1" tp="$2" cvd="$3"
+    echo "Launching vllm serve on ${bind_host}:${SERVE_PORT} (TP=${tp}, CUDA_VISIBLE_DEVICES=${cvd:-all}, mem=${SERVE_GPU_MEM_UTIL}, log: $SERVE_LOG)..."
+    # Only pin GPUs when a non-empty set is given; an empty CUDA_VISIBLE_DEVICES
+    # would expose *zero* GPUs (not all), so leave it unset to use the whole node.
+    local -a gpu_env=()
+    [ -n "$cvd" ] && gpu_env=(env "CUDA_VISIBLE_DEVICES=$cvd")
+    # Optional single-value memory knobs (each a space-free env value, so they
+    # survive nemo_run's unquoted `export FOO=value`; assembled into --flag value
+    # pairs here). --cpu-offload-gb spills N GB of weights/GPU to host RAM, the
+    # key lever for fitting a large model on too-few GPUs (slower, prefill-only
+    # use tolerates it). --max-model-len / --max-num-seqs trim KV/activation.
+    local -a opt_args=()
+    [ -n "${SERVE_CPU_OFFLOAD_GB:-}" ] && opt_args+=(--cpu-offload-gb "$SERVE_CPU_OFFLOAD_GB")
+    [ -n "${SERVE_MAX_MODEL_LEN:-}" ]  && opt_args+=(--max-model-len "$SERVE_MAX_MODEL_LEN")
+    [ -n "${SERVE_MAX_NUM_SEQS:-}" ]   && opt_args+=(--max-num-seqs "$SERVE_MAX_NUM_SEQS")
+    # --no-enable-chunked-prefill / --no-enable-prefix-caching: the
+    # ExampleHiddenStatesConnector captures hidden states during prefill; both
+    # features skip recomputing cached/partial prefixes, which yields short or
+    # empty hidden_states. Required, not optional.
+    # --no-enable-flashinfer-autotune: on big NVFP4 MoE (Kimi) the flashinfer
+    # trtllm_fp4_block_scale_moe autotuner re-tunes on the first real serving
+    # step and stalls a worker past vLLM's execute-model timeout -> EngineCore
+    # dies with "RPC call to sample_tokens timed out" -> 500s -> trainer aborts.
+    # Disabling autotune keeps kernels static (and pairs with the larger
+    # VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS set in the example env).
+    "${gpu_env[@]}" vllm serve "$HF_MODEL_CKPT" \
+        --host "$bind_host" \
+        --port "$SERVE_PORT" \
+        --tensor-parallel-size "$tp" \
+        --enforce-eager \
+        --no-enable-chunked-prefill \
+        --no-enable-prefix-caching \
+        --no-enable-flashinfer-autotune \
+        --gpu-memory-utilization "$SERVE_GPU_MEM_UTIL" \
+        "${opt_args[@]}" \
+        ${SERVE_EXTRA_ARGS:-} \
+        --speculative-config "{
+            \"method\":\"extract_hidden_states\",
+            \"num_speculative_tokens\":1,
+            \"draft_model_config\":{
+                \"hf_config\":{
+                    \"eagle_aux_hidden_state_layer_ids\":$EAGLE_CAPTURE_IDS
+                }
+            }
+        }" \
+        --kv-transfer-config "{
+            \"kv_connector\":\"ExampleHiddenStatesConnector\",
+            \"kv_role\":\"kv_producer\",
+            \"kv_connector_extra_config\":{\"shared_storage_path\":\"$SERVE_SCRATCH\"}
+        }" \
+        > "$SERVE_LOG" 2>&1 &
+    SERVE_PID=$!
+}
+
+# Poll until the server answers (or, if we own it, dies). $1 = base URL.
+wait_vllm_ready() {
+    local url="$1" tries=$(( SERVE_READY_TIMEOUT / 5 ))
+    echo "Waiting for vllm serve at ${url} to become ready (up to ${SERVE_READY_TIMEOUT}s)..."
+    for ((i = 0; i < tries; i++)); do
+        if curl -fsS "${url}/v1/models" > /dev/null 2>&1; then echo "vllm serve ready."; return 0; fi
+        if [ -n "$SERVE_PID" ] && ! kill -0 "$SERVE_PID" 2>/dev/null; then
+            echo "vllm serve died early. Tail of $SERVE_LOG:"; tail -100 "$SERVE_LOG"; return 1
+        fi
+        sleep 5
+    done
+    echo "Server not ready in ${SERVE_READY_TIMEOUT}s. Tail:"; tail -100 "$SERVE_LOG"; return 1
+}
+
+# Run the trainer then export the HF checkpoint.
+#   $1 = streaming server base URL   $2 = CUDA_VISIBLE_DEVICES ("" -> all)
+# dataloader_num_workers must be 0: the streaming dataset owns one asyncio loop
+# per process; multiple workers would duplicate requests against the server.
+run_trainer_and_export() {
+    local url="$1" cvd="$2"
+    echo "Launching trainer (server=${url}, CUDA_VISIBLE_DEVICES=${cvd:-all})..."
+    # Empty cvd -> use all GPUs on the node (don't set the var; "" would hide all).
+    local -a gpu_env=()
+    [ -n "$cvd" ] && gpu_env=(env "CUDA_VISIBLE_DEVICES=$cvd")
+    "${gpu_env[@]}" bash modules/Model-Optimizer/examples/speculative_decoding/launch_train.sh \
+        "${SCRIPT_ARGS[@]}" \
+        data.streaming_server_url="$url" \
+        data.streaming_model_name="$HF_MODEL_CKPT" \
+        data.streaming_shared_storage_path="$SERVE_SCRATCH" \
+        training.dataloader_num_workers=0 || { echo "ERROR: trainer failed." >&2; return 1; }
+
+    python3 modules/Model-Optimizer/examples/speculative_decoding/scripts/export_hf_checkpoint.py \
+        --model_path /scratchspace/eagle3 \
+        --export_path /scratchspace/export
+}
+
+# ---------------------------------------------------------------------------
+# Topology dispatch (driven by the Slurm allocation, i.e. the yaml `nodes:`):
+#   SLURM_NNODES == 1  -> co-located: vllm on $SERVE_GPU, trainer on the rest.
+#   SLURM_NNODES >= 2  -> split: node 0 serves on all its GPUs, node 1 trains on
+#                         all its GPUs; they rendezvous via /scratchspace.
+# nemo_run runs this script once per node, so we branch on $SLURM_NODEID.
+# ---------------------------------------------------------------------------
+NNODES="${SLURM_NNODES:-1}"
+NODEID="${SLURM_NODEID:-0}"
+
+if [ "$NNODES" -le 1 ]; then
+    # ----------------------------- single node -----------------------------
+    SERVE_HOST="${SERVE_HOST:-127.0.0.1}"
+    SERVE_GPU="${SERVE_GPU:-0}"
+    SERVE_TP="${SERVE_TP:-1}"
+    SERVE_GPU_MEM_UTIL="${SERVE_GPU_MEM_UTIL:-0.4}"
+
+    if [ -z "$TRAIN_GPUS" ]; then
+        TRAIN_GPUS=$(python3 - <<PY
+total = int("$(gpus_on_node)")
 exclude = {int(x) for x in "$SERVE_GPU".split(",") if x != ""}
 print(",".join(str(i) for i in range(total) if i not in exclude))
 PY
 )
-fi
-if [ -z "$TRAIN_GPUS" ]; then
-    echo "ERROR: no GPUs left for the trainer (SERVE_GPU=$SERVE_GPU consumed them all)." >&2; exit 1
-fi
-
-SERVE_SCRATCH="/scratchspace/streaming_serve_scratch"
-SERVE_LOG="/scratchspace/vllm_serve.log"
-mkdir -p "$SERVE_SCRATCH"
-
-echo "Launching vllm serve on $SERVE_HOST:$SERVE_PORT (GPUs=$SERVE_GPU, TP=$SERVE_TP, log: $SERVE_LOG)..."
-CUDA_VISIBLE_DEVICES="$SERVE_GPU" vllm serve "$HF_MODEL_CKPT" \
-    --host "$SERVE_HOST" \
-    --port "$SERVE_PORT" \
-    --tensor-parallel-size "$SERVE_TP" \
-    --enforce-eager \
-    --gpu-memory-utilization "$SERVE_GPU_MEM_UTIL" \
-    --speculative-config "{
-        \"method\":\"extract_hidden_states\",
-        \"num_speculative_tokens\":1,
-        \"draft_model_config\":{
-            \"hf_config\":{
-                \"eagle_aux_hidden_state_layer_ids\":$EAGLE_CAPTURE_IDS
-            }
-        }
-    }" \
-    --kv-transfer-config "{
-        \"kv_connector\":\"ExampleHiddenStatesConnector\",
-        \"kv_role\":\"kv_producer\",
-        \"kv_connector_extra_config\":{\"shared_storage_path\":\"$SERVE_SCRATCH\"}
-    }" \
-    > "$SERVE_LOG" 2>&1 &
-SERVE_PID=$!
-
-cleanup() {
-    echo "Cleaning up vllm serve (PID=$SERVE_PID)..."
-    kill $SERVE_PID 2>/dev/null || true
-    wait $SERVE_PID 2>/dev/null || true
-}
-trap cleanup INT TERM EXIT
-
-echo "Waiting for vllm serve to become ready (up to 15 min)..."
-READY=0
-for i in $(seq 1 180); do
-    if curl -fsS "http://$SERVE_HOST:$SERVE_PORT/v1/models" > /dev/null 2>&1; then
-        READY=1; break
     fi
-    if ! kill -0 $SERVE_PID 2>/dev/null; then
-        echo "vllm serve died early. Tail of $SERVE_LOG:"; tail -100 "$SERVE_LOG"; exit 1
+    if [ -z "$TRAIN_GPUS" ]; then
+        echo "ERROR: no GPUs left for the trainer (SERVE_GPU=$SERVE_GPU consumed them all)." >&2; exit 1
     fi
-    sleep 5
-done
-[ "$READY" = "1" ] || { echo "Server not ready in 900s. Tail:"; tail -100 "$SERVE_LOG"; exit 1; }
-echo "vllm serve ready."
 
-# Train. dataloader_num_workers must be 0 (the streaming dataset owns one
-# asyncio loop per process; multi-worker would duplicate it). Server URL,
-# served-model-name, and ``shared_storage_path`` (must match the connector's,
-# used as the trainer-side allowlist) are injected here.
-echo "Launching trainer on GPUs=$TRAIN_GPUS..."
-CUDA_VISIBLE_DEVICES="$TRAIN_GPUS" bash modules/Model-Optimizer/examples/speculative_decoding/launch_train.sh \
-    "${@}" \
-    data.streaming_server_url="http://$SERVE_HOST:$SERVE_PORT" \
-    data.streaming_model_name="$HF_MODEL_CKPT" \
-    data.streaming_shared_storage_path="$SERVE_SCRATCH" \
-    training.dataloader_num_workers=0
+    trap cleanup INT TERM EXIT
+    launch_vllm "$SERVE_HOST" "$SERVE_TP" "$SERVE_GPU"
+    wait_vllm_ready "http://${SERVE_HOST}:${SERVE_PORT}" || exit 1
+    run_trainer_and_export "http://${SERVE_HOST}:${SERVE_PORT}" "$TRAIN_GPUS" || exit 1
 
-python3 modules/Model-Optimizer/examples/speculative_decoding/scripts/export_hf_checkpoint.py \
-    --model_path /scratchspace/eagle3 \
-    --export_path /scratchspace/export
+elif [ "$NODEID" -eq 0 ]; then
+    # ----------------------- multi-node: serve node ------------------------
+    SERVE_GPU_MEM_UTIL="${SERVE_GPU_MEM_UTIL:-0.9}"   # dedicated node -> use most of it
+    SERVE_TP="${SERVE_TP:-$(gpus_on_node)}"            # default: all GPUs on this node
+    rm -f "$SERVE_ADDR_FILE" "$DONE_FILE"              # clear stale rendezvous state
+
+    trap cleanup INT TERM EXIT
+    launch_vllm "0.0.0.0" "$SERVE_TP" ""
+    wait_vllm_ready "http://127.0.0.1:${SERVE_PORT}" || exit 1
+
+    # Publish a *routable* address for the trainer node. `hostname -I` can list a
+    # link-local (169.254.x) or loopback address first, which is unreachable from
+    # the other node, so resolve the Slurm node name and fall back to the first
+    # non-link-local / non-loopback IP.
+    serve_addr="${SERVE_ADVERTISE_IP:-}"
+    if [ -z "$serve_addr" ]; then
+        serve_addr=$(getent hosts "${SLURMD_NODENAME:-$(hostname)}" 2>/dev/null | awk '{print $1}' | head -1)
+    fi
+    if [ -z "$serve_addr" ]; then
+        serve_addr=$(hostname -I | tr ' ' '\n' | grep -vE '^(127\.|169\.254\.|fe80:|::1)' | head -1)
+    fi
+    [ -z "$serve_addr" ] && serve_addr=$(hostname -I | awk '{print $1}')
+    echo "$serve_addr" > "$SERVE_ADDR_FILE"
+    echo "Serve node published ${serve_addr}; holding the server up until the trainer signals done..."
+    while [ ! -f "$DONE_FILE" ]; do sleep 10; done
+    echo "Training-done sentinel seen; serve node exiting (EXIT trap stops vllm)."
+
+elif [ "$NODEID" -eq 1 ]; then
+    # ---------------------- multi-node: trainer node -----------------------
+    # Release the serve node on any exit (success or failure) so it doesn't hang.
+    trap 'touch "$DONE_FILE" 2>/dev/null || true' EXIT
+
+    echo "Trainer node waiting (up to ${SERVE_READY_TIMEOUT}s) for the serve address..."
+    for ((i = 0; i < SERVE_READY_TIMEOUT; i++)); do
+        [ -f "$SERVE_ADDR_FILE" ] && break
+        sleep 1
+    done
+    [ -f "$SERVE_ADDR_FILE" ] || { echo "ERROR: serve node never published its address." >&2; exit 1; }
+    URL="http://$(cat "$SERVE_ADDR_FILE"):${SERVE_PORT}"
+
+    wait_vllm_ready "$URL" || exit 1
+    run_trainer_and_export "$URL" "" || exit 1
+
+else
+    # ------------- multi-node: extra nodes (unused by default) -------------
+    echo "Node rank ${NODEID} idle: the default split uses node 0 = vllm serve, node 1 = trainer."
+    echo "Multi-node *training* (>1 trainer node) is not wired up yet; allocate exactly 2 nodes."
+    while [ ! -f "$DONE_FILE" ]; do sleep 10; done
+fi
 
 ###################################################################################################
 

--- a/tools/launcher/common/eagle3/train_eagle_streaming.sh
+++ b/tools/launcher/common/eagle3/train_eagle_streaming.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# EAGLE3 streaming training: co-locates `vllm serve` (KV-transfer producer of
+# hidden states) with the trainer on the same node, and routes hidden states
+# over HTTP rather than dumping to disk. Sibling of train_eagle.sh.
+#
+# Env vars (required):
+#   HF_MODEL_CKPT       Target model path. Used by both vllm serve (as the
+#                       model arg, becomes the served-model-name) and the
+#                       trainer (data.streaming_model_name).
+#   EAGLE_CAPTURE_IDS   JSON list of 1-based layer ids vllm should capture.
+#                       Must equal default_eagle_aux_layer_ids(L) shifted by +1,
+#                       plus the final layer L. For Qwen3-8B (L=36):
+#                       default = [1,17,32] -> capture = [2,18,33,36].
+#
+# Env vars (optional):
+#   SERVE_HOST          default 127.0.0.1
+#   SERVE_PORT          default 8765
+#   SERVE_GPU           CUDA_VISIBLE_DEVICES for vllm serve. default "0"
+#   SERVE_TP            tensor-parallel-size for vllm serve. default 1
+#   SERVE_GPU_MEM_UTIL  default 0.4
+#   TRAIN_GPUS          CUDA_VISIBLE_DEVICES for the trainer. default = all
+#                       local GPUs except SERVE_GPU.
+#
+# All script args after the env-var setup are forwarded to launch_train.sh
+# (typically: --config <yaml> plus OmegaConf dotlist overrides).
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "${SCRIPT_DIR}/../service_utils.sh"
+
+###################################################################################################
+# Container provisioning
+#
+# vllm/vllm-openai:* has vllm and torch but not modelopt or the speculative
+# trainer's deps. modelopt is bind-mounted at
+# /usr/local/lib/python3.12/dist-packages/modelopt, but it has no .dist-info
+# (so `importlib.metadata.version('nvidia-modelopt')` would fail). nemo_run
+# only ships modelopt subdirs, not the real pyproject.toml, so we synthesize
+# a minimal one with a correctly-scoped setuptools.packages.find include —
+# without `include = ["modelopt*"]`, setuptools sees both `modelopt/` and
+# `modelopt_recipes/` at the top level and refuses with a "flat-layout"
+# error. We then `pip install -e .` to register the dist-info.
+
+TOML=modules/Model-Optimizer/pyproject.toml
+if [ ! -f "$TOML" ]; then
+    cat > "$TOML" <<'EOF'
+[build-system]
+requires = ["setuptools>=80"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nvidia-modelopt"
+version = "0.0.0"
+dependencies = [
+    "omegaconf>=2.3.0",
+    "PyYAML>=6.0",
+    "pulp<4.0",
+    "pydantic>=2.0",
+    "regex",
+    "rich",
+    "safetensors",
+    "scipy",
+    "nvidia-ml-py>=12",
+    "packaging",
+    "tqdm",
+]
+
+[tool.setuptools.packages.find]
+include = ["modelopt*", "modelopt_recipes*"]
+EOF
+fi
+pip install --no-cache-dir -e modules/Model-Optimizer/
+pip install --no-cache-dir -r modules/Model-Optimizer/examples/speculative_decoding/requirements.txt
+pip install --no-cache-dir 'datasets' 'huggingface-hub>=1.2.1'
+export PATH=$PATH:/workspace/.local/bin
+
+###################################################################################################
+
+trap 'error_handler $0 $LINENO' ERR # ERROR HANDLER
+
+if [ -z "$HF_MODEL_CKPT" ]; then
+    echo "ERROR: HF_MODEL_CKPT must be set." >&2; exit 1
+fi
+if [ -z "$EAGLE_CAPTURE_IDS" ]; then
+    echo "ERROR: EAGLE_CAPTURE_IDS must be set (e.g. '[2, 18, 33, 36]' for Qwen3-8B)." >&2; exit 1
+fi
+
+SERVE_HOST="${SERVE_HOST:-127.0.0.1}"
+SERVE_PORT="${SERVE_PORT:-8765}"
+SERVE_GPU="${SERVE_GPU:-0}"
+SERVE_TP="${SERVE_TP:-1}"
+SERVE_GPU_MEM_UTIL="${SERVE_GPU_MEM_UTIL:-0.4}"
+
+if [ -z "$TRAIN_GPUS" ]; then
+    TRAIN_GPUS=$(python3 - <<PY
+total = int("$(nvidia-smi --query-gpu=count --format=csv,noheader,nounits | head -n1)")
+exclude = {int(x) for x in "$SERVE_GPU".split(",") if x != ""}
+print(",".join(str(i) for i in range(total) if i not in exclude))
+PY
+)
+fi
+if [ -z "$TRAIN_GPUS" ]; then
+    echo "ERROR: no GPUs left for the trainer (SERVE_GPU=$SERVE_GPU consumed them all)." >&2; exit 1
+fi
+
+SERVE_SCRATCH="/scratchspace/streaming_serve_scratch"
+SERVE_LOG="/scratchspace/vllm_serve.log"
+mkdir -p "$SERVE_SCRATCH"
+
+echo "Launching vllm serve on $SERVE_HOST:$SERVE_PORT (GPUs=$SERVE_GPU, TP=$SERVE_TP, log: $SERVE_LOG)..."
+CUDA_VISIBLE_DEVICES="$SERVE_GPU" vllm serve "$HF_MODEL_CKPT" \
+    --host "$SERVE_HOST" \
+    --port "$SERVE_PORT" \
+    --tensor-parallel-size "$SERVE_TP" \
+    --enforce-eager \
+    --gpu-memory-utilization "$SERVE_GPU_MEM_UTIL" \
+    --speculative-config "{
+        \"method\":\"extract_hidden_states\",
+        \"num_speculative_tokens\":1,
+        \"draft_model_config\":{
+            \"hf_config\":{
+                \"eagle_aux_hidden_state_layer_ids\":$EAGLE_CAPTURE_IDS
+            }
+        }
+    }" \
+    --kv-transfer-config "{
+        \"kv_connector\":\"ExampleHiddenStatesConnector\",
+        \"kv_role\":\"kv_producer\",
+        \"kv_connector_extra_config\":{\"shared_storage_path\":\"$SERVE_SCRATCH\"}
+    }" \
+    > "$SERVE_LOG" 2>&1 &
+SERVE_PID=$!
+
+cleanup() {
+    echo "Cleaning up vllm serve (PID=$SERVE_PID)..."
+    kill $SERVE_PID 2>/dev/null || true
+    wait $SERVE_PID 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+echo "Waiting for vllm serve to become ready (up to 15 min)..."
+READY=0
+for i in $(seq 1 180); do
+    if curl -fsS "http://$SERVE_HOST:$SERVE_PORT/v1/models" > /dev/null 2>&1; then
+        READY=1; break
+    fi
+    if ! kill -0 $SERVE_PID 2>/dev/null; then
+        echo "vllm serve died early. Tail of $SERVE_LOG:"; tail -100 "$SERVE_LOG"; exit 1
+    fi
+    sleep 5
+done
+[ "$READY" = "1" ] || { echo "Server not ready in 900s. Tail:"; tail -100 "$SERVE_LOG"; exit 1; }
+echo "vllm serve ready."
+
+# Train. dataloader_num_workers must be 0 (the streaming dataset owns one
+# asyncio loop per process; multi-worker would duplicate it). Server URL,
+# served-model-name, and ``shared_storage_path`` (must match the connector's,
+# used as the trainer-side allowlist) are injected here.
+echo "Launching trainer on GPUs=$TRAIN_GPUS..."
+CUDA_VISIBLE_DEVICES="$TRAIN_GPUS" bash modules/Model-Optimizer/examples/speculative_decoding/launch_train.sh \
+    "${@}" \
+    data.streaming_server_url="http://$SERVE_HOST:$SERVE_PORT" \
+    data.streaming_model_name="$HF_MODEL_CKPT" \
+    data.streaming_shared_storage_path="$SERVE_SCRATCH" \
+    training.dataloader_num_workers=0
+
+python3 modules/Model-Optimizer/examples/speculative_decoding/scripts/export_hf_checkpoint.py \
+    --model_path /scratchspace/eagle3 \
+    --export_path /scratchspace/export
+
+###################################################################################################
+
+#exit_handler $0

--- a/tools/launcher/core.py
+++ b/tools/launcher/core.py
@@ -253,13 +253,22 @@ def build_slurm_executor(
         f"{job_dir}/{experiment_title}:/{experiment_title}",
     ]
 
-    tunnel = run.SSHTunnel(
-        host=slurm_config.host,
-        user=user or getattr(slurm_config, "user", None) or getpass.getuser(),
-        port=slurm_config.port,
-        job_dir=job_dir,
-        identity=identity,
-    )
+    # When launching from a login node inside the cluster (host is localhost),
+    # use a LocalTunnel: nemo_run then runs sbatch and copies artifacts via local
+    # subprocess/shutil instead of ssh+rsync. This avoids flaky/hanging ssh-to-
+    # localhost (e.g. MaxStartups throttling on a shared login node, or clusters
+    # like HSG that are only reachable through an sss proxy so paramiko can't
+    # tunnel in from outside). For real remote hosts, keep the SSHTunnel.
+    if slurm_config.host in ("localhost", "127.0.0.1"):
+        tunnel = run.LocalTunnel(job_dir=job_dir)
+    else:
+        tunnel = run.SSHTunnel(
+            host=slurm_config.host,
+            user=user or getattr(slurm_config, "user", None) or getpass.getuser(),
+            port=slurm_config.port,
+            job_dir=job_dir,
+            identity=identity,
+        )
 
     executor = run.SlurmExecutor(
         account=slurm_config.account,

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_eagle3.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_eagle3.yaml
@@ -2,12 +2,14 @@
 #
 # 3-step pipeline:
 #   task_0: Build input conversations (jsonl)
-#   task_1: Streaming train — vllm serve + trainer co-located on one node;
-#           hidden states are fetched per sample over HTTP (no on-disk dump)
+#   task_1: Streaming train — vllm serve + trainer; hidden states are fetched
+#           per sample over HTTP (no on-disk dump)
 #   task_2: Benchmark — evaluate speculative decoding speedup via VLLM
 #
-# task_1 runs vllm serve on GPU 0 (TP=1) and the trainer on GPUs 1-7. All tasks
-# share /scratchspace to pass artifacts between steps.
+# task_1 here uses the multi-node split (nodes=2): node 0 runs vllm serve, node 1
+# runs the trainer; they rendezvous via the shared /scratchspace mount. (Set
+# nodes=1 to co-locate both on one node instead.) All tasks share /scratchspace
+# to pass artifacts between steps.
 #
 # Usage:
 #   uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_streaming_eagle3.yaml --yes
@@ -52,19 +54,18 @@ pipeline:
       - training.disable_tqdm=true
       - training.ar_validate_steps=500000
       - training.num_train_epochs=1
+      - eagle.eagle_use_torch_compile=false
     environment:
       - HF_MODEL_CKPT: <<global_vars.hf_model>>
       # No spaces: nemo_run emits `export FOO=value` without quotes, so a
       # space-separated value would be split by the shell.
       - EAGLE_CAPTURE_IDS: "[2,18,33,36]"
-      - SERVE_GPU: "0"
       - SERVE_TP: "1"
-      - SERVE_GPU_MEM_UTIL: "0.4"
     slurm_config:
       _factory_: "slurm_factory"
-      nodes: 1
+      nodes: 2
       ntasks_per_node: 1
-      gpus_per_node: 8
+      gpus_per_node: 1
       container: vllm/vllm-openai:latest
 
   # Step 3: Benchmark speculative decoding (VLLM backend)

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_eagle3.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_eagle3.yaml
@@ -1,0 +1,90 @@
+# EAGLE3 streaming speculative decoding pipeline for Qwen3-8B.
+#
+# 3-step pipeline:
+#   task_0: Build input conversations (jsonl)
+#   task_1: Streaming train — vllm serve + trainer co-located on one node;
+#           hidden states are fetched per sample over HTTP (no on-disk dump)
+#   task_2: Benchmark — evaluate speculative decoding speedup via VLLM
+#
+# task_1 runs vllm serve on GPU 0 (TP=1) and the trainer on GPUs 1-7. All tasks
+# share /scratchspace to pass artifacts between steps.
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_streaming_eagle3.yaml --yes
+
+job_name: Qwen3-8B_EAGLE3_streaming
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3-8B
+
+  # Step 1: Build input conversations
+  task_0:
+    script: common/eagle3/make_dataset.sh
+    args:
+      - -f modules/Model-Optimizer/examples/dataset/example_data_config.yaml
+      - --full-conversations
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+
+  # Step 2: Streaming EAGLE3 training
+  #
+  # Qwen3-8B has 36 hidden layers; default_eagle_aux_layer_ids(36) = [1, 17, 32];
+  # vllm capture ids are those shifted by +1, plus the final layer:
+  #   [2, 18, 33] + [36] = [2, 18, 33, 36].
+  task_1:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.mode=streaming
+      - data.data_path=/scratchspace/data/train.jsonl
+      - data.streaming_prefetch=64
+      - training.output_dir=/scratchspace/eagle3
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+      - training.num_train_epochs=1
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # No spaces: nemo_run emits `export FOO=value` without quotes, so a
+      # space-separated value would be split by the shell.
+      - EAGLE_CAPTURE_IDS: "[2,18,33,36]"
+      - SERVE_GPU: "0"
+      - SERVE_TP: "1"
+      - SERVE_GPU_MEM_UTIL: "0.4"
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      container: vllm/vllm-openai:latest
+
+  # Step 3: Benchmark speculative decoding (VLLM backend)
+  task_2:
+    script: common/specdec_bench/quick_check.sh
+    args:
+      - --draft_model_dir /scratchspace/export
+      - --draft_length 3
+      - --output_length 4096
+      - --engine VLLM
+      - --tp_size 1
+      - --ep_size 1
+      - --speculative_algorithm EAGLE3
+      - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
+      - --concurrency 1
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: vllm/vllm-openai:latest

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_eagle3_dryrun.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_eagle3_dryrun.yaml
@@ -1,0 +1,60 @@
+# EAGLE3 dry-run smoke test for Kimi-K2.5 (NVFP4).
+#
+# Single-task pipeline that exercises the full convert→save→export path WITHOUT
+# actually training. The launcher's `common/eagle3/train_eagle.sh` is unchanged —
+# all dry-run behaviour is expressed as dotlist overrides on `main.py`:
+#
+#   --dry_run                              → main.py skips trainer.train(), saves
+#                                            the (untrained) ModelOpt checkpoint
+#                                            right after mtsp.convert
+#   model.use_fake_base_for_offline=true   → load only embed_tokens + lm_head from
+#                                            the base model (FakeBaseModel); the
+#                                            ~1T MoE base weights are never read, so
+#                                            this fits on a single GPU
+#   model.trust_remote_code=true           → Kimi-K2.5 (deepseek_v3 arch) ships a
+#                                            custom modeling file
+#   data.offline_data_path=<placeholder>   → required to route into the
+#                                            FakeBaseModel path; contents are never
+#                                            read in --dry_run mode
+#
+# Useful for:
+#   - End-to-end smoke tests of the launcher / Docker / Slurm plumbing
+#   - Validating downstream stacks (vLLM, TRT-LLM) can load ModelOpt-exported
+#     EAGLE3 checkpoints without paying for a real training run
+#   - Fast local iteration when only the export structure matters, not draft
+#     accuracy
+#
+# The exported checkpoint at /scratchspace/export has the correct EAGLE3
+# architecture (layer shapes, lm_head, config.json) but untrained draft-head
+# weights — its acceptance rate will be ~0%, by design.
+#
+# Usage:
+#   uv run launch.py --yaml examples/moonshotai/Kimi-K2.5/hf_eagle3_dryrun.yaml --yes
+
+job_name: Kimi-K2.5_EAGLE3_dryrun
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/nvidia/Kimi-K2.5-NVFP4
+
+  # Convert → save → export (no training).
+  task_0:
+    script: common/eagle3/train_eagle.sh
+    args:
+      - --dry_run
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - model.use_fake_base_for_offline=true
+      - model.trust_remote_code=true
+      - data.offline_data_path=/tmp/dryrun-placeholder
+      - training.output_dir=/scratchspace/eagle3
+      - training.disable_tqdm=true
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_eagle3.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_eagle3.yaml
@@ -1,0 +1,119 @@
+# EAGLE3 streaming speculative decoding for Kimi-K2.5-NVFP4 on GB200/Blackwell
+# (HSG). This is the streaming config that actually runs end-to-end: on CW H100
+# the ~551 GB model needed cpu-offload (-> ~1 tok/s -> vLLM EngineCore
+# TimeoutError), so the working path is GB200.
+#
+# Why GB200: nodes have only 4 GPUs each (vs CW's 8), but 192 GB/GPU and native
+# NVFP4. Kimi-K2.5-NVFP4 (~551 GB) fits at TP=4 on ONE node (4 x 192 = 768 GB,
+# ~138 GB/GPU of weights) with NO cpu-offload. So here: node 0 = vllm serve
+# (TP=4, whole node), node 1 = EAGLE3 trainer (fake base), 4 GPUs each, 2 nodes.
+#
+# Capture ids: kimi_k25 (deepseek_v3 arch), 61 layers. aux states are indexed
+# by layer INPUT (0..60); the final layer is NOT capturable, so the base is 60.
+# captured = [2,30,58] aux + [60] base = 4, matching the trainer's 3-aux+base.
+#
+# Run ON the HSG login node (paramiko can't reach HSG through the sss proxy):
+#   export SLURM_HOST=localhost SLURM_ACCOUNT=coreai_dlalgo_modelopt \
+#          SLURM_PARTITION=batch \
+#          SLURM_HF_LOCAL=/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_modelopt/hf-local \
+#          SLURM_JOB_DIR=/lustre/fs1/portfolios/coreai/projects/coreai_dlalgo_modelopt/users/haoguo/experiments \
+#          NEMORUN_HOME=$PWD
+#   uv run launch.py --yaml examples/moonshotai/Kimi-K2.5/hf_streaming_eagle3.yaml \
+#          identity=$HOME/.ssh/id_ecdsa detach=True --yes
+
+job_name: Kimi-K2.5-NVFP4_EAGLE3_streaming
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/nvidia/Kimi-K2.5-NVFP4
+
+  # Step 1: Build input conversations (model-agnostic)
+  task_0:
+    script: common/eagle3/make_dataset.sh
+    args:
+      - -f modules/Model-Optimizer/examples/dataset/example_data_config.yaml
+      - --full-conversations
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      # HSG QOS (QOSMinGRES) requires whole-node GPU allocation (4 on GB200),
+      # so request 4 even though make_dataset is CPU-only.
+      gpus_per_node: 4
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+
+  # Step 2: Streaming EAGLE3 training (node0 serve TP=4 / node1 train), 4 GPU/node
+  task_1:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - model.use_fake_base_for_offline=true
+      - model.trust_remote_code=true
+      - data.mode=streaming
+      - data.data_path=/scratchspace/data/train.jsonl
+      # Keep concurrent in-flight requests low: a 64-wide flood made cold NVFP4
+      # MoE kernels/flashinfer autotune stall a worker past vLLM's engine<->worker
+      # timeout, killing EngineCore (TimeoutError) mid-serve -> 500s -> trainer abort.
+      - data.streaming_prefetch=8
+      - training.output_dir=/scratchspace/eagle3
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+      - training.num_train_epochs=1
+      - training.max_steps=3000
+      - eagle.eagle_use_torch_compile=false
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # No spaces in values: nemo_run emits `export FOO=value` unquoted.
+      - EAGLE_CAPTURE_IDS: "[2,30,58,60]"
+      - SERVE_TP: "4"
+      # Kimi-K2.5-NVFP4 ~138 GB weights/GPU at TP=4; GB200 has 184 GB. The model's
+      # native max_seq_len is 262144, whose KV cache OOMs (first attempt died with
+      # 183/184 GB used). Cap context to the training seq len and leave headroom
+      # for activation spikes during the profiling forward.
+      - SERVE_MAX_MODEL_LEN: "4096"
+      # Small batches: smaller per-step MoE compute stays under the engine timeout.
+      - SERVE_MAX_NUM_SEQS: "4"
+      - SERVE_GPU_MEM_UTIL: "0.8"
+      - SERVE_READY_TIMEOUT: "2400"
+      - SERVE_EXTRA_ARGS: "--trust-remote-code"
+      # The killer was "RPC call to sample_tokens timed out" — a worker stalls on
+      # the first real serving step (cold NVFP4 MoE kernels) past vLLM's default
+      # execute-model timeout, so EngineCore dies. Extend the timeouts that govern
+      # that path (seconds). VLLM_RPC_TIMEOUT (ms) is a different RPC and didn't help.
+      - VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1200"
+      - VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 2
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      container: vllm/vllm-openai:latest
+
+  # Step 3: Benchmark speculative decoding (VLLM backend, Kimi served at TP=4)
+  task_2:
+    script: common/specdec_bench/quick_check.sh
+    args:
+      - --draft_model_dir /scratchspace/export
+      - --draft_length 3
+      - --output_length 4096
+      - --engine VLLM
+      - --tp_size 4
+      - --ep_size 1
+      - --speculative_algorithm EAGLE3
+      - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
+      - --concurrency 32
+      # Kimi has custom modeling code; bench run.py loads base+tokenizer and needs this.
+      - --trust_remote_code
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      container: vllm/vllm-openai:latest


### PR DESCRIPTION
### What does this PR do?

Type of change: new feature

**Design doc:** https://gist.github.com/h-guo18/241c94968b0591324c361d97cf995dd0
Jira ticket: https://jirasw.nvidia.com/browse/OMNIML-4341
Sandbox CI: https://gitlab-master.nvidia.com/omniml/integration/nmm-sandbox/-/jobs/327911555#L2228

Streaming hidden-states dataset: per-sample activations pulled from a live `vllm serve` over HTTP, replacing on-disk activation dumps.

Two axes for future extensions:
- **Backend** (`_fetch`): vLLM now; TRT-LLM / SGLang next.
- **Algorithm** (`_format`): Eagle now; distillation / probing next.
- **Sandbox CI**: https://gitlab-master.nvidia.com/omniml/integration/nmm-sandbox/-/merge_requests/169

Shared plumbing — async producer, token-level truncation to `training_seq_len`, loss-mask alignment, DDP via Accelerate's dispatcher (rank 0 fetches, broadcasts), circuit breaker, resume — lives in `StreamingDataset`. First instance: **`EagleVllmStreamingDataset`**.

API: `data.mode ∈ {online, offline, streaming}`; legacy configs auto-promote.

### Usage

```yaml
data:
  mode: streaming
  data_path: input_conversations/train.jsonl
  streaming_server_url: http://localhost:8000
  streaming_model_name: meta-llama/Llama-3.1-8B-Instruct
training:
  training_seq_len: 4096   # also caps the prompt sent to vllm
```

Requires `vllm serve` with `ExampleHiddenStatesConnector` and `dataloader_num_workers=0`.

End-to-end Slurm pipeline: `tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_eagle3.yaml`.

### Testing

- **Unit**: full-corpus invariant, rank-0-only iter, resume, circuit breaker, mocked-httpx integration.
- **E2E**: `launch_train.sh` against a stdlib `HTTPServer` mimicking the connector.
- **Smoke** (Qwen3-8B / 8×H100 / 4096 ultrachat samples, single epoch): train_loss 32 → 18, MT-Bench AR 1.003 → 1.20.

### TODO before un-drafting

- [ ] Observability counters (filtered, fetch failures, queue depth, latency).
- [ ] Changelog entry.
- [x] Add test in sandbox.

**Non-goals (v1):** multi-epoch streaming, cross-rank dynamic load balancing.

### Before your PR is "*Ready for review*"

- Backward compatible: ✅ (legacy configs auto-promote)
- New PIP dep: N/A
- New tests: ✅
- Changelog: ❌ (TODO above)
- Claude approval: ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming training mode with server-backed hidden-state fetching, deterministic seed control, resume support, and streaming-specific dataset options (server, model, prefetch, shared storage).

* **Behavior / Bug Fixes**
  * Stronger mode validation; offline behavior derived from data mode; resume handling adjusted to avoid double-skip during streaming runs.

* **Tests**
  * End-to-end CI streaming test and expanded unit tests covering streaming, resume, DDP, determinism, and failure cases.

* **Infrastructure**
  * Launcher script and pipeline config for end-to-end streaming training.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
