### PR TITLE
[minor] fix for GLM4.7 mtp module in PTQ

### DIFF
--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -312,13 +312,13 @@ def get_inlined_mtp_prefixes(config: Any) -> list[str]:
 def _keys_to_prefixes(keys: Iterable[str]) -> set[str]:
     """Invert separate-file MTP keys into the prefixes the exporter needs for exclude_modules.
     ``"mtp.fc.weight"`` → ``{"mtp"}``; ``"mtp.layers.0.q_proj.weight"`` →
-    ``{"mtp", "mtp.layers.0"}``. Caller must filter out inlined keys; otherwise
-    ``"model.layers.78.eh_proj.weight"`` would emit ``"model"`` as a prefix.
+    ``{"mtp", "mtp.layers.0"}``. ``"model"`` top-level is dropped to avoid the
+    ``"model*"`` wildcard covering the whole backbone (nvbug 6108133).
     """
     prefixes: set[str] = set()
     for key in keys:
         parts = key.split(".")
-        if parts:
+        if parts and parts[0] != "model":
             prefixes.add(parts[0])
         for i, part in enumerate(parts):
             if part == "layers" and i + 1 < len(parts) and parts[i + 1].isdigit():

--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -313,7 +313,7 @@ def _keys_to_prefixes(keys: Iterable[str]) -> set[str]:
     """Invert separate-file MTP keys into the prefixes the exporter needs for exclude_modules.
     ``"mtp.fc.weight"`` → ``{"mtp"}``; ``"mtp.layers.0.q_proj.weight"`` →
     ``{"mtp", "mtp.layers.0"}``. ``"model"`` top-level is dropped to avoid the
-    ``"model*"`` wildcard covering the whole backbone (nvbug 6108133).
+    ``"model*"`` wildcard covering the whole backbone.
     """
     prefixes: set[str] = set()
     for key in keys:

--- a/tests/examples/llm_ptq/test_example_utils.py
+++ b/tests/examples/llm_ptq/test_example_utils.py
@@ -134,6 +134,16 @@ def test_load_mtp_weights_separate_indexed_shard(tmp_path):
     assert set(orphans) == set(mtp_tensors)
 
 
+def test_keys_to_prefixes_drops_model_top_level():
+    # nvbug 6108133: inlined keys like "model.layers.92.X" must NOT emit "model"
+    # as a top-level prefix (would become "model*" excluding the whole backbone).
+    out = example_utils._keys_to_prefixes(
+        ["model.layers.92.eh_proj.weight", "mtp.fc.weight", "mtp.layers.0.q_proj.weight"]
+    )
+    assert "model" not in out
+    assert out == {"mtp", "mtp.layers.0", "model.layers.92"}
+
+
 def test_load_mtp_weights_no_mtp_returns_empty(tmp_path):
     # Also pins the ``num_nextn_predict_layers=None`` regression: some configs
     # set the field explicitly to None, which must not crash ``int(None)``.


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->


  `_keys_to_prefixes` now drops a top-level `"model"` key fragment instead of emitting it as a prefix. Without this guard, an inlined-MTP key like `model.layers.92.eh_proj.weight`  would emit `"model"` → exporter wraps it as `"model*"` in `quantization_config.exclude_modules` → `fnmatch` in TRT-LLM matches every `model.layers.X.*` module → entire backbone is treated as unquantized → FP8 weights get loaded into BF16 buffers via `.view(bf16)` (which halves the last dim of an FP8 tensor) → loader crashes with `tensor a (5120) must match tensor b (2560) at non-singleton dimension 1`.

  The main-branch caller in `load_mtp_weights` (PR #1532) already filters inlined keys before invoking `_keys_to_prefixes`, so this guard is defense-in-depth on `main` today. It freezes the invariant in code rather than as a docstring caveat — the same regression cannot return if a future caller forgets to filter. Adds a focused unit test that pins the behavior.


### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
 - New unit test `tests/examples/llm_ptq/test_example_utils.py::test_keys_to_prefixes_drops_model_top_level`: passes with this PR, would fail without the guard. 
### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅  <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅  <!--- Mandatory -->
- Did you write any new necessary tests?: ✅  <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅  <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prefix handling in LLM post-training quantization examples: the top-level "model" prefix is now omitted when deriving exclusion prefixes to avoid overly broad wildcard exclusions.

* **Tests**
  * Added test coverage verifying correct conversion of tensor keys to exclusion prefixes, including cases with top-level "model" keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->