### PR TITLE
AGENTS.md: carve out autonomous-runner exception to the no-push rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,22 @@ These instructions apply to AI-assisted work in this repository.
 - **Signed commit:** Use `git commit -s -S -m "<message>"` for commits so they
   follow the [signing your work](CONTRIBUTING.md#-signing-your-work)
   requirements.
-- **Never `git push` without explicit approval in the current turn.** Commit
-  locally is fine; publishing to a remote is not.
+- **Interactive sessions: never `git push` without explicit approval in the
+  current turn.** Commit locally is fine; publishing to a remote is not.
 - After `git commit`, stop and wait for the user to say "push", "publish",
   "ship", or equivalent before running `git push`, `gh pr create`, or any
   push-option flags like `-o merge_request.create`.
+- **Exception — autonomous runners.** When either of the env vars
+  `PENSIEVE_INTERN_RUNNER_PROMPT_PATH` or `INTERN_TICKET` is set, you are
+  running as the pensieve-intern AgentLoop (or another autonomous
+  cluster-test runner). The SPEC on the JIRA ticket has already been
+  reviewed by a human and IS the standing approval — `git commit`,
+  `git push`, draft-PR creation, and any cluster-job submission the SPEC
+  directs are expected actions, not destructive surprises. The
+  "wait for human approval" rule above does **not** apply in this mode;
+  follow the SPEC end-to-end and stamp the result back via the engine's
+  worklog conventions. (The human reviews the resulting draft PR — not
+  every intermediate step.)
 
 ## Contributing and PR readiness
 


### PR DESCRIPTION
Surfaced on OMNIML-4886 — the pensieve-intern AgentLoop cell agent reads AGENTS.md, sees the no-push rule, and refuses to commit/push/PR/submit slurm even though the SPEC explicitly instructs it to do all four.

Adds an env-var-gated carve-out: `$PENSIEVE_INTERN_RUNNER_PROMPT_PATH` or `$INTERN_TICKET` being set means "you are the autonomous runner; the SPEC IS the human approval." Interactive sessions (neither env set) are unaffected.

CLAUDE.md is symlinked to AGENTS.md — single-file edit covers both.

Full rationale in the commit message.

Maintainers: this is unblocking the inaugural specdec_bench workflow (https://jirasw.nvidia.com/browse/OMNIML-4885).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow documentation to clarify autonomous runner behavior. Agents can proceed with automatic git operations and submissions without approval when specific environment conditions are set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->