### PR TITLE
Update Qwen3-8B EAGLE3 example to online training pipeline

### DIFF
--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_online_eagle3.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_online_eagle3.yaml
@@ -1,16 +1,14 @@
-# EAGLE3 offline speculative decoding pipeline for Qwen3-8B.
+# EAGLE3 online speculative decoding pipeline for Qwen3-8B.
 #
-# 4-step pipeline:
-#   task_0: Data synthesis — query TRT-LLM server to generate prompt samples
-#   task_1: Dump hidden states — run target model to capture hidden states
-#   task_2: Offline training — train the EAGLE3 draft head
-#   task_3: Benchmark — evaluate speculative decoding speedup via VLLM
+# 2-step pipeline:
+#   task_0: Online training — train the EAGLE3 draft head against a prebuilt dataset
+#   task_1: Benchmark — evaluate speculative decoding speedup via VLLM
 #
-# All tasks share /scratchspace to pass artifacts between steps.
+# Uses a prebuilt conversation dataset, so no data-synthesis step is needed.
 #
 # Usage:
-#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_offline_eagle3.yaml --yes
-#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/Qwen3-8B/hf_offline_eagle3.yaml --yes
+#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_online_eagle3.yaml --yes
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/Qwen3-8B/hf_online_eagle3.yaml --yes
 
 job_name: Qwen3-8B_EAGLE3_online
 pipeline:
@@ -21,32 +19,19 @@ pipeline:
   global_vars:
     hf_model: /hf-local/Qwen/Qwen3-8B
 
+  # Step 1: Online EAGLE3 draft-head training
   task_0:
-    script: common/eagle3/make_dataset.sh
-    args:
-      - -f modules/Model-Optimizer/examples/speculative_decoding/prepare_input_conversations/example_data_config.yaml
-      - --full-conversations
-    slurm_config:
-      _factory_: "slurm_factory"
-      nodes: 1
-      ntasks_per_node: 1
-      gpus_per_node: 1
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
-
-  task_1:
     script: common/eagle3/train_eagle.sh
     args:
       - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
       - model.model_name_or_path=<<global_vars.hf_model>>
-      - data.data_path=/scratchspace/data/train.jsonl
+      - data.data_path=/hf-local/modelopt/Speculative-Decoding-Dataset-v1-Qwen3-8B/sample-100K-openai.jsonl
+      - data.chat_template=examples/Qwen/Qwen3-8B/chat_template_train.jinja
       - training.output_dir=/scratchspace/eagle3
       - training.training_seq_len=4096
       - training.disable_tqdm=true
       - training.ar_validate_steps=500000
       - training.num_train_epochs=1
-    environment:
-      - HOME: /tmp
-      - TORCHINDUCTOR_CACHE_DIR: /tmp/torch_cache
     slurm_config:
       _factory_: "slurm_factory"
       nodes: 1
@@ -54,7 +39,8 @@ pipeline:
       gpus_per_node: 8
       container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
 
-  task_2:
+  # Step 2: Benchmark speculative decoding (VLLM backend)
+  task_1:
     script: common/specdec_bench/quick_check.sh
     args:
       - --draft_model_dir /scratchspace/export
@@ -68,8 +54,6 @@ pipeline:
       - --concurrency 1
     environment:
       - HF_MODEL_CKPT: <<global_vars.hf_model>>
-      - HOME: /tmp
-      - TORCHINDUCTOR_CACHE_DIR: /tmp/torch_cache
     slurm_config:
       _factory_: "slurm_factory"
       nodes: 1


### PR DESCRIPTION
## What

Updates `tools/launcher/examples/Qwen/Qwen3-8B/hf_online_eagle3.yaml` to use a streamlined **online** EAGLE3 training pipeline.

## Changes

- Replaces the offline 4-step pipeline (data synthesis → hidden-state dump → offline training → benchmark) with a 2-step online pipeline:
  - `task_0`: Online training — train the EAGLE3 draft head against a prebuilt dataset
  - `task_1`: Benchmark — evaluate speculative decoding speedup via VLLM
- Uses a prebuilt conversation dataset (`Speculative-Decoding-Dataset-v1-Qwen3-8B`), so no data-synthesis step is needed.
- Adds a chat template (`chat_template_train.jinja`) for training.
- Removes now-unnecessary `HOME` / `TORCHINDUCTOR_CACHE_DIR` environment overrides.
- Updates header comments and usage examples to reference the online config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)