### PR TITLE
[Auto-23/24][ONNX][Autocast] Clear stale Cast-output type metadata before ORT InferenceSession load

### DIFF
--- a/modelopt/onnx/autocast/referencerunner.py
+++ b/modelopt/onnx/autocast/referencerunner.py
@@ -295,8 +295,7 @@ class ReferenceRunner:
         ort.set_default_logger_severity(3)
 
         model_copy = copy.deepcopy(self.model)
-        # Stale value_info from upstream exporters would otherwise trip ORT's
-        # graph type checker on load. See onnx_utils.clear_stale_value_info.
+        # Clear stale type metadata to prevent type check failures in ORT
         onnx_utils.clear_stale_value_info(model_copy)
         modify_outputs = ModifyOnnxOutputs(model_copy, outputs=constants.MARK_ALL)
 

--- a/modelopt/onnx/autocast/referencerunner.py
+++ b/modelopt/onnx/autocast/referencerunner.py
@@ -295,6 +295,9 @@ class ReferenceRunner:
         ort.set_default_logger_severity(3)
 
         model_copy = copy.deepcopy(self.model)
+        # Stale value_info from upstream exporters would otherwise trip ORT's
+        # graph type checker on load. See onnx_utils.clear_stale_value_info.
+        onnx_utils.clear_stale_value_info(model_copy)
         modify_outputs = ModifyOnnxOutputs(model_copy, outputs=constants.MARK_ALL)
 
         # Load the modified model and create an inference session

