### PR TITLE
Refine static NVFP4 MSE calibration

### DIFF
--- a/examples/llm_ptq/cast_mxfp4_to_nvfp4.py
+++ b/examples/llm_ptq/cast_mxfp4_to_nvfp4.py
@@ -297,8 +297,8 @@ def force_weight_quantizers_static(quant_cfg: list) -> None:
     The MXFP4 -> NVFP4 cast needs the per-block weight ``_amax`` to be recorded
     by max-cal (so it can be paired with the pinned global_amax later). Setting
     ``block_sizes['type'] = 'static'`` makes ``is_static_block_quant`` True so
-    ``promote_nvfp4_static_quantizers`` picks the entry up automatically at the
-    end of max_calibrate.
+    static NVFP4 finalization picks the entry up automatically at the end of
+    max_calibrate.
     """
     for i, entry in enumerate(quant_cfg):
         qname = entry.get("quantizer_name", "")

--- a/modelopt/torch/quantization/calib/mse.py
+++ b/modelopt/torch/quantization/calib/mse.py
@@ -194,7 +194,7 @@ class NVFP4MSECalibrator(MseCalibrator):
         super().__init__(amax=amax, axis=axis, quant_func=quant_func, error_func=error_func)
         self._global_amax = global_amax.to(dtype=torch.float32)
         # Set by collect() after either sweep path; consumed by compute_amax.
-        self._best_amax_fast: torch.Tensor | None = None
+        self._best_amax: torch.Tensor | None = None
 
     def _compute_candidate_amax(self, candidates: torch.Tensor) -> torch.Tensor:
         if candidates.ndim != 0:  # Called during final compute amax
@@ -237,7 +237,7 @@ class NVFP4MSECalibrator(MseCalibrator):
     @torch.no_grad()
     def collect(self, x: torch.Tensor):
         """Collect input statistics and cache the final per-block amax."""
-        if self._best_amax_fast is not None:
+        if self._best_amax is not None:
             raise RuntimeError(
                 "NVFP4MSECalibrator: a previous collect() call produced a final amax; "
                 "multi-collect is not supported. Call reset() to start a fresh cycle."
@@ -248,9 +248,7 @@ class NVFP4MSECalibrator(MseCalibrator):
             best_flat = nvfp4_fp8_scale_sweep(x.detach(), self._global_amax, block_size=x.shape[-1])
             # Store the selected amax in fp32; the fake-quant kernel still returns
             # tensors in the requested output dtype.
-            self._best_amax_fast = best_flat.reshape(self._initial_amax.shape).to(
-                dtype=torch.float32
-            )
+            self._best_amax = best_flat.reshape(self._initial_amax.shape).to(dtype=torch.float32)
             return
 
         self._run_reference_collect(x)
@@ -258,7 +256,7 @@ class NVFP4MSECalibrator(MseCalibrator):
     def _run_reference_collect(self, x: torch.Tensor):
         super().collect(x)
         best_amax = super().compute_amax(verbose=False)
-        self._best_amax_fast = best_amax.to(dtype=torch.float32) if best_amax is not None else None
+        self._best_amax = best_amax.to(dtype=torch.float32) if best_amax is not None else None
         self._losses_sum = None
         # Synchronize before calibrating another weight so reference MSE sweeps do
         # not overlap. _losses_sum stores one fp32 reduced loss per candidate per
@@ -270,7 +268,7 @@ class NVFP4MSECalibrator(MseCalibrator):
     @torch.no_grad()
     def compute_amax(self, verbose: bool = False):
         """Return the cached per-block amax."""
-        return self._best_amax_fast
+        return self._best_amax
 
     def reset(self):
         """Reset per-cycle state. Keep ``_initial_amax`` so the calibrator stays reusable.
@@ -280,7 +278,7 @@ class NVFP4MSECalibrator(MseCalibrator):
         small enough to keep so a follow-up ``collect()`` can run again on the same
         calibrator instance.
         """
-        self._best_amax_fast = None
+        self._best_amax = None
         self._losses_sum = None
         self._candidates = None
         self._amax = None

--- a/modelopt/torch/quantization/calib/mse.py
+++ b/modelopt/torch/quantization/calib/mse.py
@@ -178,9 +178,8 @@ class NVFP4MSECalibrator(MseCalibrator):
     Uses a fused Triton kernel as an internal fast path on the first ``collect`` call
     when (a) ``error_func is None``, (b) the input tensor is on CUDA in the standard
     blocked ``[n_blocks, block_size]`` layout, and (c) Triton + the kernel package are
-    importable. Falls back to the reference 126-step Python sweep otherwise (custom
-    ``error_func`` users, multi-``collect`` activation flows, CPU inputs, or when the
-    fast path is disabled via ``MODELOPT_NVFP4_TRITON_SWEEP=0``).
+    importable. Falls back to the reference 126-step Python sweep otherwise and caches
+    the final amax immediately, so this calibrator is one-shot between resets.
     """
 
     def __init__(
@@ -193,14 +192,16 @@ class NVFP4MSECalibrator(MseCalibrator):
     ):
         """Initialize NVFP4 MSE calibrator with per-block and global amax."""
         super().__init__(amax=amax, axis=axis, quant_func=quant_func, error_func=error_func)
-        self._global_amax = global_amax
-        # Set by the Triton fast path on its (one-shot) collect; consumed by compute_amax.
+        self._global_amax = global_amax.to(dtype=torch.float32)
+        # Set by collect() after either sweep path; consumed by compute_amax.
         self._best_amax_fast: torch.Tensor | None = None
 
     def _compute_candidate_amax(self, candidates: torch.Tensor) -> torch.Tensor:
         if candidates.ndim != 0:  # Called during final compute amax
             candidates = candidates.view_as(self._initial_amax)
-        return torch.ones_like(self._initial_amax) * self._global_amax * candidates
+        return torch.ones_like(self._initial_amax, dtype=torch.float32) * (
+            self._global_amax * candidates
+        )
 
     def _generate_candidates(self, device: torch.device) -> torch.Tensor:
         """Generate the 126 valid FP8 E4M3 scale candidates."""
@@ -235,35 +236,41 @@ class NVFP4MSECalibrator(MseCalibrator):
 
     @torch.no_grad()
     def collect(self, x: torch.Tensor):
-        """Collect input statistics. Uses the Triton fast path when eligible."""
+        """Collect input statistics and cache the final per-block amax."""
         if self._best_amax_fast is not None:
             raise RuntimeError(
-                "NVFP4MSECalibrator: the Triton fast path produced a final amax on a "
-                "previous collect() call; multi-collect after the fast path is not "
-                "supported. Call reset() to start a fresh cycle, set "
-                "MODELOPT_NVFP4_TRITON_SWEEP=0, or pass a non-None error_func to force "
-                "the reference path for activation-style accumulation."
+                "NVFP4MSECalibrator: a previous collect() call produced a final amax; "
+                "multi-collect is not supported. Call reset() to start a fresh cycle."
             )
-        # Fast path is eligible only on the first call, before the reference accumulator
-        # has produced any state.
-        if self._losses_sum is None and self._can_use_triton_fast_path(x):
+        if self._can_use_triton_fast_path(x):
             from modelopt.torch.kernels.quantization.gemm import nvfp4_fp8_scale_sweep
 
             best_flat = nvfp4_fp8_scale_sweep(x.detach(), self._global_amax, block_size=x.shape[-1])
-            # Match the original shape/dtype of the initial amax so downstream
-            # load_calib_amax behaves identically to the reference path.
+            # Store the selected amax in fp32; the fake-quant kernel still returns
+            # tensors in the requested output dtype.
             self._best_amax_fast = best_flat.reshape(self._initial_amax.shape).to(
-                self._initial_amax.dtype
+                dtype=torch.float32
             )
             return
+
+        self._run_reference_collect(x)
+
+    def _run_reference_collect(self, x: torch.Tensor):
         super().collect(x)
+        best_amax = super().compute_amax(verbose=False)
+        self._best_amax_fast = best_amax.to(dtype=torch.float32) if best_amax is not None else None
+        self._losses_sum = None
+        # Synchronize before calibrating another weight so reference MSE sweeps do
+        # not overlap. _losses_sum stores one fp32 reduced loss per candidate per
+        # block. With 16-element NVFP4 blocks and bf16 weights, this is roughly
+        # 128 / 16 * (4 / 2) = 16x the calibrated weight size.
+        if x.is_cuda:
+            torch.cuda.synchronize(x.device)
 
     @torch.no_grad()
     def compute_amax(self, verbose: bool = False):
-        """Return the per-block amax — from the fast path if it ran, else from the reference sweep."""
-        if self._best_amax_fast is not None:
-            return self._best_amax_fast
-        return super().compute_amax(verbose=verbose)
+        """Return the cached per-block amax."""
+        return self._best_amax_fast
 
     def reset(self):
         """Reset per-cycle state. Keep ``_initial_amax`` so the calibrator stays reusable.

--- a/modelopt/torch/quantization/config.py
+++ b/modelopt/torch/quantization/config.py
@@ -722,9 +722,9 @@ class MseCalibConfig(QuantizeAlgorithmConfig):
     Finds a scale s (via amax a, with s = a / q_max) that minimizes the
     reconstruction error of a tensor after uniform Q→DQ:
 
-        s* = argmin_s  E[(X - DQ(Q(X; s)))^2],   X ∈ {weights | activations}
+        s* = argmin_s  E[(W - DQ(Q(W; s)))^2],   W ∈ weights
 
-    When fp8_scale_sweep is enabled, step_size is ignored.
+    When fp8_scale_sweep is enabled for a supported FP8-scale format, step_size is ignored.
     """
 
     method: Literal["mse"] = ModeloptField("mse")
@@ -755,8 +755,8 @@ class MseCalibConfig(QuantizeAlgorithmConfig):
         default=False,
         title="Enable FP8 scale sweep for NVFP4 per-block quantization.",
         description="If True, sweep all 128 FP8 E4M3 scale values instead of using multipliers. "
