### PR TITLE
[fix] Fix NVFP4 AWQ GQA prequant fusion

### DIFF
--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -328,7 +328,7 @@ def requantize_resmooth_fused_llm_layers(model: torch.nn.Module):
     #    the later gate up fusion.
     # Fuse pre_quant_scale to the linear weights if possible
     if quantization_format is not None and "nvfp4_awq" in quantization_format.lower():
-        fuse_prequant_to_linear(model)
+        fuse_prequant_to_linear(model, fuse_grouped_heads=True)
 
     # Pre-process MoE experts
     for name, module in model.named_modules():

--- a/tests/unit/torch/export/test_unified_export_hf.py
+++ b/tests/unit/torch/export/test_unified_export_hf.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import torch
+
+import modelopt.torch.export.unified_export_hf as export_hf
+
+
+class _DummyModel(torch.nn.Module):
+    config = SimpleNamespace(is_encoder_decoder=False)
+    device = torch.device("cpu")
+
+
+def test_nvfp4_awq_export_enables_grouped_head_prequant_fusion(monkeypatch):
+    """NVFP4 AWQ export should fuse GQA/MQA o_proj scales when possible."""
+    fuse_calls = []
+
+    monkeypatch.setattr(export_hf, "get_quantization_format", lambda model: "nvfp4_awq")
+    monkeypatch.setattr(
+        export_hf,
+        "fuse_prequant_to_linear",
+        lambda model, **kwargs: fuse_calls.append(kwargs),
+    )
+    monkeypatch.setattr(export_hf, "is_moe", lambda module: False)
+    monkeypatch.setattr(
+        export_hf,
+        "collect_shared_input_modules",
+        lambda model, forward, collect_layernorms=True: ({}, {}),
+    )
+    monkeypatch.setattr(export_hf, "_fuse_shared_input_modules", lambda *args, **kwargs: {})
+
+    export_hf.requantize_resmooth_fused_llm_layers(_DummyModel())
+
+    assert fuse_calls == [{"fuse_grouped_heads": True}]


### PR DESCRIPTION
## Summary

- Enable the existing grouped-head pre-quant-scale fusion path for NVFP4 AWQ export.
- Add a unit regression test to ensure `requantize_resmooth_fused_llm_layers()` calls `fuse_prequant_to_linear(..., fuse_grouped_heads=True)` for `nvfp4_awq` checkpoints.

## Motivation

`fuse_prequant_to_linear()` already supports GQA/MQA grouped-head fusion, but the unified HF export path called it without enabling that mode. For GQA/MQA models, this can leave `o_proj.pre_quant_scale` unfused because hidden-size pre-quant scales do not match KV projection output channels.

Native vLLM real-quant ModelOpt NVFP4 loading does not consume `pre_quant_scale`, so AWQ exports should fold these scales when possible.

## Validation

- `uv run pytest tests/unit/torch/export/test_unified_export_hf.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NVFP4-AWQ model export now enables grouped-head prequant fusion for improved quantization handling.

* **Tests**
  * Added test validation for NVFP4-AWQ export behavior with grouped-head prequant fusion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->