### PR TITLE
docs(launcher): scope CLAUDE.md "new model config" section to Megatron-LM PTQ

### DIFF
--- a/tools/launcher/CLAUDE.md
+++ b/tools/launcher/CLAUDE.md
@@ -84,7 +84,11 @@ launch.py → imports core.py + slurm_config.py
 - `report_versions(base_dir)` — prints git commit/branch for launcher + submodules
 - `get_default_env(title)` — returns `(slurm_env, local_env)` dicts
 
-## Adding a New Model Config
+## Adding a New Megatron-LM PTQ Model Config
+
+Steps below apply to `examples/<Org>/<Model>/megatron_lm_ptq.yaml`. Other pipelines
+(HF PTQ, HF / offline / streaming EAGLE3, dflash) use different env vars — copy
+the closest sibling yaml in the same directory as a starting point.
 
 1. Create `examples/<Org>/<Model>/megatron_lm_ptq.yaml` following the format above
 2. Set `MLM_MODEL_CFG` to the HuggingFace repo ID


### PR DESCRIPTION
### What does this PR do?

Type of change: docs

The "Adding a New Model Config" section in `tools/launcher/CLAUDE.md` is written for the **Megatron-LM PTQ** pipeline specifically — its env vars (`MLM_MODEL_CFG`, `QUANT_CFG`) only apply there. But the generic title and step 1's `megatron_lm_ptq.yaml` filename were being read as universal:

- CodeRabbit recently flagged a streaming EAGLE3 yaml ([PR #1509](https://github.com/NVIDIA/Model-Optimizer/pull/1509)) for "missing" `MLM_MODEL_CFG` / `QUANT_CFG`, citing this section as the authoritative guideline.
- Empirically, no other `tools/launcher/examples/**` yaml sets these vars (HF PTQ, HF / offline / streaming EAGLE3, dflash all use different env conventions).

This PR retitles the section to make scope explicit and adds a one-line lead-in pointing other pipelines at sibling yamls as templates.

### Before your PR is "*Ready for review*"

- Backward compatible: ✅ (doc-only)
- New PIP dep: N/A
- New tests: N/A
- Changelog: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for adding new Megatron-LM PTQ model configurations with clearer instructions on proper placement and how to copy related pipeline configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->