### PR TITLE
[6058870] Fix ONNX AutoCast keep_io_types for empty I/O tensors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,7 @@ Changelog
 
 - In Megatron-Core only do EP amax sync for routed expert weights if ``sync_expert_weight_amax=True``. Previously EP amax sync would sync routed expert weights across EP ranks even when ``sync_expert_weight_amax`` was False.
 - Fix Megatron-Core HF importer to load fused ``TELayerNormColumnParallelLinear.layer_norm_weight`` from HF for GPT-family models (Qwen3 etc.) under ``--export-default-te-spec``. Importer now prefers per-context keys ``fused_input_layernorm`` / ``fused_pre_mlp_layernorm`` (fallback ``fused_norm`` for Nemotron-H backward compatibility); ``mcore_qwen.py`` provides the new rules. Without this fix, post-prune MMLU sat at chance.
+- Fix ONNX AutoCast ``keep_io_types=True`` sanity-check failure (``Unexpected type in I/O tensor ...``) when a network input/output is an empty tensor (a dimension of size 0). Such tensors were "fake-cast" (retyped in place) to the low precision type; because the value-info map aliases the ``graph.input``/``graph.output`` ``ValueInfoProto``, this silently changed the model's I/O type. AutoCast now inserts a real ``Cast`` for protected I/O tensors instead.
 
 **Deprecations**
 