--- a/modelopt/onnx/quantization/quantize.py
+++ b/modelopt/onnx/quantization/quantize.py
@@ -73,6 +73,7 @@ from modelopt.onnx.trt_utils import interpret_trt_plugins_precision_flag, load_o
 from modelopt.onnx.utils import (
     BASE_MIN_OPSET,
     QDQ_PRECISION_MIN_OPSET,
+    clear_stale_value_info,
     duplicate_shared_constants,
     get_opset_version,
     name_onnx_nodes,
@@ -118,6 +119,17 @@ def _preprocess_onnx(
         use_external_data_format,
         intermediate_generated_files,
     )
+
+    # Some ONNX exporters emit stale value_info that disagrees with the dtype
+    # the upstream node actually produces. quantize_static's augmented_model
+    # inherits that bad metadata and ORT rejects it on load. Clear it now so
+    # the preprocessed model handed to quantize_static is clean for any
+    # downstream ORT consumer. See onnx_utils.clear_stale_value_info.
+    if clear_stale_value_info(onnx_model):
+        onnx_path = os.path.join(output_dir, f"{model_name}_reconciled.onnx")
+        save_onnx(onnx_model, onnx_path, use_external_data_format)
+        intermediate_generated_files.append(onnx_path)
+
     if has_custom_op:
         onnx_path = os.path.join(output_dir, f"{model_name}_ort_support.onnx")
         save_onnx(onnx_model, onnx_path, use_external_data_format)

--- a/modelopt/onnx/quantization/quantize.py
+++ b/modelopt/onnx/quantization/quantize.py
@@ -120,11 +120,7 @@ def _preprocess_onnx(
         intermediate_generated_files,
     )
 
-    # Some ONNX exporters emit stale value_info that disagrees with the dtype
-    # the upstream node actually produces. quantize_static's augmented_model
-    # inherits that bad metadata and ORT rejects it on load. Clear it now so
-    # the preprocessed model handed to quantize_static is clean for any
-    # downstream ORT consumer. See onnx_utils.clear_stale_value_info.
+    # Clear stale type metadata to prevent type check failures in ORT
     if clear_stale_value_info(onnx_model):
         onnx_path = os.path.join(output_dir, f"{model_name}_reconciled.onnx")
         save_onnx(onnx_model, onnx_path, use_external_data_format)

--- a/modelopt/onnx/utils.py
+++ b/modelopt/onnx/utils.py
@@ -35,6 +35,53 @@ from modelopt.onnx.logging_config import logger
 BASE_MIN_OPSET = 19
 
 
+def clear_stale_value_info(model: onnx.ModelProto) -> int:
+    """Clear stale type metadata that would otherwise trip ORT's type checker.
+
+    Walks every ``Cast`` node and forces the ``elem_type`` of any
+    ``graph.output`` entry produced by that Cast to match the Cast's ``to``
+    attribute (the spec-defined contract for a Cast's output dtype). Then
+    clears ``value_info`` wholesale so ORT/shape-inference re-derives
+    intermediate-tensor types from the operator graph during session setup.
+    Returns the total number of entries reconciled or cleared.
+
+    Some ONNX exporters (notably TF SavedModel → ONNX paths for
+    FP16-compressed models) emit declarations that disagree with what the
+    upstream node actually produces. ORT rejects such models on load with
+    errors of the form ``Type Error: Type (tensor(float16)) of output arg
+    X of node Y does not match expected type (tensor(float))``. Splitting
+    the fix into "reconcile graph.output by Cast `to`" + "clear value_info"
+    handles both the model-contract surface (where blanket-clear would lose
+    the user's I/O declarations) and the intermediate surface (where
+    selective reconciliation is unnecessary because ORT recomputes anyway).
+
+    Both autocast's ``ReferenceRunner`` (on a deep-copied throwaway model)
+    and quantization's ``_preprocess_onnx`` (before ``quantize_static``
+    reads the preprocessed file) call this helper for the same reason.
+    """
+    # Build Cast.output -> `to` lookup so we can reconcile graph.output
+    # entries that the user declares but whose producing Cast disagrees with.
+    cast_to_by_output = {}
+    for node in model.graph.node:
+        if node.op_type != "Cast":
+            continue
+        to_attr = next((a.i for a in node.attribute if a.name == "to"), None)
+        if to_attr is not None and node.output:
+            cast_to_by_output[node.output[0]] = to_attr
+
+    fixed_outputs = 0
+    for o in model.graph.output:
+        to_attr = cast_to_by_output.get(o.name)
+        if to_attr is not None and o.type.tensor_type.elem_type != to_attr:
+            o.type.tensor_type.elem_type = to_attr
+            fixed_outputs += 1
+
+    n_vi = len(model.graph.value_info)
+    if n_vi:
+        del model.graph.value_info[:]
+    return fixed_outputs + n_vi
+
+
 def get_input_names_from_bytes(model_bytes: bytes, external_inputs_only: bool = True) -> list[str]:
     """This function returns the inputs names of the given onnx model in bytes.
 

--- a/modelopt/onnx/utils.py
+++ b/modelopt/onnx/utils.py
@@ -35,53 +35,6 @@ from modelopt.onnx.logging_config import logger
 BASE_MIN_OPSET = 19
 
 
-def clear_stale_value_info(model: onnx.ModelProto) -> int:
-    """Clear stale type metadata that would otherwise trip ORT's type checker.
-
-    Walks every ``Cast`` node and forces the ``elem_type`` of any
-    ``graph.output`` entry produced by that Cast to match the Cast's ``to``
-    attribute (the spec-defined contract for a Cast's output dtype). Then
-    clears ``value_info`` wholesale so ORT/shape-inference re-derives
-    intermediate-tensor types from the operator graph during session setup.
-    Returns the total number of entries reconciled or cleared.
-
-    Some ONNX exporters (notably TF SavedModel → ONNX paths for
-    FP16-compressed models) emit declarations that disagree with what the
-    upstream node actually produces. ORT rejects such models on load with
-    errors of the form ``Type Error: Type (tensor(float16)) of output arg
-    X of node Y does not match expected type (tensor(float))``. Splitting
-    the fix into "reconcile graph.output by Cast `to`" + "clear value_info"
-    handles both the model-contract surface (where blanket-clear would lose
-    the user's I/O declarations) and the intermediate surface (where
-    selective reconciliation is unnecessary because ORT recomputes anyway).
-
-    Both autocast's ``ReferenceRunner`` (on a deep-copied throwaway model)
-    and quantization's ``_preprocess_onnx`` (before ``quantize_static``
-    reads the preprocessed file) call this helper for the same reason.
-    """
-    # Build Cast.output -> `to` lookup so we can reconcile graph.output
-    # entries that the user declares but whose producing Cast disagrees with.
-    cast_to_by_output = {}
-    for node in model.graph.node:
-        if node.op_type != "Cast":
-            continue
-        to_attr = next((a.i for a in node.attribute if a.name == "to"), None)
-        if to_attr is not None and node.output:
-            cast_to_by_output[node.output[0]] = to_attr
-
-    fixed_outputs = 0
-    for o in model.graph.output:
-        to_attr = cast_to_by_output.get(o.name)
-        if to_attr is not None and o.type.tensor_type.elem_type != to_attr:
-            o.type.tensor_type.elem_type = to_attr
-            fixed_outputs += 1
-
-    n_vi = len(model.graph.value_info)
-    if n_vi:
-        del model.graph.value_info[:]
-    return fixed_outputs + n_vi
-
-
 def get_input_names_from_bytes(model_bytes: bytes, external_inputs_only: bool = True) -> list[str]:
     """This function returns the inputs names of the given onnx model in bytes.
 
@@ -1907,3 +1860,37 @@ def change_casts_to_fp16(model: onnx.ModelProto, target_op_types: list[str]) -> 
                 break
 
     return model
+
+
+def clear_stale_value_info(model: onnx.ModelProto) -> int:
+    """Clear stale type metadata that would otherwise trip ORT's type checker.
+
+    Walks every ``Cast`` node and forces the ``elem_type`` of any
+    ``graph.output`` entry produced by that Cast to match the Cast's ``to``
+    attribute (the spec-defined contract for a Cast's output dtype). Then
+    clears ``value_info`` wholesale so ORT/shape-inference re-derives
+    intermediate-tensor types from the operator graph during session setup.
+
+    Args:
+        model: Loaded in-memory onnx ModelProto.
+
+    Returns:
+        Total number of entries reconciled or cleared.
+    """
+    cast_to_by_output = {
+        node.output[0]: get_cast_to_type(node)
+        for node in model.graph.node
+        if node.op_type == "Cast" and node.output
+    }
+
+    fixed_outputs = 0
+    for o in model.graph.output:
+        to_attr = cast_to_by_output.get(o.name)
+        if to_attr is not None and o.type.tensor_type.elem_type != to_attr:
+            o.type.tensor_type.elem_type = to_attr
+            fixed_outputs += 1
+
+    n_vi = len(model.graph.value_info)
+    if n_vi:
+        del model.graph.value_info[:]
+    return fixed_outputs + n_vi

--- a/tests/unit/onnx/test_onnx_utils.py
+++ b/tests/unit/onnx/test_onnx_utils.py
@@ -30,6 +30,7 @@ from onnx.helper import (
 
 from modelopt.onnx.trt_utils import load_onnx_model
 from modelopt.onnx.utils import (
+    clear_stale_value_info,
     get_input_names_from_bytes,
     get_output_names_from_bytes,
     randomize_weights_onnx_bytes,
@@ -329,3 +330,46 @@ def test_ir_version_support(tmp_path):
     assert model_reload.ir_version == 10, (
         f"The maximum supported IR version is 10, but version {model_reload.ir_version} was detected."
     )
+
+
+def _make_cast_model(cast_to, output_elem_type, with_value_info=False):
+    """Build a tiny X -> Cast(to=cast_to) -> Y model."""
+    nodes = [make_node("Cast", ["X"], ["Y"], to=cast_to, name="cast")]
+    inputs = [make_tensor_value_info("X", onnx.TensorProto.FLOAT16, [1, 4])]
+    outputs = [make_tensor_value_info("Y", output_elem_type, [1, 4])]
+    value_info = (
+        [make_tensor_value_info("Y", onnx.TensorProto.FLOAT16, [1, 4])]
+        if with_value_info
+        else []
+    )
+    graph = make_graph(nodes, "cast_graph", inputs, outputs, value_info=value_info)
+    return make_model(
+        graph, producer_name="modelopt test", opset_imports=[make_opsetid("", 17)]
+    )
+
+
+def test_clear_stale_value_info_reconciles_output_and_clears_value_info():
+    # graph.output declares FP16 but Cast.to=FLOAT — stale.
+    model = _make_cast_model(
+        cast_to=onnx.TensorProto.FLOAT,
+        output_elem_type=onnx.TensorProto.FLOAT16,
+        with_value_info=True,
+    )
+
+    count = clear_stale_value_info(model)
+
+    assert model.graph.output[0].type.tensor_type.elem_type == onnx.TensorProto.FLOAT
+    assert len(model.graph.value_info) == 0
+    assert count == 2  # 1 output reconciled + 1 value_info entry cleared
+
+
+def test_clear_stale_value_info_noop_when_output_matches_cast():
+    model = _make_cast_model(
+        cast_to=onnx.TensorProto.FLOAT,
+        output_elem_type=onnx.TensorProto.FLOAT,
+    )
+
+    count = clear_stale_value_info(model)
+
+    assert model.graph.output[0].type.tensor_type.elem_type == onnx.TensorProto.FLOAT
+    assert count == 0

--- a/tests/unit/onnx/test_onnx_utils.py
+++ b/tests/unit/onnx/test_onnx_utils.py
@@ -338,38 +338,29 @@ def _make_cast_model(cast_to, output_elem_type, with_value_info=False):
     inputs = [make_tensor_value_info("X", onnx.TensorProto.FLOAT16, [1, 4])]
     outputs = [make_tensor_value_info("Y", output_elem_type, [1, 4])]
     value_info = (
-        [make_tensor_value_info("Y", onnx.TensorProto.FLOAT16, [1, 4])]
-        if with_value_info
-        else []
+        [make_tensor_value_info("Y", onnx.TensorProto.FLOAT16, [1, 4])] if with_value_info else []
     )
     graph = make_graph(nodes, "cast_graph", inputs, outputs, value_info=value_info)
-    return make_model(
-        graph, producer_name="modelopt test", opset_imports=[make_opsetid("", 17)]
-    )
+    return make_model(graph, producer_name="modelopt test", opset_imports=[make_opsetid("", 17)])
 
 
-def test_clear_stale_value_info_reconciles_output_and_clears_value_info():
-    # graph.output declares FP16 but Cast.to=FLOAT — stale.
+@pytest.mark.parametrize(
+    ("output_elem_type", "with_value_info", "expected_count"),
+    [
+        (onnx.TensorProto.FLOAT16, True, 2),  # stale output + value_info: reconcile + clear
+        (onnx.TensorProto.FLOAT, False, 0),  # output already matches Cast.to: no-op
+    ],
+    ids=["stale_output_and_value_info", "no_op_when_matching"],
+)
+def test_clear_stale_value_info(output_elem_type, with_value_info, expected_count):
     model = _make_cast_model(
         cast_to=onnx.TensorProto.FLOAT,
-        output_elem_type=onnx.TensorProto.FLOAT16,
-        with_value_info=True,
+        output_elem_type=output_elem_type,
+        with_value_info=with_value_info,
     )
 
     count = clear_stale_value_info(model)
 
     assert model.graph.output[0].type.tensor_type.elem_type == onnx.TensorProto.FLOAT
     assert len(model.graph.value_info) == 0
-    assert count == 2  # 1 output reconciled + 1 value_info entry cleared
-
-
-def test_clear_stale_value_info_noop_when_output_matches_cast():
-    model = _make_cast_model(
-        cast_to=onnx.TensorProto.FLOAT,
-        output_elem_type=onnx.TensorProto.FLOAT,
-    )
-
-    count = clear_stale_value_info(model)
-
-    assert model.graph.output[0].type.tensor_type.elem_type == onnx.TensorProto.FLOAT
-    assert count == 0
+    assert count == expected_count


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

**Error:**
```
onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Type Error: Type (tensor(float16)) of output arg (node_5bc985fa) of node (node_5bc985fa) does not match expected type (tensor(float)).
```

**Root cause:**
- Some ONNX exporters emit `graph.output` / `value_info` entries whose dtype disagrees with the upstream `Cast` node's `to` attribute.
- ORT's type checker rejects such models on session load.

**Fix:**
- New helper `modelopt.onnx.utils.clear_stale_value_info()` reconciles each `graph.output` elem_type to its producing Cast's `to`, then clears `value_info` so ORT recomputes intermediate types.
- Called from `autocast/referencerunner.py` and `quantization/quantize.py::_preprocess_onnx`.

### Usage

```python
# Internal fix; no new flag introduced. Generic CLI to exercise the affected Autocast path:
$ python -m modelopt.onnx.autocast --onnx=model.onnx
```

### Testing

```
pytest tests/unit/onnx/test_onnx_utils.py::test_clear_stale_value_info
```

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic cleaning and reconciliation of stale ONNX type metadata before runtime and quantization; reconciled model files are produced and used when inconsistencies are found.
* **Tests**
  * New unit tests covering metadata-cleaning behavior across cast/type scenarios to ensure correctness and prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->