### PR TITLE
fix(quantization): accept QuantizeAlgorithmConfig in get_modelike_from_algo_cfg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Changelog
 **Bug Fixes**
 
 - Fix Megatron-Core HF importer to load fused ``TELayerNormColumnParallelLinear.layer_norm_weight`` from HF for GPT-family models (Qwen3 etc.) under ``--export-default-te-spec``. Importer now prefers per-context keys ``fused_input_layernorm`` / ``fused_pre_mlp_layernorm`` (fallback ``fused_norm`` for Nemotron-H backward compatibility); ``mcore_qwen.py`` provides the new rules. Without this fix, post-prune MMLU sat at chance.
+- Fix ``QuantizeAlgorithmConfig`` instances being rejected with ``ValueError`` when passed as the ``algorithm`` in a quantization config (e.g. ``cfg["algorithm"] = mtq.MaxCalibConfig(...)``). Such instances are now accepted, consistent with the ``algorithm`` field's type annotation.
 
 0.44 (2026-05-14)
 ^^^^^^^^^^^^^^^^^

--- a/modelopt/torch/quantization/mode.py
+++ b/modelopt/torch/quantization/mode.py
@@ -16,7 +16,7 @@
 """This module contains the mode descriptor for the quantization mode."""
 
 from abc import abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 from modelopt.torch.opt.config import ModeloptBaseConfig
 from modelopt.torch.opt.conversion import ModelLikeModule
@@ -374,7 +374,9 @@ def get_modelike_from_algo_cfg(algo_cfg: QuantizeAlgoCfgType) -> ModeConfigList:
         return [get_modelike_from_algo_cfg(c)[0] for c in algo_cfg]
     if algo_cfg is None or isinstance(algo_cfg, str):
         algo_name, algo_cfg = algo_cfg, {}
-    elif isinstance(algo_cfg, dict):
+    elif isinstance(algo_cfg, Mapping):
+        # Normalize any mapping (incl. ModeloptBaseConfig instances) to a plain dict.
+        algo_cfg = dict(algo_cfg)
         algo_name = algo_cfg["method"]
     else:
         raise ValueError(f"Invalid config type: {type(algo_cfg)}")

--- a/tests/unit/torch/quantization/test_mode.py
+++ b/tests/unit/torch/quantization/test_mode.py
@@ -19,11 +19,16 @@ import pytest
 
 from modelopt.torch.opt.config import ModeloptField
 from modelopt.torch.opt.mode import _ModeRegistryCls
-from modelopt.torch.quantization.config import QuantizeAlgorithmConfig
+from modelopt.torch.quantization.config import (
+    MaxCalibConfig,
+    QuantizeAlgorithmConfig,
+    SmoothQuantCalibConfig,
+)
 from modelopt.torch.quantization.mode import (
     BaseCalibrateModeDescriptor,
     CalibrateModeRegistry,
     QuantizeModeRegistry,
+    get_modelike_from_algo_cfg,
 )
 
 
@@ -60,3 +65,20 @@ def test_calibrate_mode_registry_with_custom_mode():
         @CalibrateModeRegistry.register_mode
         class TestIncorrectCalibrateModeDescriptor:
             pass
+
+
+def test_get_modelike_from_algo_cfg_accepts_config_instance():
+    """Regression test for GitHub issue #201.
+
+    A ``QuantizeAlgorithmConfig`` instance passed as the ``algorithm`` config is
+    normalized to a dict and accepted, instead of raising ``ValueError``.
+    """
+    mode_name, algo_cfg = get_modelike_from_algo_cfg(MaxCalibConfig(distributed_sync=False))[0]
+    assert mode_name == "max_calibrate"
+    assert isinstance(algo_cfg, dict)
+    assert algo_cfg["distributed_sync"] is False
+    MaxCalibConfig(**algo_cfg)
+
+    modes = get_modelike_from_algo_cfg([MaxCalibConfig(), SmoothQuantCalibConfig()])
+    assert [name for name, _ in modes] == ["max_calibrate", "smoothquant_calibrate"]
+    assert all(isinstance(cfg, dict) for _, cfg in modes)

--- a/tests/unit/torch/quantization/test_quantize_cpu.py
+++ b/tests/unit/torch/quantization/test_quantize_cpu.py
@@ -32,7 +32,7 @@ from pydantic import ValidationError
 import modelopt.torch.opt as mto
 import modelopt.torch.quantization as mtq
 from modelopt.torch.quantization.calib import MaxCalibrator
