### PR TITLE
feat: EAGLE3 LoRA co-training improvements

### DIFF
--- a/examples/speculative_decoding/eagle_utils.py
+++ b/examples/speculative_decoding/eagle_utils.py
@@ -191,29 +191,6 @@ class LoRAWarmupCallback(TrainerCallback):
             raw_model = model.module if hasattr(model, "module") else model
             if hasattr(raw_model, "_lora_cotraining_active"):
                 raw_model._lora_cotraining_active = True
-                # Unfreeze LoRA parameters
-                lora_params = []
-                for name, param in raw_model._base_model.named_parameters():
-                    if "lora_" in name:
-                        param.requires_grad = True
-                        lora_params.append(param)
-
-                # Add LoRA params to optimizer — they were excluded at creation time
-                # because requires_grad was False during warmup.
-                optimizer = kwargs.get("optimizer")
-                if optimizer is not None and lora_params:
-                    existing_ids = {id(p) for g in optimizer.param_groups for p in g["params"]}
-                    new_params = [p for p in lora_params if id(p) not in existing_ids]
-                    if new_params:
-                        optimizer.add_param_group(
-                            {
-                                "params": new_params,
-                                "lr": optimizer.param_groups[0]["lr"],
-                                "weight_decay": 0.0,
-                            }
-                        )
-                        print_rank_0(f"  Added {len(new_params)} LoRA params to optimizer")
-
                 print_rank_0(
                     f"Step {state.global_step}: LoRA warmup complete, enabling co-training."
                 )

