### PR TITLE
remove deprecated get_default_load_sharded_strategy

### DIFF
--- a/modelopt/torch/opt/plugins/mcore_dist_checkpointing.py
+++ b/modelopt/torch/opt/plugins/mcore_dist_checkpointing.py
@@ -23,8 +23,8 @@ from typing import Any
 
 import torch
 from megatron.core import dist_checkpointing, mpu
-from megatron.core.dist_checkpointing.serialization import get_default_load_sharded_strategy
 from megatron.core.dist_checkpointing.strategies.common import COMMON_STATE_FNAME
+from megatron.core.dist_checkpointing.strategies.torch import TorchDistLoadShardedStrategy
 from megatron.core.dist_checkpointing.validation import StrictHandling
 from megatron.core.transformer.module import Float16Module
 
@@ -162,7 +162,7 @@ def _load_extra_state_from_sharded_checkpoint(
     extra_state_dict = dist_checkpointing.load(
         extra_sharded_state_dict,
         checkpoint_name,
-        get_default_load_sharded_strategy(checkpoint_name),
+        TorchDistLoadShardedStrategy(),
         strict=StrictHandling.LOG_UNEXPECTED,
     )
     extra_state_dict_no_prefix = {}


### PR DESCRIPTION
### What does this PR do?

uses `TorchDistLoadShardedStrategy` instead of deprecated `get_default_load_sharded_strategy`.

<!-- Details about the change. -->

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved distributed checkpoint loading strategy for enhanced reliability and consistency when loading sharded checkpoint extra-state data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->