-        "Only applies to NVFP4 weight quantization. When enabled, num_steps, step_size, "
-        "start_multiplier, and stop_multiplier are ignored.",
+        "Applies to ModelOpt static NVFP4 weight quantizers and registered custom backends with "
+        "FP8 sweep support. Other weight quantizers use the multiplier search.",
     )
 
     distributed_sync: bool | None = ModeloptField(

--- a/modelopt/torch/quantization/model_calib.py
+++ b/modelopt/torch/quantization/model_calib.py
@@ -77,7 +77,7 @@ __all__ = [
 def _is_calibrated_nvfp4_static(q) -> bool:
     """True iff ``q`` is an enabled NVFP4-static weight quantizer with ``_amax`` set."""
     return (
-        isinstance(q, TensorQuantizer)
+        isinstance(q, NVFP4StaticQuantizer)
         and not q._disabled
         and q.is_nvfp4_static
         and getattr(q, "_amax", None) is not None
@@ -106,8 +106,12 @@ def _collect_grouped_linears(model: nn.Module) -> list[list[nn.Module]]:
     return groups
 
 
+def _collect_weight_stats(quantizer: nn.Module, weight: torch.Tensor) -> None:
+    quantizer(weight)
+
+
 @torch.no_grad()
-def _bootstrap_uncalibrated_static_weight_quantizers(model: nn.Module) -> int:
+def _bootstrap_uncalibrated_weight_quantizers(model: nn.Module) -> int:
     """Re-run weight calibration on the weight tensor for quantizers missing ``_amax``.
 
     Covers MoE experts that ``max_calibrate`` skipped (no routed tokens) so MSE
@@ -121,19 +125,19 @@ def _bootstrap_uncalibrated_static_weight_quantizers(model: nn.Module) -> int:
             continue
         with enable_weight_access_and_writeback(module, model, name_to_module):
             for weight, q in module.iter_weights_for_calibration():
-                if not isinstance(q, TensorQuantizer) or q._disabled or q._dynamic:
+                if (
+                    not isinstance(q, TensorQuantizer)
+                    or q._disabled
+                    or q._dynamic
+                    or q._calibrator is None
+                ):
                     continue
-                if q._calibrator is None:
+                if weight.is_meta:
                     continue
-                if getattr(q, "_amax", None) is not None and not torch.all(q._amax == 0):
+                amax = q.amax
+                if amax is not None and (amax.is_meta or not torch.all(amax == 0)):
                     continue
-                q.disable_quant()
-                q.enable_calib()
-                q(weight)
-                if q._calibrator.compute_amax() is not None:
-                    q.load_calib_amax()
-                q.enable_quant()
-                q.disable_calib()
+                _run_and_load_max_stats(q, partial(_collect_weight_stats, weight=weight))
                 if hasattr(q._calibrator, "reset"):
                     q._calibrator.reset()
                 n += 1
@@ -160,18 +164,18 @@ def _sync_grouped_weight_global_amax(model: nn.Module) -> int:
     # quant_utils imports back from this module; top-level would cycle.
     from modelopt.torch.export.quant_utils import preprocess_linear_fusion
 
-    wq_attr = quantizer_attr_names("weight").weight_quantizer
     n_groups = 0
     for group in _collect_grouped_linears(model):
-        for child in group:
-            wq = getattr(child, wq_attr)
-            if not isinstance(wq, NVFP4StaticQuantizer):
-                NVFP4StaticQuantizer.from_tensor_quantizer(
-                    wq, global_amax=reduce_amax(wq._amax, axis=None)
-                )
         preprocess_linear_fusion(group)
         n_groups += 1
     return n_groups
+
+
+@torch.no_grad()
+def _promote_nvfp4_static_quantizers_with_global_amax_sync(model: nn.Module) -> None:
+    """Promote static NVFP4 weight quantizers and sync grouped global amax."""
+    promote_nvfp4_static_quantizers(model)
+    _sync_grouped_weight_global_amax(model)
 
 
 CalibratorFactory: TypeAlias = Callable[
@@ -197,6 +201,11 @@ def _register_fp8_sweep_calibrator(backend: str, calibrator_factory: CalibratorF
     _FP8_SWEEP_CALIBRATOR_REGISTRY[backend] = calibrator_factory
 
 
+def _uses_modelopt_fp8_weight_scales(weight_quantizer: TensorQuantizer) -> bool:
+    """Whether the internal ModelOpt FP8-scale MSE sweep applies to this quantizer."""
+    return weight_quantizer.backend is None and weight_quantizer.is_nvfp4_static
+
+
 def weight_only_quantize(model: nn.Module):
     """Just quantize the weights of the model."""
     name_to_module = dict(model.named_modules())
@@ -210,6 +219,16 @@ def weight_only_quantize(model: nn.Module):
                 for weight, weight_quantizer in module.iter_weights_for_calibration():
                     weight_quantizer(weight)
         seen_modules.add(module)
+
+
+def _run_and_load_max_stats(model: nn.Module, forward_loop: ForwardLoop | None = None):
+    """Run max-stat collection and load collected stats without post-processing."""
+    enable_stats_collection(model)
+    if forward_loop is None:
+        weight_only_quantize(model)
+    else:
+        forward_loop(model)
+    finish_stats_collection(model)
 
 
 def _has_expert_parallelism(module: nn.Module) -> bool:
@@ -285,12 +304,7 @@ def max_calibrate(
     See :class:`MaxCalibConfig <modelopt.torch.quantization.config.MaxCalibConfig>` for
     details on the remaining arguments.
     """
-    enable_stats_collection(model)
-    if forward_loop is None:
-        weight_only_quantize(model)
-    else:
-        forward_loop(model)
-    finish_stats_collection(model)
+    _run_and_load_max_stats(model, forward_loop)
 
     # Sync quantizer amax across local experts within each rank (for SequentialMLP)
     for name, module in model.named_modules():
@@ -300,12 +314,14 @@ def max_calibrate(
     # Fail fast on NVFP4 static-block with TP>1 (sharded_state_dict treats _amax as replicated).
     _check_nvfp4_static_tp_supported(model)
 
+    _bootstrap_uncalibrated_weight_quantizers(model)
+
     # Promote eligible static-block NVFP4 weight quantizers to NVFP4StaticQuantizer so
     # the static blockwise fake-quant path is used in forward and export picks up the
     # two-level (per-block + global) scaling. Run before the ``distributed_sync`` early
     # return so single-process callers also get the promotion. No-op for dynamic-block
     # / non-NVFP4 configs.
-    promote_nvfp4_static_quantizers(model)
+    _promote_nvfp4_static_quantizers_with_global_amax_sync(model)
 
     if not distributed_sync:
         return
@@ -451,6 +467,52 @@ def _mse_quant_func(x, amax, quantizer):
     return xq
 
 
+def _make_weight_mse_calibrator(
+    weight_quantizer: TensorQuantizer,
+    step_size: float,
+    start_multiplier: float,
+    stop_multiplier: float,
+    fp8_scale_sweep: bool,
+) -> _Calibrator | None:
+    """Create the MSE calibrator for one eligible weight quantizer."""
+    if (
+        not isinstance(weight_quantizer, TensorQuantizer)
+        or not weight_quantizer.is_enabled
+        or weight_quantizer._dynamic
+        or weight_quantizer._calibrator is None
+        or getattr(weight_quantizer, "_amax", None) is None
+    ):
+        return None
+
+    initial_amax = weight_quantizer._amax.clone().detach()
+    axis = weight_quantizer._calibrator._axis
+    quant_func = partial(_mse_quant_func, quantizer=weight_quantizer)
+
+    if fp8_scale_sweep:
+        backend: str | None = getattr(weight_quantizer, "backend", None)
+        backend_factory = (
+            _FP8_SWEEP_CALIBRATOR_REGISTRY.get(backend) if backend is not None else None
+        )
+        if backend is not None and backend_factory is not None:
+            return backend_factory(initial_amax, axis, quant_func)
+        elif _uses_modelopt_fp8_weight_scales(weight_quantizer):
+            return NVFP4MSECalibrator(
+                amax=initial_amax,
+                axis=axis,
+                global_amax=weight_quantizer.global_amax,
+                quant_func=quant_func,
+            )
+
+    return MseCalibrator(
+        amax=initial_amax,
+        axis=axis,
+        step_size=step_size,
+        start_multiplier=start_multiplier,
+        stop_multiplier=stop_multiplier,
+        quant_func=quant_func,
+    )
+
+
 @torch.no_grad()
 def mse_calibrate(
     model: nn.Module,
@@ -461,11 +523,11 @@ def mse_calibrate(
     stop_multiplier: float = 4.0,
     fp8_scale_sweep: bool = False,
 ):
-    """Calibrate the model using MSE-based amax search.
+    """Calibrate weight quantizers using MSE-based amax search.
 
-    This calibration method first uses max calibration to get initial amax values,
-    then searches for better amax values by minimizing the MSE between original
-    and quantized tensors.
+    This calibration method first uses max calibration to initialize amax values for
+    all quantizers, then searches for better weight amax values by minimizing the MSE
+    between original and quantized weights.
 
     Args:
         model: Model to be calibrated.
@@ -475,121 +537,43 @@ def mse_calibrate(
         step_size: Step size for amax search (default: 0.1).
         start_multiplier: Starting multiplier for amax search (default: 0.25).
         stop_multiplier: Ending multiplier for amax search (default: 4.0).
-        fp8_scale_sweep: If True, sweep over all 128 possible FP8 E4M3 scale values
-            for NVFP4 per-block quantization instead of using multipliers.
-            This is specifically designed for optimizing the FP8-quantized
-            per-block scales in NVFP4 format (default: False).
+        fp8_scale_sweep: If True, use FP8 E4M3 scale-value sweep for supported
+            FP8-scale weight quantizers instead of multiplier search. Currently this
+            covers ModelOpt static NVFP4 weights and registered custom backends.
+            Other weight quantizers use the multiplier search.
 
     See :class:`MseCalibConfig <modelopt.torch.quantization.config.MseCalibConfig>` for
     details on the remaining arguments.
     """
-    # Step 1: max calibrate, bootstrap dead-expert weight quantizers,
-    # unify grouped NVFP4 global_amax so MSE sees a consistent FP8 grid.
+    # max_calibrate initializes activations and weights; MSE only refines weights below.
     max_calibrate(model, forward_loop, distributed_sync)
-    _bootstrap_uncalibrated_static_weight_quantizers(model)
-    _sync_grouped_weight_global_amax(model)
-
-    # Step 2: replace calibrators with MseCalibrator for enabled quantizers.
-    for name, module in list(model.named_modules()):
-        if isinstance(module, TensorQuantizer) and not module._disabled:
-            if module._calibrator is not None and not module._dynamic and hasattr(module, "_amax"):
-                initial_amax = module._amax.clone().detach()
-
-                # Promote standalone NVFP4-static quantizers; grouped siblings
-                # already promoted by _sync_grouped_weight_global_amax above.
-                if module.is_nvfp4_static and not isinstance(module, NVFP4StaticQuantizer):
-                    global_amax = reduce_amax(initial_amax, axis=None)
-                    NVFP4StaticQuantizer.from_tensor_quantizer(module, global_amax=global_amax)
-
-                is_nvfp4_static = isinstance(module, NVFP4StaticQuantizer)
-
-                if fp8_scale_sweep:
-                    # Check if backend has a registered custom calibrator factory.
-                    _backend: str | None = getattr(module, "backend", None)
-                    backend_factory = (
-                        _FP8_SWEEP_CALIBRATOR_REGISTRY.get(_backend)
-                        if _backend is not None
-                        else None
-                    )
-                    if backend_factory is not None:
-                        module._calibrator = backend_factory(
-                            initial_amax,
-                            module._calibrator._axis,
-                            partial(_mse_quant_func, quantizer=module),
-                        )
-                        continue
-
-                if fp8_scale_sweep and is_nvfp4_static:
-                    # NVFP4MSECalibrator internally selects a fused Triton kernel for
-                    # the standard squared-error sweep; set MODELOPT_NVFP4_TRITON_SWEEP=0
-                    # to force the reference Python sweep for debugging.
-                    module._calibrator = NVFP4MSECalibrator(
-                        amax=initial_amax,
-                        axis=module._calibrator._axis,
-                        global_amax=module.global_amax,
-                        quant_func=partial(_mse_quant_func, quantizer=module),
-                    )
-
-                if not fp8_scale_sweep:
-                    # Create MSE calibrator with quant_func
-                    module._calibrator = MseCalibrator(
-                        amax=initial_amax,
-                        axis=module._calibrator._axis,
-                        step_size=step_size,
-                        start_multiplier=start_multiplier,
-                        stop_multiplier=stop_multiplier,
-                        quant_func=partial(_mse_quant_func, quantizer=module),
-                    )
-
-    # Step 3: calibrate weight quantizers via iter_weights_for_calibration.
     name_to_module = dict(model.named_modules())
     seen_modules: set[int] = set()
     pbar = tqdm(desc="MSE weight calibration")
-    n_calibrated = 0
     for parent_module in name_to_module.values():
         if id(parent_module) in seen_modules or not isinstance(parent_module, QuantModule):
             continue
         seen_modules.add(id(parent_module))
         with enable_weight_access_and_writeback(parent_module, model, name_to_module):
             for weight, weight_quantizer in parent_module.iter_weights_for_calibration():
-                if not (
-                    isinstance(weight_quantizer, TensorQuantizer)
-                    and weight_quantizer.is_enabled
-                    and getattr(weight_quantizer, "_calibrator", None) is not None
-                ):
+                cal = _make_weight_mse_calibrator(
+                    weight_quantizer,
+                    step_size,
+                    start_multiplier,
+                    stop_multiplier,
+                    fp8_scale_sweep,
+                )
+                if cal is None:
                     continue
-                weight_quantizer.disable_quant()
-                weight_quantizer.enable_calib()
-                weight_quantizer(weight)
-
-                cal = weight_quantizer._calibrator
-                if cal.compute_amax() is not None:
-                    weight_quantizer.load_calib_amax()
-
-                weight_quantizer.enable_quant()
-                weight_quantizer.disable_calib()
-
-                if torch.cuda.is_available():
-                    for dev_id in range(torch.cuda.device_count()):
-                        torch.cuda.synchronize(torch.device(f"cuda:{dev_id}"))
-
+                weight_quantizer._calibrator = cal
+                _run_and_load_max_stats(
+                    weight_quantizer, partial(_collect_weight_stats, weight=weight)
+                )
                 if hasattr(cal, "reset"):
                     cal.reset()
 
                 pbar.update(1)
-                n_calibrated += 1
-                if n_calibrated % 10 == 0 and torch.cuda.is_available():
-                    for dev_id in range(torch.cuda.device_count()):
-                        torch.cuda.synchronize(torch.device(f"cuda:{dev_id}"))
-                    torch.cuda.empty_cache()
     pbar.close()
-
-    if torch.cuda.is_available():
-        for dev_id in range(torch.cuda.device_count()):
-            torch.cuda.synchronize(torch.device(f"cuda:{dev_id}"))
-        torch.cuda.empty_cache()
-
-    # TODO: Sync amax across distributed processes
 
 
 @torch.no_grad()
@@ -736,8 +720,6 @@ def local_hessian_calibrate(
     # This calibrates both weight_quantizer and input_quantizer with max calibration
     print_rank_0("local_hessian: Running max calibration for all quantizers...")
     max_calibrate(model, forward_loop, distributed_sync)
-
-    _sync_grouped_weight_global_amax(model)
 
     # Setup helpers for all quantized linear modules
     name_to_module = dict(model.named_modules())
@@ -1305,9 +1287,14 @@ def awq_lite(
     enable_stats_collection(model)
     forward_loop(model)
 
-    # Call max_calibrate to load the amax values collected during the caching mode forward pass
+    # Load the amax values collected during the caching mode forward pass
     # This will also perform distributed amax sync for input_quantizers
-    max_calibrate(model, lambda model: None)
+    with set_quantizer_by_cfg_context(
+        model,
+        [{"quantizer_name": "*weight_quantizer", "enable": False}],
+    ):
+        max_calibrate(model, lambda model: None, distributed_sync=True)
+    finish_stats_collection(model)
 
     def sync_act_scale_across_dp(module, data_parallel_group):
         """Sync activation scale across Data Parallel (DP)."""
@@ -1634,9 +1621,14 @@ def awq_clip(
     # This will collect amax for input_quantizers and KV quantizers during the caching mode forward pass
     enable_stats_collection(model)
     forward_loop(model)
-    # Call max_calibrate to load the amax values collected during the caching mode forward pass
+    # Load the amax values collected during the caching mode forward pass
     # This will also perform distributed amax sync for input_quantizers
-    max_calibrate(model, lambda model: None)
+    with set_quantizer_by_cfg_context(
+        model,
+        [{"quantizer_name": "*weight_quantizer", "enable": False}],
+    ):
+        max_calibrate(model, lambda model: None, distributed_sync=True)
+    finish_stats_collection(model)
 
     def postprocess(module):
         update_best_params(module)
@@ -1871,7 +1863,6 @@ def gptq(
 
     # TODO: Add support for other scale setting strateiges like weight-mse or local-hessian
     max_calibrate(model, forward_loop=forward_loop)
-    promote_nvfp4_static_quantizers(model)
 
     quantized_layers = [
         (n, m)

--- a/modelopt/torch/quantization/model_calib.py
+++ b/modelopt/torch/quantization/model_calib.py
@@ -495,14 +495,18 @@ def _make_weight_mse_calibrator(
         )
         if backend is not None and backend_factory is not None:
             return backend_factory(initial_amax, axis, quant_func)
-        elif _uses_modelopt_fp8_weight_scales(weight_quantizer):
+        if _uses_modelopt_fp8_weight_scales(weight_quantizer):
             return NVFP4MSECalibrator(
                 amax=initial_amax,
                 axis=axis,
                 global_amax=weight_quantizer.global_amax,
                 quant_func=quant_func,
             )
+        # fp8_scale_sweep covers only registered backends and static NVFP4 weights;
+        # skip MSE calibration for all other quantizers (no multiplier search).
+        return None
 
+    # fp8_scale_sweep disabled: multiplier-search MSE calibration for all quantizers.
     return MseCalibrator(
         amax=initial_amax,
         axis=axis,
@@ -537,10 +541,11 @@ def mse_calibrate(
         step_size: Step size for amax search (default: 0.1).
         start_multiplier: Starting multiplier for amax search (default: 0.25).
         stop_multiplier: Ending multiplier for amax search (default: 4.0).
-        fp8_scale_sweep: If True, use FP8 E4M3 scale-value sweep for supported
-            FP8-scale weight quantizers instead of multiplier search. Currently this
-            covers ModelOpt static NVFP4 weights and registered custom backends.
-            Other weight quantizers use the multiplier search.
+        fp8_scale_sweep: If True, only ModelOpt static NVFP4 weights and registered
+            custom backends are MSE-calibrated (via FP8 E4M3 scale-value sweep); all
+            other weight quantizers (INT8, plain FP8, unregistered backends, etc.) are
+            skipped and left at their max-calibrated amax. If False, all weight
+            quantizers use the multiplier search.
 
     See :class:`MseCalibConfig <modelopt.torch.quantization.config.MseCalibConfig>` for
     details on the remaining arguments.

--- a/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
+++ b/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
@@ -337,6 +337,9 @@ class TensorQuantizer(nn.Module):
         if not isinstance(value, torch.Tensor):
             value = torch.tensor(value)
 
+        self._amax_setter_helper(value)
+
+    def _amax_setter_helper(self, value):
         if not hasattr(self, "_amax"):
             self.register_buffer("_amax", value.clone().detach())
         else:
@@ -633,10 +636,7 @@ class TensorQuantizer(nn.Module):
                     err_msg
                     + " Passing 'strict=False' to `load_calib_amax()` will ignore the error."
                 )
-        if not hasattr(self, "_amax"):
-            self.register_buffer("_amax", calib_amax.clone().detach())
-        else:
-            self._amax.data.copy_(calib_amax.clone().detach())
+        self.amax = calib_amax
 
     def load_calib_bias(self, *args, **kwargs):
         """Load affine bias for quantization."""
@@ -1356,7 +1356,20 @@ class NVFP4StaticQuantizer(TensorQuantizer):
     """TensorQuantizer for NVFP4 static block quantization with two-level scaling.
 
     Uses _global_amax and inherited _amax for per-block amax values.
+    Preserves both amax states in fp32.
     """
+
+    def _preserve_amax_in_fp32(self):
+        amax = getattr(self, "_amax", None)
+        if amax is not None:
+            self._amax = amax.to(dtype=torch.float32)
+        global_amax = getattr(self, "_global_amax", None)
+        if global_amax is not None:
+            self._global_amax = global_amax.to(dtype=torch.float32)
+
+    def _amax_setter_helper(self, value):
+        super()._amax_setter_helper(value)
+        self._preserve_amax_in_fp32()
 
     @classmethod
     def from_tensor_quantizer(
@@ -1368,14 +1381,18 @@ class NVFP4StaticQuantizer(TensorQuantizer):
             tq: The TensorQuantizer to convert.
             global_amax: Optional global amax value to set on the quantizer.
         """
-        if isinstance(tq, cls):
+
+        def _preserve_and_set_global_amax(tq):
+            tq._preserve_amax_in_fp32()
             if global_amax is not None:
                 tq.global_amax = global_amax
+
+        if isinstance(tq, cls):
+            _preserve_and_set_global_amax(tq)
             return tq
         tq.__class__ = cls
         tq._is_nvfp4_static_quantizer = True
-        if global_amax is not None:
-            tq.global_amax = global_amax
+        _preserve_and_set_global_amax(tq)
         return tq
 
     @property
@@ -1393,10 +1410,27 @@ class NVFP4StaticQuantizer(TensorQuantizer):
             return
         if not isinstance(value, torch.Tensor):
             value = torch.tensor(value)
-        if not hasattr(self, "_global_amax") or self._global_amax is None:
+
+        global_amax = getattr(self, "_global_amax", None)
+        if global_amax is None:
             self.register_buffer("_global_amax", value.clone().detach())
+            global_amax = self._global_amax
         else:
-            self._global_amax.data.copy_(value.clone().detach().to(self._global_amax.device))
+            global_amax.data.copy_(value.clone().detach().to(global_amax.device))
+        self._preserve_amax_in_fp32()
+
+    def _apply(self, fn, recurse=True):
+        """Apply module transforms without rounding static scale state."""
+        amax = getattr(self, "_amax", None)
+        global_amax = getattr(self, "_global_amax", None)
+
+        module = super()._apply(fn, recurse=recurse)
+        self._preserve_amax_in_fp32()
+        if amax is not None:
+            self.amax = amax
+        if global_amax is not None:
+            self.global_amax = global_amax
+        return module
 
     def _fake_quantize(self, inputs):
         """Fake quantization using two-level scaling with _amax and _global_amax."""

--- a/modelopt/torch/quantization/utils/core_utils.py
+++ b/modelopt/torch/quantization/utils/core_utils.py
@@ -960,11 +960,17 @@ def promote_nvfp4_static_quantizers(model: nn.Module) -> int:
 
     converted = 0
     for _name, module in list(model.named_modules()):
-        if isinstance(module, TensorQuantizer) and not module._disabled:
-            if module._calibrator is not None and not module._dynamic and hasattr(module, "_amax"):
-                if module.is_nvfp4_static:
-                    initial_amax = module._amax.clone().detach()
-                    global_amax = reduce_amax(initial_amax, axis=None)
-                    NVFP4StaticQuantizer.from_tensor_quantizer(module, global_amax=global_amax)
-                    converted += 1
+        if not isinstance(module, TensorQuantizer) or not module.is_enabled:
+            continue
+        if not module.is_nvfp4_static:
+            continue
+        amax = module.amax
+        if amax is None:
+            continue
+
+        already_promoted = isinstance(module, NVFP4StaticQuantizer)
+        global_amax = reduce_amax(amax.clone().detach(), axis=None)
+        NVFP4StaticQuantizer.from_tensor_quantizer(module, global_amax=global_amax)
+        if not already_promoted:
+            converted += 1
     return converted

--- a/tests/gpu/torch/quantization/plugins/test_accelerate_gpu.py
+++ b/tests/gpu/torch/quantization/plugins/test_accelerate_gpu.py
@@ -25,11 +25,83 @@ from accelerate import init_empty_weights, load_checkpoint_and_dispatch
 from transformers import AutoConfig, AutoModelForCausalLM
 
 import modelopt.torch.quantization as mtq
+from modelopt.torch.quantization.extensions import get_cuda_ext_mx
+from modelopt.torch.quantization.nn import TensorQuantizer
 from modelopt.torch.quantization.utils import (
     enable_weight_access_and_writeback,
     is_quantized_linear,
 )
 from modelopt.torch.quantization.utils.layerwise_calib import _layer_dir
+
+NVFP4_WEIGHT_MSE_FP8_SWEEP_CFG = {
+    "quant_cfg": [
+        {
+            "quantizer_name": "*weight_quantizer",
+            "cfg": {
+                "num_bits": (2, 1),
+                "block_sizes": {-1: 16, "type": "static", "scale_bits": (4, 3)},
+                "axis": None,
+            },
+            "enable": True,
+        },
+        {"quantizer_name": "*input_quantizer", "enable": False},
+    ],
+    "algorithm": {
+        "method": "mse",
+        "fp8_scale_sweep": True,
+    },
+}
+
+
+def _nvfp4_static_amax_dtypes(model):
+    amax_dtypes = {}
+    for name, module in model.named_modules():
+        if (
+            isinstance(module, TensorQuantizer)
+            and module.is_nvfp4_static
+            and module.amax is not None
+        ):
+            amax_dtypes[name] = module.amax.dtype
+    return amax_dtypes
+
+
+def _assert_nvfp4_static_amaxes_fp32(amax_dtypes, model_dtype, label):
+    assert amax_dtypes, f"{label}: expected NVFP4 static amaxes for model dtype {model_dtype}"
+    assert all(amax_dtype == torch.float32 for amax_dtype in amax_dtypes.values()), (
+        f"{label}: expected all NVFP4 static amaxes to be fp32 for model dtype {model_dtype}, "
+        f"got {amax_dtypes}"
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_transformers_mse_calibrate_fp32_amax_save_restore(tmp_path, dtype):
+    if get_cuda_ext_mx() is None:
+        pytest.skip("cuda_ext_mx is not available")
+
+    tiny_llama_dir = create_tiny_llama_dir(tmp_path, dtype=dtype)
+    model = AutoModelForCausalLM.from_pretrained(tiny_llama_dir, torch_dtype=dtype).cuda()
+    input_ids = torch.randint(0, model.config.vocab_size, (1, 4), device="cuda")
+    cfg = copy.deepcopy(NVFP4_WEIGHT_MSE_FP8_SWEEP_CFG)
+
+    mtq.quantize(model, cfg, lambda model: model(input_ids))
+    amax_dtypes = _nvfp4_static_amax_dtypes(model)
+    _assert_nvfp4_static_amaxes_fp32(amax_dtypes, dtype, "mse calibrated")
+
+    with torch.no_grad():
+        output = model(input_ids).logits.detach().clone()
+    assert output.dtype == dtype
+
+    ckpt_path = tmp_path / f"transformers_mse_{str(dtype).rpartition('.')[-1]}"
+    model.save_pretrained(ckpt_path)
+    assert os.path.exists(ckpt_path / "modelopt_state.pth")
+    restored_model = AutoModelForCausalLM.from_pretrained(ckpt_path, torch_dtype=dtype).cuda()
+    restored_amax_dtypes = _nvfp4_static_amax_dtypes(restored_model)
+    _assert_nvfp4_static_amaxes_fp32(restored_amax_dtypes, dtype, "restored")
+
+    with torch.no_grad():
+        restored_output = restored_model(input_ids).logits.detach().clone()
+    assert restored_output.dtype == dtype
+    assert torch.equal(output, restored_output)
 
 
 def test_cpu_offloaded_tinyllama(tmp_path):

--- a/tests/gpu/torch/quantization/test_gptq.py
+++ b/tests/gpu/torch/quantization/test_gptq.py
@@ -25,7 +25,6 @@ import modelopt.torch.quantization as mtq
 from modelopt.torch.export.unified_export_hf import _export_quantized_weight
 from modelopt.torch.quantization.model_calib import gptq
 from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
-from modelopt.torch.quantization.utils import promote_nvfp4_static_quantizers
 from modelopt.torch.quantization.utils.calib_utils import (
     compute_hessian_inverse,
     gptq_blockwise_update,
@@ -265,7 +264,6 @@ def _make_nvfp4_test_data(quant_block_size, out_features, dim):
     }
     inp = torch.randn(4, 32, dim, device="cuda")
     mtq.quantize(model, quant_cfg, forward_loop=lambda m: m(inp))
-    promote_nvfp4_static_quantizers(model)
 
     # Restore original weight (GPTQ operates on original weights)
     model.weight.data = weight.clone()

--- a/tests/gpu/torch/quantization/test_nvfp4_fp8_sweep_kernel.py
+++ b/tests/gpu/torch/quantization/test_nvfp4_fp8_sweep_kernel.py
@@ -28,9 +28,14 @@ from contextlib import contextmanager
 
 import pytest
 import torch
+from _test_utils.torch.quantization.models import SimpleLinear
 from conftest import requires_triton
 
+import modelopt.torch.opt as mto
+import modelopt.torch.quantization as mtq
 from modelopt.torch.quantization.calib import NVFP4MSECalibrator
+from modelopt.torch.quantization.extensions import get_cuda_ext_mx
+from modelopt.torch.quantization.nn import TensorQuantizer
 from modelopt.torch.quantization.tensor_quant import static_blockwise_fp4_fake_quant
 
 BLOCK_SIZE = 16
@@ -67,6 +72,26 @@ def _make_calibrator(per_block_amax, global_amax):
         axis=0,
         global_amax=global_amax,
         quant_func=_reference_quant_func(global_amax),
+    )
+
+
+def _nvfp4_static_amax_dtypes(model):
+    amax_dtypes = {}
+    for name, module in model.named_modules():
+        if (
+            isinstance(module, TensorQuantizer)
+            and module.is_nvfp4_static
+            and module.amax is not None
+        ):
+            amax_dtypes[name] = module.amax.dtype
+    return amax_dtypes
+
+
+def _assert_nvfp4_static_amaxes_fp32(amax_dtypes, model_dtype, label):
+    assert amax_dtypes, f"{label}: expected NVFP4 static amaxes for model dtype {model_dtype}"
+    assert all(amax_dtype == torch.float32 for amax_dtype in amax_dtypes.values()), (
+        f"{label}: expected all NVFP4 static amaxes to be fp32 for model dtype {model_dtype}, "
+        f"got {amax_dtypes}"
     )
 
 
@@ -130,8 +155,30 @@ def test_quantized_output_matches():
 
 
 @requires_triton
+@pytest.mark.parametrize("triton_enabled", [True, False])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_sweep_stores_fp32_amax_and_preserves_output_dtype(dtype, triton_enabled):
+    """NVFP4 MSE stores selected amax in fp32 without changing fake-quant output dtype."""
+    torch.manual_seed(11)
+    device = "cuda"
+    num_blocks = 64
+    x = torch.randn(num_blocks, BLOCK_SIZE, device=device, dtype=dtype)
+    per_block_amax = x.abs().amax(dim=-1).to(dtype=dtype)
+    global_amax = per_block_amax.max()
+
+    with _force_sweep_path(triton_enabled=triton_enabled):
+        cal = _make_calibrator(per_block_amax, global_amax)
+        cal.collect(x)
+        amax = cal.compute_amax()
+
+    assert amax.dtype == torch.float32
+    xq = static_blockwise_fp4_fake_quant(x, amax, global_amax, True, x.dtype)
+    assert xq.dtype == x.dtype
+
+
+@requires_triton
 def test_reset_allows_recollect():
-    """After the fast path runs, a second collect() requires reset() in between."""
+    """After collect() caches an amax, a second collect() requires reset() in between."""
     torch.manual_seed(0)
     device = "cuda"
     num_blocks = 32
@@ -143,10 +190,10 @@ def test_reset_allows_recollect():
         cal = _make_calibrator(per_block_amax, global_amax)
         cal.collect(x)
         first = cal.compute_amax().clone()
-        assert cal._best_amax_fast is not None  # fast path was taken
+        assert cal._best_amax_fast is not None  # final amax was cached
 
-        # Second collect after the fast path is not allowed without a reset.
-        with pytest.raises(RuntimeError, match="multi-collect after the fast path"):
+        # Second collect after a final amax is cached is not allowed without a reset.
+        with pytest.raises(RuntimeError, match="multi-collect"):
             cal.collect(x)
 
         cal.reset()
@@ -197,22 +244,6 @@ def test_dispatch_fast_path_default():
 
 
 @requires_triton
-def test_dispatch_env_optout_falls_back():
-    """``MODELOPT_NVFP4_TRITON_SWEEP=0`` forces the reference 126-step sweep."""
-    torch.manual_seed(0)
-    num_blocks = 32
-    x = torch.randn(num_blocks, BLOCK_SIZE, device="cuda", dtype=torch.float32)
-    per_block_amax = x.abs().amax(dim=-1)
-    global_amax = per_block_amax.max()
-
-    with _force_sweep_path(triton_enabled=False):
-        cal = _make_calibrator(per_block_amax, global_amax)
-        cal.collect(x)
-        assert cal._best_amax_fast is None
-        assert cal._losses_sum is not None
-
-
-@requires_triton
 def test_dispatch_custom_error_func_falls_back():
     """A non-None ``error_func`` keeps the reference path so the user's metric is honored.
 
@@ -238,8 +269,8 @@ def test_dispatch_custom_error_func_falls_back():
             error_func=hessian_like_error,
         )
         cal.collect(x)
-        assert cal._best_amax_fast is None
-        assert cal._losses_sum is not None
+        assert cal._best_amax_fast is not None
+        assert cal._losses_sum is None
 
 
 @requires_triton
@@ -263,14 +294,11 @@ def test_dispatch_cpu_path_excluded():
 
 
 @requires_triton
-def test_mse_calibrate_end_to_end(monkeypatch):
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_mse_calibrate_end_to_end(monkeypatch, tmp_path, dtype):
     """End-to-end: the ``mse``/``fp8_scale_sweep=True`` path produces the same quantized
-    weights with the fast path on (default) and off (``MODELOPT_NVFP4_TRITON_SWEEP=0``)."""
-    from _test_utils.torch.quantization.models import SimpleLinear
-
-    import modelopt.torch.quantization as mtq
-    from modelopt.torch.quantization.extensions import get_cuda_ext_mx
-
+    weights with the fast path on (default) and off (``MODELOPT_NVFP4_TRITON_SWEEP=0``),
+    and stores/restores NVFP4 static amax in fp32 for fp32 and bf16 model forwards."""
     if get_cuda_ext_mx() is None:
         pytest.skip("cuda_ext_mx is not available")
 
@@ -290,35 +318,57 @@ def test_mse_calibrate_end_to_end(monkeypatch):
         "algorithm": {"method": "mse", "fp8_scale_sweep": True},
     }
 
-    def _run_calibrated(env_value):
+    def _run_calibrated(env_value, label):
         torch.manual_seed(0)
-        model = SimpleLinear().cuda()
+        model = SimpleLinear(dtype=dtype).cuda()
         # Snapshot the pre-calibration weights so both runs start from identical state.
         weight_snapshots = {n: p.detach().clone() for n, p in model.named_parameters()}
         if env_value is None:
             monkeypatch.delenv("MODELOPT_NVFP4_TRITON_SWEEP", raising=False)
         else:
             monkeypatch.setenv("MODELOPT_NVFP4_TRITON_SWEEP", env_value)
-        calib_data = [model.get_input().cuda() for _ in range(2)]
+        calib_data = [model.get_input().cuda().to(dtype=dtype) for _ in range(2)]
 
         def forward_loop(m):
             for batch in calib_data:
                 m(batch)
 
         mtq.quantize(model, cfg, forward_loop=forward_loop)
+        amax_dtypes = _nvfp4_static_amax_dtypes(model)
+        _assert_nvfp4_static_amaxes_fp32(amax_dtypes, dtype, label)
+
+        ckpt_path = tmp_path / f"mse_calibrate_{label}_{str(dtype).rpartition('.')[-1]}.pt"
+        mto.save(model, ckpt_path)
+        restored_model = mto.restore(SimpleLinear(dtype=dtype).cuda(), ckpt_path)
+        restored_amax_dtypes = _nvfp4_static_amax_dtypes(restored_model)
+        _assert_nvfp4_static_amaxes_fp32(restored_amax_dtypes, dtype, f"{label} restored")
+
         # Run a deterministic input through and snapshot the output.
         torch.manual_seed(1)
-        x = torch.randn(4, 16, device="cuda")
+        x = torch.randn(4, 16, device="cuda", dtype=dtype)
         with torch.no_grad():
             y = model(x).detach().clone()
-        return y, weight_snapshots
+            y_restored = restored_model(x).detach().clone()
+        assert y_restored.dtype == dtype
+        assert torch.equal(y, y_restored)
+        return y, weight_snapshots, amax_dtypes, restored_amax_dtypes
 
-    y_default, w0 = _run_calibrated(env_value=None)
-    y_optout, w1 = _run_calibrated(env_value="0")
+    y_default, w0, dtypes_default, restored_dtypes_default = _run_calibrated(
+        env_value=None, label="fast"
+    )
+    y_optout, w1, dtypes_optout, restored_dtypes_optout = _run_calibrated(
+        env_value="0", label="reference"
+    )
     # Both runs must start from the same weights (sanity: SimpleLinear is deterministic
     # under the same seed) before we compare post-calibration outputs.
     for name in w0:
         assert torch.equal(w0[name], w1[name]), name
+    _assert_nvfp4_static_amaxes_fp32(dtypes_default, dtype, "fast")
+    _assert_nvfp4_static_amaxes_fp32(dtypes_optout, dtype, "reference")
+    _assert_nvfp4_static_amaxes_fp32(restored_dtypes_default, dtype, "fast restored")
+    _assert_nvfp4_static_amaxes_fp32(restored_dtypes_optout, dtype, "reference restored")
+    assert y_default.dtype == dtype
+    assert y_optout.dtype == dtype
     assert torch.equal(y_default, y_optout)
 
 

--- a/tests/gpu/torch/quantization/test_nvfp4_fp8_sweep_kernel.py
+++ b/tests/gpu/torch/quantization/test_nvfp4_fp8_sweep_kernel.py
@@ -190,7 +190,7 @@ def test_reset_allows_recollect():
         cal = _make_calibrator(per_block_amax, global_amax)
         cal.collect(x)
         first = cal.compute_amax().clone()
-        assert cal._best_amax_fast is not None  # final amax was cached
+        assert cal._best_amax is not None  # final amax was cached
 
         # Second collect after a final amax is cached is not allowed without a reset.
         with pytest.raises(RuntimeError, match="multi-collect"):
@@ -239,7 +239,7 @@ def test_dispatch_fast_path_default():
         cal = _make_calibrator(per_block_amax, global_amax)
         cal.collect(x)
         # Fast path stashes the final amax directly; reference accumulator stays empty.
-        assert cal._best_amax_fast is not None
+        assert cal._best_amax is not None
         assert cal._losses_sum is None
 
 
@@ -269,7 +269,7 @@ def test_dispatch_custom_error_func_falls_back():
             error_func=hessian_like_error,
         )
         cal.collect(x)
-        assert cal._best_amax_fast is not None
+        assert cal._best_amax is not None
         assert cal._losses_sum is None
 
 

--- a/tests/gpu/torch/quantization/test_nvfp4_static_quantizer_cuda.py
+++ b/tests/gpu/torch/quantization/test_nvfp4_static_quantizer_cuda.py
@@ -326,7 +326,7 @@ class TestNVFP4MSECalibrator:
         x = torch.randn(num_blocks, block_size, device=device)
         cal.collect(x)
 
-        assert cal._best_amax_fast is not None
+        assert cal._best_amax is not None
         assert cal._losses_sum is None
 
         amax = cal.compute_amax()
@@ -358,7 +358,7 @@ class TestNVFP4MSECalibrator:
 
         cal.collect(x1)
         first = cal.compute_amax().clone()
-        assert cal._best_amax_fast is not None
+        assert cal._best_amax is not None
         assert cal._losses_sum is None
 
         with pytest.raises(RuntimeError, match="multi-collect"):

--- a/tests/gpu/torch/quantization/test_nvfp4_static_quantizer_cuda.py
+++ b/tests/gpu/torch/quantization/test_nvfp4_static_quantizer_cuda.py
@@ -41,13 +41,17 @@ class TestNVFP4StaticQuantizer:
             block_sizes={-1: 16, "type": "static", "scale_bits": (4, 3)},
         )
         tq = TensorQuantizer(quant_attribute_cfg=cfg).to(device)
-        tq.amax = torch.tensor([1.0, 2.0, 3.0, 4.0], device=device)
+        tq.amax = torch.tensor([1.0, 2.0, 3.0, 4.0], device=device, dtype=torch.float16)
 
         nvfp4_quantizer = NVFP4StaticQuantizer.from_tensor_quantizer(tq)
 
         assert nvfp4_quantizer.global_amax is None
         assert nvfp4_quantizer._num_bits == (2, 1)
-        assert torch.allclose(nvfp4_quantizer._amax, tq._amax)
+        assert nvfp4_quantizer._amax.dtype == torch.float32
+        torch.testing.assert_close(
+            nvfp4_quantizer._amax,
+            torch.tensor([1.0, 2.0, 3.0, 4.0], device=device),
+        )
 
     def test_global_amax_property(self, device):
         """Test global_amax property getter/setter."""
@@ -59,15 +63,108 @@ class TestNVFP4StaticQuantizer:
 
         assert quantizer.global_amax is None
 
-        quantizer.global_amax = torch.tensor(5.0, device=device)
+        quantizer.global_amax = torch.tensor(5.0, device=device, dtype=torch.float16)
         assert quantizer.global_amax is not None
+        assert quantizer.global_amax.dtype == torch.float32
         assert torch.isclose(quantizer.global_amax, torch.tensor(5.0, device=device))
 
         quantizer.global_amax = 10.0
+        assert quantizer.global_amax.dtype == torch.float32
         assert torch.isclose(quantizer.global_amax, torch.tensor(10.0, device=device))
 
         quantizer.global_amax = None
         assert quantizer.global_amax is None
+
+    def test_dtype_cast_preserves_fp32_scale_state(self, device):
+        """Casting the module dtype should not demote static scale state."""
+        cfg = QuantizerAttributeConfig(
+            num_bits=(2, 1),
+            block_sizes={-1: 16, "type": "static", "scale_bits": (4, 3)},
+        )
+        quantizer = NVFP4StaticQuantizer(quant_attribute_cfg=cfg).to(device)
+        expected_amax = torch.tensor(
+            [1.0001, 1.0002, 1.0003, 1.0004], device=device, dtype=torch.float32
+        )
+        expected_global_amax = torch.tensor(4.0003, device=device, dtype=torch.float32)
+        quantizer.amax = expected_amax
+        quantizer.global_amax = expected_global_amax
+
+        assert quantizer.amax.dtype == torch.float32
+        assert quantizer.global_amax.dtype == torch.float32
+
+        quantizer = quantizer.half()
+
+        assert quantizer.amax.dtype == torch.float32
+        assert quantizer.global_amax.dtype == torch.float32
+        torch.testing.assert_close(quantizer.amax, expected_amax)
+        torch.testing.assert_close(quantizer.global_amax, expected_global_amax)
+
+        quantizer = quantizer.to(dtype=torch.bfloat16)
+
+        assert quantizer.amax.dtype == torch.float32
+        assert quantizer.global_amax.dtype == torch.float32
+        torch.testing.assert_close(quantizer.amax, expected_amax)
+        torch.testing.assert_close(quantizer.global_amax, expected_global_amax)
+
+    def test_load_calib_amax_preserves_fp32_result_dtype(self, device):
+        """Loading NVFP4 MSE amax should leave static scale state in fp32."""
+        cfg = QuantizerAttributeConfig(
+            num_bits=(2, 1),
+            block_sizes={-1: 16, "type": "static", "scale_bits": (4, 3)},
+        )
+        quantizer = NVFP4StaticQuantizer(quant_attribute_cfg=cfg).to(device)
+        quantizer.register_buffer("_amax", torch.ones(4, device=device, dtype=torch.float16))
+        expected = torch.arange(1, 5, device=device, dtype=torch.float32)
+
+        class Calibrator:
+            def compute_amax(self):
+                return expected
+
+        quantizer._calibrator = Calibrator()
+        quantizer.load_calib_amax()
+
+        assert quantizer.amax.dtype == torch.float32
+        torch.testing.assert_close(quantizer.amax, expected)
+
+    def test_load_state_dict_preserves_fp32_scale_state(self, device):
+        """Loading lower-precision state should keep NVFP4 static scale buffers fp32."""
+        cfg = QuantizerAttributeConfig(
+            num_bits=(2, 1),
+            block_sizes={-1: 16, "type": "static", "scale_bits": (4, 3)},
+        )
+        source = NVFP4StaticQuantizer(quant_attribute_cfg=cfg).to(device)
+        source.amax = torch.arange(1, 5, device=device, dtype=torch.float32)
+        source.global_amax = torch.tensor(5.0, device=device)
+        state_dict = source.state_dict()
+        state_dict["_amax"] = state_dict["_amax"].to(dtype=torch.float16)
+        state_dict["_global_amax"] = state_dict["_global_amax"].to(dtype=torch.float16)
+
+        target = NVFP4StaticQuantizer(quant_attribute_cfg=cfg).to(device)
+        target.amax = torch.zeros(4, device=device)
+        target.global_amax = torch.tensor(0.0, device=device)
+        target.load_state_dict(state_dict)
+
+        assert target.amax.dtype == torch.float32
+        assert target.global_amax.dtype == torch.float32
+        torch.testing.assert_close(target.amax, source.amax)
+        torch.testing.assert_close(target.global_amax, source.global_amax)
+
+    def test_modelopt_state_restore_uses_fp32_scale_metadata(self, device):
+        """ModelOpt metadata restore should use the saved fp32 static scale metadata."""
+        cfg = QuantizerAttributeConfig(
+            num_bits=(2, 1),
+            block_sizes={-1: 16, "type": "static", "scale_bits": (4, 3)},
+        )
+        quantizer = NVFP4StaticQuantizer(quant_attribute_cfg=cfg).to(device)
+        quantizer.amax = torch.arange(1, 5, device=device, dtype=torch.float32)
+        quantizer.global_amax = torch.tensor(5.0, device=device)
+        modelopt_state = quantizer.get_modelopt_state()
+
+        restored = NVFP4StaticQuantizer(quant_attribute_cfg=cfg)
+        restored.set_from_modelopt_state(modelopt_state)
+
+        assert restored.amax.dtype == torch.float32
+        assert restored.global_amax.dtype == torch.float32
 
     def test_export_fp8_scale_no_nan_for_zero_amax_block(self, device):
         """Regression: export must not emit fp8 NaN bytes for an all-zero block.
@@ -187,6 +284,15 @@ class TestNVFP4MSECalibrator:
         assert cal._losses_sum is None
         assert cal._amax is None
 
+    def test_compute_amax_before_collect_returns_none(self, device):
+        """Test that compute_amax returns None before a final amax is cached."""
+        num_blocks = 4
+        amax = torch.ones(num_blocks, device=device)
+        global_amax = torch.tensor(10.0, device=device)
+        cal = NVFP4MSECalibrator(amax=amax, global_amax=global_amax)
+
+        assert cal.compute_amax() is None
+
     def test_fp8_candidates_generation(self, device):
         """Test that 126 valid FP8 candidates are generated."""
         num_blocks = 4
@@ -201,13 +307,7 @@ class TestNVFP4MSECalibrator:
         assert torch.all(candidates > 0)
 
     def test_collect_and_compute_amax(self, device, monkeypatch):
-        """Test reference-path collect and compute_amax workflow.
-
-        Pinned to the reference 126-step sweep (``MODELOPT_NVFP4_TRITON_SWEEP=0``)
-        because this test inspects ``_losses_sum``, which only the reference path
-        populates; the Triton fast path produces ``_best_amax_fast`` directly and
-        is covered separately in ``test_nvfp4_fp8_sweep_kernel.py``.
-        """
+        """Test reference-path collect caches the final amax immediately."""
         monkeypatch.setenv("MODELOPT_NVFP4_TRITON_SWEEP", "0")
         num_blocks = 8
         block_size = 16
@@ -226,8 +326,8 @@ class TestNVFP4MSECalibrator:
         x = torch.randn(num_blocks, block_size, device=device)
         cal.collect(x)
 
-        assert cal._losses_sum is not None
-        assert len(cal._losses_sum) == 126
+        assert cal._best_amax_fast is not None
+        assert cal._losses_sum is None
 
         amax = cal.compute_amax()
 
@@ -236,13 +336,8 @@ class TestNVFP4MSECalibrator:
         assert torch.all(torch.isfinite(amax))
         assert torch.all(amax > 0)
 
-    def test_multiple_collections(self, device, monkeypatch):
-        """Test that multiple collections accumulate correctly.
-
-        Multi-collect is reference-path-only — the Triton fast path is one-shot
-        and refuses a second ``collect()`` until ``reset()``. Forcing the env var
-        keeps this exercising the accumulator.
-        """
+    def test_reference_path_reset_allows_recollect(self, device, monkeypatch):
+        """Test that reference fallback is one-shot until reset."""
         monkeypatch.setenv("MODELOPT_NVFP4_TRITON_SWEEP", "0")
         num_blocks = 4
         block_size = 16
@@ -262,13 +357,16 @@ class TestNVFP4MSECalibrator:
         x2 = torch.randn(num_blocks, block_size, device=device)
 
         cal.collect(x1)
-        losses_after_first = [loss.clone() for loss in cal._losses_sum]
+        first = cal.compute_amax().clone()
+        assert cal._best_amax_fast is not None
+        assert cal._losses_sum is None
 
-        cal.collect(x2)
-        losses_after_second = cal._losses_sum
+        with pytest.raises(RuntimeError, match="multi-collect"):
+            cal.collect(x2)
 
-        for loss1, loss2 in zip(losses_after_first, losses_after_second):
-            assert torch.all(loss2 >= loss1 - 1e-6)
+        cal.reset()
+        cal.collect(x1)
+        assert torch.equal(first, cal.compute_amax())
 
     def test_per_block_independent_optimization(self, device):
         """Test that each block is optimized independently.

--- a/tests/unit/torch/quantization/plugins/test_fused_experts.py
+++ b/tests/unit/torch/quantization/plugins/test_fused_experts.py
@@ -656,20 +656,15 @@ class TestFusedExpertsCalibration:
 
         self._cleanup_registry(expert_type)
 
-    def test_bootstrap_populates_dead_expert_quantizers(self):
-        """`_bootstrap_uncalibrated_weight_quantizers` fills `_amax` on experts the
-        forward pass never routed to.
+    def test_max_calibrate_populates_dead_static_nvfp4_expert_quantizers(self):
+        """max calibration fills static NVFP4 ``_amax`` on experts the forward never routed to.
 
         Regression for the dead-expert MSE skip: with partial routing during max
         calibration, never-routed experts' weight quantizers stay with
-        ``_amax=None``; bootstrap must run the calibrator on the per-expert weight
-        slice (via ``iter_weights_for_calibration``) to populate them so MSE
-        doesn't skip them.
+        ``_amax=None`` unless static NVFP4 finalization bootstraps them from the
+        per-expert weight slice.
         """
         import modelopt.torch.quantization as mtq
-        from modelopt.torch.quantization.model_calib import (
-            _bootstrap_uncalibrated_static_weight_quantizers,
-        )
 
         model = _TinyMoEModel()
         expert_type = type(model.moe.experts)
@@ -680,11 +675,17 @@ class TestFusedExpertsCalibration:
                 {"quantizer_name": "*", "enable": False},
                 {
                     "quantizer_name": "*gate_up_proj_weight_quantizer",
-                    "cfg": {"num_bits": 8, "axis": 0},
+                    "cfg": {
+                        "num_bits": (2, 1),
+                        "block_sizes": {-1: 16, "type": "static", "scale_bits": (4, 3)},
+                    },
                 },
                 {
                     "quantizer_name": "*down_proj_weight_quantizer",
-                    "cfg": {"num_bits": 8, "axis": 0},
+                    "cfg": {
+                        "num_bits": (2, 1),
+                        "block_sizes": {-1: 16, "type": "static", "scale_bits": (4, 3)},
+                    },
                 },
             ],
             "algorithm": "max",
@@ -711,41 +712,25 @@ class TestFusedExpertsCalibration:
 
         experts = model.moe.experts
 
-        # Pre-bootstrap: dead experts have no/zero _amax.
-        for idx in dead:
-            gu_q = experts.gate_up_proj_weight_quantizers[idx]
-            d_q = experts.down_proj_weight_quantizers[idx]
-            assert getattr(gu_q, "_amax", None) is None or torch.all(gu_q._amax == 0), (
-                f"Dead expert {idx} gate_up_proj should be uncalibrated pre-bootstrap"
-            )
-            assert getattr(d_q, "_amax", None) is None or torch.all(d_q._amax == 0), (
-                f"Dead expert {idx} down_proj should be uncalibrated pre-bootstrap"
-            )
-
-        n_bootstrapped = _bootstrap_uncalibrated_static_weight_quantizers(model)
-        assert n_bootstrapped >= 2 * len(dead), (
-            f"Expected ≥{2 * len(dead)} bootstrapped (gate_up + down per dead expert), "
-            f"got {n_bootstrapped}"
-        )
-
-        # Post-bootstrap: every expert has populated _amax matching max(|weight|).
+        # Static NVFP4 finalization in max_calibrate bootstraps every expert.
         for idx in range(NUM_EXPERTS):
             gu_q = experts.gate_up_proj_weight_quantizers[idx]
             d_q = experts.down_proj_weight_quantizers[idx]
             assert gu_q._amax is not None and not torch.all(gu_q._amax == 0), (
-                f"Expert {idx} gate_up_proj _amax not populated after bootstrap"
+                f"Expert {idx} gate_up_proj _amax not populated after max_calibrate"
             )
             assert d_q._amax is not None and not torch.all(d_q._amax == 0), (
-                f"Expert {idx} down_proj _amax not populated after bootstrap"
+                f"Expert {idx} down_proj _amax not populated after max_calibrate"
             )
 
-        # For dead experts, bootstrap reads max(|weight|). Sanity-check it matches
-        # the actual weight tensor's per-row max (axis=0 reduces over hidden_dim).
+        # For dead experts, bootstrap reads blockwise max(|weight|). Sanity-check it
+        # matches the actual weight tensor's per-block max over hidden_dim.
         for idx in dead:
-            expected = experts.gate_up_proj.data[idx].abs().amax(dim=1)
+            expected = experts.gate_up_proj.data[idx].reshape(2 * INTERMEDIATE_DIM, 2, 16)
+            expected = expected.abs().amax(dim=2).flatten()
             got = experts.gate_up_proj_weight_quantizers[idx]._amax.flatten()
             assert torch.allclose(got, expected, atol=1e-4), (
-                f"Expert {idx} bootstrap amax should equal per-row max(|weight|); "
+                f"Expert {idx} amax should equal blockwise max(|weight|); "
                 f"max diff {(got - expected).abs().max().item()}"
             )
 

--- a/tests/unit/torch/quantization/test_mse_calibrator.py
+++ b/tests/unit/torch/quantization/test_mse_calibrator.py
@@ -624,13 +624,13 @@ class TestRegisterFP8SweepCalibrator:
 
         assert len(factory_calls) == 0
 
-    def test_unregistered_backend_uses_default_mse_calibrator(self):
-        """A quantizer with an unregistered backend falls through to MseCalibrator."""
+    def test_unregistered_backend_skipped_when_fp8_sweep_enabled(self):
+        """An unregistered backend is skipped under fp8_scale_sweep, leaving the max calibrator."""
         model = self._quantize_and_calibrate("_test_unregistered", fp8_scale_sweep=True)
         for module in model.modules():
             if isinstance(module, TensorQuantizer) and module.is_enabled:
                 if getattr(module, "_calibrator", None) is not None:
-                    assert isinstance(module._calibrator, calib.MseCalibrator)
+                    assert not isinstance(module._calibrator, calib.MseCalibrator)
 
     def test_modelopt_static_nvfp4_uses_fp8_scale_sweep(self):
         """Internal ModelOpt static NVFP4 weights use the FP8-scale MSE calibrator."""
@@ -656,8 +656,8 @@ class TestRegisterFP8SweepCalibrator:
 
         assert isinstance(cal, calib.NVFP4MSECalibrator)
 
-    def test_internal_int8_uses_multiplier_search_when_fp8_sweep_enabled(self):
-        """Internal formats without FP8 block scales keep the normal MSE calibrator."""
+    def test_internal_int8_skipped_when_fp8_sweep_enabled(self):
+        """INT8 is skipped under fp8_scale_sweep but uses the multiplier search otherwise."""
         q = TensorQuantizer(
             QuantizerAttributeConfig(num_bits=8, axis=None),
             amax=torch.tensor(2.0),
@@ -669,6 +669,16 @@ class TestRegisterFP8SweepCalibrator:
             start_multiplier=0.25,
             stop_multiplier=4.0,
             fp8_scale_sweep=True,
+        )
+
+        assert cal is None
+
+        cal = _make_weight_mse_calibrator(
+            q,
+            step_size=0.1,
+            start_multiplier=0.25,
+            stop_multiplier=4.0,
+            fp8_scale_sweep=False,
         )
 
         assert isinstance(cal, calib.MseCalibrator)

--- a/tests/unit/torch/quantization/test_mse_calibrator.py
+++ b/tests/unit/torch/quantization/test_mse_calibrator.py
@@ -17,10 +17,22 @@
 
 import torch
 
+import modelopt.torch.quantization as mtq
 from modelopt.torch.quantization import calib
 from modelopt.torch.quantization.config import QuantizerAttributeConfig
-from modelopt.torch.quantization.nn import TensorQuantizer
-from modelopt.torch.quantization.utils import enable_fake_quant
+from modelopt.torch.quantization.model_calib import (
+    _FP8_SWEEP_CALIBRATOR_REGISTRY,
+    _make_weight_mse_calibrator,
+    _promote_nvfp4_static_quantizers_with_global_amax_sync,
+    _register_fp8_sweep_calibrator,
+    mse_calibrate,
+)
+from modelopt.torch.quantization.nn import NVFP4StaticQuantizer, TensorQuantizer
+from modelopt.torch.quantization.nn.modules.tensor_quantizer import (
+    _QUANT_FUNCTIONAL_BACKENDS,
+    register_quant_backend,
+)
+from modelopt.torch.quantization.utils import enable_fake_quant, promote_nvfp4_static_quantizers
 
 
 # TODO: avoid code duplication in this file
@@ -532,20 +544,10 @@ class TestRegisterFP8SweepCalibrator:
     """Tests for _register_fp8_sweep_calibrator and its dispatch in mse_calibrate."""
 
     def setup_method(self):
-        from modelopt.torch.quantization.model_calib import _FP8_SWEEP_CALIBRATOR_REGISTRY
-        from modelopt.torch.quantization.nn.modules.tensor_quantizer import (
-            _QUANT_FUNCTIONAL_BACKENDS,
-        )
-
         self._orig_fp8_registry = dict(_FP8_SWEEP_CALIBRATOR_REGISTRY)
         self._orig_quant_backends = dict(_QUANT_FUNCTIONAL_BACKENDS)
 
     def teardown_method(self):
-        from modelopt.torch.quantization.model_calib import _FP8_SWEEP_CALIBRATOR_REGISTRY
-        from modelopt.torch.quantization.nn.modules.tensor_quantizer import (
-            _QUANT_FUNCTIONAL_BACKENDS,
-        )
-
         _FP8_SWEEP_CALIBRATOR_REGISTRY.clear()
         _FP8_SWEEP_CALIBRATOR_REGISTRY.update(self._orig_fp8_registry)
         _QUANT_FUNCTIONAL_BACKENDS.clear()
@@ -553,10 +555,6 @@ class TestRegisterFP8SweepCalibrator:
 
     def _quantize_and_calibrate(self, backend_name, fp8_scale_sweep=True):
         """Quantize a small Linear with the given backend and run mse_calibrate."""
-        import modelopt.torch.quantization as mtq
-        from modelopt.torch.quantization.model_calib import mse_calibrate
-        from modelopt.torch.quantization.nn.modules.tensor_quantizer import register_quant_backend
-
         register_quant_backend(backend_name, lambda x, tq: x)
         model = torch.nn.Linear(8, 8, bias=False)
         inputs = torch.randn(1, 8)
@@ -571,15 +569,15 @@ class TestRegisterFP8SweepCalibrator:
             "algorithm": "max",
         }
         mtq.quantize(model, config, forward_loop=lambda m: m(inputs))
-        mse_calibrate(model, lambda m: m(inputs), fp8_scale_sweep=fp8_scale_sweep)
+        mse_calibrate(
+            model,
+            lambda m: m(inputs),
+            fp8_scale_sweep=fp8_scale_sweep,
+        )
         return model
 
     def test_register(self):
         """_register_fp8_sweep_calibrator stores factories by backend key and allows overwrite."""
-        from modelopt.torch.quantization.model_calib import (
-            _FP8_SWEEP_CALIBRATOR_REGISTRY,
-            _register_fp8_sweep_calibrator,
-        )
 
         def factory_a(amax, axis, qf):
             return None
@@ -595,12 +593,9 @@ class TestRegisterFP8SweepCalibrator:
 
     def test_mse_calibrate_dispatches_to_registered_factory(self):
         """mse_calibrate with fp8_scale_sweep=True calls the registered factory once per quantizer."""
-        from modelopt.torch.quantization.calib.mse import MseCalibrator
-        from modelopt.torch.quantization.model_calib import _register_fp8_sweep_calibrator
-
         factory_calls: list = []
 
-        class _RecordingCalibrator(MseCalibrator):
+        class _RecordingCalibrator(calib.MseCalibrator):
             def collect(self, x):
                 pass
 
@@ -618,8 +613,6 @@ class TestRegisterFP8SweepCalibrator:
 
     def test_mse_calibrate_skips_registry_when_fp8_sweep_false(self):
         """Registry factory is not invoked when fp8_scale_sweep=False."""
-        from modelopt.torch.quantization.model_calib import _register_fp8_sweep_calibrator
-
         factory_calls: list = []
 
         def my_factory(amax, axis, quant_func):
@@ -630,3 +623,145 @@ class TestRegisterFP8SweepCalibrator:
         self._quantize_and_calibrate("_test_no_sweep", fp8_scale_sweep=False)
 
         assert len(factory_calls) == 0
+
+    def test_unregistered_backend_uses_default_mse_calibrator(self):
+        """A quantizer with an unregistered backend falls through to MseCalibrator."""
+        model = self._quantize_and_calibrate("_test_unregistered", fp8_scale_sweep=True)
+        for module in model.modules():
+            if isinstance(module, TensorQuantizer) and module.is_enabled:
+                if getattr(module, "_calibrator", None) is not None:
+                    assert isinstance(module._calibrator, calib.MseCalibrator)
+
+    def test_modelopt_static_nvfp4_uses_fp8_scale_sweep(self):
+        """Internal ModelOpt static NVFP4 weights use the FP8-scale MSE calibrator."""
+        q = TensorQuantizer(
+            QuantizerAttributeConfig(
+                num_bits=(2, 1),
+                block_sizes={-1: 16, "type": "static", "scale_bits": (4, 3)},
+                axis=None,
+            ),
+            amax=torch.tensor([1.0, 2.0]),
+        )
+        model = torch.nn.Module()
+        model.weight_quantizer = q
+        _promote_nvfp4_static_quantizers_with_global_amax_sync(model)
+
+        cal = _make_weight_mse_calibrator(
+            q,
+            step_size=0.1,
+            start_multiplier=0.25,
+            stop_multiplier=4.0,
+            fp8_scale_sweep=True,
+        )
+
+        assert isinstance(cal, calib.NVFP4MSECalibrator)
+
+    def test_internal_int8_uses_multiplier_search_when_fp8_sweep_enabled(self):
+        """Internal formats without FP8 block scales keep the normal MSE calibrator."""
+        q = TensorQuantizer(
+            QuantizerAttributeConfig(num_bits=8, axis=None),
+            amax=torch.tensor(2.0),
+        )
+
+        cal = _make_weight_mse_calibrator(
+            q,
+            step_size=0.1,
+            start_multiplier=0.25,
+            stop_multiplier=4.0,
+            fp8_scale_sweep=True,
+        )
+
+        assert isinstance(cal, calib.MseCalibrator)
+
+    def test_max_calibrate_bootstraps_non_nvfp4_dead_weight_quantizer(self):
+        """Non-NVFP4 weights skipped by the forward loop still get weight amax."""
+
+        class _TwoLinears(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.live = torch.nn.Linear(8, 8, bias=False)
+                self.dead = torch.nn.Linear(8, 8, bias=False)
+
+            def forward(self, x):
+                return self.live(x)
+
+        model = _TwoLinears()
+        inputs = torch.randn(1, 8)
+        config = {
+            "quant_cfg": [
+                {"quantizer_name": "*", "enable": False},
+                {"quantizer_name": "*weight_quantizer", "cfg": {"num_bits": 8, "axis": None}},
+            ],
+            "algorithm": "max",
+        }
+        mtq.quantize(model, config, forward_loop=lambda m: m(inputs))
+
+        assert model.dead.weight_quantizer.amax is not None
+
+    def test_max_calibrate_bootstrap_skips_meta_weight_quantizer(self):
+        """Meta weights cannot provide real stats for bootstrap calibration."""
+
+        class _MetaLinear(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layer = torch.nn.Linear(8, 8, bias=False, device="meta")
+
+            def forward(self, x):
+                return self.layer(x)
+
+        model = _MetaLinear()
+        config = {
+            "quant_cfg": [
+                {"quantizer_name": "*", "enable": False},
+                {"quantizer_name": "*weight_quantizer", "cfg": {"num_bits": 8, "axis": None}},
+            ],
+            "algorithm": "max",
+        }
+
+        mtq.quantize(model, config)
+
+        assert model.layer.weight_quantizer.amax.is_meta
+
+
+class TestStaticNVFP4Promotion:
+    class _LinearLike(torch.nn.Module):
+        def __init__(self, amax):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.empty(1, 16))
+            cfg = QuantizerAttributeConfig(
+                num_bits=(2, 1),
+                block_sizes={-1: 16, "type": "static", "scale_bits": (4, 3)},
+                axis=None,
+            )
+            self.weight_quantizer = TensorQuantizer(quant_attribute_cfg=cfg, amax=amax)
+            self.input_quantizer = TensorQuantizer()
+            self.input_quantizer.disable()
+
+    def test_standalone_static_nvfp4_quantizer_is_promoted(self):
+        model = self._LinearLike(torch.tensor([1.0, 5.0]))
+
+        _promote_nvfp4_static_quantizers_with_global_amax_sync(model)
+
+        assert isinstance(model.weight_quantizer, NVFP4StaticQuantizer)
+        assert torch.equal(model.weight_quantizer.global_amax, torch.tensor(5.0))
+
+    def test_promote_static_nvfp4_quantizers_returns_promoted_count(self):
+        model = self._LinearLike(torch.tensor([1.0, 5.0]))
+
+        count = promote_nvfp4_static_quantizers(model)
+
+        assert count == 1
+        assert isinstance(model.weight_quantizer, NVFP4StaticQuantizer)
+        assert torch.equal(model.weight_quantizer.global_amax, torch.tensor(5.0))
+
+    def test_grouped_static_nvfp4_quantizers_share_global_amax(self):
+        model = torch.nn.Module()
+        model.q_proj = self._LinearLike(torch.tensor([1.0, 2.0]))
+        model.k_proj = self._LinearLike(torch.tensor([3.0, 4.0]))
+        model.v_proj = self._LinearLike(torch.tensor([5.0, 6.0]))
+
+        _promote_nvfp4_static_quantizers_with_global_amax_sync(model)
+
+        for child in (model.q_proj, model.k_proj, model.v_proj):
+            assert isinstance(child.weight_quantizer, NVFP4StaticQuantizer)
+            assert torch.equal(child.weight_quantizer.global_amax, torch.tensor(6.0))


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Refines static NVFP4 MSE calibration and forces static NVFP4 amax state to stay FP32 across calibration loading, quantizer promotion, dtype casts, and restore paths.

Main changes:

- Tighten max/MSE calibration bootstrap and static NVFP4 quantizer promotion.
- Keep static NVFP4 `_amax` and `_global_amax` in FP32.
- Update focused GPU/unit coverage for FP8 sweep calibration, promotion, restore, and FP32 amax preservation.

### Usage

```yaml
algorithm:
  method: mse
  fp8_scale_sweep: true
```

### Testing

```bash
pre-commit run --files modelopt/torch/quantization/nn/modules/tensor_quantizer.py tests/gpu/torch/quantization/test_nvfp4_static_quantizer_cuda.py
pytest_pwd tests/gpu/torch/quantization/test_nvfp4_static_quantizer_cuda.py -q
```

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors).

- Is this change backward compatible?: Yes
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: Yes
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: Yes

### Additional Information

N/A
