### PR TITLE
fix(quant): sync NVFP4StaticQuantizer global_amax across TP and EP

### DIFF
--- a/modelopt/torch/quantization/model_calib.py
+++ b/modelopt/torch/quantization/model_calib.py
@@ -291,6 +291,13 @@ def max_calibrate(
         if getattr(quantizer, "_amax", None) is not None:
             quantizer.sync_amax_across_distributed_group(parallel_state.data_parallel_group)
             quantizer.sync_amax_across_distributed_group(parallel_state.expert_model_parallel_group)
+        # NVFP4StaticQuantizer._global_amax is computed locally during promotion, so for
+        # MoE EP (different experts per rank) it diverges across ranks. Reconcile it
+        # alongside the per-block _amax sync.
+        if isinstance(quantizer, NVFP4StaticQuantizer):
+            quantizer.sync_global_amax_across_distributed_group(
+                parallel_state.expert_model_parallel_group
+            )
         # TODO: create sync_bias_across_distributed_group
 
     # Step 2:Sync amax across data parallelism
@@ -340,6 +347,15 @@ def max_calibrate(
 
         if quantizer.axis in axes_for_sync and quantizer.amax is not None:
             quantizer.sync_amax_across_distributed_group(parallel_state.tensor_parallel_group)
+
+        # Reconcile NVFP4StaticQuantizer._global_amax across TP. The buffer is set
+        # locally during promotion from this rank's shard of _amax, so each TP rank
+        # otherwise carries a different value and the two-level NVFP4 scale becomes
+        # TP-layout-dependent.
+        if isinstance(quantizer, NVFP4StaticQuantizer):
+            quantizer.sync_global_amax_across_distributed_group(
+                parallel_state.tensor_parallel_group
+            )
 
     # Step 2: Sync amax across relevant parallelism (such as TP / EP)
     for name, module in model.named_modules():

--- a/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
+++ b/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
@@ -1353,6 +1353,23 @@ class NVFP4StaticQuantizer(TensorQuantizer):
         else:
             self._global_amax.data.copy_(value.clone().detach().to(self._global_amax.device))
 
+    def sync_global_amax_across_distributed_group(self, parallel_group: DistributedProcessGroup):
+        """All-reduce ``_global_amax`` (MAX) across the given group.
+
+        ``_global_amax`` is computed locally from each rank's shard of ``_amax`` at
+        promotion time, so for TP/EP it must be reconciled across ranks before it is
+        used as the upper level of the two-level NVFP4 scale.
+        """
+        if parallel_group.is_initialized() and getattr(self, "_global_amax", None) is not None:
+            try:
+                dist.all_reduce(self._global_amax, op=dist.ReduceOp.MAX, group=parallel_group.group)
+            except RuntimeError as e:
+                warnings.warn(
+                    f"Failed to synchronize _global_amax: {e}, probably because the tensor "
+                    "is on a device which is not supported by the current distributed backend. "
+                    "This warning can be ignored if happening during modelopt restore."
+                )
+
     def _fake_quantize(self, inputs):
         """Fake quantization using two-level scaling with _amax and _global_amax."""
         if self.amax is not None:


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

**Background.** During `max_calibrate`, `promote_nvfp4_static_quantizers(model)` is called *before* the distributed-sync block. Promotion registers `_global_amax` on each `NVFP4StaticQuantizer` from `reduce_amax(local _amax, axis=None)` — i.e. the max over **this rank's** per-block `_amax`. With TP (weight sharded across Cout or Cin) or MoE EP (different experts per rank), each rank's local `_amax` covers a different slice of the global weight, so `_global_amax` diverges across ranks.

The existing sync block only all-reduces `_amax`:
- `sync_quantizer_amax_across_dp_ep` syncs `_amax` across DP/EP.
- `sync_quantizer_amax_across_tp` syncs `_amax` across TP.

Nothing in the pipeline touches `_global_amax` after promotion, so the upper level of the two-level NVFP4 scale ends up TP/EP-layout-dependent. This violates the stated invariant on `model_calib.py:303` ("TP=8 ↔ TP=4 ↔ TP=8 should give the same quantization parameters") and produces inconsistent block-scale FP8 grids across MoE experts when EP > 1.

**Fix.** Add `NVFP4StaticQuantizer.sync_global_amax_across_distributed_group` mirroring `TensorQuantizer.sync_amax_across_distributed_group`, then call it from both `sync_quantizer_amax_across_dp_ep` (EP group) and `sync_quantizer_amax_across_tp` (TP group), right after the existing `_amax` sync. DP is omitted on purpose: weights are replicated across DP, so each rank already has the same local `_amax` and therefore the same locally-computed `_global_amax`.

### Usage

No API change. The existing calibration flow now produces consistent `_global_amax` across TP/EP automatically:

```python
import modelopt.torch.quantization as mtq
mtq.quantize(model, mtq.NVFP4_DEFAULT_CFG, forward_loop)
# Under TP and/or EP, every rank now holds the same _global_amax on
# each NVFP4StaticQuantizer after max_calibrate / mse_calibrate.
```

### Testing

- `pre-commit run --files modelopt/torch/quantization/model_calib.py modelopt/torch/quantization/nn/modules/tensor_quantizer.py` — passes (ruff / mypy / format / bandit clean).
- `pytest tests/unit/torch/quantization/test_calib.py -q` — 12 passed, 1 skipped (CUDA-only).
- Multi-rank verification: deferred (draft). Planning to add a dist-launched unit test that runs `max_calibrate` under fake TP and EP groups and asserts `_global_amax` is bit-identical across ranks for NVFP4-static weight quantizers.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ — purely additive; only behavior change is that `_global_amax` is now consistent across TP/EP ranks, which was the documented intent.
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ❌ — draft; will add multi-rank test before flipping to ready-for-review.
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌ — will add a bug-fix entry before flipping to ready-for-review.
- Did you get Claude approval on this PR?: N/A — draft.

### Additional Information

Related: #1536 (in-flight refactor of static-NVFP4 finalization). That PR consolidates `promote_nvfp4_static_quantizers` + `_sync_grouped_weight_global_amax` into `max_calibrate` but does **not** change the promote-vs-TP/EP-sync ordering and does not add a cross-TP/EP `_global_amax` reduction — `_sync_grouped_weight_global_amax` only unifies grouped Q/K/V/gate/up siblings *within* a rank. This PR layers cleanly on top of #1536 or stands alone on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)