-from modelopt.torch.quantization.config import QuantizerAttributeConfig
+from modelopt.torch.quantization.config import MaxCalibConfig, QuantizerAttributeConfig
 from modelopt.torch.quantization.conversion import set_quantizer_attributes_full
 from modelopt.torch.quantization.nn.modules.tensor_quantizer import (
     SequentialQuantizer,
@@ -165,6 +165,18 @@ def test_inplace_backward_compatibility():
             model(batch)
 
     mtq.quantize(model, mtq.INT8_DEFAULT_CFG, forward_loop=forward_loop)
+
+
+def test_quantize_accepts_algo_config_instance_end_to_end():
+    """Regression test for GitHub issue #201.
+
+    A ``QuantizeAlgorithmConfig`` instance set as ``config["algorithm"]`` must not
+    raise ``ValueError`` through the full quantize/calibrate flow.
+    """
+    quant_config = copy.deepcopy(mtq.INT8_DEFAULT_CFG)
+    quant_config["algorithm"] = MaxCalibConfig(distributed_sync=False)
+    model = SimpleLinear()
+    quantize_model_and_forward(model, quant_config, [model.get_input() for _ in range(2)])
 
 
 def test_custom_calib_config():


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fixes #201 - `get_modelike_from_algo_cfg` rejected `QuantizeAlgorithmConfig` instances with `ValueError`, despite the `algorithm` field's type annotation allowing them.

**Root cause:** `QuantizeAlgoCfgType` (`modelopt/torch/quantization/config.py`) explicitly includes `QuantizeAlgorithmConfig`, and `QuantizeConfig.algorithm` is typed with it. But `get_modelike_from_algo_cfg` only matched `list` / `None` / `str` / `dict` and fell through to `raise ValueError(f"Invalid config type: {type(algo_cfg)}")` for a config instance:

```
ValueError: Invalid config type: <class 'modelopt.torch.quantization.config.MaxCalibConfig'>
```

**Fix:** `ModeloptBaseConfig` is a `collections.abc.MutableMapping`, so the type cascade's `dict` check is widened to `Mapping`, and the matched config is materialized with `dict(...)` so the resolved config keeps its `ConfigDict` (`dict[str, Any]`) type:

```python
elif isinstance(algo_cfg, Mapping):
    # Normalize any mapping (incl. ModeloptBaseConfig instances) to a plain dict.
    algo_cfg = dict(algo_cfg)
    algo_name = algo_cfg["method"]
```

The change is a strict no-op for the previously supported `str` / `dict` / `None` / `list` inputs (a plain `dict` is a `Mapping`); only the path that previously raised changes.

### Usage

```python
import modelopt.torch.quantization as mtq

cfg = mtq.INT8_DEFAULT_CFG
cfg["algorithm"] = mtq.MaxCalibConfig(method="max", distributed_sync=False)

# Previously: ValueError: Invalid config type: <class '...MaxCalibConfig'>
# Now accepted, consistent with the `algorithm` field's type annotation.
mtq.quantize(model, cfg, forward_loop)
```

### Testing

Added two regression tests:

- `tests/unit/torch/quantization/test_mode.py::test_get_modelike_from_algo_cfg_accepts_config_instance` - a single config instance and a list of config instances (resolved mode names, dict round-trip).
- `tests/unit/torch/quantization/test_quantize_cpu.py::test_quantize_accepts_algo_config_instance_end_to_end` - the issue's repro through the full `mtq.quantize` / calibrate flow.

```bash
pytest tests/unit/torch/quantization/test_mode.py::test_get_modelike_from_algo_cfg_accepts_config_instance \
       tests/unit/torch/quantization/test_quantize_cpu.py::test_quantize_accepts_algo_config_instance_end_to_end
```

Without the fix both tests fail with the exact `ValueError: Invalid config type`; with it they pass. The full `test_mode.py` and `test_quantize_cpu.py` suites pass locally, and `ruff check` / `ruff format --check` are clean on the changed files.

### Before your PR is "*Ready for review*"

Make sure you read and follow the [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices for contributors](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅
- Did you get Claude approval on this PR?: N/A

### Additional Information

Closes #201. Bug confirmed by @realAsma on the issue thread. The fix uses the `Mapping`-based approach suggested by @shengliangxu in review (`ModeloptBaseConfig` became a `MutableMapping` in #1405). Change is +41/-4 across `modelopt/torch/quantization/mode.py`, the two test files, and `CHANGELOG.rst`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quantization now accepts algorithm configuration objects as the algorithm parameter instead of rejecting them with an error.

* **Tests**
  * Added regression and end-to-end tests to verify algorithm config instances are accepted and preserved through the quantization workflow.

* **Documentation**
  * Changelog updated to record the bug fix in version 0.45.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->