### PR TITLE
Launcher nvrx install from PyPI; specdec_bench guard modelopt import

### DIFF
--- a/examples/specdec_bench/specdec_bench/__init__.py
+++ b/examples/specdec_bench/specdec_bench/__init__.py
@@ -17,4 +17,10 @@
 # tracks the parent package without a separate semver source of truth.
 # Breaking schema/methodology changes are recorded in commit messages and
 # fingerprinted by `specdec_bench_sha` in configuration.json.
-from modelopt import __version__
+try:
+    from modelopt import __version__
+except Exception:  # vllm container does not have modelopt installed
+    from warnings import warn as _warn
+
+    _warn("modelopt not found, using 0.0.0 as specdec_bench version")
+    __version__ = "0.0.0"

--- a/examples/specdec_bench/specdec_bench/__init__.py
+++ b/examples/specdec_bench/specdec_bench/__init__.py
@@ -19,7 +19,7 @@
 # fingerprinted by `specdec_bench_sha` in configuration.json.
 try:
     from modelopt import __version__
-except Exception:  # vllm container does not have modelopt installed
+except ModuleNotFoundError:  # vllm container does not have modelopt installed
     from warnings import warn as _warn
 
     _warn("modelopt not found, using 0.0.0 as specdec_bench version")

--- a/tools/launcher/common/service_utils.sh
+++ b/tools/launcher/common/service_utils.sh
@@ -57,13 +57,12 @@ function util_install_extra_dep {
             report_result "FAIL: util_install_extra_dep: pip install diskcache failed"
             exit 1
         fi
-        local _nvrx_dir
-        _nvrx_dir="$(mktemp -d)/nvidia-resiliency-ext"
-        if ! git clone --depth 1 https://github.com/NVIDIA/nvidia-resiliency-ext "${_nvrx_dir}"; then
-            report_result "FAIL: util_install_extra_dep: git clone nvidia-resiliency-ext failed"
-            exit 1
-        fi
-        if ! pip install "${_nvrx_dir}"; then
+        # Megatron-LM asserts nvrx >= 0.6.0 on import. nemo containers ship
+        # nvrx in two Python envs; `pip` targets the system one, `python -m
+        # pip` the uv venv. Uninstall from both, install into the venv.
+        pip uninstall -y nvidia-resiliency-ext 2>/dev/null || true
+        python -m pip uninstall -y nvidia-resiliency-ext 2>/dev/null || true
+        if ! python -m pip install --upgrade "nvidia-resiliency-ext>=0.6.0"; then
             report_result "FAIL: util_install_extra_dep: pip install nvidia-resiliency-ext failed"
             exit 1
         fi


### PR DESCRIPTION
## Summary

- **`tools/launcher/common/service_utils.sh`** — Megatron-LM (post PR #4522) asserts `nvrx >= 0.6.0` on import. The previous git-clone-HEAD install in `util_install_extra_dep` produced setuptools_scm versions like `0.0.0.dev1+hash` whenever upstream HEAD landed between tags, failing that assertion. Switch to a PyPI install pinned at `>= 0.6.0`. nemo containers ship nvrx in two Python envs; `pip` (system) and `python -m pip` (uv venv) target different ones, so uninstall from both and install into the venv where Python actually imports from.
- **`examples/specdec_bench/specdec_bench/__init__.py`** — guard the `from modelopt import __version__` import so `specdec_bench` can be loaded inside a vllm container that doesn't have modelopt installed.

## Test plan

- [x] Launcher YAMLs (e.g. Qwen3-8B PTQ on ComputeLab) install `nvidia-resiliency-ext>=0.6.0` and don't trip the Megatron-LM `has_nvrx_async_support` assertion.
- [x] `specdec_bench` imports cleanly under a vllm container with no modelopt installed (prints the warning and uses `__version__ = "0.0.0"`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined dependency installation: removed fragile repo-based install and now ensures a clean uninstall/upgrade flow for the external resiliency package to improve reliability across environments.
  * Improved version handling: added guarded fallback and warning when an optional package is missing, reporting a safe default version to avoid runtime errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/Model-Optimizer/pull/1567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->