### PR TITLE
[6/n] Replace skip-softmax calibration formula

### DIFF
--- a/examples/diffusers/README.md
+++ b/examples/diffusers/README.md
@@ -314,7 +314,7 @@ By following these steps, your PEFT LoRA model should be efficiently quantized u
 
 ## Sparse Attention (Skip-Softmax)
 
-Skip-softmax sparse attention skips KV tiles whose attention scores are negligible during the softmax computation, reducing FLOPs without retraining. An exponential model (`scale_factor = a * exp(b * target_sparsity)`) is calibrated once, then the target sparsity can be adjusted at runtime without recalibration.
+Skip-softmax sparse attention skips KV tiles whose attention scores are negligible during the softmax computation, reducing FLOPs without retraining. A dynamic threshold model (`t = 1 - exp(-a * (S/(1-S))^b / L^c)`) is calibrated once, then the target sparsity can be adjusted at runtime without recalibration.
 
 ### Getting Started
 

--- a/examples/diffusers/sparsity/README.md
+++ b/examples/diffusers/sparsity/README.md
@@ -20,11 +20,10 @@ reducing FLOPs without retraining.
 Two modes are supported:
 - **Fixed threshold** — pass a BLASST lambda threshold directly. No calibration
   needed. Good for quick testing and sweeps.
-- **Calibrated threshold** — an exponential model
-  (`scale_factor = a * exp(b * target_sparsity)`) is calibrated once via the
-  Triton calibration kernel, then the target sparsity can be adjusted at runtime
-  without recalibration. Log-space fitting (`fit_logspace=True`) is recommended
-  for diffusion models where scale_factors span many orders of magnitude.
+- **Calibrated threshold** — the dynamic threshold model
+  (`t = 1 - exp(-a * (S/(1-S))^b / L^c)`) is calibrated once via the Triton
+  calibration kernel, then the target sparsity can be adjusted at runtime
+  without recalibration.
 
 ## Supported Models
 
@@ -66,9 +65,9 @@ python wan22_skip_softmax.py \
 
 | Mode | How threshold reaches the kernel | Use case |
 |------|----------------------------------|----------|
-| **Fixed threshold** (`--skip-softmax-threshold 0.61557`) | Kernel converts the lambda threshold with `log2(lambda)` | Quick testing, sweeps |
-| **Calibrated** (`--calibrate --target-sparsity 0.5`) | `scale_factor = a * exp(b * target)`, then backend computes `threshold = scale_factor / seq_k`, then kernel converts `log2(threshold)` | Production use with automatic seqlen adaptation |
-| **Static lambda** (default `skip_softmax_threshold=0.1`) | Kernel converts `log2(lambda)` | Fallback when neither fixed nor calibrated |
+| **Fixed threshold** (`--skip-softmax-threshold 0.61557`) | Kernel converts the threshold with `log2(t)` | Quick testing, sweeps |
+| **Calibrated** (`--calibrate --target-sparsity 0.5`) | `scale = a * (S/(1-S))^b`; backend computes `t = 1 - exp(-scale / L^c)`; kernel converts `log2(t)` | Production use with automatic seqlen adaptation |
+| **Static threshold** (default `skip_softmax_threshold=0.1`) | Kernel converts `log2(t)` | Fallback when neither fixed nor calibrated |
 
 ## Known Issues
 

--- a/examples/diffusers/sparsity/wan22_skip_softmax.py
+++ b/examples/diffusers/sparsity/wan22_skip_softmax.py
@@ -23,12 +23,12 @@ generation model (text-to-video). Four modes are supported:
    (no skip-softmax, same kernel as sparse runs for apples-to-apples comparison).
 3. **Fixed skip-softmax threshold** — pass ``--skip-softmax-threshold`` to
    supply the BLASST lambda threshold. No calibration data is needed.
-4. **Calibrated threshold** — pass ``--calibrate`` to run exponential-model
-   calibration (``scale_factor = a * exp(b * target_sparsity)``).
+4. **Calibrated threshold** — pass ``--calibrate`` to run the dynamic threshold
+   calibration (``t = 1 - exp(-a * (S/(1-S))^b / L^c)``).
 
 During calibration, ``triton_skip_softmax`` with the Triton calibration kernel
 collects sparsity statistics across multiple threshold trials. The fitted
-exponential model then allows runtime control of the target sparsity ratio
+model then allows runtime control of the target sparsity ratio
 without recalibration.
 
 The Wan 2.2 5B model has 40 transformer blocks with self-attention (attn1)
@@ -217,8 +217,8 @@ def build_sparse_config(args: argparse.Namespace, num_blocks: int) -> dict:
     - **Fixed threshold**: ``--skip-softmax-threshold`` sets
       ``skip_softmax_threshold`` directly — no calibration needed.
     - **Calibrated**: ``--calibrate`` collects multi-threshold sparsity statistics
-      via the Triton calibration kernel, then fits an exponential model:
-      ``scale_factor = a * exp(b * sparsity)``.
+      via the Triton calibration kernel, then fits the dynamic threshold model:
+      ``t = 1 - exp(-a * (S/(1-S))^b / L^c)``.
     """
     attn_cfg: dict = {
         "method": "triton_skip_softmax",
@@ -251,7 +251,6 @@ def build_sparse_config(args: argparse.Namespace, num_blocks: int) -> dict:
         sparse_cfg["calibration"] = {
             "target_sparse_ratio": {"prefill": args.target_sparsity},
             "threshold_trials": DEFAULT_THRESHOLD_TRIALS,
-            "fit_logspace": True,
         }
 
     return config

--- a/modelopt/torch/kernels/sparsity/attention/diffusers_triton_attention.py
+++ b/modelopt/torch/kernels/sparsity/attention/diffusers_triton_attention.py
@@ -53,6 +53,7 @@ def set_triton_skip_softmax_config(
     calibration_mode: bool = False,
     threshold_trials: list[float] | None = None,
     scale_factor: float | None = None,
+    length_exponent: float = 1.0,
     measure_sparsity: bool = False,
 ) -> None:
     """Set thread-local skip-softmax config for the next Triton attention call.
