### PR TITLE
Fix: use python3 in debugger server.sh

### DIFF
--- a/tools/debugger/server.sh
+++ b/tools/debugger/server.sh
@@ -99,7 +99,7 @@ mkdir -p "$CMD_DIR" "$RESULT_DIR"
 
 # Ensure modelopt is editable-installed from WORKDIR
 check_modelopt_local() {
-    python -c "
+    python3 -c "
 import modelopt, os, sys
 actual = os.path.realpath(modelopt.__path__[0])
 expected = os.path.realpath('$WORKDIR')
@@ -112,11 +112,11 @@ if os.path.commonpath([actual, expected]) != expected:
 if check_modelopt_local >/dev/null 2>&1; then
     echo "[server] modelopt already editable-installed from $WORKDIR, skipping pip install."
 else
-    echo "[server] Installing modelopt (pip install -e .[dev]) ..."
-    (cd "$WORKDIR" && pip install -e ".[dev]")
+    echo "[server] Installing modelopt (python3 -m pip install -e .[dev]) ..."
+    (cd "$WORKDIR" && python3 -m pip install -e ".[dev]")
     if ! check_modelopt_local; then
         echo "[server] ERROR: modelopt is not running from the local folder ($WORKDIR)."
-        echo "[server] Try: pip install -e '.[dev]' inside the container, then restart the server."
+        echo "[server] Try: python3 -m pip install -e '.[dev]' inside the container, then restart the server."
         exit 1
     fi
     echo "[server] Install done."


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

`tools/debugger/server.sh` invokes `python -c "..."` inside `check_modelopt_local` (and `pip install -e .[dev]` in the fallback path). Containers that only ship `python3` (no `python` shim) cause the check to fail with `python: command not found`, exit 127. The server interprets this as "modelopt not editable-installed", runs `pip install`, the second check fails the same way, and the server aborts before it ever listens for commands.

Switches both the inline import check and the install fallback to `python3` / `python3 -m pip`.

### Usage

```bash
bash tools/debugger/server.sh
# now starts cleanly on python3-only images
```

### Testing

Verified inside a container where `which python` returns nothing and `python3` is `/usr/bin/python3` (Python 3.12). With the old script, `server.sh` aborted at `check_modelopt_local`. With this fix, the check passes against an existing editable install and the server proceeds to wait for the client handshake.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ — `python3` is present on every image that previously had `python`.
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A — internal tooling shell script.
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A — internal debugger tooling, not user-facing.
- Did you get Claude approval on this PR?: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated debugger tooling to ensure consistent use of Python 3 for package validation and installation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->