### PR TITLE
[OMNIML-4886] specdec_bench cell t0_d3 — Qwen/Qwen3.5-4B / MTP / vllm

### DIFF
--- a/tools/launcher/common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t0_d3.yaml
+++ b/tools/launcher/common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t0_d3.yaml
@@ -1,0 +1,4 @@
+sampling_kwargs:
+  temperature: 0
+engine_args:
+  max_model_len: 40960

--- a/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t0_d3.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm_t0_d3.yaml
@@ -1,0 +1,58 @@
+job_name: Qwen3.5-4B_specdec_bench_mtp_vllm_t0_d3
+
+pipeline:
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3.5-4B
+
+  task_0:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/qualitative
+      - --engine VLLM
+      - --speculative_algorithm MTP
+      - --draft_length 3
+      - --runtime_params common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t0_d3.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 32
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/qwen35_4b_mtp_vllm_t0_d3/qualitative
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130
+
+  task_1:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/throughput_32k
+      - --engine VLLM
+      - --speculative_algorithm MTP
+      - --draft_length 3
+      - --runtime_params common/specdec_bench/_cells/qwen35_4b_mtp_vllm_t0_d3.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 8
+      - --num_requests 80
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/qwen35_4b_mtp_vllm_t0_d3/throughput_32k
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130


### PR DESCRIPTION
## Summary
- add SPEED-bench MTP vLLM cell t0_d3 for Qwen3.5-4B

## Testing
- not run (cell config + slurm submission only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added benchmark configuration files for speculative decoding performance testing with optimized sampling and engine parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->