### PR TITLE
fix: preserve inlined MTP layers for GLM5

### DIFF
--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -30,6 +30,7 @@ import torch
 import transformers
 from accelerate import infer_auto_device_map, init_empty_weights
 from accelerate.utils import get_max_memory
+from safetensors import safe_open
 from safetensors.torch import load_file
 from transformers import (
     AutoConfig,
@@ -315,98 +316,157 @@ def get_processor(
             return None
 
 
+def _load_inlined_mtp_tensors(model_path: Path, mtp_prefixes: set[str]) -> dict[str, torch.Tensor]:
+    """Stream tensors whose keys start with any ``{prefix}.`` from on-disk shards.
+
+    Walks ``model.safetensors.index.json`` when present, else falls back to a
+    single ``model.safetensors`` file. Returns an empty dict if no matching
+    keys are found.
+    """
+
+    def _matches(key: str) -> bool:
+        return any(key.startswith(p + ".") for p in mtp_prefixes)
+
+    tensors: dict[str, torch.Tensor] = {}
+    index_file = model_path / "model.safetensors.index.json"
+    if index_file.exists():
+        weight_map = json.load(open(index_file))["weight_map"]
+        per_shard: dict[str, list[str]] = {}
+        for key, shard in weight_map.items():
+            if _matches(key):
+                per_shard.setdefault(shard, []).append(key)
+        for shard, keys in per_shard.items():
+            with safe_open(str(model_path / shard), framework="pt", device="cpu") as f:
+                for k in keys:
+                    tensors[k] = f.get_tensor(k)
+    else:
+        single = model_path / "model.safetensors"
+        if single.exists():
+            with safe_open(str(single), framework="pt", device="cpu") as f:
+                # safe_open is not a dict; ``.keys()`` is the public listing API.
+                for k in f.keys():  # noqa: SIM118
+                    if _matches(k):
+                        tensors[k] = f.get_tensor(k)
+    return tensors
+
+
 def load_mtp_weights(
     model: torch.nn.Module, model_path: str
 ) -> tuple[list[str], dict[str, torch.Tensor]]:
     """Load MTP weights from the model checkpoint.
 
-    Some models store additional layers in separate safetensors files with non-standard
-    names (e.g., mtp.safetensors). HuggingFace's from_pretrained() may not load these
-    files even though they're referenced in model.safetensors.index.json.
+    Detects MTP layers under two on-disk conventions:
 
-    This function detects such cases and explicitly loads the missing weights.
+    1. Separate-file: weights live in a non-standard safetensors file (e.g.,
+       ``mtp.safetensors``) with keys prefixed by ``mtp``.
+    2. Inlined: weights live in the main shards under
+       ``model.layers[num_hidden : num_hidden + num_nextn_predict_layers]``
+       (DeepSeek-V3, GLM-5.1 ``GlmMoeDsa``, GLM-4.7).
+
+    Whether the HF model class actually instantiates the MTP module varies:
+    DeepSeek-V3's modeling code adds the extra decoder layers, while
+    ``GlmMoeDsaModel`` in transformers >=5.7 builds only ``num_hidden`` layers
+    and leaves the inlined-MTP keys orphaned. To keep both paths correct, we
+    always read the tensors off disk here and split them: any key that maps
+    to a parameter in ``model.state_dict()`` is loaded into the model;
+    the remainder is returned as ``not_in_state_dict`` for the exporter to
+    merge in via ``extra_state_dict``.
 
     Args:
         model: The loaded model that may be missing weights
         model_path: Path to the model directory
 
     Returns:
-        List of layer prefixes that were loaded from non-standard safetensors files.
-        These layers should typically be excluded from quantization.
-        Empty list if no additional weights were loaded.
-        Dictionary of MTP weights that were not loaded into the model state dict.
+        List of layer prefixes that should be excluded from quantization
+        (e.g., ``"mtp.layers.0"`` or ``"model.layers.78"``). Empty if no MTP
+        layers were detected.
+        Dictionary of MTP weights that have no slot in the model's state
+        dict; ``export_hf_checkpoint`` merges these via ``extra_state_dict``.
     """
-    model_path = Path(model_path)
-    index_file = model_path / "model.safetensors.index.json"
-
-    if not index_file.exists():
-        return [], {}
-
-    # Load the index to find all referenced safetensors files
-    index = json.load(open(index_file))
-    weight_map = index["weight_map"]
-    # Find all files in weight_map whose key or value contains "mtp"
-    mtp_weight_map = {}
-    for k, v in weight_map.items():
-        if "mtp" in k or "mtp" in v:
-            mtp_weight_map.setdefault(v, []).append(k)
-
-    if not mtp_weight_map:
-        return [], {}
-
-    def _extract_layer_prefixes(keys):
-        mtp_layer_prefixes = set()
-        for key in keys:
-            parts = key.split(".")
-            # Capture the top-level MTP module prefix (e.g., "mtp" from "mtp.fc.weight")
-            # so that non-layer MTP weights like mtp.fc, mtp.norm are also excluded
-            if parts:
-                mtp_layer_prefixes.add(parts[0])
-            # Also capture specific layer prefixes (e.g., "mtp.layers.0")
-            for i, part in enumerate(parts):
-                if part == "layers" and i + 1 < len(parts) and parts[i + 1].isdigit():
-                    prefix = ".".join(parts[: i + 2])
-                    mtp_layer_prefixes.add(prefix)
-                    break
-
-        return mtp_layer_prefixes
-
-    # Flatten mtp_weight_map.values() (list of list of str) to a single list of str
-    mtp_keys = [k for keys in mtp_weight_map.values() for k in keys]
-    mtp_layer_prefixes = _extract_layer_prefixes(mtp_keys)
-
-    # Check which non-standard files exist and have missing weights
+    mtp_layer_prefixes: set[str] = set()
+    not_in_state_dict: dict[str, torch.Tensor] = {}
+    model_dir = Path(model_path)
     model_state = model.state_dict()
-    total_loaded = 0
 
-    not_in_state_dict = {}
+    # Inlined-MTP convention: keys ``model.layers.{i}.*`` for
+    # ``i in [num_hidden, num_hidden + num_nextn)``.
+    cfg = model.config
+    num_nextn = int(getattr(cfg, "num_nextn_predict_layers", 0))
+    num_hidden = cfg.num_hidden_layers
+    if num_nextn:
+        inlined_prefixes = {f"model.layers.{i}" for i in range(num_hidden, num_hidden + num_nextn)}
+        inlined_tensors = _load_inlined_mtp_tensors(model_dir, inlined_prefixes)
+        if inlined_tensors:
+            mtp_layer_prefixes |= inlined_prefixes
+            in_state_dict = {k: v for k, v in inlined_tensors.items() if k in model_state}
+            not_in_state_dict |= {k: v for k, v in inlined_tensors.items() if k not in model_state}
+            if in_state_dict:
+                model.load_state_dict(in_state_dict, strict=False)
+            print(
+                f"✓ Detected {len(inlined_tensors)} inlined MTP tensors under "
+                f"{sorted(inlined_prefixes)} "
+                f"(loaded into model: {len(in_state_dict)}, orphaned: {len(not_in_state_dict)})"
+            )
 
-    for filename, mtp_keys in mtp_weight_map.items():
-        filepath = model_path / filename
-        if not filepath.exists():
-            continue
+    index_file = model_dir / "model.safetensors.index.json"
 
-        print(f"Loading {len(mtp_keys)} mtp weights from {filename}...")
-        weights = load_file(str(filepath), device="cpu")
-        weights = {k: v for k, v in weights.items() if k in mtp_keys}
-        # Load the MTP weights to the model state dict
-        in_state_dict = {k: weights[k] for k in weights if k in model_state}
-        not_in_state_dict = not_in_state_dict | {
-            k: weights[k] for k in weights if k not in model_state
-        }
+    if index_file.exists():
+        # Separate-file MTP detection via safetensors index.
+        index = json.load(open(index_file))
+        weight_map = index["weight_map"]
+        # Find all files in weight_map whose key or value contains "mtp"
+        mtp_weight_map: dict[str, list[str]] = {}
+        for k, v in weight_map.items():
+            if "mtp" in k or "mtp" in v:
+                mtp_weight_map.setdefault(v, []).append(k)
 
-        if in_state_dict:
-            model.load_state_dict(in_state_dict, strict=False)
-            total_loaded += len(in_state_dict)
+        if mtp_weight_map:
 
-    if total_loaded > 0:
-        print(
-            f"✓ Successfully loaded {total_loaded} MTP weights, "
-            f"{len(not_in_state_dict)} MTP weights not in model.state_dict"
-        )
+            def _extract_layer_prefixes(keys):
+                prefixes = set()
+                for key in keys:
+                    parts = key.split(".")
+                    # Capture the top-level MTP module prefix (e.g., "mtp" from "mtp.fc.weight")
+                    # so that non-layer MTP weights like mtp.fc, mtp.norm are also excluded
+                    if parts:
+                        prefixes.add(parts[0])
+                    # Also capture specific layer prefixes (e.g., "mtp.layers.0")
+                    for i, part in enumerate(parts):
+                        if part == "layers" and i + 1 < len(parts) and parts[i + 1].isdigit():
+                            prefixes.add(".".join(parts[: i + 2]))
+                            break
+                return prefixes
+
+            mtp_keys_flat = [k for keys in mtp_weight_map.values() for k in keys]
+            mtp_layer_prefixes |= _extract_layer_prefixes(mtp_keys_flat)
+
+            # Load any weights missing from model.state_dict from the non-standard files.
+            total_loaded = 0
+            for filename, mtp_keys in mtp_weight_map.items():
+                filepath = model_dir / filename
+                if not filepath.exists():
+                    continue
+
+                print(f"Loading {len(mtp_keys)} mtp weights from {filename}...")
+                weights = load_file(str(filepath), device="cpu")
+                weights = {k: v for k, v in weights.items() if k in mtp_keys}
+                in_state_dict = {k: weights[k] for k in weights if k in model_state}
+                not_in_state_dict = not_in_state_dict | {
+                    k: weights[k] for k in weights if k not in model_state
+                }
+
+                if in_state_dict:
+                    model.load_state_dict(in_state_dict, strict=False)
+                    total_loaded += len(in_state_dict)
+
+            if total_loaded > 0:
+                print(
+                    f"✓ Successfully loaded {total_loaded} MTP weights, "
+                    f"{len(not_in_state_dict)} MTP weights not in model.state_dict"
+                )
 
     if mtp_layer_prefixes:
-        print(f"✓ Detected MTP layers to exclude from quantization: {mtp_layer_prefixes}")
+        print(f"✓ Detected MTP layers to exclude from quantization: {sorted(mtp_layer_prefixes)}")
 
     return list(mtp_layer_prefixes), not_in_state_dict
 

--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -23,6 +23,7 @@ import os
 import shutil
 import sys
 import warnings
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -316,16 +317,19 @@ def get_processor(
             return None
 
 
-def _load_inlined_mtp_tensors(model_path: Path, mtp_prefixes: set[str]) -> dict[str, torch.Tensor]:
+def _load_inlined_mtp_tensors(
+    model_path: Path, mtp_prefixes: Iterable[str]
+) -> dict[str, torch.Tensor]:
     """Stream tensors whose keys start with any ``{prefix}.`` from on-disk shards.
 
     Walks ``model.safetensors.index.json`` when present, else falls back to a
     single ``model.safetensors`` file. Returns an empty dict if no matching
     keys are found.
     """
+    prefix_tuple = tuple(p + "." for p in mtp_prefixes)
 
     def _matches(key: str) -> bool:
-        return any(key.startswith(p + ".") for p in mtp_prefixes)
+        return key.startswith(prefix_tuple)
 
     tensors: dict[str, torch.Tensor] = {}
     index_file = model_path / "model.safetensors.index.json"
@@ -343,11 +347,89 @@ def _load_inlined_mtp_tensors(model_path: Path, mtp_prefixes: set[str]) -> dict[
         single = model_path / "model.safetensors"
         if single.exists():
             with safe_open(str(single), framework="pt", device="cpu") as f:
-                # safe_open is not a dict; ``.keys()`` is the public listing API.
-                for k in f.keys():  # noqa: SIM118
+                for k in f.keys():  # noqa: SIM118 - safe_open is not iterable
                     if _matches(k):
                         tensors[k] = f.get_tensor(k)
     return tensors
+
+
+def get_inlined_mtp_prefixes(config: Any) -> list[str]:
+    """Pure: HF config → state-dict-key prefixes for inlined MTP layers.
+
+    Inlined-MTP convention (DeepSeek-V3, GLM-5.1 ``GlmMoeDsa``, GLM-4.7):
+    MTP tensors live under ``model.layers[i]`` for
+    ``i in [num_hidden, num_hidden + num_nextn_predict_layers)``. Returns
+    ``[]`` when the config does not declare any MTP layers.
+    """
+    num_nextn = int(getattr(config, "num_nextn_predict_layers", 0))
+    if not num_nextn:
+        return []
+    num_hidden = config.num_hidden_layers
+    return [f"model.layers.{i}" for i in range(num_hidden, num_hidden + num_nextn)]
+
+
+def _scan_separate_file_mtp(
+    model_dir: Path,
+) -> tuple[set[str], dict[str, torch.Tensor]]:
+    """Disk → (prefixes, tensors) for the legacy ``mtp.*``-keyed convention.
+
+    Walks ``model.safetensors.index.json`` for keys/values containing
+    ``"mtp"``, loads the matching tensors from their referenced shards, and
+    returns both the prefixes (e.g. ``"mtp"``, ``"mtp.layers.0"``) and the
+    raw tensors. Returns empty when no index file exists or no MTP keys
+    are present.
+    """
+    index_file = model_dir / "model.safetensors.index.json"
+    if not index_file.exists():
+        return set(), {}
+
+    weight_map = json.load(open(index_file))["weight_map"]
+    mtp_weight_map: dict[str, list[str]] = {}
+    for k, v in weight_map.items():
+        if "mtp" in k or "mtp" in v:
+            mtp_weight_map.setdefault(v, []).append(k)
+    if not mtp_weight_map:
+        return set(), {}
+
+    prefixes: set[str] = set()
+    for key in (k for keys in mtp_weight_map.values() for k in keys):
+        parts = key.split(".")
+        # Top-level MTP module prefix (e.g. "mtp" from "mtp.fc.weight") so
+        # non-layer MTP weights like mtp.fc, mtp.norm are also excluded.
+        if parts:
+            prefixes.add(parts[0])
+        # Specific layer prefixes like "mtp.layers.0".
+        for i, part in enumerate(parts):
+            if part == "layers" and i + 1 < len(parts) and parts[i + 1].isdigit():
+                prefixes.add(".".join(parts[: i + 2]))
+                break
+
+    tensors: dict[str, torch.Tensor] = {}
+    for filename, mtp_keys in mtp_weight_map.items():
+        filepath = model_dir / filename
+        if not filepath.exists():
+            continue
+        print(f"Loading {len(mtp_keys)} mtp weights from {filename}...")
+        loaded = load_file(str(filepath), device="cpu")
+        for k in mtp_keys:
+            if k in loaded:
+                tensors[k] = loaded[k]
+    return prefixes, tensors
+
+
+def _apply_to_model_state_dict(
+    model: torch.nn.Module, tensors: dict[str, torch.Tensor]
+) -> dict[str, torch.Tensor]:
+    """Split ``tensors`` by whether each key is in ``model.state_dict()``.
+    Load the matching keys into the model in-place; return the remainder
+    (orphans) so the exporter can route them through ``extra_state_dict``.
+    """
+    model_state = model.state_dict()
+    in_state_dict = {k: v for k, v in tensors.items() if k in model_state}
+    out_state_dict = {k: v for k, v in tensors.items() if k not in model_state}
+    if in_state_dict:
+        model.load_state_dict(in_state_dict, strict=False)
+    return out_state_dict
 
 
 def load_mtp_weights(
@@ -382,93 +464,36 @@ def load_mtp_weights(
         layers were detected.
         Dictionary of MTP weights that have no slot in the model's state
         dict; ``export_hf_checkpoint`` merges these via ``extra_state_dict``.
-    """
-    mtp_layer_prefixes: set[str] = set()
-    not_in_state_dict: dict[str, torch.Tensor] = {}
-    model_dir = Path(model_path)
-    model_state = model.state_dict()
 
-    # Inlined-MTP convention: keys ``model.layers.{i}.*`` for
-    # ``i in [num_hidden, num_hidden + num_nextn)``.
-    cfg = model.config
-    num_nextn = int(getattr(cfg, "num_nextn_predict_layers", 0))
-    num_hidden = cfg.num_hidden_layers
-    if num_nextn:
-        inlined_prefixes = {f"model.layers.{i}" for i in range(num_hidden, num_hidden + num_nextn)}
+    See Also:
+        ``examples/llm_ptq/MTP_DETECTION.md`` for the design rationale and
+        planned migration path to a library-side detector registry.
+    """
+    model_dir = Path(model_path)
+    prefixes: set[str] = set()
+    tensors: dict[str, torch.Tensor] = {}
+
+    inlined_prefixes = get_inlined_mtp_prefixes(model.config)
+    if inlined_prefixes:
         inlined_tensors = _load_inlined_mtp_tensors(model_dir, inlined_prefixes)
         if inlined_tensors:
-            mtp_layer_prefixes |= inlined_prefixes
-            in_state_dict = {k: v for k, v in inlined_tensors.items() if k in model_state}
-            not_in_state_dict |= {k: v for k, v in inlined_tensors.items() if k not in model_state}
-            if in_state_dict:
-                model.load_state_dict(in_state_dict, strict=False)
-            print(
-                f"✓ Detected {len(inlined_tensors)} inlined MTP tensors under "
-                f"{sorted(inlined_prefixes)} "
-                f"(loaded into model: {len(in_state_dict)}, orphaned: {len(not_in_state_dict)})"
-            )
+            prefixes.update(inlined_prefixes)
+            tensors.update(inlined_tensors)
 
-    index_file = model_dir / "model.safetensors.index.json"
+    separate_prefixes, separate_tensors = _scan_separate_file_mtp(model_dir)
+    prefixes.update(separate_prefixes)
+    tensors.update(separate_tensors)
 
-    if index_file.exists():
-        # Separate-file MTP detection via safetensors index.
-        index = json.load(open(index_file))
-        weight_map = index["weight_map"]
-        # Find all files in weight_map whose key or value contains "mtp"
-        mtp_weight_map: dict[str, list[str]] = {}
-        for k, v in weight_map.items():
-            if "mtp" in k or "mtp" in v:
-                mtp_weight_map.setdefault(v, []).append(k)
+    not_in_state_dict = _apply_to_model_state_dict(model, tensors)
 
-        if mtp_weight_map:
+    if prefixes:
+        print(
+            f"✓ Detected {len(tensors)} MTP tensors under {sorted(prefixes)} "
+            f"(loaded into model: {len(tensors) - len(not_in_state_dict)}, "
+            f"orphaned: {len(not_in_state_dict)})"
+        )
 
-            def _extract_layer_prefixes(keys):
-                prefixes = set()
-                for key in keys:
-                    parts = key.split(".")
-                    # Capture the top-level MTP module prefix (e.g., "mtp" from "mtp.fc.weight")
-                    # so that non-layer MTP weights like mtp.fc, mtp.norm are also excluded
-                    if parts:
-                        prefixes.add(parts[0])
-                    # Also capture specific layer prefixes (e.g., "mtp.layers.0")
-                    for i, part in enumerate(parts):
-                        if part == "layers" and i + 1 < len(parts) and parts[i + 1].isdigit():
-                            prefixes.add(".".join(parts[: i + 2]))
-                            break
-                return prefixes
-
-            mtp_keys_flat = [k for keys in mtp_weight_map.values() for k in keys]
-            mtp_layer_prefixes |= _extract_layer_prefixes(mtp_keys_flat)
-
-            # Load any weights missing from model.state_dict from the non-standard files.
-            total_loaded = 0
-            for filename, mtp_keys in mtp_weight_map.items():
-                filepath = model_dir / filename
-                if not filepath.exists():
-                    continue
-
-                print(f"Loading {len(mtp_keys)} mtp weights from {filename}...")
-                weights = load_file(str(filepath), device="cpu")
-                weights = {k: v for k, v in weights.items() if k in mtp_keys}
-                in_state_dict = {k: weights[k] for k in weights if k in model_state}
-                not_in_state_dict = not_in_state_dict | {
-                    k: weights[k] for k in weights if k not in model_state
-                }
-
-                if in_state_dict:
-                    model.load_state_dict(in_state_dict, strict=False)
-                    total_loaded += len(in_state_dict)
-
-            if total_loaded > 0:
-                print(
-                    f"✓ Successfully loaded {total_loaded} MTP weights, "
-                    f"{len(not_in_state_dict)} MTP weights not in model.state_dict"
-                )
-
-    if mtp_layer_prefixes:
-        print(f"✓ Detected MTP layers to exclude from quantization: {sorted(mtp_layer_prefixes)}")
-
-    return list(mtp_layer_prefixes), not_in_state_dict
+    return sorted(prefixes), not_in_state_dict
 
 
 def get_dtype(dtype):

--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -23,7 +23,7 @@ import os
 import shutil
 import sys
 import warnings
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
 
@@ -32,7 +32,6 @@ import transformers
 from accelerate import infer_auto_device_map, init_empty_weights
 from accelerate.utils import get_max_memory
 from safetensors import safe_open
-from safetensors.torch import load_file
 from transformers import (
     AutoConfig,
     AutoModel,
@@ -317,42 +316,6 @@ def get_processor(
             return None
 
 
-def _load_inlined_mtp_tensors(
-    model_path: Path, mtp_prefixes: Iterable[str]
-) -> dict[str, torch.Tensor]:
-    """Stream tensors whose keys start with any ``{prefix}.`` from on-disk shards.
-
-    Walks ``model.safetensors.index.json`` when present, else falls back to a
-    single ``model.safetensors`` file. Returns an empty dict if no matching
-    keys are found.
-    """
-    prefix_tuple = tuple(p + "." for p in mtp_prefixes)
-
-    def _matches(key: str) -> bool:
-        return key.startswith(prefix_tuple)
-
-    tensors: dict[str, torch.Tensor] = {}
-    index_file = model_path / "model.safetensors.index.json"
-    if index_file.exists():
-        weight_map = json.load(open(index_file))["weight_map"]
-        per_shard: dict[str, list[str]] = {}
-        for key, shard in weight_map.items():
-            if _matches(key):
-                per_shard.setdefault(shard, []).append(key)
-        for shard, keys in per_shard.items():
-            with safe_open(str(model_path / shard), framework="pt", device="cpu") as f:
-                for k in keys:
-                    tensors[k] = f.get_tensor(k)
-    else:
-        single = model_path / "model.safetensors"
-        if single.exists():
-            with safe_open(str(single), framework="pt", device="cpu") as f:
-                for k in f.keys():  # noqa: SIM118 - safe_open is not iterable
-                    if _matches(k):
-                        tensors[k] = f.get_tensor(k)
-    return tensors
-
-
 def get_inlined_mtp_prefixes(config: Any) -> list[str]:
     """Pure: HF config → state-dict-key prefixes for inlined MTP layers.
 
@@ -361,60 +324,77 @@ def get_inlined_mtp_prefixes(config: Any) -> list[str]:
     ``i in [num_hidden, num_hidden + num_nextn_predict_layers)``. Returns
     ``[]`` when the config does not declare any MTP layers.
     """
-    num_nextn = int(getattr(config, "num_nextn_predict_layers", 0))
+    # ``or 0`` guards against configs that set ``num_nextn_predict_layers``
+    # explicitly to ``None`` rather than omitting the field.
+    num_nextn = int(getattr(config, "num_nextn_predict_layers", 0) or 0)
     if not num_nextn:
         return []
     num_hidden = config.num_hidden_layers
     return [f"model.layers.{i}" for i in range(num_hidden, num_hidden + num_nextn)]
 
 
-def _scan_separate_file_mtp(
-    model_dir: Path,
-) -> tuple[set[str], dict[str, torch.Tensor]]:
-    """Disk → (prefixes, tensors) for the legacy ``mtp.*``-keyed convention.
+def _keys_to_prefixes(keys: Iterable[str]) -> set[str]:
+    """Pure: separate-file MTP keys → state-dict prefixes for ``exclude_modules``.
 
-    Walks ``model.safetensors.index.json`` for keys/values containing
-    ``"mtp"``, loads the matching tensors from their referenced shards, and
-    returns both the prefixes (e.g. ``"mtp"``, ``"mtp.layers.0"``) and the
-    raw tensors. Returns empty when no index file exists or no MTP keys
-    are present.
+    For each key, extracts:
+    - the top-level module prefix (e.g. ``"mtp"`` from ``"mtp.fc.weight"``)
+      so non-layer MTP weights like ``mtp.fc`` and ``mtp.norm`` are excluded.
+    - the specific layer prefix (e.g. ``"mtp.layers.0"`` from
+      ``"mtp.layers.0.q_proj.weight"``).
     """
-    index_file = model_dir / "model.safetensors.index.json"
-    if not index_file.exists():
-        return set(), {}
-
-    weight_map = json.load(open(index_file))["weight_map"]
-    mtp_weight_map: dict[str, list[str]] = {}
-    for k, v in weight_map.items():
-        if "mtp" in k or "mtp" in v:
-            mtp_weight_map.setdefault(v, []).append(k)
-    if not mtp_weight_map:
-        return set(), {}
-
     prefixes: set[str] = set()
-    for key in (k for keys in mtp_weight_map.values() for k in keys):
+    for key in keys:
         parts = key.split(".")
-        # Top-level MTP module prefix (e.g. "mtp" from "mtp.fc.weight") so
-        # non-layer MTP weights like mtp.fc, mtp.norm are also excluded.
         if parts:
             prefixes.add(parts[0])
-        # Specific layer prefixes like "mtp.layers.0".
         for i, part in enumerate(parts):
             if part == "layers" and i + 1 < len(parts) and parts[i + 1].isdigit():
                 prefixes.add(".".join(parts[: i + 2]))
                 break
+    return prefixes
 
+
+def _load_tensors_matching(
+    model_dir: Path, predicate: Callable[[str, str | None], bool]
+) -> dict[str, torch.Tensor]:
+    """Stream tensors satisfying ``predicate`` from every safetensors source
+    in ``model_dir`` via ``safe_open``.
+
+    Sources walked (each at most once):
+    1. Sharded layout: shards referenced by ``model.safetensors.index.json``.
+       The predicate sees ``(key, shard_filename)``.
+    2. Standalone files: any ``*.safetensors`` not referenced by the index
+       (including a standalone ``model.safetensors`` when no index exists and
+       legacy auxiliary files like ``mtp.safetensors``). The predicate sees
+       ``(key, file_name)``.
+
+    Returns an empty dict if no tensor matches.
+    """
     tensors: dict[str, torch.Tensor] = {}
-    for filename, mtp_keys in mtp_weight_map.items():
-        filepath = model_dir / filename
-        if not filepath.exists():
+    seen_shards: set[str] = set()
+
+    index_file = model_dir / "model.safetensors.index.json"
+    if index_file.exists():
+        with open(index_file) as f:
+            weight_map = json.load(f)["weight_map"]
+        per_shard: dict[str, list[str]] = {}
+        for key, shard_name in weight_map.items():
+            if predicate(key, shard_name):
+                per_shard.setdefault(shard_name, []).append(key)
+        for shard_name, keys in per_shard.items():
+            seen_shards.add(shard_name)
+            with safe_open(str(model_dir / shard_name), framework="pt", device="cpu") as f:
+                for k in keys:
+                    tensors[k] = f.get_tensor(k)
+
+    for shard in sorted(model_dir.glob("*.safetensors")):
+        if shard.name in seen_shards:
             continue
-        print(f"Loading {len(mtp_keys)} mtp weights from {filename}...")
-        loaded = load_file(str(filepath), device="cpu")
-        for k in mtp_keys:
-            if k in loaded:
-                tensors[k] = loaded[k]
-    return prefixes, tensors
+        with safe_open(str(shard), framework="pt", device="cpu") as f:
+            for k in f.keys():  # noqa: SIM118 - safe_open is not iterable
+                if predicate(k, shard.name):
+                    tensors[k] = f.get_tensor(k)
+    return tensors
 
 
 def _apply_to_model_state_dict(
@@ -464,25 +444,26 @@ def load_mtp_weights(
         layers were detected.
         Dictionary of MTP weights that have no slot in the model's state
         dict; ``export_hf_checkpoint`` merges these via ``extra_state_dict``.
-
-    See Also:
-        ``examples/llm_ptq/MTP_DETECTION.md`` for the design rationale and
-        planned migration path to a library-side detector registry.
     """
     model_dir = Path(model_path)
-    prefixes: set[str] = set()
-    tensors: dict[str, torch.Tensor] = {}
 
-    inlined_prefixes = get_inlined_mtp_prefixes(model.config)
-    if inlined_prefixes:
-        inlined_tensors = _load_inlined_mtp_tensors(model_dir, inlined_prefixes)
-        if inlined_tensors:
-            prefixes.update(inlined_prefixes)
-            tensors.update(inlined_tensors)
+    inlined_prefixes = set(get_inlined_mtp_prefixes(model.config))
+    inlined_tuple = tuple(p + "." for p in inlined_prefixes)
 
-    separate_prefixes, separate_tensors = _scan_separate_file_mtp(model_dir)
-    prefixes.update(separate_prefixes)
-    tensors.update(separate_tensors)
+    def predicate(key: str, shard_name: str | None) -> bool:
+        # Inlined: key prefix matches an MTP layer index from the config.
+        if inlined_tuple and key.startswith(inlined_tuple):
+            return True
+        # Separate-file legacy: ``"mtp"`` in the key or in the shard filename
+        # (e.g. ``mtp.safetensors`` referenced or sitting alongside the index).
+        return "mtp" in key or (shard_name is not None and "mtp" in shard_name)
+
+    tensors = _load_tensors_matching(model_dir, predicate)
+
+    # Anything we loaded that isn't covered by an inlined prefix came from the
+    # separate-file convention; derive its prefixes from the keys themselves.
+    separate_keys = [k for k in tensors if not k.startswith(inlined_tuple)]
+    prefixes = inlined_prefixes | _keys_to_prefixes(separate_keys) if tensors else set()
 
     not_in_state_dict = _apply_to_model_state_dict(model, tensors)
 

--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -317,7 +317,7 @@ def get_processor(
 
 
 def get_inlined_mtp_prefixes(config: Any) -> list[str]:
-    """turn an HF config into the list of state-dict prefixes for inlined-MTP layers."""
+    """Turn an HF config into the list of state-dict prefixes for inlined-MTP layers."""
     # ``or 0``: some configs set num_nextn_predict_layers=None rather than omit it.
     num_nextn = int(getattr(config, "num_nextn_predict_layers", 0) or 0)
     if not num_nextn:
@@ -327,9 +327,10 @@ def get_inlined_mtp_prefixes(config: Any) -> list[str]:
 
 
 def _keys_to_prefixes(keys: Iterable[str]) -> set[str]:
-    """invert separate-file MTP keys into the prefixes the exporter needs for exclude_modules.
+    """Invert separate-file MTP keys into the prefixes the exporter needs for exclude_modules.
     ``"mtp.fc.weight"`` → ``{"mtp"}``; ``"mtp.layers.0.q_proj.weight"`` →
-    ``{"mtp", "mtp.layers.0"}``.
+    ``{"mtp", "mtp.layers.0"}``. Caller must filter out inlined keys; otherwise
+    ``"model.layers.78.eh_proj.weight"`` would emit ``"model"`` as a prefix.
     """
     prefixes: set[str] = set()
     for key in keys:
@@ -344,11 +345,11 @@ def _keys_to_prefixes(keys: Iterable[str]) -> set[str]:
 
 
 def _load_tensors_matching(
-    model_dir: Path, predicate: Callable[[str, str | None], bool]
+    model_dir: Path, predicate: Callable[[str], bool]
 ) -> dict[str, torch.Tensor]:
-    """Stream tensors satisfying ``predicate(key, shard_name)`` from every
-    safetensors source in ``model_dir`` (indexed shards + standalone files,
-    each opened at most once).
+    """Stream tensors satisfying ``predicate(key)`` from every safetensors
+    source in ``model_dir`` (indexed shards + standalone files, each opened
+    at most once).
     """
     tensors: dict[str, torch.Tensor] = {}
     seen_shards: set[str] = set()
@@ -359,7 +360,7 @@ def _load_tensors_matching(
             weight_map = json.load(f)["weight_map"]
         per_shard: dict[str, list[str]] = {}
         for key, shard_name in weight_map.items():
-            if predicate(key, shard_name):
+            if predicate(key):
                 per_shard.setdefault(shard_name, []).append(key)
         for shard_name, keys in per_shard.items():
             seen_shards.add(shard_name)
@@ -372,7 +373,7 @@ def _load_tensors_matching(
             continue
         with safe_open(str(shard), framework="pt", device="cpu") as f:
             for k in f.keys():  # noqa: SIM118 - safe_open is not iterable
-                if predicate(k, shard.name):
+                if predicate(k):
                     tensors[k] = f.get_tensor(k)
     return tensors
 
@@ -417,24 +418,23 @@ def load_mtp_weights(
     inlined_tuple = tuple(p + "." for p in inlined_prefixes)
 
     # Combined predicate covering both conventions in one pass.
-    def predicate(key: str, shard_name: str | None) -> bool:
-        if inlined_tuple and key.startswith(inlined_tuple):
-            return True
-        return "mtp" in key or (shard_name is not None and "mtp" in shard_name)
+    def predicate(key: str) -> bool:
+        return key.startswith(inlined_tuple) or "mtp" in key
 
     tensors = _load_tensors_matching(model_dir, predicate)
+    if not tensors:
+        return [], {}
 
     separate_keys = [k for k in tensors if not k.startswith(inlined_tuple)]
-    prefixes = inlined_prefixes | _keys_to_prefixes(separate_keys) if tensors else set()
+    prefixes = inlined_prefixes | _keys_to_prefixes(separate_keys)
 
     not_in_state_dict = _apply_to_model_state_dict(model, tensors)
 
-    if prefixes:
-        print(
-            f"✓ Detected {len(tensors)} MTP tensors under {sorted(prefixes)} "
-            f"(loaded into model: {len(tensors) - len(not_in_state_dict)}, "
-            f"orphaned: {len(not_in_state_dict)})"
-        )
+    print(
+        f"✓ Detected {len(tensors)} MTP tensors under {sorted(prefixes)} "
+        f"(loaded into model: {len(tensors) - len(not_in_state_dict)}, "
+        f"orphaned: {len(not_in_state_dict)})"
+    )
 
     return sorted(prefixes), not_in_state_dict
 

--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -317,15 +317,8 @@ def get_processor(
 
 
 def get_inlined_mtp_prefixes(config: Any) -> list[str]:
-    """Pure: HF config → state-dict-key prefixes for inlined MTP layers.
-
-    Inlined-MTP convention (DeepSeek-V3, GLM-5.1 ``GlmMoeDsa``, GLM-4.7):
-    MTP tensors live under ``model.layers[i]`` for
-    ``i in [num_hidden, num_hidden + num_nextn_predict_layers)``. Returns
-    ``[]`` when the config does not declare any MTP layers.
-    """
-    # ``or 0`` guards against configs that set ``num_nextn_predict_layers``
-    # explicitly to ``None`` rather than omitting the field.
+    """turn an HF config into the list of state-dict prefixes for inlined-MTP layers."""
+    # ``or 0``: some configs set num_nextn_predict_layers=None rather than omit it.
     num_nextn = int(getattr(config, "num_nextn_predict_layers", 0) or 0)
     if not num_nextn:
         return []
@@ -334,13 +327,9 @@ def get_inlined_mtp_prefixes(config: Any) -> list[str]:
 
 
 def _keys_to_prefixes(keys: Iterable[str]) -> set[str]:
-    """Pure: separate-file MTP keys → state-dict prefixes for ``exclude_modules``.
-
-    For each key, extracts:
-    - the top-level module prefix (e.g. ``"mtp"`` from ``"mtp.fc.weight"``)
-      so non-layer MTP weights like ``mtp.fc`` and ``mtp.norm`` are excluded.
-    - the specific layer prefix (e.g. ``"mtp.layers.0"`` from
-      ``"mtp.layers.0.q_proj.weight"``).
+    """invert separate-file MTP keys into the prefixes the exporter needs for exclude_modules.
+    ``"mtp.fc.weight"`` → ``{"mtp"}``; ``"mtp.layers.0.q_proj.weight"`` →
+    ``{"mtp", "mtp.layers.0"}``.
     """
     prefixes: set[str] = set()
     for key in keys:
@@ -357,18 +346,9 @@ def _keys_to_prefixes(keys: Iterable[str]) -> set[str]:
 def _load_tensors_matching(
     model_dir: Path, predicate: Callable[[str, str | None], bool]
 ) -> dict[str, torch.Tensor]:
-    """Stream tensors satisfying ``predicate`` from every safetensors source
-    in ``model_dir`` via ``safe_open``.
-
-    Sources walked (each at most once):
-    1. Sharded layout: shards referenced by ``model.safetensors.index.json``.
-       The predicate sees ``(key, shard_filename)``.
-    2. Standalone files: any ``*.safetensors`` not referenced by the index
-       (including a standalone ``model.safetensors`` when no index exists and
-       legacy auxiliary files like ``mtp.safetensors``). The predicate sees
-       ``(key, file_name)``.
-
-    Returns an empty dict if no tensor matches.
+    """Stream tensors satisfying ``predicate(key, shard_name)`` from every
+    safetensors source in ``model_dir`` (indexed shards + standalone files,
+    each opened at most once).
     """
     tensors: dict[str, torch.Tensor] = {}
     seen_shards: set[str] = set()
@@ -400,9 +380,8 @@ def _load_tensors_matching(
 def _apply_to_model_state_dict(
     model: torch.nn.Module, tensors: dict[str, torch.Tensor]
 ) -> dict[str, torch.Tensor]:
-    """Split ``tensors`` by whether each key is in ``model.state_dict()``.
-    Load the matching keys into the model in-place; return the remainder
-    (orphans) so the exporter can route them through ``extra_state_dict``.
+    """Load tensors with a slot in ``model.state_dict()`` in-place; return the
+    rest as orphans for ``extra_state_dict``.
     """
     model_state = model.state_dict()
     in_state_dict = {k: v for k, v in tensors.items() if k in model_state}
@@ -415,53 +394,36 @@ def _apply_to_model_state_dict(
 def load_mtp_weights(
     model: torch.nn.Module, model_path: str
 ) -> tuple[list[str], dict[str, torch.Tensor]]:
-    """Load MTP weights from the model checkpoint.
+    """Detect and load MTP weights. Support matrix:
 
-    Detects MTP layers under two on-disk conventions:
+        Convention     Architectures             On-disk shape
+        -------------  ------------------------  -------------------------------
+        inlined        GLM-5.1 (``GlmMoeDsa``),  ``model.layers.{N}.*``
+                       DeepSeek-V3
+        separate-file  GLM-4.7                   standalone ``mtp.safetensors``
+        separate-file  Qwen3-Next                indexed ``mtp.*`` tail shard
 
-    1. Separate-file: weights live in a non-standard safetensors file (e.g.,
-       ``mtp.safetensors``) with keys prefixed by ``mtp``.
-    2. Inlined: weights live in the main shards under
-       ``model.layers[num_hidden : num_hidden + num_nextn_predict_layers]``
-       (DeepSeek-V3, GLM-5.1 ``GlmMoeDsa``, GLM-4.7).
+    Inlined ``N`` in ``[num_hidden, num_hidden + num_nextn_predict_layers)``;
+    may be orphaned at ``from_pretrained`` time if the HF class only builds
+    ``num_hidden`` decoders.
 
-    Whether the HF model class actually instantiates the MTP module varies:
-    DeepSeek-V3's modeling code adds the extra decoder layers, while
-    ``GlmMoeDsaModel`` in transformers >=5.7 builds only ``num_hidden`` layers
-    and leaves the inlined-MTP keys orphaned. To keep both paths correct, we
-    always read the tensors off disk here and split them: any key that maps
-    to a parameter in ``model.state_dict()`` is loaded into the model;
-    the remainder is returned as ``not_in_state_dict`` for the exporter to
-    merge in via ``extra_state_dict``.
-
-    Args:
-        model: The loaded model that may be missing weights
-        model_path: Path to the model directory
-
-    Returns:
-        List of layer prefixes that should be excluded from quantization
-        (e.g., ``"mtp.layers.0"`` or ``"model.layers.78"``). Empty if no MTP
-        layers were detected.
-        Dictionary of MTP weights that have no slot in the model's state
-        dict; ``export_hf_checkpoint`` merges these via ``extra_state_dict``.
+    Returns ``(prefixes, not_in_state_dict)``: ``prefixes`` populates
+    ``quantization_config.exclude_modules``; ``not_in_state_dict`` is fed to
+    ``export_hf_checkpoint(extra_state_dict=...)``.
     """
     model_dir = Path(model_path)
 
     inlined_prefixes = set(get_inlined_mtp_prefixes(model.config))
     inlined_tuple = tuple(p + "." for p in inlined_prefixes)
 
+    # Combined predicate covering both conventions in one pass.
     def predicate(key: str, shard_name: str | None) -> bool:
-        # Inlined: key prefix matches an MTP layer index from the config.
         if inlined_tuple and key.startswith(inlined_tuple):
             return True
-        # Separate-file legacy: ``"mtp"`` in the key or in the shard filename
-        # (e.g. ``mtp.safetensors`` referenced or sitting alongside the index).
         return "mtp" in key or (shard_name is not None and "mtp" in shard_name)
 
     tensors = _load_tensors_matching(model_dir, predicate)
 
-    # Anything we loaded that isn't covered by an inlined prefix came from the
-    # separate-file convention; derive its prefixes from the keys themselves.
     separate_keys = [k for k in tensors if not k.startswith(inlined_tuple)]
     prefixes = inlined_prefixes | _keys_to_prefixes(separate_keys) if tensors else set()
 

--- a/tests/_test_utils/examples/llm_ptq_example_utils.py
+++ b/tests/_test_utils/examples/llm_ptq_example_utils.py
@@ -12,15 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Importer for ``examples/llm_ptq/example_utils.py``.
-
-The module lives next to the example script (not inside the ``modelopt``
-package), so we add ``examples/llm_ptq/`` to ``sys.path`` once here and
-re-export the module. Tests then import it as::
-
-    from _test_utils.examples.llm_ptq_example_utils import example_utils
-
-instead of repeating ``sys.path`` manipulation in every test file.
+"""Re-export ``examples/llm_ptq/example_utils`` so tests can import it via
+``from _test_utils.examples.llm_ptq_example_utils import example_utils``
+without per-file ``sys.path`` shims.
 """
 
 import sys

--- a/tests/_test_utils/examples/llm_ptq_example_utils.py
+++ b/tests/_test_utils/examples/llm_ptq_example_utils.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Importer for ``examples/llm_ptq/example_utils.py``.
+
+The module lives next to the example script (not inside the ``modelopt``
+package), so we add ``examples/llm_ptq/`` to ``sys.path`` once here and
+re-export the module. Tests then import it as::
+
+    from _test_utils.examples.llm_ptq_example_utils import example_utils
+
+instead of repeating ``sys.path`` manipulation in every test file.
+"""
+
+import sys
+
+from _test_utils.examples.run_command import MODELOPT_ROOT
+
+_LLM_PTQ_DIR = MODELOPT_ROOT / "examples" / "llm_ptq"
+if str(_LLM_PTQ_DIR) not in sys.path:
+    sys.path.insert(0, str(_LLM_PTQ_DIR))
+
+import example_utils
+
+__all__ = ["example_utils"]

--- a/tests/examples/llm_ptq/test_example_utils.py
+++ b/tests/examples/llm_ptq/test_example_utils.py
@@ -17,7 +17,27 @@
 from types import SimpleNamespace
 
 import pytest
+import torch
 from _test_utils.examples.llm_ptq_example_utils import example_utils
+from safetensors.torch import save_file
+
+
+class _FakeModel:
+    """Minimal stand-in for an HF causal-LM. ``load_mtp_weights`` touches only
+    ``model.config``, ``model.state_dict()`` and ``model.load_state_dict()``.
+    """
+
+    def __init__(self, config, state_dict_keys):
+        self.config = config
+        self._sd = {k: torch.zeros(1) for k in state_dict_keys}
+        self.loaded = {}
+
+    def state_dict(self):
+        return dict(self._sd)
+
+    def load_state_dict(self, state_dict, strict=True):
+        self.loaded.update(state_dict)
+        self._sd.update(state_dict)
 
 
 @pytest.mark.parametrize(
@@ -38,3 +58,91 @@ def test_get_inlined_mtp_prefixes_missing_field_returns_empty():
     """Configs without num_nextn_predict_layers (non-MTP architectures) yield []."""
     cfg = SimpleNamespace(num_hidden_layers=32)
     assert example_utils.get_inlined_mtp_prefixes(cfg) == []
+
+
+def test_get_inlined_mtp_prefixes_none_field_returns_empty():
+    """``num_nextn_predict_layers=None`` must not crash with ``int(None)``."""
+    cfg = SimpleNamespace(num_hidden_layers=32, num_nextn_predict_layers=None)
+    assert example_utils.get_inlined_mtp_prefixes(cfg) == []
+
+
+def _write_safetensors(path, tensors):
+    save_file(tensors, str(path), metadata={"format": "pt"})
+
+
+def test_load_mtp_weights_inlined_orphaned(tmp_path):
+    """GLM-5.1 case: HF model class doesn't instantiate MTP, so inlined MTP
+    tensors at ``model.layers.{N}.*`` are returned as orphans for
+    ``extra_state_dict``."""
+    main_keys = ["model.embed_tokens.weight", "model.layers.0.x.weight"]
+    mtp_keys = ["model.layers.4.eh_proj.weight", "model.layers.4.enorm.weight"]
+    _write_safetensors(
+        tmp_path / "model.safetensors",
+        {k: torch.zeros(2, 2) for k in main_keys + mtp_keys},
+    )
+
+    cfg = SimpleNamespace(num_hidden_layers=4, num_nextn_predict_layers=1)
+    model = _FakeModel(cfg, state_dict_keys=main_keys)
+    prefixes, orphans = example_utils.load_mtp_weights(model, str(tmp_path))
+
+    assert prefixes == ["model.layers.4"]
+    assert set(orphans) == set(mtp_keys)
+    assert model.loaded == {}  # nothing matched the (MTP-less) state_dict
+
+
+def test_load_mtp_weights_inlined_in_state_dict(tmp_path):
+    """DeepSeek-V3 case: HF *does* instantiate the inlined layers, so the
+    matching keys are loaded into the model and the orphan dict is empty."""
+    main_keys = ["model.embed_tokens.weight"]
+    mtp_keys = ["model.layers.4.eh_proj.weight", "model.layers.4.enorm.weight"]
+    _write_safetensors(
+        tmp_path / "model.safetensors",
+        {k: torch.ones(2, 2) for k in main_keys + mtp_keys},
+    )
+
+    cfg = SimpleNamespace(num_hidden_layers=4, num_nextn_predict_layers=1)
+    model = _FakeModel(cfg, state_dict_keys=main_keys + mtp_keys)
+    prefixes, orphans = example_utils.load_mtp_weights(model, str(tmp_path))
+
+    assert prefixes == ["model.layers.4"]
+    assert orphans == {}
+    assert set(model.loaded) == set(mtp_keys)
+
+
+def test_load_mtp_weights_separate_standalone_file(tmp_path):
+    """Legacy case: a standalone ``mtp.safetensors`` sits alongside the main
+    checkpoint with no shard index. The unified loader must still discover and
+    load the standalone file."""
+    _write_safetensors(
+        tmp_path / "model.safetensors", {"model.embed_tokens.weight": torch.zeros(2, 2)}
+    )
+    _write_safetensors(
+        tmp_path / "mtp.safetensors",
+        {
+            "mtp.fc.weight": torch.zeros(2, 2),
+            "mtp.layers.0.q_proj.weight": torch.zeros(2, 2),
+        },
+    )
+
+    cfg = SimpleNamespace(num_hidden_layers=4, num_nextn_predict_layers=0)
+    model = _FakeModel(cfg, state_dict_keys=["model.embed_tokens.weight"])
+    prefixes, orphans = example_utils.load_mtp_weights(model, str(tmp_path))
+
+    assert set(prefixes) == {"mtp", "mtp.layers.0"}
+    assert set(orphans) == {"mtp.fc.weight", "mtp.layers.0.q_proj.weight"}
+
+
+def test_load_mtp_weights_no_mtp_returns_empty(tmp_path):
+    """Plain (non-MTP) checkpoint must return ``([], {})``."""
+    _write_safetensors(
+        tmp_path / "model.safetensors",
+        {
+            "model.embed_tokens.weight": torch.zeros(2, 2),
+            "model.layers.0.x.weight": torch.zeros(2, 2),
+        },
+    )
+    cfg = SimpleNamespace(num_hidden_layers=4, num_nextn_predict_layers=0)
+    model = _FakeModel(cfg, state_dict_keys=["model.embed_tokens.weight"])
+    prefixes, orphans = example_utils.load_mtp_weights(model, str(tmp_path))
+    assert prefixes == []
+    assert orphans == {}

--- a/tests/examples/llm_ptq/test_example_utils.py
+++ b/tests/examples/llm_ptq/test_example_utils.py
@@ -12,20 +12,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for ``examples/llm_ptq/example_utils.py``."""
+"""End-to-end unit tests for ``examples/llm_ptq/example_utils.load_mtp_weights``.
 
+One test per supported on-disk MTP convention (inlined-orphaned, inlined-in-state-dict,
+separate-file-standalone, separate-file-indexed) plus a negative case.
+"""
+
+import json
 from types import SimpleNamespace
 
-import pytest
 import torch
 from _test_utils.examples.llm_ptq_example_utils import example_utils
 from safetensors.torch import save_file
 
 
 class _FakeModel:
-    """Minimal stand-in for an HF causal-LM. ``load_mtp_weights`` touches only
-    ``model.config``, ``model.state_dict()`` and ``model.load_state_dict()``.
-    """
+    """Stub exposing only the surface ``load_mtp_weights`` touches."""
 
     def __init__(self, config, state_dict_keys):
         self.config = config
@@ -40,40 +42,12 @@ class _FakeModel:
         self._sd.update(state_dict)
 
 
-@pytest.mark.parametrize(
-    ("num_nextn", "num_hidden", "expected"),
-    [
-        (0, 80, []),
-        (1, 78, ["model.layers.78"]),
-        (3, 80, ["model.layers.80", "model.layers.81", "model.layers.82"]),
-    ],
-)
-def test_get_inlined_mtp_prefixes_returns_expected_prefixes(num_nextn, num_hidden, expected):
-    """Pure config -> prefix list. Documents the inlined-MTP detection contract."""
-    cfg = SimpleNamespace(num_nextn_predict_layers=num_nextn, num_hidden_layers=num_hidden)
-    assert example_utils.get_inlined_mtp_prefixes(cfg) == expected
-
-
-def test_get_inlined_mtp_prefixes_missing_field_returns_empty():
-    """Configs without num_nextn_predict_layers (non-MTP architectures) yield []."""
-    cfg = SimpleNamespace(num_hidden_layers=32)
-    assert example_utils.get_inlined_mtp_prefixes(cfg) == []
-
-
-def test_get_inlined_mtp_prefixes_none_field_returns_empty():
-    """``num_nextn_predict_layers=None`` must not crash with ``int(None)``."""
-    cfg = SimpleNamespace(num_hidden_layers=32, num_nextn_predict_layers=None)
-    assert example_utils.get_inlined_mtp_prefixes(cfg) == []
-
-
 def _write_safetensors(path, tensors):
     save_file(tensors, str(path), metadata={"format": "pt"})
 
 
 def test_load_mtp_weights_inlined_orphaned(tmp_path):
-    """GLM-5.1 case: HF model class doesn't instantiate MTP, so inlined MTP
-    tensors at ``model.layers.{N}.*`` are returned as orphans for
-    ``extra_state_dict``."""
+    # GLM-5.1: HF builds only num_hidden decoders → MTP keys orphaned.
     main_keys = ["model.embed_tokens.weight", "model.layers.0.x.weight"]
     mtp_keys = ["model.layers.4.eh_proj.weight", "model.layers.4.enorm.weight"]
     _write_safetensors(
@@ -91,8 +65,7 @@ def test_load_mtp_weights_inlined_orphaned(tmp_path):
 
 
 def test_load_mtp_weights_inlined_in_state_dict(tmp_path):
-    """DeepSeek-V3 case: HF *does* instantiate the inlined layers, so the
-    matching keys are loaded into the model and the orphan dict is empty."""
+    # DeepSeek-V3 via trust_remote_code: MTP slots exist → keys loaded, no orphans.
     main_keys = ["model.embed_tokens.weight"]
     mtp_keys = ["model.layers.4.eh_proj.weight", "model.layers.4.enorm.weight"]
     _write_safetensors(
@@ -110,9 +83,7 @@ def test_load_mtp_weights_inlined_in_state_dict(tmp_path):
 
 
 def test_load_mtp_weights_separate_standalone_file(tmp_path):
-    """Legacy case: a standalone ``mtp.safetensors`` sits alongside the main
-    checkpoint with no shard index. The unified loader must still discover and
-    load the standalone file."""
+    # GLM-4.7: standalone mtp.safetensors with no shard index.
     _write_safetensors(
         tmp_path / "model.safetensors", {"model.embed_tokens.weight": torch.zeros(2, 2)}
     )
@@ -132,8 +103,40 @@ def test_load_mtp_weights_separate_standalone_file(tmp_path):
     assert set(orphans) == {"mtp.fc.weight", "mtp.layers.0.q_proj.weight"}
 
 
+def test_load_mtp_weights_separate_indexed_shard(tmp_path):
+    # Qwen3-Next: mtp.* keys in a dedicated indexed tail shard (filename has no "mtp").
+    main_shard = "model-00001-of-00002.safetensors"
+    mtp_shard = "model-00002-of-00002.safetensors"
+    _write_safetensors(tmp_path / main_shard, {"model.embed_tokens.weight": torch.zeros(2, 2)})
+    mtp_tensors = {
+        "mtp.fc.weight": torch.zeros(2, 2),
+        "mtp.norm.weight": torch.zeros(2),
+        "mtp.layers.0.input_layernorm.weight": torch.zeros(2),
+        "mtp.layers.0.self_attn.q_proj.weight": torch.zeros(2, 2),
+    }
+    _write_safetensors(tmp_path / mtp_shard, mtp_tensors)
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.embed_tokens.weight": main_shard,
+                    **dict.fromkeys(mtp_tensors, mtp_shard),
+                }
+            }
+        )
+    )
+
+    cfg = SimpleNamespace(num_hidden_layers=4, num_nextn_predict_layers=0)
+    model = _FakeModel(cfg, state_dict_keys=["model.embed_tokens.weight"])
+    prefixes, orphans = example_utils.load_mtp_weights(model, str(tmp_path))
+
+    assert set(prefixes) == {"mtp", "mtp.layers.0"}
+    assert set(orphans) == set(mtp_tensors)
+
+
 def test_load_mtp_weights_no_mtp_returns_empty(tmp_path):
-    """Plain (non-MTP) checkpoint must return ``([], {})``."""
+    # Also pins the ``num_nextn_predict_layers=None`` regression: some configs
+    # set the field explicitly to None, which must not crash ``int(None)``.
     _write_safetensors(
         tmp_path / "model.safetensors",
         {
@@ -141,7 +144,7 @@ def test_load_mtp_weights_no_mtp_returns_empty(tmp_path):
             "model.layers.0.x.weight": torch.zeros(2, 2),
         },
     )
-    cfg = SimpleNamespace(num_hidden_layers=4, num_nextn_predict_layers=0)
+    cfg = SimpleNamespace(num_hidden_layers=4, num_nextn_predict_layers=None)
     model = _FakeModel(cfg, state_dict_keys=["model.embed_tokens.weight"])
     prefixes, orphans = example_utils.load_mtp_weights(model, str(tmp_path))
     assert prefixes == []

--- a/tests/examples/llm_ptq/test_example_utils.py
+++ b/tests/examples/llm_ptq/test_example_utils.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ``examples/llm_ptq/example_utils.py``."""
+
+from types import SimpleNamespace
+
+import pytest
+from _test_utils.examples.llm_ptq_example_utils import example_utils
+
+
+@pytest.mark.parametrize(
+    ("num_nextn", "num_hidden", "expected"),
+    [
+        (0, 80, []),
+        (1, 78, ["model.layers.78"]),
+        (3, 80, ["model.layers.80", "model.layers.81", "model.layers.82"]),
+    ],
+)
+def test_get_inlined_mtp_prefixes_returns_expected_prefixes(num_nextn, num_hidden, expected):
+    """Pure config -> prefix list. Documents the inlined-MTP detection contract."""
+    cfg = SimpleNamespace(num_nextn_predict_layers=num_nextn, num_hidden_layers=num_hidden)
+    assert example_utils.get_inlined_mtp_prefixes(cfg) == expected
+
+
+def test_get_inlined_mtp_prefixes_missing_field_returns_empty():
+    """Configs without num_nextn_predict_layers (non-MTP architectures) yield []."""
+    cfg = SimpleNamespace(num_hidden_layers=32)
+    assert example_utils.get_inlined_mtp_prefixes(cfg) == []


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix  <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

Extends `load_mtp_weights` to detect *inlined* MTP layers — keys `model.layers.{i}.*` for `i in [num_hidden, num_hidden +  num_nextn_predict_layers)` — in addition to the existing `mtp.*` separate-file convention.

  **Bug.** `load_mtp_weights()` only matched the substring `"mtp"` in safetensors keys. GLM-5.1 (`GlmMoeDsaForCausalLM`) stores MTP at `model.layers.78.*` with no `mtp` substring, so detection returned `([], {})`, `_mtp_layer_prefixes` was never set, and MTP tensors were silently dropped from the exported safetensors (had to be re-added manually).

**Detection.**

  1. **Detect** via `config.num_nextn_predict_layers` (the model's own declaration of how many MTP layers exist). 
  2. **Compute** the inlined layer indices: `model.layers.{i}` for `i in range(num_hidden, num_hidden + num_nextn)`.
  3. **Load** matching tensors from the on-disk shards via `safe_open` (walks `model.safetensors.index.json` if present,else falls back to the single shard).
  4. **Split** the loaded tensors by whether `model.state_dict()` has a slot for them:
     - keys present in `model.state_dict()` → `model.load_state_dict(..., strict=False)` (DeepSeek-V3 case: HF instantiates the extra layers).
     - keys absent from `model.state_dict()` → returned as `not_in_state_dict` so the exporter routes them through `extra_state_dict` (GLM-5.1
  case: `GlmMoeDsaModel` in transformers ≥5.7 only builds `num_hidden` decoders, leaving MTP keys orphaned at `from_pretrained` time).
 The returned prefixes flow into the existing plumbing — `_mtp_layer_prefixes` → `quant_cfg` disable +`quantization_config.exclude_modules` — unchanged.

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
 Verified end-to-end on a mini GLM-5.1 fixture (4 hidden layers + 1 inlined MTP at `model.layers.4`, 7 synthesized MTP tensors mirroring the full GLM-5.1 layout)
To be verified with full model

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Quantization utilities now stream safetensors and unify loading of multi-token-prediction (MTP) weights from both inline and separate/sharded conventions, reporting detected MTP prefixes and counts of loaded vs orphaned tensors.
* **Tests**
  * Added unit tests and a test import helper covering MTP discovery, loading behaviors (inlined vs standalone/indexed shards), orphan reporting, and non‑MTP checkpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->