### PR TITLE
[Feat]: Eagle Dry Run Mode

### DIFF
--- a/examples/speculative_decoding/main.py
+++ b/examples/speculative_decoding/main.py
@@ -59,7 +59,7 @@ from modelopt.torch.speculative.plugins.hf_training_args import (
 )
 from modelopt.torch.speculative.utils import load_vlm_or_llm, patch_transformers5_params_loading
 from modelopt.torch.utils import print_rank_0
-from modelopt.torch.utils.distributed import is_master
+from modelopt.torch.utils.distributed import is_master, local_rank
 
 torch.manual_seed(0)
 mto.enable_huggingface_checkpointing()
@@ -235,7 +235,9 @@ def train():
             raise ValueError(f"Unsupported speculative recipe type: {type(recipe).__name__}")
 
     if dry_run:
-        if is_master():
+        # is_master() is unreliable here: we return before the HF Trainer inits torch.distributed,
+        # so use local_rank() (env-based) to keep a single writer to output_dir.
+        if local_rank() == 0:
             os.makedirs(training_args.output_dir, exist_ok=True)
             model.save_pretrained(training_args.output_dir)
             tokenizer.save_pretrained(training_args.output_dir)

--- a/examples/speculative_decoding/main.py
+++ b/examples/speculative_decoding/main.py
@@ -79,8 +79,8 @@ HfTrainingArguments = dataclasses.make_dataclass(
 )
 
 
-def _parse_cli() -> tuple[str, list[str]]:
-    """Parse --config (required) from argv; return remaining args as dotlist overrides.
+def _parse_cli() -> tuple[str, bool, list[str]]:
+    """Parse --config (required) and --dry_run from argv; return remaining args as dotlist overrides.
 
     Extra positional args use dotlist syntax, e.g.
     ``model.model_name_or_path=meta-llama/Llama-3.2-1B training.output_dir=ckpts/test``.
@@ -94,8 +94,15 @@ def _parse_cli() -> tuple[str, list[str]]:
             "(speculative_eagle / speculative_dflash / speculative_medusa)."
         ),
     )
+    p.add_argument(
+        "--dry_run",
+        action="store_true",
+        help="Skip training: load base + mtsp.convert + save_pretrained, then exit. "
+        "Produces a ModelOpt HF checkpoint with untrained draft-head weights, suitable "
+        "for end-to-end plumbing tests (e.g. running scripts/export_hf_checkpoint.py).",
+    )
     args, overrides = p.parse_known_args()
-    return args.config, overrides
+    return args.config, args.dry_run, overrides
 
 
 def init_distributed_env(training_args: transformers.TrainingArguments) -> None:
@@ -139,7 +146,7 @@ def init_distributed_env(training_args: transformers.TrainingArguments) -> None:
 
 
 def train():