@@ -64,8 +65,12 @@ def set_triton_skip_softmax_config(
         threshold_trials: List of thresholds to measure sparsity for
             (only used when calibration_mode=True).
         scale_factor: Calibrated scale factor for dynamic threshold computation.
-            When set, the actual threshold is computed as ``scale_factor / seq_k``
-            at attention call time, adapting to the actual sequence length.
+            When set, the actual threshold is computed as
+            ``1 - exp(-scale_factor / seq_k**length_exponent)`` at attention call
+            time, adapting to the actual sequence length.
+        length_exponent: The ``c`` exponent in the threshold envelope. Default 1.0
+            falls back to the legacy ``scale_factor / seq_k`` form (Taylor
+            expansion of the envelope for small ``scale_factor / seq_k``).
         measure_sparsity: If True, count total and skipped tiles during
             inference via atomic counters in the forward kernel.
     """
@@ -73,6 +78,7 @@ def set_triton_skip_softmax_config(
     _thread_local.calibration_mode = calibration_mode
     _thread_local.threshold_trials = threshold_trials
     _thread_local.scale_factor = scale_factor
+    _thread_local.length_exponent = float(length_exponent)
     _thread_local.measure_sparsity = measure_sparsity
     # Accumulated counters across all attention calls in one forward pass
     _thread_local.calibration_counters = None
@@ -184,8 +190,11 @@ def _diffusers_triton_attention(
     # --- Inference mode: skip-softmax with dynamic or static threshold ---
     scale_factor = getattr(_thread_local, "scale_factor", None)
     if scale_factor is not None and scale_factor > 0.0:
-        # Dynamic threshold: adapt to actual sequence length.
-        kw["skip_softmax_threshold"] = scale_factor / seq_k
+        # Dynamic threshold: t = 1 - exp(-scale_factor / L^c).
+        # Bounded in (0, 1); reduces to the legacy ``scale_factor / seq_k`` for
+        # small scale_factor / L^c (which is the dominant case at long ctx).
+        length_exponent = float(getattr(_thread_local, "length_exponent", 1.0))
+        kw["skip_softmax_threshold"] = 1.0 - math.exp(-scale_factor / (seq_k**length_exponent))
     else:
         threshold = getattr(_thread_local, "skip_threshold", None)
         if threshold is not None and threshold > 0.0:

--- a/modelopt/torch/kernels/sparsity/attention/ltx_triton_attention.py
+++ b/modelopt/torch/kernels/sparsity/attention/ltx_triton_attention.py
@@ -41,6 +41,7 @@ def set_ltx_triton_context(
     calibration_mode: bool = False,
     threshold_trials: list[float] | None = None,
     scale_factor: float | None = None,
+    length_exponent: float = 1.0,
     **kwargs,
 ) -> None:
     """Set thread-local Triton config for LTX-2 attention."""
@@ -49,6 +50,7 @@ def set_ltx_triton_context(
     _thread_local.calibration_mode = calibration_mode
     _thread_local.threshold_trials = threshold_trials
     _thread_local.scale_factor = scale_factor
+    _thread_local.length_exponent = float(length_exponent)
     if not calibration_mode:
         _thread_local.calibration_counters = None
     _thread_local.calibration_seq_k = None
@@ -61,16 +63,18 @@ def clear_ltx_triton_context() -> None:
     _thread_local.calibration_mode = False
     _thread_local.threshold_trials = None
     _thread_local.scale_factor = None
+    _thread_local.length_exponent = 1.0
     _thread_local.calibration_counters = None
     _thread_local.calibration_seq_k = None
 
 
-def _get_ltx_triton_context() -> tuple[bool, float | None, float | None]:
-    """Return (active, threshold, scale_factor)."""
+def _get_ltx_triton_context() -> tuple[bool, float | None, float | None, float]:
+    """Return (active, threshold, scale_factor, length_exponent)."""
     return (
         getattr(_thread_local, "active", False),
         getattr(_thread_local, "threshold", None),
         getattr(_thread_local, "scale_factor", None),
+        float(getattr(_thread_local, "length_exponent", 1.0)),
     )
 
 
@@ -145,7 +149,9 @@ def _ltx_triton_attention(
     # --- Inference mode: dynamic or static threshold ---
     scale_factor = getattr(_thread_local, "scale_factor", None)
     if scale_factor is not None and scale_factor > 0.0:
-        kw["skip_softmax_threshold"] = scale_factor / seq_k
+        # Dynamic threshold: t = 1 - exp(-scale_factor / L^c).
+        length_exponent = float(getattr(_thread_local, "length_exponent", 1.0))
+        kw["skip_softmax_threshold"] = 1.0 - math.exp(-scale_factor / (seq_k**length_exponent))
     elif threshold is not None and threshold > 0.0:
         kw["skip_softmax_threshold"] = threshold
 
@@ -163,7 +169,7 @@ class _TritonLTXAttentionWrapper:
         self._original_fn = original_fn
 
     def __call__(self, q, k, v, heads, mask=None):
-        active, threshold, _scale_factor = _get_ltx_triton_context()
+        active, threshold, _scale_factor, _length_exponent = _get_ltx_triton_context()
         if active:
             return _ltx_triton_attention(q, k, v, heads, mask, threshold)
         return self._original_fn(q, k, v, heads, mask)

--- a/modelopt/torch/sparsity/attention_sparsity/calibration/calibrate.py
+++ b/modelopt/torch/sparsity/attention_sparsity/calibration/calibrate.py
@@ -300,7 +300,6 @@ def calibrate_sparse_attention(
 
         prefill_calibrator = DynamicThresholdCalibrator(
             threshold_trials=calib_config.threshold_trials,
-            fit_logspace=calib_config.fit_logspace,
         )
         prefill_result = prefill_calibrator.calibrate(model, prefill_forward_loop, phase="prefill")
 
@@ -323,7 +322,6 @@ def calibrate_sparse_attention(
 
         decode_calibrator = DynamicThresholdCalibrator(
             threshold_trials=calib_config.threshold_trials,
-            fit_logspace=calib_config.fit_logspace,
         )
         decode_result = decode_calibrator.calibrate(model, decode_forward_loop, phase="decode")
 
@@ -337,7 +335,7 @@ def calibrate_sparse_attention(
         warnings.warn("No calibration produced valid results")
         return {}
 
-    # Extract a, b, and observed sparsity range for each phase
+    # Extract a, b, c, and observed sparsity range for each phase
     calibration_params: dict[str, dict[str, float]] = {}
     for phase in ["prefill", "decode"]:
         if phase in calibration_results:
@@ -345,6 +343,7 @@ def calibrate_sparse_attention(
             params: dict[str, float] = {
                 "a": result["a"],
                 "b": result["b"],
+                "c": result.get("c", 1.0),
             }
             if "min_observed_sparsity" in result:
                 params["min_observed_sparsity"] = result["min_observed_sparsity"]
@@ -360,7 +359,10 @@ def calibrate_sparse_attention(
     for phase, params in calibration_params.items():
         result = calibration_results[phase]
         print(f"  {phase}:")
-        print(f"    Model: scale_factor = {params['a']:.6e} * exp({params['b']:.4f} * sparsity)")
+        print(
+            f"    Model: t = 1 - exp(-{params['a']:.4e} * (S/(1-S))^{params['b']:.3f}"
+            f" / L^{params['c']:.3f})"
+        )
         print(f"    R-squared: {result['r_squared']:.6f}")
 
     for module_name, module in sparse_modules:

--- a/modelopt/torch/sparsity/attention_sparsity/calibration/calibrator.py
+++ b/modelopt/torch/sparsity/attention_sparsity/calibration/calibrator.py
@@ -23,48 +23,42 @@ from typing import Any
 import numpy as np
 import torch
 import torch.nn as nn
-from scipy.optimize import curve_fit
 
 from ..stats_manager import SparseAttentionStatsManager
 from ..utils import get_sparse_attention_modules
 
 
 class DynamicThresholdCalibrator:
-    """Dynamic threshold calibrator using Exponential model.
+    """Dynamic threshold calibrator.
 
-    Calibration Algorithm:
-        1. For each threshold λ_j in threshold_trials:
-           - Run ALL samples through forward_loop
-           - For each sample i with length L_i, collect sparsity S_ij
-           - Compute scale_factor_ij = λ_j × L_i
+    The calibration fits the model::
 
-        2. Fit Exponential model to ALL individual (sf_ij, S_ij) pairs:
-           scale_factor = a * exp(b * sparsity)
+        t = 1 - exp(-a * (S / (1 - S)) ^ b / L ^ c)
 
-        3. Return fitted a and b parameters
+    to ``(t_j, S_ij, L_i)`` tuples collected from a forward pass. Taking logs
+    yields a linear model in ``(log a, b, -c)``::
 
-    At inference time (user specifies target_sparsity S*):
-        scale_factor = a * exp(b * S*)
-        threshold = scale_factor / seqlen
+        log(-log(1-t_j)) = log(a) + b * logit(S_ij) - c * log(L_i)
 
-    Key insight: Using all individual data points (N_thresholds × N_samples)
-    instead of per-threshold averages provides more accurate fitting without
-    additional calibration time cost.
+    which is solved in closed form with ``np.linalg.lstsq``. At inference
+    time, given target sparsity ``S``, the threshold is
+    ``t = 1 - exp(-a * (S / (1-S))^b / L^c)``.
+
+    Properties:
+        - Bounded in ``(0, 1)`` by construction (no clamping required).
+        - Correct asymptotes: ``t->0`` as ``S->0`` or ``L->inf``; ``t->1`` as
+          ``S->1`` or ``L->0``.
     """
 
     def __init__(
         self,
         threshold_trials: list[float] | None = None,
-        fit_logspace: bool = False,
     ):
         """Initialize dynamic threshold calibrator.
 
         Args:
             threshold_trials: List of thresholds to try during calibration.
                 Should span a range that achieves sparsities from ~10% to ~95%.
-            fit_logspace: If True, fit the exponential model in log space
-                (minimizes relative error). Recommended for diffusion models
-                where scale_factors span many orders of magnitude.
         """
         # Default threshold trials if not provided
         self.threshold_trials = threshold_trials or [
@@ -89,32 +83,32 @@ class DynamicThresholdCalibrator:
             9.5e-1,
             9.9e-1,
         ]
-        self.fit_logspace = fit_logspace
 
     def calibrate(self, model: nn.Module, forward_loop: Callable, phase: str) -> dict[str, Any]:
-        """Calibrate a and b parameters for Exponential model.
+        """Calibrate (a, b, c) for the dynamic threshold model.
 
-        Algorithm:
-            1. Set thresholds = threshold_trials on all modules, run ONE forward pass.
-               Each module returns a sparsity list (one entry per threshold) per sample.
-               Unpack to get (scale_factor_ij = λ_j × L_i, sparsity_ij) pairs.
+        Algorithm: set thresholds = ``threshold_trials`` on all modules and
+        run ONE forward pass. Each module returns a sparsity list (one entry
+        per threshold) per sample. For each ``(t_j, L_i, S_ij)`` triple, form::
 
-            2. Fit Exponential model to ALL (sf_ij, S_ij) pairs:
-               scale_factor = a * exp(b * sparsity)
+            y_ij = log(-log(1 - t_j))
+            x_S  = logit(S_ij) = log(S_ij / (1 - S_ij))
+            x_L  = log(L_i)
 
-            3. Return fitted a and b parameters
+        The model ``log(-log(1-t)) = log(a) + b*logit(S) - c*log(L)`` is
+        linear in ``(log a, b, -c)`` and solved with ``np.linalg.lstsq``.
 
-        At inference time (user specifies target_sparsity S*):
-            scale_factor = a * exp(b * S*)
-            threshold = scale_factor / seqlen
+        At inference time, given target sparsity ``S``, the threshold is
+        ``t = 1 - exp(-a * (S / (1 - S))^b / L^c)``.
 
         Args:
-            model: The model with sparse attention modules
-            forward_loop: Callable that takes model and forwards calibration data
-            phase: Phase to calibrate ('prefill' or 'decode')
+            model: The model with sparse attention modules.
+            forward_loop: Callable that takes model and forwards calibration data.
+            phase: Phase to calibrate (``'prefill'`` or ``'decode'``).
 
         Returns:
-            Dict with calibration results including a, b, r_squared, and num_data_points
+            Dict with calibration results including ``a``, ``b``, ``c``,
+            ``r_squared``, and ``num_data_points``.
         """
         # Extract attention modules
         attention_modules = get_sparse_attention_modules(model)
@@ -122,15 +116,15 @@ class DynamicThresholdCalibrator:
         if not attention_modules:
             raise ValueError("No sparse attention modules found for calibration")
 
-        print(f"Starting Exponential model calibration ({phase} phase)")
+        print(f"Starting dynamic threshold calibration ({phase} phase)")
         print(f"Threshold trials: {len(self.threshold_trials)}")
 
-        # Stage 1: Collect ALL (scale_factor, sparsity) pairs in a single forward pass.
-        # All threshold_trials are passed at once; each module returns a sparsity list
-        # with one entry per threshold, eliminating the need for repeated forward passes.
+        # Stage 1: collect (t, L, S) triples in a single forward pass. All
+        # threshold_trials are passed at once; each module returns a sparsity
+        # list with one entry per threshold.
         print(f"\nStage 1: Collecting {phase} sparsity data for all thresholds in one pass...")
 
-        all_data_points = []  # List of {"threshold", "length", "scale_factor", "sparsity"}
+        all_data_points = []  # List of {"threshold", "length", "sparsity"}
 
         self._set_thresholds(attention_modules, self.threshold_trials)
         self._enable_calibration_mode(attention_modules)
@@ -143,12 +137,10 @@ class DynamicThresholdCalibrator:
             length = sample_stat["sample_length"]
             sparsity_list = sample_stat["sparsity"]
             for threshold, sparsity in zip(self.threshold_trials, sparsity_list):
-                scale_factor = threshold * length
                 all_data_points.append(
                     {
                         "threshold": threshold,
                         "length": length,
-                        "scale_factor": scale_factor,
                         "sparsity": sparsity,
                     }
                 )
@@ -160,129 +152,109 @@ class DynamicThresholdCalibrator:
             )
             return {}
 
-        print(f"Collected {len(all_data_points)} individual (scale_factor, sparsity) pairs")
+        print(f"Collected {len(all_data_points)} individual (t, L, S) triples")
 
-        # Stage 2: Fit Exponential model: scale_factor = a * exp(b * sparsity)
-        print("\nStage 2: Fitting Exponential model to all data points...")
+        # Stage 2: closed-form linear fit on the transformed coordinates.
+        print("\nStage 2: Fitting threshold model (closed-form linear lstsq)...")
 
-        # Extract data for fitting
-        scale_factors = np.array([pt["scale_factor"] for pt in all_data_points])
-        sparsities = np.array([pt["sparsity"] for pt in all_data_points])
+        thresholds_arr = np.array([pt["threshold"] for pt in all_data_points], dtype=np.float64)
+        lengths_arr = np.array([pt["length"] for pt in all_data_points], dtype=np.float64)
+        sparsities_arr = np.array([pt["sparsity"] for pt in all_data_points], dtype=np.float64)
 
-        # Filter out extreme sparsities (must be in (10%, 90%))
-        # Extreme values are unreliable for fitting
-        valid_mask = (sparsities >= 0.10) & (sparsities <= 0.90)
-        if self.fit_logspace:
-            valid_mask &= scale_factors > 0  # log requires positive values
-        scale_factors = scale_factors[valid_mask]
-        sparsities = sparsities[valid_mask]
+        # Filter:
+        #  - extreme sparsities (must be in (10%, 90%); extremes are unreliable)
+        #  - t must be in (0, 1) for log(-log(1-t)) to be defined
+        #  - L must be > 0
+        valid_mask = (
+            (sparsities_arr >= 0.10)
+            & (sparsities_arr <= 0.90)
+            & (thresholds_arr > 0)
+            & (thresholds_arr < 1)
+            & (lengths_arr > 0)
+        )
 
-        if len(scale_factors) < 3:
+        if int(valid_mask.sum()) < 3:
             warnings.warn(
-                f"Not enough valid data points after filtering. Got {len(scale_factors)}."
+                f"Not enough valid data points after filtering. Got {int(valid_mask.sum())}."
             )
             return {}
 
-        # Record observed sparsity range for feasibility checks at inference
-        min_observed_sparsity = float(np.min(sparsities))
-        max_observed_sparsity = float(np.max(sparsities))
+        # Uppercase L, S, X below match the regression notation used in
+        # the model docstring above.
+        t_obs = thresholds_arr[valid_mask]
+        L = lengths_arr[valid_mask]  # noqa: N806
+        S = sparsities_arr[valid_mask]  # noqa: N806
+
+        y = np.log(-np.log(1.0 - t_obs))
+        logit_S = np.log(S / (1.0 - S))  # noqa: N806
+        log_L = np.log(L)  # noqa: N806
+
+        # Design matrix X with columns [1, logit(S), -log(L)] so coefficients
+        # are [log(a), b, c] in that order.
+        X = np.column_stack([np.ones_like(y), logit_S, -log_L])  # noqa: N806
 
         try:
-            if self.fit_logspace:
-                # Log-space fit: minimizes relative error. Recommended for
-                # diffusion models where scale_factors span many orders of
-                # magnitude (e.g. 0.06 to 57,000) — a linear-space fit would
-                # be dominated by the largest values.
-                log_scale_factors = np.log(scale_factors)
-
-                def log_exponential(sparsity, log_a, b):
-                    return log_a + b * sparsity
-
-                popt, pcov = curve_fit(
-                    log_exponential,
-                    sparsities,
-                    log_scale_factors,
-                    p0=[0.0, 10.0],
-                    maxfev=10000,
-                )
-                log_a, b = popt
-                a = np.exp(log_a)
-
-                # R-squared in log space (where the fit was performed)
-                pred = log_exponential(sparsities, log_a, b)
-                ss_res = np.sum((log_scale_factors - pred) ** 2)
-                ss_tot = np.sum((log_scale_factors - np.mean(log_scale_factors)) ** 2)
-            else:
-                # Linear-space fit (default): minimizes absolute error.
-
-                def exponential(sparsity, a, b):
-                    return a * np.exp(b * sparsity)
-
-                popt, pcov = curve_fit(
-                    exponential,
-                    sparsities,
-                    scale_factors,
-                    p0=[1.0, 5.0],
-                    bounds=([0.0, 0.0], [np.inf, 20.0]),
-                    maxfev=10000,
-                )
-                a, b = popt
-
-                pred = exponential(sparsities, a, b)
-                ss_res = np.sum((scale_factors - pred) ** 2)
-                ss_tot = np.sum((scale_factors - np.mean(scale_factors)) ** 2)
+            coefs, _residuals, _rank, _sv = np.linalg.lstsq(X, y, rcond=None)
         except Exception as e:
-            warnings.warn(f"Curve fitting failed: {e}")
+            warnings.warn(f"Linear fit failed: {e}")
             return {}
 
-        r_squared = 1 - (ss_res / ss_tot) if ss_tot > 0 else 0
+        log_a, b, c = coefs.tolist()
+        a = float(np.exp(log_a))
 
-        fit_label = "log-space" if self.fit_logspace else "linear-space"
-        print(f"\n{phase.capitalize()} Calibration Results (Exponential Model, {fit_label} fit):")
-        print("  Model: scale_factor = a * exp(b * sparsity)")
-        print(f"  Fitted a: {a:.6e}")
-        print(f"  Fitted b: {b:.4f}")
-        print(f"  R-squared: {r_squared:.6f}")
+        pred = X @ coefs
+        ss_res = float(np.sum((y - pred) ** 2))
+        ss_tot = float(np.sum((y - np.mean(y)) ** 2))
+        r_squared = 1.0 - (ss_res / ss_tot) if ss_tot > 0 else 0.0
+
+        min_observed_sparsity = float(S.min())
+        max_observed_sparsity = float(S.max())
+
+        print(f"\n{phase.capitalize()} Calibration Results:")
+        print("  Model: t = 1 - exp(-a * (S/(1-S))^b / L^c)")
+        print(f"  Fitted a:     {a:.6e}")
+        print(f"  Fitted b:     {b:.4f}")
+        print(f"  Fitted c:     {c:.4f}")
+        print(f"  R-squared:    {r_squared:.6f}")
         print(
             f"  Observed sparsity range: [{min_observed_sparsity:.1%}, {max_observed_sparsity:.1%}]"
         )
-        print(f"  Data points used: {int(np.sum(valid_mask))} / {len(all_data_points)}")
+        print(f"  Data points used: {int(valid_mask.sum())} / {len(all_data_points)}")
 
-        # Show scale_factor for various target sparsities
-        print("\nScale factors for different target sparsities:")
-        print(f"  {'Target':<10} {'Scale Factor':<15} {'Note':<20}")
-        print(f"  {'-' * 10} {'-' * 15} {'-' * 20}")
-        for target in [0.3, 0.4, 0.5, 0.6, 0.7, 0.8]:
-            sf = a * np.exp(b * target)
+        # Show predicted threshold for a few (S, L) combinations.
+        print("\nExample thresholds t(S, L) = 1 - exp(-a*(S/(1-S))^b / L^c):")
+        print(f"  {'Target S':<12} {'L=4096':<14} {'L=16384':<14} {'L=65536':<14}")
+        print(f"  {'-' * 12} {'-' * 14} {'-' * 14} {'-' * 14}")
+        for target in [0.3, 0.5, 0.7, 0.9]:
+            scale = a * (target / (1.0 - target)) ** b
+            tvals = [1.0 - np.exp(-scale / (Lx**c)) for Lx in (4096, 16384, 65536)]
             note = ""
             if target < min_observed_sparsity or target > max_observed_sparsity:
-                note = "(extrapolation)"
-            print(f"  {target:<10.0%} {sf:<15.4f} {note:<20}")
+                note = " (extrapolation)"
+            print(f"  {target:<12.0%} {tvals[0]:<14.4e} {tvals[1]:<14.4e} {tvals[2]:<14.4e}{note}")
 
-        # Print calibration data summary by threshold
+        # Per-threshold summary (handy for debugging).
         print("\nCalibration data summary (per threshold):")
-        print(f"  {'Threshold':<12} {'Avg SF':<12} {'Avg Sparsity':<12} {'Samples':<8}")
-        print(f"  {'-' * 12} {'-' * 12} {'-' * 12} {'-' * 8}")
-
-        # Group by threshold for summary
+        print(f"  {'Threshold':<12} {'Avg Sparsity':<14} {'Avg L':<12} {'Samples':<8}")
+        print(f"  {'-' * 12} {'-' * 14} {'-' * 12} {'-' * 8}")
         by_threshold = defaultdict(list)
         for point in all_data_points:
             by_threshold[point["threshold"]].append(point)
-
         for threshold in sorted(by_threshold.keys()):
             points = by_threshold[threshold]
-            avg_sf = np.mean([p["scale_factor"] for p in points])
             avg_s = np.mean([p["sparsity"] for p in points])
-            print(f"  {threshold:<12.4f} {avg_sf:<12.2f} {avg_s:<12.2%} {len(points):<8}")
+            avg_l = np.mean([p["length"] for p in points])
+            print(f"  {threshold:<12.4f} {avg_s:<14.2%} {avg_l:<12.1f} {len(points):<8}")
 
         return {
             "phase": phase,
             "a": float(a),
             "b": float(b),
+            "c": float(c),
             "r_squared": float(r_squared),
-            "num_data_points": int(np.sum(valid_mask)),
+            "num_data_points": int(valid_mask.sum()),
             "total_samples": len(all_data_points),
-            "calibration_type": "exponential",
+            "calibration_type": "dynamic_threshold",
             "min_observed_sparsity": min_observed_sparsity,
             "max_observed_sparsity": max_observed_sparsity,
         }

--- a/modelopt/torch/sparsity/attention_sparsity/config.py
+++ b/modelopt/torch/sparsity/attention_sparsity/config.py
@@ -267,20 +267,23 @@ class SparseAttentionAttributeConfig(ModeloptBaseConfig):
 class CalibrationConfig(ModeloptBaseConfig):
     """Configuration for automatic threshold calibration using RULER dataset.
 
-    Calibration fits an Exponential model to determine dynamic thresholds that
-    achieve target sparsity. The model learns parameters a and b per phase:
+    Calibration determines dynamic thresholds that achieve target sparsity.
+    Three parameters (a, b, c) are fit per phase via closed-form linear
+    regression on
 
-        scale_factor = a * exp(b * target_sparsity)
+        log(-log(1 - t)) = log(a) + b * logit(S) - c * log(L)
 
-    At inference time, the threshold is computed as:
+    At inference time, the threshold is computed as
 
-        threshold = scale_factor / sequence_length
+        threshold = 1 - exp(-a * (S / (1 - S))^b / L^c)
 
-    Key benefits:
+    Key properties:
+    - Bounded in (0, 1) by construction (no runtime clamp needed)
+    - Correct asymptotes: t->0 as S->0 or L->inf; t->1 as S->1 or L->0
     - Target sparsity can be changed at runtime without recalibration
-    - Threshold automatically adapts to sequence length
+    - Threshold adapts to sequence length via the L^c term
     - Supports independent prefill and decode phase calibration
-    - Exponential model provides better fit (lower RMSE)
+    - Closed-form linear fit (np.linalg.lstsq); no nonlinear curve_fit needed
     """
 
     target_sparse_ratio: dict[str, float] = ModeloptField(
@@ -339,15 +342,6 @@ class CalibrationConfig(ModeloptBaseConfig):
             "If None, uses default: [1e-6, 5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3, 5e-3, "
             "1e-2, 2e-2, 5e-2, 1e-1, 2e-1, 3e-1, 5e-1, 7e-1]. "
             "Increasing the number of trials improves calibration accuracy but slows down calibration."
-        ),
-    )
-
-    fit_logspace: bool = ModeloptField(
-        default=False,
-        title="Fit in log space",
-        description=(
-            "If True, fit the exponential model in log space (minimizes relative error). "
-            "Recommended for diffusion models where scale_factors span many orders of magnitude."
         ),
     )
 
@@ -523,8 +517,8 @@ SKIP_SOFTMAX_DEFAULT = {
 
 
 # Configuration with RULER calibration
-# Note: threshold field is omitted - calibration determines dynamic threshold lambda = a / length
-# The calibrated threshold adapts to sequence length for optimal sparsity
+# Note: threshold field is omitted - calibration determines a dynamic threshold t
+# from target sparsity and sequence length using the fitted (a, b, c) parameters.
 SKIP_SOFTMAX_CALIB = {
     "sparse_cfg": {
         "calibration": {

--- a/modelopt/torch/sparsity/attention_sparsity/conversion.py
+++ b/modelopt/torch/sparsity/attention_sparsity/conversion.py
@@ -374,12 +374,12 @@ def _get_sparse_softmax_export_config(module: SparseAttentionModule) -> dict[str
 def export_sparse_attention_config(model: nn.Module) -> dict[str, Any] | None:
     """Extract sparse attention config for export to config.json.
 
-    Extracts calibrated skip-softmax parameters and N:M sparse-softmax metadata
-    from sparse attention modules.
+    Extracts calibrated skip-softmax parameters and N:M sparse-softmax
+    metadata from sparse attention modules.
 
-    The exported config allows computing threshold at runtime:
-        scale_factor = a * exp(b * target_sparsity)
-        threshold = scale_factor / seqlen
+    The exported config allows computing threshold at runtime as
+
+        threshold = 1 - exp(-a * (S / (1 - S))^b / L^c)
 
     Args:
         model: Model with sparse attention applied
@@ -395,9 +395,9 @@ def export_sparse_attention_config(model: nn.Module) -> dict[str, Any] | None:
                 "group_0": {"sparse_algo": "softmax_skip", "targets": ["LlamaAttention"]}
             },
             "threshold_scale_factor": {
-                "formula": "a * exp(b * target_sparsity)",
-                "prefill": {"a": 7.93, "b": 8.61},
-                "decode": {"a": 0.12, "b": 9.85},
+                "formula": "1 - exp(-a * (S/(1-S))^b / L^c)",
+                "prefill": {"a": 7.93, "b": 0.86, "c": 1.26},
+                "decode": {"a": 0.12, "b": 0.91, "c": 1.18},
             },
             "sparse_softmax": {
                 "sparsity_n": 2,
@@ -461,13 +461,15 @@ def export_sparse_attention_config(model: nn.Module) -> dict[str, Any] | None:
     if calibration_params is not None:
         # Build threshold_scale_factor with model parameters
         threshold_scale_factor: dict[str, Any] = {
-            "formula": "a * exp(b * target_sparsity)",
+            "formula": "1 - exp(-a * (S/(1-S))^b / L^c)",
         }
         for phase in ["prefill", "decode"]:
             if phase in calibration_params:
+                params = calibration_params[phase]
                 threshold_scale_factor[phase] = {
-                    "a": calibration_params[phase]["a"],
-                    "b": calibration_params[phase]["b"],
+                    "a": params["a"],
+                    "b": params["b"],
+                    "c": params.get("c", 1.0),
                 }
         export_config["threshold_scale_factor"] = threshold_scale_factor
 
@@ -537,15 +539,17 @@ def _format_threshold(info: dict) -> str:
     """Format threshold info for display."""
     t = info.get("type")
     if t == "dynamic_calibrated":
-        # Exponential model: threshold = a * exp(b * sparsity) / seqlen
+        # Dynamic threshold: t = 1 - exp(-a * (S/(1-S))^b / L^c)
         params = info.get("calibration_params", {})
         target = info.get("target_sparse_ratio", {})
         parts = []
         for phase in ["prefill", "decode"]:
             if phase in params:
-                a, b = params[phase]["a"], params[phase]["b"]
+                a = params[phase]["a"]
+                b = params[phase]["b"]
+                c = params[phase].get("c", 1.0)
                 s = target.get(phase, 0.5)
-                parts.append(f"{phase}: a={a:.4f}, b={b:.2f}, target={s:.0%}")
+                parts.append(f"{phase}: a={a:.4f}, b={b:.2f}, c={c:.2f}, target={s:.0%}")
         return f"calibrated({', '.join(parts)})"
     if t == "static":
         v = info.get("value")

--- a/modelopt/torch/sparsity/attention_sparsity/methods/flash_skip_softmax.py
+++ b/modelopt/torch/sparsity/attention_sparsity/methods/flash_skip_softmax.py
@@ -146,13 +146,21 @@ class FlashSkipSoftmax(SparseAttentionMethod):
         )
 
         if use_calibration_params:
