### PR TITLE
fix(export): align offloaded modules before pre-quant-scale fuse (#795)

### DIFF
--- a/modelopt/torch/export/quant_utils.py
+++ b/modelopt/torch/export/quant_utils.py
@@ -1253,6 +1253,26 @@ def fuse_prequant_to_linear(model: torch.nn.Module, fuse_grouped_heads=False):
     Returns:
         fused_modules: A list of modules of which pre_quant_scale is fused to the previous linear layer.
     """
+    # When models are loaded with accelerate's device_map (e.g. `device_map="auto"` plus
+    # tight `max_memory`), offloaded leaf modules have weights on the meta device until
+    # their forward hook fires. ``weight_access_and_writeback_context`` materializes the
+    # weight from the offload hook, lets us mutate it, and writes the fused value back to
+    # the offload weights_map so it survives once the hook is removed. Fall back to a
+    # no-op context when the module isn't hooked or accelerate is unavailable (#795).
+    from contextlib import nullcontext
+
+    try:
+        from modelopt.torch.quantization.plugins.accelerate import (
+            weight_access_and_writeback_context,
+        )
+    except ImportError:
+        weight_access_and_writeback_context = None
+
+    def _materialize(mod):
+        if weight_access_and_writeback_context is not None and hasattr(mod, "_hf_hook"):
+            return weight_access_and_writeback_context(mod)
+        return nullcontext()
+
     # Fuse pre_quant_scale to the linear weights
     for _, module in model.named_modules():
         for module_map in PQS_FUSE_MODULE_MAPPING:
@@ -1264,60 +1284,61 @@ def fuse_prequant_to_linear(model: torch.nn.Module, fuse_grouped_heads=False):
                 if hasattr(linear_pqs_from, "input_quantizer") and hasattr(
                     linear_pqs_from.input_quantizer, "_pre_quant_scale"
                 ):
-                    pre_quant_scale = linear_pqs_from.input_quantizer._pre_quant_scale
+                    with _materialize(linear_fuse_into):
+                        pre_quant_scale = linear_pqs_from.input_quantizer._pre_quant_scale
 
-                    # for GQA/MQA models, we can apply averaging to the pre_quant_scale for shared head groups
-                    if pre_quant_scale.numel() != linear_fuse_into.weight.shape[-2]:
-                        if (
-                            not fuse_grouped_heads
-                            or "attention" not in type(module).__name__.lower()
-                        ):
-                            warn(
-                                f"Skipping pattern fuse prequant for {type(module).__name__}"
-                                f"pre_quant_scale dim {pre_quant_scale.numel()} != "
-                                f"out_channel dim {linear_fuse_into.weight.shape[-2]}"
+                        # for GQA/MQA models, we can apply averaging to the pre_quant_scale for shared head groups
+                        if pre_quant_scale.numel() != linear_fuse_into.weight.shape[-2]:
+                            if (
+                                not fuse_grouped_heads
+                                or "attention" not in type(module).__name__.lower()
+                            ):
+                                warn(
+                                    f"Skipping pattern fuse prequant for {type(module).__name__}"
+                                    f"pre_quant_scale dim {pre_quant_scale.numel()} != "
+                                    f"out_channel dim {linear_fuse_into.weight.shape[-2]}"
+                                )
+                                continue
+                            config = module.config
+                            num_kv_heads = config.num_key_value_heads
+                            kv_head_dim = linear_fuse_into.weight.shape[0] // num_kv_heads
+                            n_rep = pre_quant_scale.numel() // num_kv_heads // kv_head_dim
+
+                            # Reshape:(num_kv_heads, n_rep, kv_head_dim)
+                            # n_rep is the number of query group
+                            averaged_scale = pre_quant_scale.view(
+                                num_kv_heads, n_rep, kv_head_dim
+                            ).mean(dim=1)
+
+                            # To update o_proj, we need to repeat back to original shape
+                            repeated_scale = (
+                                averaged_scale.unsqueeze(1)
+                                .expand(num_kv_heads, n_rep, kv_head_dim)
+                                .reshape(-1)
                             )
-                            continue
-                        config = module.config
-                        num_kv_heads = config.num_key_value_heads
-                        kv_head_dim = linear_fuse_into.weight.shape[0] // num_kv_heads
-                        n_rep = pre_quant_scale.numel() // num_kv_heads // kv_head_dim
+                            # Update o_proj's pre_quant_scale
+                            _update_pre_quant_scale(linear_pqs_from, repeated_scale)
 
-                        # Reshape:(num_kv_heads, n_rep, kv_head_dim)
-                        # n_rep is the number of query group
-                        averaged_scale = pre_quant_scale.view(
-                            num_kv_heads, n_rep, kv_head_dim
-                        ).mean(dim=1)
+                            # Use averaged scale (flattened) for v_proj fusion
+                            pre_quant_scale = averaged_scale.reshape(-1)
 
-                        # To update o_proj, we need to repeat back to original shape
-                        repeated_scale = (
-                            averaged_scale.unsqueeze(1)
-                            .expand(num_kv_heads, n_rep, kv_head_dim)
-                            .reshape(-1)
+                        # Fuse the pre_quant_scale to weight
+                        linear_fuse_into.weight = torch.nn.Parameter(
+                            linear_fuse_into.weight * pre_quant_scale.view(-1, 1)
                         )
-                        # Update o_proj's pre_quant_scale
-                        _update_pre_quant_scale(linear_pqs_from, repeated_scale)
+                        if hasattr(linear_fuse_into, "bias") and linear_fuse_into.bias is not None:
+                            linear_fuse_into.bias = torch.nn.Parameter(
+                                linear_fuse_into.bias * pre_quant_scale
+                            )
 
-                        # Use averaged scale (flattened) for v_proj fusion
-                        pre_quant_scale = averaged_scale.reshape(-1)
+                        # Recalibrate the weight quantizer for linear_fuse_into
+                        linear_fuse_into.weight_quantizer.reset_amax()
+                        enable_stats_collection(linear_fuse_into.weight_quantizer)
+                        linear_fuse_into.weight_quantizer(linear_fuse_into.weight)
+                        finish_stats_collection(linear_fuse_into.weight_quantizer)
 
-                    # Fuse the pre_quant_scale to weight
-                    linear_fuse_into.weight = torch.nn.Parameter(
-                        linear_fuse_into.weight * pre_quant_scale.view(-1, 1)
-                    )
-                    if hasattr(linear_fuse_into, "bias") and linear_fuse_into.bias is not None:
-                        linear_fuse_into.bias = torch.nn.Parameter(
-                            linear_fuse_into.bias * pre_quant_scale
-                        )
-
-                    # Recalibrate the weight quantizer for linear_fuse_into
-                    linear_fuse_into.weight_quantizer.reset_amax()
-                    enable_stats_collection(linear_fuse_into.weight_quantizer)
-                    linear_fuse_into.weight_quantizer(linear_fuse_into.weight)
-                    finish_stats_collection(linear_fuse_into.weight_quantizer)
-
-                    delattr(linear_pqs_from.input_quantizer, "_pre_quant_scale")
-                    setattr(linear_pqs_from, "fused_with_prequant", True)
+                        delattr(linear_pqs_from.input_quantizer, "_pre_quant_scale")
+                        setattr(linear_pqs_from, "fused_with_prequant", True)
 
 
 def _layernorm_uses_weight_plus_one(module: torch.nn.Module) -> bool:

--- a/tests/unit/torch/export/test_quant_utils.py
+++ b/tests/unit/torch/export/test_quant_utils.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-only unit tests for ``modelopt.torch.export.quant_utils``."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytest.importorskip("accelerate")
+
+from accelerate.hooks import AlignDevicesHook, add_hook_to_module
+from accelerate.utils import set_module_tensor_to_device
+
+from modelopt.torch.export.quant_utils import fuse_prequant_to_linear
+from modelopt.torch.quantization.nn import TensorQuantizer
+
+
+class LlamaMLP(nn.Module):
+    """Stub class with the name expected by ``PQS_FUSE_MODULE_MAPPING``."""
+
+    def __init__(self, hidden_size=8, intermediate_size=8):
+        super().__init__()
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+        # ``fuse_prequant_to_linear`` calls reset_amax / enable_stats_collection /
+        # the quantizer forward on ``up_proj.weight_quantizer`` - it needs to exist.
+        self.up_proj.weight_quantizer = TensorQuantizer()
+        self.down_proj.input_quantizer = TensorQuantizer()
+
+
+def _offload_weight_to_meta(linear: nn.Linear) -> dict:
+    """Simulate accelerate CPU offload: move the weight to meta, attach an offload hook."""
+    weights_map: dict[str, torch.Tensor] = {"weight": linear.weight.data.clone()}
+    set_module_tensor_to_device(linear, "weight", "meta")
+    hook = AlignDevicesHook(
+        execution_device=torch.device("cpu"),
+        offload=True,
+        weights_map=weights_map,
+        place_submodules=False,
+    )
+    add_hook_to_module(linear, hook)
+    return weights_map
+
+
+def test_fuse_prequant_to_linear_with_offloaded_weight():
+    """Regression test for #795: meta-device weight on the ``fuse_into`` linear.
+
+    Reproduces the failure mode triggered by HF ``device_map="auto"`` with tight
+    ``max_memory``: the linear we mutate has its weight on meta because accelerate has
+    offloaded it. The fuse path must materialize the weight via the offload hook,
+    perform the multiplication, and write the fused weight back to the offload map.
+    """
+    torch.manual_seed(0)
+    module = LlamaMLP(hidden_size=8, intermediate_size=8)
+
+    pre_quant_scale = torch.linspace(0.1, 0.8, steps=8)
+    module.down_proj.input_quantizer._pre_quant_scale = pre_quant_scale.clone()
+
+    original_weight = module.up_proj.weight.data.clone()
+    weights_map = _offload_weight_to_meta(module.up_proj)
+    assert module.up_proj.weight.device.type == "meta"
+
+    fuse_prequant_to_linear(module)
+
+    # The hook's post_forward re-evicts the parameter to meta after the context exits.
+    assert module.up_proj.weight.device.type == "meta"
+
+    # The fused weight should have been written back to the offload weights_map.
+    expected = original_weight * pre_quant_scale.view(-1, 1)
+    assert torch.allclose(weights_map["weight"], expected), (
+        "Offload weights_map should hold the fused weight after fuse_prequant_to_linear"
+    )
+
+    # pre_quant_scale is consumed and the module is flagged.
+    assert not hasattr(module.down_proj.input_quantizer, "_pre_quant_scale")
+    assert getattr(module.down_proj, "fused_with_prequant", False) is True
+
+
+def test_fuse_prequant_to_linear_without_offload():
+    """The non-offloaded path must still produce the in-place fused weight."""
+    torch.manual_seed(0)
+    module = LlamaMLP(hidden_size=8, intermediate_size=8)
+
+    pre_quant_scale = torch.linspace(0.1, 0.8, steps=8)
+    module.down_proj.input_quantizer._pre_quant_scale = pre_quant_scale.clone()
+    original_weight = module.up_proj.weight.data.clone()
+
+    fuse_prequant_to_linear(module)
+
+    expected = original_weight * pre_quant_scale.view(-1, 1)
+    assert torch.allclose(module.up_proj.weight.data, expected)
+    assert not hasattr(module.down_proj.input_quantizer, "_pre_quant_scale")
+    assert getattr(module.down_proj, "fused_with_prequant", False) is True


### PR DESCRIPTION
Partial fix for #795.

`fuse_prequant_to_linear` does direct `linear_fuse_into.weight * pre_quant_scale.view(-1, 1)` mutation. When a model is loaded with HF `device_map="auto"` and tight `max_memory` so some layers are offloaded (their weight is on `meta` until a forward hook fires), the multiplication blows up:

```
RuntimeError: Tensor on device cuda:0 is not on the expected device meta!
  File "modelopt/torch/export/quant_utils.py", line 1306, in fuse_prequant_to_linear
    linear_fuse_into.weight * pre_quant_scale.view(-1, 1)
```

This wraps the per-module mutation in `modelopt.torch.quantization.plugins.accelerate.weight_access_and_writeback_context` so the offload hook materializes the weight from `weights_map`, the fuse runs, and the fused weight is written back to the offload map so it survives once hooks are stripped. Falls back to a no-op context when accelerate is unavailable or the module isn't hooked.

**Regression test:** new `tests/unit/torch/export/test_quant_utils.py` builds a tiny stub MLP, attaches an `AlignDevicesHook(offload=True)` to evict the linear's weight to meta, runs `fuse_prequant_to_linear`, and asserts the fused value lands in the offload `weights_map`. CPU-only, no GPU required. The test fails on `main` and passes with this fix.

**End-to-end verification (Qwen3-1.7B + `max_memory={0: "2GiB", "cpu": "20GiB"}` + `NVFP4_AWQ_LITE_CFG`):** the specific failure in `fuse_prequant_to_linear` is resolved. Note: the full export pipeline then surfaces a separate meta-tensor assertion in `get_weight_scaling_factor` (`quant_utils.py:382`, `weight_scaling_factor_2.to(weight.device)`) which is **not** addressed by this PR -- looks like it needs a similar `weight_access_and_writeback_context` wrap in `_export_quantized_weight`, but that path is larger and worth a follow-up PR with its own test. Filing this one separately keeps each fix reviewable.

Opened by OnCallBot on behalf of realAsma. Please review the diff before merging.

cc Zhiyu Cheng (module owner for export/deploy), Chenjie Luo (torch.quantization)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pre-quantization scale fusion to correctly handle weight materialization in device-offloaded models.

* **Tests**
  * Added unit test coverage for pre-quantization fusion with both offloaded and standard module configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->