-    config_path, overrides = _parse_cli()
+    config_path, dry_run, overrides = _parse_cli()
     recipe = load_recipe(config_path, overrides=overrides)
     if not isinstance(recipe, ModelOptSpeculativeRecipeBase):
         raise ValueError(
@@ -152,7 +159,7 @@ def train():
     training_args = HfTrainingArguments(**recipe.training.model_dump())
     init_distributed_env(training_args)
 
-    if not recipe.data.data_path and not recipe.data.offline_data_path:
+    if not dry_run and not recipe.data.data_path and not recipe.data.offline_data_path:
         raise ValueError(
             "Either data.data_path or data.offline_data_path must be set in the config."
         )
@@ -226,6 +233,17 @@ def train():
             mtsp.convert(model, [("dflash", dflash_cfg)])
         else:
             raise ValueError(f"Unsupported speculative recipe type: {type(recipe).__name__}")
+
+    if dry_run:
+        if is_master():
+            os.makedirs(training_args.output_dir, exist_ok=True)
+            model.save_pretrained(training_args.output_dir)
+            tokenizer.save_pretrained(training_args.output_dir)
+            print_rank_0(
+                f"[dry-run] saved ModelOpt HF checkpoint (untrained draft head) to "
+                f"{training_args.output_dir}"
+            )
+        return
 
     # Move any remaining CPU buffers to CUDA so DDP (NCCL-only) can broadcast
     # them.  We iterate named_buffers and reassign via the owning module to

--- a/modelopt/torch/speculative/plugins/modeling_fakebase.py
+++ b/modelopt/torch/speculative/plugins/modeling_fakebase.py
@@ -23,6 +23,7 @@ import torch.nn as nn
 import transformers
 from huggingface_hub import hf_hub_download
 from huggingface_hub.errors import EntryNotFoundError
+from safetensors import safe_open
 from safetensors.torch import load_file as safetensors_load_file
 from transformers import (
     AutoConfig,
@@ -51,6 +52,7 @@ _BASE_MODEL_PATHS = [
 ]
 _VLM_CONFIG_ATTRS = ["text_config", "llm_config"]
 _SAFETENSORS_INDEX_FILENAME = "model.safetensors.index.json"
+_SAFETENSORS_SINGLE_FILENAME = "model.safetensors"
 
 
 class FakeBaseConfig(PretrainedConfig):
@@ -162,26 +164,33 @@ class FakeBaseModel(PreTrainedModel):
 
     @staticmethod
     def _load_index(source: str) -> dict:
-        """Load weight_map from model.safetensors.index.json (local directory or Hub repo)."""
-        if os.path.isdir(source):
-            index_path = os.path.join(source, _SAFETENSORS_INDEX_FILENAME)
-            if not os.path.isfile(index_path):
-                raise FileNotFoundError(
-                    f"No {_SAFETENSORS_INDEX_FILENAME} found in {source!r}. "
-                    "FakeBaseModel only supports safetensors checkpoints. "
-                    "Checkpoints using pytorch_model.bin or single-file formats are not supported."
-                )
-        else:
+        """Load weight_map from a sharded index, or synthesize one from a single safetensors file.
+
+        Sharded checkpoints ship ``model.safetensors.index.json`` mapping every key to its shard;
+        small checkpoints ship a single ``model.safetensors`` with no index — we read its keys
+        and synthesize the equivalent weight_map so downstream code stays the same.
+        """
+
+        def _try_fetch(name: str) -> str | None:
+            if os.path.isdir(source):
+                path = os.path.join(source, name)
+                return path if os.path.isfile(path) else None
             try:
-                index_path = hf_hub_download(repo_id=source, filename=_SAFETENSORS_INDEX_FILENAME)
+                return hf_hub_download(repo_id=source, filename=name)
             except EntryNotFoundError:
-                raise ValueError(
-                    f"Repository {source!r} does not contain {_SAFETENSORS_INDEX_FILENAME}. "
-                    "FakeBaseModel only supports safetensors checkpoints. "
-                    "Checkpoints using pytorch_model.bin or single-file formats are not supported."
-                ) from None
-        with open(index_path) as f:
-            return json.load(f).get("weight_map", {})
+                return None
+
+        if (index_path := _try_fetch(_SAFETENSORS_INDEX_FILENAME)) is not None:
+            with open(index_path) as f:
+                return json.load(f).get("weight_map", {})
+        if (single_path := _try_fetch(_SAFETENSORS_SINGLE_FILENAME)) is not None:
+            with safe_open(single_path, framework="pt") as h:
+                return dict.fromkeys(h.keys(), _SAFETENSORS_SINGLE_FILENAME)
+        raise FileNotFoundError(
+            f"No {_SAFETENSORS_INDEX_FILENAME} or {_SAFETENSORS_SINGLE_FILENAME} found at "
+            f"{source!r}. FakeBaseModel only supports safetensors checkpoints; "
+            "pytorch_model.bin is not supported."
+        )
 
     @staticmethod
     def _resolve_shard_paths(source: str, shard_filenames: list[str]) -> list[str]:
@@ -198,8 +207,14 @@ class FakeBaseModel(PreTrainedModel):
         """Load lm_head and embed_tokens weights from a local directory or HuggingFace Hub repo."""
         weight_map = self._load_index(source)
 
-        lm_head_key = self._find_weight_key(weight_map, _LM_HEAD_PATHS, "lm_head")
         embed_tokens_key = self._find_weight_key(weight_map, _EMBED_TOKENS_PATHS, "embed_tokens")
+        try:
+            lm_head_key = self._find_weight_key(weight_map, _LM_HEAD_PATHS, "lm_head")
+        except RuntimeError:
+            # Tied embeddings: lm_head shares embed_tokens weight and isn't stored separately.
+            if not self.config.tie_word_embeddings:
+                raise
+            lm_head_key = embed_tokens_key
 
         lm_head_path, embed_tokens_path = self._resolve_shard_paths(
             source, [weight_map[lm_head_key], weight_map[embed_tokens_key]]

--- a/modelopt/torch/speculative/plugins/modeling_fakebase.py
+++ b/modelopt/torch/speculative/plugins/modeling_fakebase.py
@@ -24,7 +24,6 @@ import transformers
 from huggingface_hub import hf_hub_download
 from huggingface_hub.errors import EntryNotFoundError
 from safetensors import safe_open
-from safetensors.torch import load_file as safetensors_load_file
 from transformers import (
     AutoConfig,
     AutoModel,
@@ -220,10 +219,12 @@ class FakeBaseModel(PreTrainedModel):
             source, [weight_map[lm_head_key], weight_map[embed_tokens_key]]
         )
 
-        lm_head_state = safetensors_load_file(lm_head_path, device="cpu")
-        embed_tokens_state = safetensors_load_file(embed_tokens_path, device="cpu")
+        # Pull only the two tensors we need; avoids materializing the whole file.
+        def _read(path: str, key: str) -> torch.Tensor:
+            with safe_open(path, framework="pt", device="cpu") as h:
+                return h.get_tensor(key)
 
-        return lm_head_state[lm_head_key], embed_tokens_state[embed_tokens_key]
+        return _read(lm_head_path, lm_head_key), _read(embed_tokens_path, embed_tokens_key)
 
     def forward(self, *args, **kwargs):
         """Not implemented: FakeBaseModel omits full model weights and cannot run inference."""

--- a/tests/examples/speculative_decoding/test_eagle.py
+++ b/tests/examples/speculative_decoding/test_eagle.py
@@ -265,6 +265,48 @@ def test_offline_eagle3_training(
     assert os.path.exists(output_subdir / "config.json")
 
 
+def test_eagle3_dry_run(tiny_llama_path, tmp_path, eagle_output_dir):
+    """Test --dry_run: load + mtsp.convert + save_pretrained, no training, then export.
+
+    Exercises the full dry-run pipeline (FakeBaseModel + skip-train + export) so users
+    can smoke-test convert→save→export plumbing without paying for an actual training run.
+    The exported checkpoint has untrained draft-head weights but a valid EAGLE3 structure.
+    """
+    output_subdir = eagle_output_dir / "eagle-tinyllama-dryrun"
+    export_subdir = eagle_output_dir / "eagle-tinyllama-dryrun-export"
+
+    overrides = [
+        f"model.model_name_or_path={tiny_llama_path}",
+        "model.use_fake_base_for_offline=true",
+        # offline_data_path is required to route into the FakeBaseModel path
+        # (use_offline_training=True), but is never actually read in --dry_run mode.
+        f"data.offline_data_path={tmp_path / 'dummy_offline'}",
+        f"training.output_dir={output_subdir}",
+        *_TINY_EAGLE_ARCH,
+    ]
+    run_example_command(
+        ["./launch_train.sh", "--config", EAGLE3_YAML, "--dry_run", *overrides],
+        "speculative_decoding",
+    )
+    assert (output_subdir / "modelopt_state.pth").exists()
+    assert (output_subdir / "config.json").exists()
+
+    # The dry-run checkpoint must be exportable to the deployment format.
+    run_example_command(
+        [
+            "python", "./scripts/export_hf_checkpoint.py",
+            "--model_path", output_subdir,
+            "--export_path", export_subdir,
+        ],
+        "speculative_decoding",
+    )
+    state_dict = safetensors.torch.load_file(export_subdir / "model.safetensors")
+    for required_key in LLAMA_EAGLE_SINGLE_LAYER["required"]:
+        assert f"{required_key}.weight" in state_dict, (
+            f"Missing key '{required_key}.weight' in state_dict"
+        )
+
+
 def test_offline_resume_training_kimi(tiny_daring_anteater_path, tmp_path, eagle_output_dir):
     """Test resume of offline Eagle3 training from a FakeBaseModel checkpoint (Kimi-K2.5).
 

--- a/tests/unit/torch/speculative/plugins/test_fakebase.py
+++ b/tests/unit/torch/speculative/plugins/test_fakebase.py
@@ -70,6 +70,39 @@ def test_fakebase_missing_index_raises(tmp_path, fake_config):
         FakeBaseModel.from_source(str(tmp_path))
 
 
+def test_fakebase_single_file_no_index(tmp_path, fake_config):
+    """Small models often ship a single ``model.safetensors`` without an index.json."""
+    tensors = {
+        "lm_head.weight": torch.zeros(_VOCAB_SIZE, _HIDDEN_SIZE),
+        "embed_tokens.weight": torch.zeros(_VOCAB_SIZE, _HIDDEN_SIZE),
+    }
+    safetensors.torch.save_file(tensors, tmp_path / "model.safetensors")
+    model = FakeBaseModel.from_source(str(tmp_path))
+    assert model.lm_head.weight.shape == torch.Size([_VOCAB_SIZE, _HIDDEN_SIZE])
+    assert model.embed_tokens.weight.shape == torch.Size([_VOCAB_SIZE, _HIDDEN_SIZE])
+
+
+def test_fakebase_tied_embeddings_falls_back_to_embed(tmp_path, fake_config):
+    """Tied-embeddings models (e.g. Llama-3.2-1B) omit ``lm_head`` from safetensors;
+    FakeBaseModel must reuse ``embed_tokens`` for both."""
+    fake_config.tie_word_embeddings = True
+    weight = torch.randn(_VOCAB_SIZE, _HIDDEN_SIZE)
+    safetensors.torch.save_file({"embed_tokens.weight": weight}, tmp_path / "model.safetensors")
+    model = FakeBaseModel.from_source(str(tmp_path))
+    torch.testing.assert_close(model.lm_head.weight, weight)
+    torch.testing.assert_close(model.embed_tokens.weight, weight)
+
+
+def test_fakebase_missing_lm_head_without_tying_raises(tmp_path, fake_config):
+    """Without ``tie_word_embeddings`` a missing ``lm_head`` is still an error."""
+    safetensors.torch.save_file(
+        {"embed_tokens.weight": torch.zeros(_VOCAB_SIZE, _HIDDEN_SIZE)},
+        tmp_path / "model.safetensors",
+    )
+    with pytest.raises(RuntimeError, match="lm_head"):
+        FakeBaseModel.from_source(str(tmp_path))
+
+
 def test_load_vlm_or_llm_returns_fakebase(fake_checkpoint):
     model = load_vlm_or_llm(str(fake_checkpoint), use_offline_training=True, use_fake_base=True)
     assert isinstance(model, FakeBaseModel)

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_eagle3_dryrun.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_eagle3_dryrun.yaml
@@ -1,0 +1,56 @@
+# EAGLE3 dry-run smoke test for Qwen3-8B.
+#
+# Single-task pipeline that exercises the full convert→save→export path WITHOUT
+# actually training. The launcher's `common/eagle3/train_eagle.sh` is unchanged —
+# all dry-run behaviour is expressed as dotlist overrides on `main.py`:
+#
+#   --dry_run                              → main.py skips trainer.train(), saves
+#                                            the (untrained) ModelOpt checkpoint
+#                                            right after mtsp.convert
+#   model.use_fake_base_for_offline=true   → load only embed_tokens + lm_head from
+#                                            the base model (FakeBaseModel); the
+#                                            full base weights are never read
+#   data.offline_data_path=<placeholder>   → required to route into the
+#                                            FakeBaseModel path; contents are never
+#                                            read in --dry_run mode
+#
+# Useful for:
+#   - End-to-end smoke tests of the launcher / Docker / Slurm plumbing
+#   - Validating downstream stacks (vLLM, TRT-LLM) can load ModelOpt-exported
+#     EAGLE3 checkpoints without paying for a real training run
+#   - Fast local iteration when only the export structure matters, not draft
+#     accuracy
+#
+# The exported checkpoint at /scratchspace/export has the correct EAGLE3
+# architecture (layer shapes, lm_head, config.json) but untrained draft-head
+# weights — its acceptance rate will be ~0%, by design.
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_eagle3_dryrun.yaml --yes
+
+job_name: Qwen3-8B_EAGLE3_dryrun
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3-8B
+
+  # Convert → save → export (no training).
+  task_0:
+    script: common/eagle3/train_eagle.sh
+    args:
+      - --dry_run
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - model.use_fake_base_for_offline=true
+      - data.offline_data_path=/tmp/dryrun-placeholder
+      - training.output_dir=/scratchspace/eagle3
+      - training.disable_tqdm=true
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10


### PR DESCRIPTION
### What does this PR do?

Type of change: new feature

Adds `--dry_run` to `examples/speculative_decoding/main.py`: load → `mtsp.convert` → save, then exit (no `trainer.train()`). With `FakeBaseModel`, the convert→save→export chain runs in seconds and produces an exportable EAGLE3 / Medusa / DFlash checkpoint with correct structure but untrained draft-head weights — useful for end-to-end plumbing smoke tests on downstream stacks (vLLM, TRT-LLM, SGLang) without paying for a real training run.

Where it sits among existing EAGLE3 modes:

```
EAGLE3 modes
├── online      base model runs forward in-loop
├── offline     reads pre-dumped hidden states from disk
├── streaming   streams hidden states from a live server in-loop
└── dry-run ★  skip training entirely; convert + save + export   ← NEW (this PR)
```

Companion `FakeBaseModel` fixes so small base checkpoints work:
- Synthesize the weight_map from a single `model.safetensors` when no sharded index is present (Llama-3.2-1B, Qwen3-0.6B, …).
- Honor `tie_word_embeddings`: reuse `embed_tokens` when `lm_head` is absent from safetensors.

A new launcher YAML (`tools/launcher/examples/Qwen/Qwen3-8B/hf_eagle3_dryrun.yaml`) wires this together as a one-task pipeline.

### Usage

```bash
# Direct
python main.py --dry_run \
  --config modelopt_recipes/general/speculative_decoding/eagle3.yaml \
  model.model_name_or_path=meta-llama/Llama-3.1-8B-Instruct \
  model.use_fake_base_for_offline=true \
  data.offline_data_path=/tmp/dryrun-placeholder \
  training.output_dir=ckpts/dryrun
python scripts/export_hf_checkpoint.py --model_path ckpts/dryrun --export_path export/dryrun

# Launcher
uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_eagle3_dryrun.yaml --yes
```

### Testing

- `tests/unit/torch/speculative/plugins/test_fakebase.py`: 3 new cases — single-file fallback, tied-embeddings fallback, and the negative case (missing `lm_head` without tying).
- `tests/examples/speculative_decoding/test_eagle.py::test_eagle3_dry_run`: full `launch_train.sh --dry_run → export_hf_checkpoint.py` chain on `tiny_llama`; asserts exported state_dict has all `LLAMA_EAGLE_SINGLE_LAYER` required keys.
- Manually verified end-to-end on Llama-3.1-8B-Instruct (sharded), Llama-3.2-1B-Instruct (single-file + tied), and Qwen3-0.6B (single-file).

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ — `--dry_run` is opt-in; `FakeBaseModel` changes are additive fallbacks.
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A — examples-only addition.
- Did you get Claude approval on this PR?: ❌

### Additional Information

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--dry_run` CLI flag to perform a fast early-exit execution that saves model artifacts without training.
  * Added support for single-file model checkpoint formats in the loader.

* **Bug Fixes**
  * Improved checkpoint-loading error messages and handling.
  * Enhanced tied-embeddings fallback when head weights are absent.

* **Tests**
  * Added integration and unit tests covering dry-run behavior and single-file/tied-embedding loading.

* **Documentation**
  * Added a launcher example for dry-run smoke testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->