-            # Calibrated dynamic threshold: bypass thresholds list entirely
+            # Calibrated dynamic threshold:
+            #   t = 1 - exp(-a * (S/(1-S))^b / L^c)
+            # Bounded in (0, 1) for all S ∈ (0, 1) and L > 0.
             assert calibration_params is not None and target_sparse_ratio is not None
-            a = calibration_params[phase]["a"]
-            b = calibration_params[phase]["b"]
+            params = calibration_params[phase]
+            a = params["a"]
+            b = params["b"]
+            c = params.get("c", 1.0)
             target_sparsity = target_sparse_ratio.get(phase, 0.5)
-            scale_factor = a * np.exp(b * target_sparsity)
-            log_thresholds = [np.log(scale_factor / seq_k)]
+            # Clip S off the open boundaries so logit stays finite.
+            s_clipped = float(np.clip(target_sparsity, 1e-6, 1.0 - 1e-6))
+            scale = a * (s_clipped / (1.0 - s_clipped)) ** b
+            t = 1.0 - np.exp(-scale / (float(seq_k) ** c))
+            t = float(np.clip(t, 1e-15, 1.0 - 1e-15))
+            log_thresholds = [np.log(t)]
         else:
             log_thresholds = [np.log(t) for t in self.thresholds]
 