--- a/modelopt/onnx/autocast/precisionconverter.py
+++ b/modelopt/onnx/autocast/precisionconverter.py
@@ -970,7 +970,15 @@ class PrecisionConverter:
         """
         # Empty tensors may have special handling in ONNX (e.g. for Resize scales) which can break when redundant casts
         # are injected. Since there's no data, it's safe to only update the metadata.
-        if self._is_empty_tensor(tensor_name):
+        # Exception: a network input/output whose original type must be preserved (keep_io_types=True) must not be
+        # retyped in place, since value_info_map aliases the graph.input/graph.output ValueInfoProto and this would
+        # silently change the model's I/O type. For those we fall through and insert a real Cast node instead.
+        must_preserve_io_type = (
+            self.keep_io_types
+            and tensor_name in self.original_network_io
+            and cast_to.onnx_type != self.original_network_io[tensor_name]
+        )
+        if self._is_empty_tensor(tensor_name) and not must_preserve_io_type:
             logger.debug(f"Fake-casting empty tensor: {tensor_name}")
             if tensor_name in self.value_info_map:
                 tensor_info = self.value_info_map[tensor_name]

--- a/tests/unit/onnx/autocast/test_precisionconverter.py
+++ b/tests/unit/onnx/autocast/test_precisionconverter.py
@@ -1019,19 +1019,12 @@ def test_empty_tensor_handling(
     assert empty_tensor_info.type.tensor_type.elem_type == expected_type
 
 
-@pytest.mark.parametrize("low_precision_type", ["fp16", "bf16"])
-@pytest.mark.parametrize("use_standalone_type_inference", [True, False])
-def test_empty_tensor_network_input_keep_io_types(
-    low_precision_type, use_standalone_type_inference
-):
-    """Empty network I/O tensors must keep their type when keep_io_types=True (nvbug 6058870).
-
-    An empty tensor consumed by a low-precision node used to be "fake-cast" (retyped in place).
-    Because setup_mappings aliases the graph.input ValueInfoProto, this silently changed the
-    network input's type to the low precision type, breaking the keep_io_types contract and
-    failing the sanity check. A real Cast must be inserted instead.
-    """
-    # Concat(X[2, 1], X_empty[2, 0]) -> Y[2, 1] along axis=1, mirroring the bug's empty-input Concat.
+####################################################################################################
+# Graph with an empty tensor (a dimension of size 0) as a network input
+####################################################################################################
+@pytest.fixture
+def model_with_empty_network_input():
+    # Concat(X[2, 1], X_empty[2, 0]) -> Relu -> Y[2, 1] along axis=1, mirroring the bug's empty-input Concat.
     x = helper.make_tensor_value_info("X", TensorProto.FLOAT, [2, 1])
     x_empty = helper.make_tensor_value_info("X_empty", TensorProto.FLOAT, [2, 0])
     y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2, 1])
@@ -1047,9 +1040,24 @@ def test_empty_tensor_network_input_keep_io_types(
     model.ir_version = 10
     onnx.checker.check_model(model)
 
-    model, value_info_map, initializer_map, node_to_init_map = setup_mappings(
-        model, use_standalone_type_inference
-    )
+    model, value_info_map, initializer_map, node_to_init_map = setup_mappings(model)
+
+    return model, value_info_map, initializer_map, node_to_init_map
+
+
+@pytest.mark.parametrize("low_precision_type", ["fp16", "bf16"])
+@pytest.mark.parametrize("use_standalone_type_inference", [True, False])
+def test_empty_tensor_network_input_keep_io_types(
+    model_with_empty_network_input, low_precision_type, use_standalone_type_inference
+):
+    """Empty network I/O tensors must keep their type when keep_io_types=True (nvbug 6058870).
+
+    An empty tensor consumed by a low-precision node used to be "fake-cast" (retyped in place).
+    Because setup_mappings aliases the graph.input ValueInfoProto, this silently changed the
+    network input's type to the low precision type, breaking the keep_io_types contract and
+    failing the sanity check. A real Cast must be inserted instead.
+    """
+    model, value_info_map, initializer_map, node_to_init_map = model_with_empty_network_input
     converter = PrecisionConverter(
         model,
         value_info_map,

--- a/tests/unit/onnx/autocast/test_precisionconverter.py
+++ b/tests/unit/onnx/autocast/test_precisionconverter.py
@@ -1019,6 +1019,68 @@ def test_empty_tensor_handling(
     assert empty_tensor_info.type.tensor_type.elem_type == expected_type
 
 
+@pytest.mark.parametrize("low_precision_type", ["fp16", "bf16"])
+@pytest.mark.parametrize("use_standalone_type_inference", [True, False])
+def test_empty_tensor_network_input_keep_io_types(
+    low_precision_type, use_standalone_type_inference
+):
+    """Empty network I/O tensors must keep their type when keep_io_types=True (nvbug 6058870).
+
+    An empty tensor consumed by a low-precision node used to be "fake-cast" (retyped in place).
+    Because setup_mappings aliases the graph.input ValueInfoProto, this silently changed the
+    network input's type to the low precision type, breaking the keep_io_types contract and
+    failing the sanity check. A real Cast must be inserted instead.
+    """
+    # Concat(X[2, 1], X_empty[2, 0]) -> Y[2, 1] along axis=1, mirroring the bug's empty-input Concat.
+    x = helper.make_tensor_value_info("X", TensorProto.FLOAT, [2, 1])
+    x_empty = helper.make_tensor_value_info("X_empty", TensorProto.FLOAT, [2, 0])
+    y = helper.make_tensor_value_info("Y", TensorProto.FLOAT, [2, 1])
+
+    concat_node = helper.make_node(
+        "Concat", ["X", "X_empty"], ["concat_output"], name="concat", axis=1
+    )
+    relu_node = helper.make_node("Relu", ["concat_output"], ["Y"], name="relu")
+
+    graph = helper.make_graph([concat_node, relu_node], "model_empty_input", [x, x_empty], [y], [])
+    model = helper.make_model(graph, producer_name="model_empty_input")
+    model.opset_import[0].version = 20
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+
+    model, value_info_map, initializer_map, node_to_init_map = setup_mappings(
+        model, use_standalone_type_inference
+    )
+    converter = PrecisionConverter(
+        model,
+        value_info_map,
+        initializer_map,
+        node_to_init_map,
+        keep_io_types=True,
+        low_precision_type=low_precision_type,
+        use_standalone_type_inference=use_standalone_type_inference,
+    )
+    assert converter._is_empty_tensor("X_empty")
+
+    converted_model = converter.convert(
+        high_precision_nodes=["relu"], low_precision_nodes=["concat"]
+    )
+
+    onnx.checker.check_model(converted_model)
+    # The empty network input (and all I/O) must remain FP32 - this is the regression guard.
+    for io in list(converted_model.graph.input) + list(converted_model.graph.output):
+        assert io.type.tensor_type.elem_type == TensorProto.FLOAT, (
+            f"I/O tensor {io.name} type changed despite keep_io_types=True"
+        )
+    # A real Cast must bridge the empty input to the low-precision Concat (not a metadata-only retype).
+    cast_consumers = [
+        n for n in converted_model.graph.node if n.op_type == "Cast" and "X_empty" in n.input
+    ]
+    assert len(cast_consumers) == 1
+    assert onnx_utils.get_cast_to_type(cast_consumers[0]) == low_precision_onnx_type(
+        low_precision_type
+    )
+
+
 @pytest.fixture
 def model_with_constant_cast_patterns():
     """Create a model with constant->cast patterns for testing folding logic."""


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

ONNX AutoCast (used by `modelopt.onnx.quantization` with `--high_precision_dtype fp16/bf16`) failed its internal sanity check with `Unexpected type in I/O tensor <name>, keep_io_types=True, original type: 1, converted type: 10` when a network input or output is an **empty tensor** (a tensor with a dimension of size 0).

Root cause: `PrecisionConverter._add_cast` treats empty tensors specially — instead of inserting a `Cast` node, it "fake-casts" them by retyping their `value_info` in place (there is no data to convert). However, `setup_mappings` stores the same `graph.input` / `graph.output` `ValueInfoProto` objects in `value_info_map`, so retyping an empty tensor that is a network input/output silently changed the model's declared I/O type to the low-precision type — violating the `keep_io_types=True` contract and tripping the sanity check.

Fix (`modelopt/onnx/autocast/precisionconverter.py`): skip the metadata-only fake-cast for protected network I/O tensors (when `keep_io_types=True` and the target type differs from the original I/O type) and fall through to insert a real `Cast` node. This preserves the declared I/O type while still bridging precision into the low-precision consumer/producer. Intermediate empty tensors are unchanged and still fake-cast.

### Usage

```bash
# Previously failed with "Sanity check failed: Unexpected type in I/O tensor ...";
# now completes and produces a valid mixed-precision model.
python -m modelopt.onnx.quantization \
    --quantize_mode int8 \
    --high_precision_dtype fp16 \
    --onnx_path model_with_empty_io_tensor.onnx \
    --output_path model_int8_fp16.onnx
```

### Testing

- Added `test_empty_tensor_network_input_keep_io_types` (fp16 + bf16, both type-inference paths) in `tests/unit/onnx/autocast/test_precisionconverter.py`, asserting network I/O types stay FP32 and a real `Cast` bridges the empty input. Verified it fails before the fix and passes after.
- Full autocast unit suite passes: `CUDA_VISIBLE_DEVICES="" pytest tests/unit/onnx/autocast/` → 202 passed.
- Reproduced the original failure on the reported model and confirmed the command now succeeds end-to-end; the resulting ONNX model passes `onnx.checker`, runs in ONNX Runtime with correct FP32 I/O, and builds a strongly-typed TensorRT engine.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an ONNX AutoCast issue where empty tensors with keep_io_types=True could silently change model I/O types; now a proper Cast is inserted for protected inputs/outputs to preserve declared I/O types.

* **Tests**
  * Added a regression test to ensure empty network-input tensors are handled correctly in mixed-precision ONNX conversion when keep_io_types=True.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->