### PR TITLE
ci: authenticate nvcr.io container pulls with NGC API key

### DIFF
--- a/.github/workflows/_example_tests_runner.yml
+++ b/.github/workflows/_example_tests_runner.yml
@@ -34,6 +34,9 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_minutes }}
     container:
       image: ${{ inputs.docker_image }}
+      credentials:
+        username: $oauthtoken
+        password: ${{ secrets.NGC_API_KEY }}
       options: --shm-size=2gb # TRT-LLM tests on 2-GPU runner needs more shared memory
       env:
         PIP_CONSTRAINT: "" # Disable pip constraint for upgrading packages

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -51,6 +51,9 @@ jobs:
     timeout-minutes: ${{ matrix.timeout }}
     container:
       image: nvcr.io/nvidia/${{ matrix.container_image }}
+      credentials:
+        username: $oauthtoken
+        password: ${{ secrets.NGC_API_KEY }}
       env:
         GIT_DEPTH: 1000 # For correct version
         PIP_CONSTRAINT: "" # Disable pip constraint for upgrading packages


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix (CI infrastructure)

NGC now requires authenticated pulls for `nvcr.io/nvidia/nemo:*` (and likely other) containers after an EULA acceptance gate. Unauthenticated pulls fail with:

```
Error response from daemon: Head "https://nvcr.io/v2/nvidia/nemo/manifests/26.04":
denied: Please accept license on the browser to be able to download
```

Add a `credentials:` block to the `container:` spec in `gpu_tests.yml` and `_example_tests_runner.yml` so GitHub Actions logs in to nvcr.io with an NGC API key before pulling.

### Usage

```yaml
container:
  image: nvcr.io/nvidia/${{ matrix.container_image }}
  credentials:
    username: $oauthtoken
    password: ${{ secrets.NGC_API_KEY }}
```

### Required follow-up (cannot be done in code)

1. Add a repo secret `NGC_API_KEY` (Settings → Secrets and variables → Actions).
2. An NGC org admin must log into ngc.nvidia.com once and accept the EULA on the relevant containers (NeMo, PyTorch, TensorRT-LLM). The API key alone does not bypass the EULA gate.

### Testing
- Workflow YAML validates locally (no syntax errors).
- Full verification requires the secret to be set and the EULA accepted — will be confirmed on the next workflow run.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information

The lint warning `Context access might be invalid: NGC_API_KEY` shown in IDE will resolve once the secret is added to the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to improve container registry authentication for test infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->