### PR TITLE
[OMNIML-4873] author_yaml

### DIFF
--- a/tools/launcher/common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t0_d3.yaml
+++ b/tools/launcher/common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t0_d3.yaml
@@ -1,0 +1,4 @@
+sampling_kwargs:
+  temperature: 0
+engine_args:
+  max_model_len: 40960

--- a/tools/launcher/common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t0_d7.yaml
+++ b/tools/launcher/common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t0_d7.yaml
@@ -1,0 +1,4 @@
+sampling_kwargs:
+  temperature: 0
+engine_args:
+  max_model_len: 40960

--- a/tools/launcher/common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t1_d3.yaml
+++ b/tools/launcher/common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t1_d3.yaml
@@ -1,0 +1,4 @@
+sampling_kwargs:
+  temperature: 1
+engine_args:
+  max_model_len: 40960

--- a/tools/launcher/common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t1_d7.yaml
+++ b/tools/launcher/common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t1_d7.yaml
@@ -1,0 +1,4 @@
+sampling_kwargs:
+  temperature: 1
+engine_args:
+  max_model_len: 40960

--- a/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t0_d3.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t0_d3.yaml
@@ -1,0 +1,63 @@
+# SPEED-bench MTP speculative-decoding cell for Qwen3.5-4B via vLLM.
+#
+# Slurm dry-run on cw_dfw:
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t0_d3.yaml --dry-run --yes
+
+job_name: Qwen3.5-4B_specdec_bench_mtp_vllm_t0_d3
+
+pipeline:
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3.5-4B
+
+  task_0:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/qualitative
+      - --engine VLLM
+      - --speculative_algorithm MTP
+      - --draft_length 3
+      - --runtime_params common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t0_d3.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 32
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/qwen35_4b_mtp_vllm_t0_d3/qualitative
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130
+
+  task_1:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/throughput_32k
+      - --engine VLLM
+      - --speculative_algorithm MTP
+      - --draft_length 3
+      - --runtime_params common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t0_d3.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 8
+      - --num_requests 80
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/qwen35_4b_mtp_vllm_t0_d3/throughput_32k
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130

--- a/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t0_d7.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t0_d7.yaml
@@ -1,0 +1,63 @@
+# SPEED-bench MTP speculative-decoding cell for Qwen3.5-4B via vLLM.
+#
+# Slurm dry-run on cw_dfw:
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t0_d7.yaml --dry-run --yes
+
+job_name: Qwen3.5-4B_specdec_bench_mtp_vllm_t0_d7
+
+pipeline:
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3.5-4B
+
+  task_0:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/qualitative
+      - --engine VLLM
+      - --speculative_algorithm MTP
+      - --draft_length 7
+      - --runtime_params common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t0_d7.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 32
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/qwen35_4b_mtp_vllm_t0_d7/qualitative
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130
+
+  task_1:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/throughput_32k
+      - --engine VLLM
+      - --speculative_algorithm MTP
+      - --draft_length 7
+      - --runtime_params common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t0_d7.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 8
+      - --num_requests 80
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/qwen35_4b_mtp_vllm_t0_d7/throughput_32k
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130

--- a/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t1_d3.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t1_d3.yaml
@@ -1,0 +1,63 @@
+# SPEED-bench MTP speculative-decoding cell for Qwen3.5-4B via vLLM.
+#
+# Slurm dry-run on cw_dfw:
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t1_d3.yaml --dry-run --yes
+
+job_name: Qwen3.5-4B_specdec_bench_mtp_vllm_t1_d3
+
+pipeline:
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3.5-4B
+
+  task_0:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/qualitative
+      - --engine VLLM
+      - --speculative_algorithm MTP
+      - --draft_length 3
+      - --runtime_params common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t1_d3.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 32
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/qwen35_4b_mtp_vllm_t1_d3/qualitative
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130
+
+  task_1:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/throughput_32k
+      - --engine VLLM
+      - --speculative_algorithm MTP
+      - --draft_length 3
+      - --runtime_params common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t1_d3.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 8
+      - --num_requests 80
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/qwen35_4b_mtp_vllm_t1_d3/throughput_32k
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130

--- a/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t1_d7.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t1_d7.yaml
@@ -1,0 +1,63 @@
+# SPEED-bench MTP speculative-decoding cell for Qwen3.5-4B via vLLM.
+#
+# Slurm dry-run on cw_dfw:
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t1_d7.yaml --dry-run --yes
+
+job_name: Qwen3.5-4B_specdec_bench_mtp_vllm_t1_d7
+
+pipeline:
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3.5-4B
+
+  task_0:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/qualitative
+      - --engine VLLM
+      - --speculative_algorithm MTP
+      - --draft_length 7
+      - --runtime_params common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t1_d7.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 32
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/qwen35_4b_mtp_vllm_t1_d7/qualitative
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130
+
+  task_1:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/throughput_32k
+      - --engine VLLM
+      - --speculative_algorithm MTP
+      - --draft_length 7
+      - --runtime_params common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t1_d7.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 8
+      - --num_requests 80
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/qwen35_4b_mtp_vllm_t1_d7/throughput_32k
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-4873](https://jirasw.nvidia.com/browse/OMNIML-4873).

Stage `author_yaml` of Epic `OMNIML-4872`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._

---

**Agent's self-narration** (stripped from PR diff; surfaced here for context):

`VERIFICATION_COMMENT.txt`:
```
Dry-run attempt: `uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t1_d7.yaml --dry-run --yes` from /tmp/pensieve-intern-agent-gxt8k8gh/workspace.

Result: failed during rsync with `Host key verification failed` (rsync exit code 255). No YAML validation errors were reported before the SSH failure.
```



_Pollution-strip removed `VERIFICATION_COMMENT.txt` from this commit (sidecar narration and/or incidental lockfile regeneration are never part of the agent's intended deliverable)._