--- a/examples/speculative_decoding/scripts/eval_lora.sh
+++ b/examples/speculative_decoding/scripts/eval_lora.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Export EAGLE3 LoRA checkpoint, merge LoRA into base, then evaluate.
+#
+# Environment variables:
+#   HF_MODEL_CKPT:  Path to the original base model (e.g. /hf-local/Qwen/Qwen3-8B)
+#   EAGLE_CKPT:     Path to the EAGLE3 training checkpoint directory
+#   OUTPUT_DIR:     Output directory (default: /scratchspace)
+#   RUN_BASELINE:   If "true", also evaluate the original base model
+#
+# Outputs to $OUTPUT_DIR/:
+#   export/          - Exported eagle draft model + LoRA adapter
+#   draft/           - Clean EAGLE3 head only (for vLLM, no LoRA adapter files)
+#   merged_base/     - Base model with LoRA merged in
+#   lm_eval/         - lm_eval results
+
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+OUTPUT_DIR="${OUTPUT_DIR:-/scratchspace}"
+
+pip install --no-deps lm_eval==0.4.11
+pip install langdetect pytablewriter word2number sacrebleu rouge_score immutabledict
+
+###################################################################################################
+
+# If EAGLE_CKPT points to a training output dir (contains checkpoint-*), resolve the latest one.
+if [ -d "${EAGLE_CKPT}" ] && ls "${EAGLE_CKPT}"/checkpoint-* &>/dev/null; then
+    LATEST=$(ls -d "${EAGLE_CKPT}"/checkpoint-* | sort -V | tail -1)
+    echo "Resolved latest checkpoint: ${LATEST}"
+    EAGLE_CKPT="${LATEST}"
+fi
+
+echo "=== Step 1: Export EAGLE3 checkpoint ==="
+python "${SCRIPT_DIR}/export_hf_checkpoint.py" \
+    --model_path "${EAGLE_CKPT}" \
+    --export_path "${OUTPUT_DIR}/export"
+
+echo "=== Step 1b: Create clean draft dir (EAGLE3 head only, no LoRA adapter) ==="
+mkdir -p "${OUTPUT_DIR}/draft"
+cp "${OUTPUT_DIR}/export/config.json" "${OUTPUT_DIR}/draft/"
+cp "${OUTPUT_DIR}/export/model.safetensors" "${OUTPUT_DIR}/draft/"
+# Copy any additional non-adapter files (e.g., generation_config)
+for f in "${OUTPUT_DIR}/export"/*.json; do
+    base=$(basename "$f")
+    if [[ "$base" != "adapter_config.json" ]]; then
+        cp "$f" "${OUTPUT_DIR}/draft/"
+    fi
+done
+
+echo "=== Step 2: Merge LoRA into base model ==="
+python "${SCRIPT_DIR}/merge_lora.py" \
+    --base_model_path "${HF_MODEL_CKPT}" \
+    --exported_lora_dir "${OUTPUT_DIR}/export" \
+    --output_path "${OUTPUT_DIR}/merged_base"
+
+echo "=== Step 3: Run lm_eval ==="
+mkdir -p "${OUTPUT_DIR}/lm_eval"
+
+python -m lm_eval --model hf \
+    --model_args "pretrained=${OUTPUT_DIR}/merged_base,trust_remote_code=True" \
+    --tasks ifeval,arc_challenge,winogrande \
+    --batch_size auto \
+    --output_path "${OUTPUT_DIR}/lm_eval" \
+    --log_samples
+
+if [[ "${RUN_BASELINE:-false}" == "true" ]]; then
+    echo "=== Step 3b: Run lm_eval on original base model (baseline) ==="
+    mkdir -p "${OUTPUT_DIR}/lm_eval_baseline"
+
+    python -m lm_eval --model hf \
+        --model_args "pretrained=${HF_MODEL_CKPT},trust_remote_code=True" \
+        --tasks ifeval,arc_challenge,winogrande \
+        --batch_size auto \
+        --output_path "${OUTPUT_DIR}/lm_eval_baseline" \
+        --log_samples
+fi
+
+echo "PASS: eval_lora export + merge + lm_eval"

--- a/examples/speculative_decoding/scripts/eval_lora.sh
+++ b/examples/speculative_decoding/scripts/eval_lora.sh
@@ -21,6 +21,7 @@
 #   EAGLE_CKPT:     Path to the EAGLE3 training checkpoint directory
 #   OUTPUT_DIR:     Output directory (default: /scratchspace)
 #   RUN_BASELINE:   If "true", also evaluate the original base model
+#   TRUST_REMOTE_CODE: If "true", opt in to remote-code execution during eval (default: false)
 #
 # Outputs to $OUTPUT_DIR/:
 #   export/          - Exported eagle draft model + LoRA adapter
@@ -32,6 +33,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 OUTPUT_DIR="${OUTPUT_DIR:-/scratchspace}"
+TRUST_REMOTE_CODE="${TRUST_REMOTE_CODE:-False}"
+
+: "${HF_MODEL_CKPT:?Set HF_MODEL_CKPT to the base model checkpoint path}"
+: "${EAGLE_CKPT:?Set EAGLE_CKPT to the EAGLE training checkpoint path}"
 
 pip install --no-deps lm_eval==0.4.11
 pip install langdetect pytablewriter word2number sacrebleu rouge_score immutabledict
@@ -63,16 +68,21 @@ for f in "${OUTPUT_DIR}/export"/*.json; do
 done
 
 echo "=== Step 2: Merge LoRA into base model ==="
-python "${SCRIPT_DIR}/merge_lora.py" \
-    --base_model_path "${HF_MODEL_CKPT}" \
-    --exported_lora_dir "${OUTPUT_DIR}/export" \
+MERGE_ARGS=(
+    --base_model_path "${HF_MODEL_CKPT}"
+    --exported_lora_dir "${OUTPUT_DIR}/export"
     --output_path "${OUTPUT_DIR}/merged_base"
+)
+if [[ "${TRUST_REMOTE_CODE,,}" == "true" ]]; then
+    MERGE_ARGS+=(--trust_remote_code)
+fi
+python "${SCRIPT_DIR}/merge_lora.py" "${MERGE_ARGS[@]}"
 
 echo "=== Step 3: Run lm_eval ==="
 mkdir -p "${OUTPUT_DIR}/lm_eval"
 
 python -m lm_eval --model hf \
-    --model_args "pretrained=${OUTPUT_DIR}/merged_base,trust_remote_code=True" \
+    --model_args "pretrained=${OUTPUT_DIR}/merged_base,trust_remote_code=${TRUST_REMOTE_CODE}" \
     --tasks ifeval,arc_challenge,winogrande \
     --batch_size auto \
     --output_path "${OUTPUT_DIR}/lm_eval" \
@@ -83,7 +93,7 @@ if [[ "${RUN_BASELINE:-false}" == "true" ]]; then
     mkdir -p "${OUTPUT_DIR}/lm_eval_baseline"
 
     python -m lm_eval --model hf \
-        --model_args "pretrained=${HF_MODEL_CKPT},trust_remote_code=True" \
+        --model_args "pretrained=${HF_MODEL_CKPT},trust_remote_code=${TRUST_REMOTE_CODE}" \
         --tasks ifeval,arc_challenge,winogrande \
         --batch_size auto \
         --output_path "${OUTPUT_DIR}/lm_eval_baseline" \

--- a/examples/speculative_decoding/scripts/merge_lora.py
+++ b/examples/speculative_decoding/scripts/merge_lora.py
@@ -56,6 +56,11 @@ def parse_args():
         required=True,
         help="Directory to save the merged (fused) base model.",
     )
+    parser.add_argument(
+        "--trust_remote_code",
+        action="store_true",
+        help="Allow loading models that define custom code on the HF Hub. Off by default.",
+    )
     return parser.parse_args()
 
 
@@ -79,9 +84,14 @@ def main():
     # Load the original base model
     print(f"Loading base model from {args.base_model_path}...")
     model = AutoModelForCausalLM.from_pretrained(
-        args.base_model_path, torch_dtype="auto", device_map="cpu", trust_remote_code=True
+        args.base_model_path,
+        torch_dtype="auto",
+        device_map="cpu",
+        trust_remote_code=args.trust_remote_code,
     )
-    tokenizer = AutoTokenizer.from_pretrained(args.base_model_path, trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.base_model_path, trust_remote_code=args.trust_remote_code
+    )
 
     # Load LoRA adapter into the base model (export dir uses standard peft naming)
     print("Loading LoRA adapter via PeftModel.from_pretrained...")

--- a/modelopt/torch/speculative/config.py
+++ b/modelopt/torch/speculative/config.py
@@ -249,6 +249,14 @@ class EagleConfig(ModeloptBaseConfig):
         ),
     )
 
+    eagle_base_lora_start_layer: int | None = ModeloptField(
+        default=None,
+        description=(
+            "If set, only inject LoRA into base model layers with index >= this value. "
+            "For example, setting to 17 on a 36-layer model applies LoRA to layers 17-35 only."
+        ),
+    )
+
     eagle_base_lora_logits_detach_prob: float = ModeloptField(
         default=0.5,
         description=(

--- a/modelopt/torch/speculative/eagle/eagle_model.py
+++ b/modelopt/torch/speculative/eagle/eagle_model.py
@@ -51,3 +51,4 @@ class EagleModel(DynamicModule):
         )
         self.eagle_base_lora_warmup_steps = config.eagle_base_lora_warmup_steps
         self.eagle_base_lora_logits_detach_prob = config.eagle_base_lora_logits_detach_prob
+        self.eagle_base_lora_start_layer = config.eagle_base_lora_start_layer

--- a/modelopt/torch/speculative/plugins/hf_eagle.py
+++ b/modelopt/torch/speculative/plugins/hf_eagle.py
@@ -225,13 +225,25 @@ class HFEagleModel(EagleModel):
 
         # If start_layer is set, enumerate matching modules explicitly so only
         # the desired layers get LoRA adapters.
-        if self.eagle_base_lora_start_layer is not None and target_modules is not None:
+        if self.eagle_base_lora_start_layer is not None:
+            if target_modules is None:
+                raise ValueError(
+                    "eagle_base_lora_start_layer requires eagle_base_lora_target_modules "
+                    "to be set explicitly (the start-layer filter matches module-name "
+                    "suffixes, so it cannot be combined with PEFT's default/regex targeting)."
+                )
             explicit_targets = []
             for name, _ in self._base_model.named_modules():
                 m = re.search(r"layers\.(\d+)\.", name)
                 if m and int(m.group(1)) >= self.eagle_base_lora_start_layer:
                     if any(name.endswith(mod) for mod in target_modules):
                         explicit_targets.append(name)
+            if not explicit_targets:
+                raise ValueError(
+                    f"No base model modules matched eagle_base_lora_target_modules="
+                    f"{target_modules} at or beyond layer {self.eagle_base_lora_start_layer}. "
+                    "Check the start layer index and target module names."
+                )
             target_modules = explicit_targets
 
         lora_config = LoraConfig(

--- a/modelopt/torch/speculative/plugins/hf_eagle.py
+++ b/modelopt/torch/speculative/plugins/hf_eagle.py
@@ -216,10 +216,24 @@ class HFEagleModel(EagleModel):
 
     def _inject_base_lora(self):
         """Inject HF PEFT LoRA adapters into the base model in-place and unfreeze them."""
+        import re
+
         from peft import LoraConfig
         from peft.mapping import inject_adapter_in_model
 
         target_modules = self.eagle_base_lora_target_modules or None
+
+        # If start_layer is set, enumerate matching modules explicitly so only
+        # the desired layers get LoRA adapters.
+        if self.eagle_base_lora_start_layer is not None and target_modules is not None:
+            explicit_targets = []
+            for name, _ in self._base_model.named_modules():
+                m = re.search(r"layers\.(\d+)\.", name)
+                if m and int(m.group(1)) >= self.eagle_base_lora_start_layer:
+                    if any(name.endswith(mod) for mod in target_modules):
+                        explicit_targets.append(name)
+            target_modules = explicit_targets
+
         lora_config = LoraConfig(
             r=self.eagle_base_lora_rank,
             lora_alpha=self.eagle_base_lora_alpha,
@@ -227,11 +241,16 @@ class HFEagleModel(EagleModel):
             bias="none",
         )
         inject_adapter_in_model(lora_config, self._base_model, adapter_name="default")
-        # Unfreeze LoRA parameters unless we have a warmup phase
-        freeze_lora = self.eagle_base_lora_warmup_steps > 0
+
+        # Always mark LoRA params as trainable so they are included in the
+        # optimizer from the start.  During warmup, _lora_cotraining_active
+        # stays False which prevents any gradient from flowing to LoRA via the
+        # forward path (hidden states detached, logits detached, preservation
+        # loss skipped).  This keeps the optimizer param-group count constant
+        # across checkpoints, avoiding the mismatch on resume.
         for name, param in self._base_model.named_parameters():
             if "lora_" in name:
-                param.requires_grad = not freeze_lora
+                param.requires_grad = True
 
     def _set_base_lora_enabled(self, enabled: bool) -> None:
         """Enable or disable LoRA adapters in the base model."""


### PR DESCRIPTION
## Summary
- Add `eagle_base_lora_start_layer` config for layer-restricted LoRA injection (e.g., apply LoRA only to layers 17+ for last-half experiments)
- Use explicit module name matching for reliable layer filtering when LoRA is injected into the inner base model (PEFT's `layers_to_transform` doesn't work in this context)
- Fix optimizer state mismatch on checkpoint resume: always include LoRA params in the optimizer from init rather than dynamically adding via `add_param_group` at warmup step, which breaks checkpoint compatibility
- Add `eval_lora.sh` script for export + LoRA merge + lm_eval evaluation pipeline

## Test plan
- [x] All-layers MLP LoRA co-training on Qwen3-8B (checkpoint-410k, epoch 1.67)
- [x] Last-half MLP LoRA co-training on Qwen3-8B (checkpoint-220k, epoch 0.90)
- [x] Verified checkpoint resume works correctly after optimizer fix
- [x] Eval pipeline (export + merge + lm_eval + vLLM AR benchmark) passes on both variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config option to restrict which base-model layers receive LoRA adaptation.
  * New evaluation script for LoRA-adapted EAGLE3 models with optional baseline comparison.

* **Changes**
  * LoRA parameters are now always trainable after injection.
  * Warmup flow now activates LoRA co-training when available.
  * Model-merge tool adds a CLI flag to control trusting remote model code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->