### PR TITLE
fix(quantization): accept QuantizeAlgorithmConfig in get_modelike_from_algo_cfg (#201)

### DIFF
--- a/modelopt/torch/quantization/mode.py
+++ b/modelopt/torch/quantization/mode.py
@@ -372,6 +372,8 @@ def get_modelike_from_algo_cfg(algo_cfg: QuantizeAlgoCfgType) -> ModeConfigList:
             f"Nested lists received as config! config: {algo_cfg}"
         )
         return [get_modelike_from_algo_cfg(c)[0] for c in algo_cfg]
+    if isinstance(algo_cfg, QuantizeAlgorithmConfig):
+        algo_cfg = algo_cfg.model_dump()
     if algo_cfg is None or isinstance(algo_cfg, str):
         algo_name, algo_cfg = algo_cfg, {}
     elif isinstance(algo_cfg, dict):

--- a/tests/unit/torch/quantization/test_mode.py
+++ b/tests/unit/torch/quantization/test_mode.py
@@ -19,11 +19,12 @@ import pytest
 
 from modelopt.torch.opt.config import ModeloptField
 from modelopt.torch.opt.mode import _ModeRegistryCls
-from modelopt.torch.quantization.config import QuantizeAlgorithmConfig
+from modelopt.torch.quantization.config import MaxCalibConfig, QuantizeAlgorithmConfig
 from modelopt.torch.quantization.mode import (
     BaseCalibrateModeDescriptor,
     CalibrateModeRegistry,
     QuantizeModeRegistry,
+    get_modelike_from_algo_cfg,
 )
 
 
@@ -60,3 +61,19 @@ def test_calibrate_mode_registry_with_custom_mode():
         @CalibrateModeRegistry.register_mode
         class TestIncorrectCalibrateModeDescriptor:
             pass
+
+
+def test_get_modelike_from_algo_cfg_accepts_quantize_algorithm_config():
+    """Regression test for #201: ``QuantizeAlgorithmConfig`` instances must be accepted."""
+    cfg_obj = MaxCalibConfig(method="max", distributed_sync=False)
+    cfg_dict = cfg_obj.model_dump()
+
+    from_obj = get_modelike_from_algo_cfg(cfg_obj)
+    from_dict = get_modelike_from_algo_cfg(cfg_dict)
+
+    assert from_obj == from_dict
+    assert from_obj[0][1] == cfg_dict
+
+    # List handling should also accept ``QuantizeAlgorithmConfig`` instances.
+    from_list = get_modelike_from_algo_cfg([cfg_obj])
+    assert from_list == from_obj


### PR DESCRIPTION
Fixes #201

`get_modelike_from_algo_cfg` was typed to accept `QuantizeAlgoCfgType` (which includes `QuantizeAlgorithmConfig` instances), but the body only handled list / str / None / dict and raised `ValueError("Invalid config type")` for `QuantizeAlgorithmConfig` instances. This broke the documented pattern of passing typed config objects (`MaxCalibConfig`, `AWQLiteCalibConfig`, etc.) via `quant_config['algorithm']`.

The fix pre-converts a `QuantizeAlgorithmConfig` instance to its `model_dump()` dict at function entry, so the existing dict path handles it unchanged. Two-line change; no new branch needed.

Verification: added a unit test in `tests/unit/torch/quantization/test_mode.py` that builds a `MaxCalibConfig`, calls `get_modelike_from_algo_cfg` on both the object and its equivalent dict, and asserts the two paths produce the same tuple. Also covers the list-of-object path.

Opened by OnCallBot on behalf of realAsma. Please review the diff before merging.

cc Chenjie Luo (module owner for torch.quantization)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `get_modelike_from_algo_cfg` now accepts configuration objects directly alongside existing input formats.

* **Tests**
  * Added regression test to verify configuration object handling works correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->