@@ -339,25 +347,30 @@ class FlashSkipSoftmax(SparseAttentionMethod):
         target_sparse_ratio = self.target_sparse_ratio
 
         if calibration_params is not None and target_sparse_ratio is not None:
-            # Per-phase calibrated dynamic threshold using Exponential model
+            # Per-phase calibrated dynamic threshold:
+            #   t = 1 - exp(-a * (S/(1-S))^b / L^c)
             example_lengths = [1024, 4096, 16384, 65536, 131072]
             phase_info = {}
             for phase, params in calibration_params.items():
-                a, b = params["a"], params["b"]
+                a = params["a"]
+                b = params["b"]
+                c = params.get("c", 1.0)
                 target_sparsity = target_sparse_ratio.get(phase, 0.5)
-                scale_factor = a * np.exp(b * target_sparsity)
+                s_clipped = float(np.clip(target_sparsity, 1e-6, 1.0 - 1e-6))
+                scale = a * (s_clipped / (1.0 - s_clipped)) ** b
                 phase_info[phase] = {
                     "a": a,
                     "b": b,
+                    "c": c,
                     "target_sparsity": target_sparsity,
-                    "scale_factor": scale_factor,
                     "example_thresholds": {
-                        length: scale_factor / length for length in example_lengths
+                        length: float(1.0 - np.exp(-scale / (length**c)))
+                        for length in example_lengths
                     },
                 }
             return {
                 "type": "dynamic_calibrated",
-                "formula": "threshold = a * exp(b * target_sparsity) / seqlen",
+                "formula": "threshold = 1 - exp(-a * (S/(1-S))^b / L^c)",
                 "calibration_params": calibration_params,
                 "target_sparse_ratio": target_sparse_ratio,
                 "phases": phase_info,

--- a/modelopt/torch/sparsity/attention_sparsity/methods/triton_skip_softmax.py
+++ b/modelopt/torch/sparsity/attention_sparsity/methods/triton_skip_softmax.py
@@ -94,7 +94,12 @@ class TritonSkipSoftmaxMethod(SparseAttentionMethod):
         # Priority: calibrated dynamic threshold > static threshold.
         scale_factor = self._get_scale_factor()
         if scale_factor is not None:
-            self._set_triton_backends(scale_factor=scale_factor, **backend_kwargs)
+            length_exponent = self._get_length_exponent()
+            self._set_triton_backends(
+                scale_factor=scale_factor,
+                length_exponent=length_exponent,
+                **backend_kwargs,
+            )
         else:
             self._set_triton_backends(threshold=self.skip_softmax_threshold, **backend_kwargs)
         with self._get_diffusers_backend_context():
@@ -122,13 +127,13 @@ class TritonSkipSoftmaxMethod(SparseAttentionMethod):
                 self._clear_triton_backends()
 
     def _get_scale_factor(self) -> float | None:
-        """Compute scale_factor from calibration params, or None if uncalibrated.
+        """Return the per-target scale factor ``a * (S / (1-S))^b``, or None if uncalibrated.
 
-        The scale_factor is sequence-length-independent. Backends divide by the
-        actual ``seq_k`` at call time: ``threshold = scale_factor / seq_k``.
+        Combined with the length exponent ``c`` (see :meth:`_get_length_exponent`),
+        the diffusers/LTX Triton backends compute the threshold envelope
+        ``t = 1 - exp(-scale / L^c)`` at attention call time.
         """
         if self.calibration_params and self.target_sparse_ratio:
-            import math
             import warnings
 
             params = self.calibration_params.get("prefill", {})
@@ -136,7 +141,6 @@ class TritonSkipSoftmaxMethod(SparseAttentionMethod):
             b = params.get("b", 0)
             target = self.target_sparse_ratio.get("prefill", 0.5)
             if a > 0 and b > 0:
-                # Warn if target is outside the calibrated range
                 min_s = params.get("min_observed_sparsity")
                 max_s = params.get("max_observed_sparsity")
                 if min_s is not None and target < min_s:
@@ -152,8 +156,16 @@ class TritonSkipSoftmaxMethod(SparseAttentionMethod):
                         f"during calibration ({max_s:.1%}). The model is extrapolating.",
                         stacklevel=2,
                     )
-                return a * math.exp(b * target)
+                s_clipped = min(max(float(target), 1e-6), 1.0 - 1e-6)
+                return float(a) * (s_clipped / (1.0 - s_clipped)) ** float(b)
         return None
+
+    def _get_length_exponent(self) -> float:
+        """Return the calibrated length exponent ``c`` (default 1.0 if uncalibrated)."""
+        if self.calibration_params:
+            params = self.calibration_params.get("prefill", {})
+            return float(params.get("c", 1.0))
+        return 1.0
 
     @staticmethod
     @contextmanager
@@ -260,8 +272,9 @@ class TritonSkipSoftmaxMethod(SparseAttentionMethod):
         if scale_factor is not None:
             return {
                 "type": "dynamic_calibrated",
-                "formula": "threshold = scale_factor / seq_k (computed at runtime)",
+                "formula": "threshold = 1 - exp(-scale_factor / L^c)",
                 "scale_factor": scale_factor,
+                "length_exponent": self._get_length_exponent(),
                 "calibration_params": self.calibration_params,
                 "target_sparse_ratio": self.target_sparse_ratio,
             }

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -69,6 +69,7 @@ def _resolve_skip_softmax_calibration(
     try:
         a = float(params["a"])
         b = float(params["b"])
+        c = float(params.get("c", 1.0))
         seq_len = int(max_seq_len)
     except (KeyError, TypeError, ValueError):
         return
@@ -76,15 +77,23 @@ def _resolve_skip_softmax_calibration(
         return
 
     target = _target_sparse_ratio_for_phase(sparse_target_ratio, phase)
-    scale_factor = a * math.exp(b * target)
-    # The current Triton kernel accepts one scalar threshold per launch. Use
-    # the max KV length in the scheduled batch; shorter sequences are denser.
-    threshold = scale_factor / seq_len
-    if threshold >= 1.0:
+    # Dynamic threshold:
+    #   scale = a * (S / (1 - S))^b
+    #   t = 1 - exp(-scale / seq_len^c)
+    # Bounded in (0, 1) by construction. The Triton kernel takes one scalar
+    # threshold per launch; we use the max KV length in the scheduled batch,
+    # so shorter sequences in the batch end up slightly denser than target.
+    s_clipped = min(max(target, 1e-6), 1.0 - 1e-6)
+    scale = a * (s_clipped / (1.0 - s_clipped)) ** b
+    threshold = 1.0 - math.exp(-scale / (seq_len**c))
+    # Sanity check: the envelope guarantees threshold ∈ (0, 1) for finite
+    # positive scale and seq_len, but clamp defensively against pathological
+    # parameter values (e.g., scale=0 -> threshold=0, which disables sparsity).
+    if not (0.0 < threshold < 1.0):
         warnings.warn(
             "Disabling calibrated skip-softmax for this vLLM launch because "
-            f"the derived threshold is outside the valid lambda range: "
-            f"phase={phase}, seq_len={seq_len}, scale_factor={scale_factor:.6g}, "
+            f"the derived threshold is outside the valid (0, 1) range: "
+            f"phase={phase}, seq_len={seq_len}, scale={scale:.6g}, "
             f"target_sparse_ratio={target:.6g}, threshold={threshold:.6g}.",
             stacklevel=2,
         )
@@ -227,7 +236,7 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
                 )
         if not sparse_kw:
             # Dynamic calibration can disable sparse work for a launch, e.g.
-            # short-prefill thresholds outside the valid lambda range. Avoid
+            # short-prefill thresholds outside the valid (0, 1) range. Avoid
             # swapping in the ModelOpt dense kernel when no sparse feature is active.
             return self._forward_vllm_flash_attn(
                 layer,

--- a/tests/unit/torch/kernels/sparsity/attention/test_ltx_triton_attention.py
+++ b/tests/unit/torch/kernels/sparsity/attention/test_ltx_triton_attention.py
@@ -51,11 +51,13 @@ class TestThreadLocalContext:
             calibration_mode=False,
             threshold_trials=[0.01, 0.1],
             scale_factor=2.0,
+            length_exponent=1.5,
         )
-        active, threshold, scale_factor = ltx_mod._get_ltx_triton_context()
+        active, threshold, scale_factor, length_exponent = ltx_mod._get_ltx_triton_context()
         assert active is True
         assert threshold == 0.1
         assert scale_factor == 2.0
+        assert length_exponent == 1.5
 
     def test_set_context_without_calibration_mode_clears_counters(self, ltx_mod):
         """Setting non-calibration mode resets calibration_counters to None."""
@@ -71,12 +73,18 @@ class TestThreadLocalContext:
         assert ltx_mod._thread_local.calibration_counters is existing
 
     def test_clear_context_resets_all(self, ltx_mod):
-        ltx_mod.set_ltx_triton_context(active=True, threshold=0.1, scale_factor=2.0)
+        ltx_mod.set_ltx_triton_context(
+            active=True,
+            threshold=0.1,
+            scale_factor=2.0,
+            length_exponent=1.5,
+        )
         ltx_mod.clear_ltx_triton_context()
-        active, threshold, scale_factor = ltx_mod._get_ltx_triton_context()
+        active, threshold, scale_factor, length_exponent = ltx_mod._get_ltx_triton_context()
         assert active is False
         assert threshold is None
         assert scale_factor is None
+        assert length_exponent == 1.0  # default reset value
 
     def test_get_calibration_counters_returns_none_initially(self, ltx_mod):
         assert ltx_mod.get_calibration_counters() is None

--- a/tests/unit/torch/sparsity/attention_sparsity/test_calibrator_fitting.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_calibrator_fitting.py
@@ -46,10 +46,6 @@ class TestDynamicThresholdCalibratorInit:
         cal = DynamicThresholdCalibrator(threshold_trials=trials)
         assert cal.threshold_trials == trials
 
-    def test_fit_logspace(self):
-        cal = DynamicThresholdCalibrator(fit_logspace=True)
-        assert cal.fit_logspace is True
-
 
 class TestExponentialFitting:
     """Test the calibration pipeline with synthetic stats injected via mock modules."""
@@ -73,19 +69,21 @@ class TestExponentialFitting:
     def _inject_synthetic_stats(self, model, threshold_trials, sample_length=4096):
         """Inject synthetic calibration stats into the sparse modules.
 
-        Generates stats matching the exponential model: scale_factor = a * exp(b * sparsity),
-        with a=0.1, b=5.0. For each threshold, the expected sparsity is:
-            sparsity = ln(threshold * sample_length / a) / b
+        Generates stats matching the calibration model
+            t = 1 - exp(-a * (S/(1-S))^b / L^c)
+        with a=1.5, b=0.86, c=1.26. Inverse:
+            S/(1-S) = (-L^c * log(1-t) / a)^(1/b)
+            S       = X / (1 + X)
         """
-        a_true, b_true = 0.1, 5.0
+        a_true, b_true, c_true = 1.5, 0.86, 1.26
 
         for module in model.modules():
             if isinstance(module, SparseAttentionModule):
                 sparsity_list = []
                 for t in threshold_trials:
-                    sf = t * sample_length
-                    # Invert the model: sparsity = ln(sf / a) / b
-                    s = np.log(sf / a_true) / b_true
+                    log_term = -np.log(1.0 - t)
+                    X = (sample_length**c_true * log_term / a_true) ** (1.0 / b_true)  # noqa: N806
+                    s = X / (1.0 + X)
                     s = max(0.0, min(1.0, s))
                     sparsity_list.append(s)
                 module._last_stats = {
@@ -94,34 +92,11 @@ class TestExponentialFitting:
                     "phase": "prefill",
                 }
 
-    def test_calibrate_with_synthetic_linear(self):
-        """Test linear-space fitting recovers known parameters."""
+    def test_calibrate_recovers_synthetic_params(self):
+        """The lstsq fit recovers known (a, b, c) from clean synthetic data."""
         model = self._make_sparse_model()
         trials = [1e-4, 5e-4, 1e-3, 5e-3, 1e-2, 5e-2, 0.1, 0.3, 0.5]
-        cal = DynamicThresholdCalibrator(threshold_trials=trials, fit_logspace=False)
-
-        def forward_loop(m):
-            # Simulate 3 samples with different lengths
-            for length in [2048, 4096, 8192]:
-                self._inject_synthetic_stats(m, trials, sample_length=length)
-                for module in m.modules():
-                    if isinstance(module, SparseAttentionModule) and module._stats_manager:
-                        stats = module._last_stats
-                        if stats:
-                            module._stats_manager.collect(stats)
-
-        result = cal.calibrate(model, forward_loop, "prefill")
-        # Should produce valid result with a and b close to ground truth
-        if result:
-            assert "a" in result
-            assert "b" in result
-            assert result["r_squared"] > 0.8
-
-    def test_calibrate_with_synthetic_logspace(self):
-        """Test log-space fitting recovers known parameters."""
-        model = self._make_sparse_model()
-        trials = [1e-4, 5e-4, 1e-3, 5e-3, 1e-2, 5e-2, 0.1, 0.3, 0.5]
-        cal = DynamicThresholdCalibrator(threshold_trials=trials, fit_logspace=True)
+        cal = DynamicThresholdCalibrator(threshold_trials=trials)
 
         def forward_loop(m):
             for length in [2048, 4096, 8192]:
@@ -133,10 +108,14 @@ class TestExponentialFitting:
                             module._stats_manager.collect(stats)
 
         result = cal.calibrate(model, forward_loop, "prefill")
-        if result:
-            assert "a" in result
-            assert "b" in result
-            assert result["r_squared"] > 0.9  # Log-space should fit better
+        assert result, "Calibration should produce a result on clean synthetic data"
+        assert "a" in result and "b" in result and "c" in result
+        # Ground-truth params from _inject_synthetic_stats: a=1.5, b=0.86, c=1.26.
+        # Clean data should recover all three to within ~1% relative error.
+        assert abs(result["a"] - 1.5) / 1.5 < 0.05
+        assert abs(result["b"] - 0.86) / 0.86 < 0.02
+        assert abs(result["c"] - 1.26) / 1.26 < 0.02
+        assert result["r_squared"] > 0.999
 
     def test_calibrate_no_modules_raises(self):
         """Test error when no sparse attention modules exist."""

--- a/tests/unit/torch/sparsity/attention_sparsity/test_flash_skip_softmax.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_flash_skip_softmax.py
@@ -323,13 +323,18 @@ class TestFlashSkipSoftmaxMethod:
                 "is_causal": True,
             }
         )
-        method.calibration_params = {"prefill": {"a": 1.0, "b": 5.0}}
+        method.calibration_params = {
+            "prefill": {"a": 1.0, "b": 1.5, "c": 1.2},
+        }
         method.target_sparse_ratio = {"prefill": 0.5}
         info = method.get_threshold_info()
         assert info["type"] == "dynamic_calibrated"
         assert "phases" in info
         assert "prefill" in info["phases"]
-        assert "scale_factor" in info["phases"]["prefill"]
+        prefill = info["phases"]["prefill"]
+        # Logit-power envelope surfaces (a, b, c).
+        assert "c" in prefill
+        assert "example_thresholds" in prefill
 
     def test_get_threshold_info_static(self):
         """get_threshold_info returns static type when no calibration."""

--- a/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attention_conversion.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attention_conversion.py
@@ -369,8 +369,8 @@ class TestExportSparseAttentionConfig:
         for module in model.modules():
             if isinstance(module, SparseAttentionModule):
                 module._sparse_method_instance.calibration_params = {
-                    "prefill": {"a": 3.14, "b": 7.5},
-                    "decode": {"a": 0.5, "b": 9.0},
+                    "prefill": {"a": 3.14, "b": 0.86, "c": 1.26},
+                    "decode": {"a": 0.5, "b": 0.91, "c": 1.18},
                 }
                 module._sparse_method_instance.target_sparse_ratio = {
                     "prefill": 0.4,
@@ -381,8 +381,9 @@ class TestExportSparseAttentionConfig:
         assert out is not None
         assert "config_groups" in out
         tsf = out["threshold_scale_factor"]
-        assert tsf["prefill"] == {"a": 3.14, "b": 7.5}
-        assert tsf["decode"] == {"a": 0.5, "b": 9.0}
+        assert tsf["prefill"] == {"a": 3.14, "b": 0.86, "c": 1.26}
+        assert tsf["decode"] == {"a": 0.5, "b": 0.91, "c": 1.18}
+        assert "1 - exp" in tsf["formula"]
         assert out["target_sparse_ratio"] == {"prefill": 0.4, "decode": 0.6}
         assert out["producer"]["name"] == "modelopt"
 
@@ -433,7 +434,7 @@ class TestExportSparseAttentionConfig:
         for module in model.modules():
             if isinstance(module, SparseAttentionModule):
                 module._sparse_method_instance.calibration_params = {
-                    "prefill": {"a": 3.14, "b": 7.5},
+                    "prefill": {"a": 3.14, "b": 0.86, "c": 1.26},
                 }
                 module._sparse_method_instance.target_sparse_ratio = {
                     "prefill": 0.4,
@@ -445,7 +446,11 @@ class TestExportSparseAttentionConfig:
         assert out is not None
         assert out["config_groups"]["group_0"]["sparse_algo"] == "softmax_skip"
         assert out["config_groups"]["group_1"]["sparse_algo"] == "sparse_softmax"
-        assert out["threshold_scale_factor"]["prefill"] == {"a": 3.14, "b": 7.5}
+        assert out["threshold_scale_factor"]["prefill"] == {
+            "a": 3.14,
+            "b": 0.86,
+            "c": 1.26,
+        }
         assert out["target_sparse_ratio"] == {"prefill": 0.4, "decode": 0.6}
         assert out["sparse_softmax"] == {
             "sparsity_n": 2,

--- a/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_config.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_config.py
@@ -102,9 +102,9 @@ class TestLoadFromCheckpointMetadata:
     def test_maps_calibrated_softmax_skip_to_dynamic_config(self):
         """Test that calibrated softmax_skip preserves checkpoint coefficients."""
         threshold_scale_factor = {
-            "formula": "a * exp(b * target_sparsity)",
-            "prefill": {"a": 2.0, "b": 3.0},
-            "decode": {"a": 5.0, "b": 7.0},
+            "formula": "1 - exp(-a * (S/(1-S))^b / L^c)",
+            "prefill": {"a": 2.0, "b": 0.86, "c": 1.26},
+            "decode": {"a": 5.0, "b": 0.91, "c": 1.18},
         }
         meta = {
             "config_groups": {"group_0": {"sparse_algo": "softmax_skip"}},
@@ -161,8 +161,8 @@ class TestLoadFromCheckpointMetadata:
     def test_maps_calibrated_softmax_skip_with_sparse_softmax_overlay(self):
         """Test that vLLM restores combined skip-softmax plus N:M sparse-softmax."""
         threshold_scale_factor = {
-            "formula": "a * exp(b * target_sparsity)",
-            "prefill": {"a": 2.0, "b": 3.0},
+            "formula": "1 - exp(-a * (S/(1-S))^b / L^c)",
+            "prefill": {"a": 2.0, "b": 0.86, "c": 1.26},
         }
         meta = {
             "config_groups": {

--- a/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_worker.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_sparse_attn_worker.py
@@ -122,10 +122,13 @@ def test_forward_delegates_cascade_metadata_to_vllm(monkeypatch):
     [
         ({"skip_softmax_threshold": 0.001}, 1, 128),
         (
+            # Pathological large `a` makes the envelope saturate to threshold=1.0
+            # exactly in float64 (1 - exp(-huge) underflows), triggering the
+            # "outside (0, 1)" warn-and-disable fallback path.
             {
                 "threshold_scale_factor": {
-                    "formula": "a * exp(b * target_sparsity)",
-                    "prefill": {"a": 10.0, "b": 0.0},
+                    "formula": "1 - exp(-a * (S/(1-S))^b / L^c)",
+                    "prefill": {"a": 1.0e9, "b": 0.0, "c": 1.0},
                 },
                 "target_sparse_ratio": {"prefill": 0.5},
             },
@@ -182,7 +185,7 @@ def test_forward_delegates_launches_without_effective_sparse_work(
     monkeypatch.setattr(FlashAttentionImpl, "forward", fake_forward)
 
     maybe_warns = (
-        pytest.warns(UserWarning, match="outside the valid lambda range")
+        pytest.warns(UserWarning, match=r"outside the valid \(0, 1\) range")
         if "threshold_scale_factor" in sparse_kw
         else nullcontext()
     )
@@ -206,15 +209,19 @@ def test_forward_resolves_calibrated_skip_softmax_threshold(monkeypatch):
     """Forward should convert checkpoint calibration params to kernel threshold."""
     max_query_len = 128
     seq_len = 128
-    expected_scale = 2.0 * math.exp(3.0 * 0.4)
+    # scale = a * (S/(1-S))^b; threshold = 1 - exp(-scale / seq_len^c)
+    target = 0.4
+    a_p, b_p, c_p = 2.0, 0.86, 1.0
+    expected_scale = a_p * (target / (1.0 - target)) ** b_p
+    expected_threshold = 1.0 - math.exp(-expected_scale / (seq_len**c_p))
     impl = _clone_sparse_impl(_make_old_impl())
     impl.sparse_kw = {
         "threshold_scale_factor": {
-            "formula": "a * exp(b * target_sparsity)",
-            "prefill": {"a": 2.0, "b": 3.0},
-            "decode": {"a": 0.1, "b": 1.0},
+            "formula": "1 - exp(-a * (S/(1-S))^b / L^c)",
+            "prefill": {"a": a_p, "b": b_p, "c": c_p},
+            "decode": {"a": 0.1, "b": 0.91, "c": 1.0},
         },
-        "target_sparse_ratio": {"prefill": 0.4, "decode": 0.6},
+        "target_sparse_ratio": {"prefill": target, "decode": 0.6},
     }
     q = torch.zeros(max_query_len, impl.num_heads, impl.head_size, dtype=torch.float16)
     kv_cache = torch.zeros(2, 1, seq_len, impl.num_kv_heads, impl.head_size, dtype=torch.float16)
@@ -248,41 +255,50 @@ def test_forward_resolves_calibrated_skip_softmax_threshold(monkeypatch):
         output=torch.empty_like(q),
     )
 
-    assert captured["skip_softmax_threshold"] == pytest.approx(expected_scale / seq_len)
+    assert captured["skip_softmax_threshold"] == pytest.approx(expected_threshold)
     assert "threshold_scale_factor" not in captured
     assert "target_sparse_ratio" not in captured
 
 
 def test_resolve_calibrated_skip_softmax_threshold_for_decode():
     """Calibration conversion is phase-aware even when decode later delegates."""
+    a_d, b_d, c_d, target_d, seq_len = 0.1, 1.0, 1.0, 0.6, 256
     sparse_kw = {
         "threshold_scale_factor": {
-            "formula": "a * exp(b * target_sparsity)",
-            "decode": {"a": 0.1, "b": 1.0},
+            "formula": "1 - exp(-a * (S/(1-S))^b / L^c)",
+            "decode": {"a": a_d, "b": b_d, "c": c_d},
         },
-        "target_sparse_ratio": {"decode": 0.6},
+        "target_sparse_ratio": {"decode": target_d},
     }
 
     vllm_plugin._resolve_skip_softmax_calibration(
         sparse_kw,
         is_prefill=False,
-        max_seq_len=256,
+        max_seq_len=seq_len,
     )
 
-    assert sparse_kw == {"skip_softmax_threshold": pytest.approx(0.1 * math.exp(1.0 * 0.6) / 256)}
+    expected_scale = a_d * (target_d / (1.0 - target_d)) ** b_d
+    expected_threshold = 1.0 - math.exp(-expected_scale / (seq_len**c_d))
+    assert sparse_kw == {"skip_softmax_threshold": pytest.approx(expected_threshold)}
 
 
 def test_resolve_calibrated_skip_softmax_warns_and_disables_for_large_threshold():
-    """A derived lambda >= 1 is invalid and disables calibrated skip-softmax."""
+    """A degenerate threshold (saturates to 1.0) disables calibrated skip-softmax.
+
+    With the bounded envelope, threshold is always in (0, 1) for finite scale.
+    But a pathologically huge `a` makes `1 - exp(-scale/seq_len^c)` round to
+    exactly 1.0 in float64, which fails the `< 1.0` check and triggers the
+    fallback to dense attention.
+    """
     sparse_kw = {
         "threshold_scale_factor": {
-            "formula": "a * exp(b * target_sparsity)",
-            "decode": {"a": 925.492, "b": 0.0},
+            "formula": "1 - exp(-a * (S/(1-S))^b / L^c)",
+            "decode": {"a": 1.0e9, "b": 0.0, "c": 1.0},
         },
         "target_sparse_ratio": {"decode": 0.5},
     }
 
-    with pytest.warns(UserWarning, match="outside the valid lambda range"):
+    with pytest.warns(UserWarning, match=r"outside the valid \(0, 1\) range"):
         vllm_plugin._resolve_skip_softmax_calibration(
             sparse_kw,
             is_prefill=False,
@@ -301,7 +317,7 @@ def test_build_sparse_kw_restores_checkpoint_sparse_metadata():
         "sparsity_m": 4,
         "dense_sink_tokens": 3,
         "dense_recent_tokens": 64,
-        "threshold_scale_factor": {"prefill": {"a": 1.0, "b": 2.0}},
+        "threshold_scale_factor": {"prefill": {"a": 1.0, "b": 0.86, "c": 1.0}},
         "target_sparse_ratio": {"prefill": 0.5},
     }
 
@@ -310,7 +326,7 @@ def test_build_sparse_kw_restores_checkpoint_sparse_metadata():
         "sparsity_m": 4,
         "dense_sink_tokens": 3,
         "dense_recent_tokens": 64,
-        "threshold_scale_factor": {"prefill": {"a": 1.0, "b": 2.0}},
+        "threshold_scale_factor": {"prefill": {"a": 1.0, "b": 0.86, "c": 1.0}},
         "target_sparse_ratio": {"prefill": 0.5},
     }
 

--- a/tests/unit/torch/sparsity/attention_sparsity/test_threshold_info.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_threshold_info.py
@@ -61,25 +61,26 @@ class TestFlashSkipSoftmaxThresholdInfo:
             }
         )
 
-        # Simulate calibration setting a and b parameters
+        # Simulate calibration setting (a, b, c) parameters
         method.calibration_params = {
-            "prefill": {"a": 150.0, "b": 1.5},
-            "decode": {"a": 200.0, "b": 1.8},
+            "prefill": {"a": 150.0, "b": 0.86, "c": 1.26},
+            "decode": {"a": 200.0, "b": 0.91, "c": 1.18},
         }
         method.target_sparse_ratio = {"prefill": 0.9, "decode": 0.9}
 
         info = method.get_threshold_info()
 
         assert info["type"] == "dynamic_calibrated"
-        assert info["formula"] == "threshold = a * exp(b * target_sparsity) / seqlen"
+        assert info["formula"] == "threshold = 1 - exp(-a * (S/(1-S))^b / L^c)"
         assert "calibration_params" in info
         assert "target_sparse_ratio" in info
         assert "phases" in info
         assert "prefill" in info["phases"]
         assert "decode" in info["phases"]
-        # Check that a and b are in phase info
+        # Check that a, b, c are surfaced per phase
         assert info["phases"]["prefill"]["a"] == 150.0
-        assert info["phases"]["prefill"]["b"] == 1.5
+        assert info["phases"]["prefill"]["b"] == 0.86
+        assert info["phases"]["prefill"]["c"] == 1.26
         assert info["phases"]["prefill"]["target_sparsity"] == 0.9
 
 
@@ -138,13 +139,13 @@ class TestSparseAttentionModuleThresholdInfo:
 
         sparse_model = sparsify(model, config)
 
-        # Find module and set calibrated params (Exponential model)
+        # Find module and set calibrated params
         module = None
         for module in sparse_model.modules():
             if isinstance(module, SparseAttentionModule):
                 module._sparse_method_instance.calibration_params = {
-                    "prefill": {"a": 150.0, "b": 1.5},
-                    "decode": {"a": 200.0, "b": 1.8},
+                    "prefill": {"a": 150.0, "b": 0.86, "c": 1.26},
+                    "decode": {"a": 200.0, "b": 0.91, "c": 1.18},
                 }
                 module._sparse_method_instance.target_sparse_ratio = {
                     "prefill": 0.9,
@@ -158,6 +159,7 @@ class TestSparseAttentionModuleThresholdInfo:
 
         assert info["type"] == "dynamic_calibrated"
         assert info["calibration_params"]["prefill"]["a"] == 150.0
+        assert info["calibration_params"]["prefill"]["c"] == 1.26
 
     def test_module_without_method_instance(self):
         """Test get_threshold_info when sparse method instance doesn't exist."""

--- a/tests/unit/torch/sparsity/attention_sparsity/test_triton_skip_softmax.py
+++ b/tests/unit/torch/sparsity/attention_sparsity/test_triton_skip_softmax.py
@@ -15,7 +15,6 @@
 
 """Unit tests for TritonSkipSoftmaxMethod (no GPU required)."""
 
-import math
 import warnings
 
 import pytest
@@ -71,9 +70,19 @@ class TestGetScaleFactor:
 
     def test_calibrated_computation(self):
         m = TritonSkipSoftmaxMethod()
-        m.calibration_params = {"prefill": {"a": 2.0, "b": 3.0}}
+        # scale = a * (S / (1 - S))^b
+        m.calibration_params = {"prefill": {"a": 2.0, "b": 0.86, "c": 1.0}}
         m.target_sparse_ratio = {"prefill": 0.5}
-        expected = 2.0 * math.exp(3.0 * 0.5)
+        # At S=0.5, S/(1-S) = 1, so scale = a regardless of b.
+        expected = 2.0
+        assert m._get_scale_factor() == pytest.approx(expected)
+
+    def test_calibrated_with_target_below_half(self):
+        m = TritonSkipSoftmaxMethod()
+        m.calibration_params = {"prefill": {"a": 2.0, "b": 0.86, "c": 1.0}}
+        m.target_sparse_ratio = {"prefill": 0.3}
+        # scale = 2.0 * (0.3/0.7)^0.86
+        expected = 2.0 * (0.3 / 0.7) ** 0.86
         assert m._get_scale_factor() == pytest.approx(expected)
 
     def test_zero_a_returns_none(self):


### PR DESCRIPTION
### What does this PR do?

Type of change: ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->
Replace the old calibration formula from `t = a * exp(b * S) / L` to `t = 1 - exp(-a * (S / (1 - S))^b / seq_k^c`. The old calibration breaks at short context. We can clamp at runtime or add `1 - exp(-...)` wrapper around t because `1 − exp(−c/L^α) \in (0, 1)`  strictly, so we don't need to hardcode where to cutoff.

<!-- Details about the change. -->

### Usage

### Testing
<!-- Mention how have you tested your change if applicable. -->
The calibration curve are shown below.

<img width="1669" height="651" alt="calibration_qwen3_30b_a3b" src="https://github.com/user-attachments/assets/b6dabdab-179d-4895-8cf6-7a7d7a92f8e6" />
<img width="1669" height="651" alt="calibration_qwen3_8b" src="https://github.com/user-attachments/assets/e5112d7f-0493-49d7-bdcc-6222bedbfaa2" />
<img width="1669" height="651" alt="calibration_llama_3_1_8b" src="https://github.com/user-attachments/assets/2098b769-6f40-4316-9ae2-9631324d10e0" />

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic skip-softmax sparse-attention threshold: t = 1 - exp(-a*(S/(1-S))^b / L^c), supporting runtime sparsity changes without recalibration and exposing a calibrated length exponent.

* **Refactor**
  * Consolidated calibrated-threshold logic and removed legacy log-space fitting flow.

* **Bug Fixes**
  * Kernel skip semantics aligned (non-strict comparison); padding-aware skip decision and consistent measurement block sizing.

* **Documentation**
  * Updated calibration docs and threshold-mode tables to match the new model.

* **Tests**
  * Updated and added tests to validate dynamic calibration and new parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->