### PR TITLE
fix(export): correct unified_export_megatron at EP > 1 and DP > 1

### DIFF
--- a/modelopt/torch/export/unified_export_megatron.py
+++ b/modelopt/torch/export/unified_export_megatron.py
@@ -18,6 +18,7 @@
 
 """Code that export quantized Megatron Core models for deployment."""
 
+import io
 import json
 import os
 import tempfile
@@ -85,6 +86,10 @@ with import_plugin("megatron"):
         HybridModel = MambaModel
     from megatron.core.models.multimodal.llava_model import LLaVAModel
     from megatron.core.parallel_state import (
+        get_data_parallel_rank,
+        get_expert_model_parallel_group,
+        get_expert_model_parallel_rank,
+        get_expert_model_parallel_world_size,
         get_pipeline_model_parallel_rank,
         get_pipeline_model_parallel_world_size,
         get_tensor_model_parallel_rank,
@@ -300,50 +305,61 @@ class GPTModelExporter:
         # We use the last PP rank and the 1st EP rank to write the config because
         # medusa_heads and eagle_module only exist in the last stage.
         if is_last_stage_main_rank:
-            # Baseline: for a local source, copy every non-safetensors file
-            # (tokenizer, remote_code *.py, README, etc.); for a Hub-ID source,
-            # snapshot_download just the *.py sidecars (tokenizer comes via the
-            # AutoTokenizer fallback below). modelopt-owned files (config.json,
-            # generation_config.json, hf_quant_config.json, preprocessor_config.json)
-            # are overwritten below.
-            if self._hf_pretrained_model_name is not None:
-                if os.path.isdir(self._hf_pretrained_model_name):
-                    copy_non_safetensor_files_from_ckpt(
-                        self._hf_pretrained_model_name, save_directory
-                    )
-                else:
-                    copy_hf_ckpt_remote_code(self._hf_pretrained_model_name, save_directory)
-            self._hf_config.save_pretrained(save_directory)
-            try:
-                generation_config = transformers.GenerationConfig.from_pretrained(
-                    self._hf_pretrained_model_name,
-                    trust_remote_code=self.trust_remote_code,
-                )
-                generation_config.save_pretrained(save_directory)
-            except OSError:
-                pass
-            # Hub-ID / None source: fetch tokenizer files via AutoTokenizer.
-            if self._hf_pretrained_model_name is None or not os.path.isdir(
-                self._hf_pretrained_model_name
-            ):
+            # Sidecar file writes (tokenizer, generation_config, hf_config,
+            # preprocessor, etc.) all target the same save_directory. At DP > 1
+            # or EP > 1 there are multiple `is_last_stage_main_rank` ranks; if
+            # they all race on these writes the contents stay correct (last
+            # writer wins with identical bytes) but partial-write windows can
+            # still corrupt a concurrent read by another rank. Pin to one rank.
+            if get_data_parallel_rank() == 0 and get_expert_model_parallel_rank() == 0:
+                # Baseline: for a local source, copy every non-safetensors file
+                # (tokenizer, remote_code *.py, README, etc.); for a Hub-ID source,
+                # snapshot_download just the *.py sidecars (tokenizer comes via the
+                # AutoTokenizer fallback below). modelopt-owned files (config.json,
+                # generation_config.json, hf_quant_config.json, preprocessor_config.json)
+                # are overwritten below.
+                if self._hf_pretrained_model_name is not None:
+                    if os.path.isdir(self._hf_pretrained_model_name):
+                        copy_non_safetensor_files_from_ckpt(
+                            self._hf_pretrained_model_name, save_directory
+                        )
+                    else:
+                        copy_hf_ckpt_remote_code(self._hf_pretrained_model_name, save_directory)
+                self._hf_config.save_pretrained(save_directory)
                 try:
-                    tokenizer = transformers.AutoTokenizer.from_pretrained(
+                    generation_config = transformers.GenerationConfig.from_pretrained(
                         self._hf_pretrained_model_name,
                         trust_remote_code=self.trust_remote_code,
                     )
-                    tokenizer.save_pretrained(save_directory)
-                except (OSError, TypeError, ValueError, ImportError):
+                    generation_config.save_pretrained(save_directory)
+                except OSError:
                     pass
-            try:
-                # Load and save preprocessor config from the original model
-                processor = AutoProcessor.from_pretrained(
-                    self._hf_pretrained_model_name, trust_remote_code=self.trust_remote_code
-                )
-                if hasattr(processor, "image_processor"):
-                    processor.image_processor.save_pretrained(save_directory)
-            except (OSError, ValueError, ImportError):
-                pass
+                # Hub-ID / None source: fetch tokenizer files via AutoTokenizer.
+                if self._hf_pretrained_model_name is None or not os.path.isdir(
+                    self._hf_pretrained_model_name
+                ):
+                    try:
+                        tokenizer = transformers.AutoTokenizer.from_pretrained(
+                            self._hf_pretrained_model_name,
+                            trust_remote_code=self.trust_remote_code,
+                        )
+                        tokenizer.save_pretrained(save_directory)
+                    except (OSError, TypeError, ValueError, ImportError):
+                        pass
+                try:
+                    # Load and save preprocessor config from the original model
+                    processor = AutoProcessor.from_pretrained(
+                        self._hf_pretrained_model_name, trust_remote_code=self.trust_remote_code
+                    )
+                    if hasattr(processor, "image_processor"):
+                        processor.image_processor.save_pretrained(save_directory)
+                except (OSError, ValueError, ImportError):
+                    pass
 
+            # MTP load is in-memory per-rank state (mutates this rank's
+            # layer_state_dicts that feeds the per-rank safetensors save
+            # later); it must run on every last-stage main rank, not just
+            # the single writer.
             mtp_state_dict = self._get_mtp_state_dict()
             if len(mtp_state_dict) > 0:
                 layer_state_dicts[self.model.config.num_layers].update(mtp_state_dict)
@@ -354,7 +370,17 @@ class GPTModelExporter:
         # kv_cache_dtype is only set on attention-owning ranks; writer rank may not be one.
         gathered_kv_cache_dtype = self._gather_kv_cache_dtype()
 
-        if is_last_stage_main_rank and quantization is not None:
+        # Pin hf_quant_config.json assembly + write to a single rank for the same
+        # reason as the sidecar block above (and for symmetry with the config.json
+        # patch below). Self._hf_quant_config remains empty on non-writer ranks,
+        # which makes the config.json gate at the bottom of this method naturally
+        # a no-op on them.
+        if (
+            is_last_stage_main_rank
+            and get_data_parallel_rank() == 0
+            and get_expert_model_parallel_rank() == 0
+            and quantization is not None
+        ):
             if combined_layer_config_dict:
                 quantization_config = process_layer_quant_config(combined_layer_config_dict)
                 quantization_config["exclude_modules"] = combined_exclude_modules
@@ -400,9 +426,23 @@ class GPTModelExporter:
         # Barrier to ensure the export_dir has been created.
         torch.distributed.barrier()
 
-        # Newer versions of VLLM expect config.json with hf_quant_config
+        # Newer versions of VLLM expect config.json with hf_quant_config.
+        # Pin the writer to a single rank: last PP stage, TP rank 0 (handled by
+        # `is_last_stage_main_rank`), DP rank 0, EP rank 0. Without the DP/EP gates,
+        # multiple ranks satisfy `is_last_stage_main_rank` simultaneously (one per
+        # DPxEP cell), read-modify-write the same file, and any pair can interleave
+        # such that another rank reads a truncated mid-write file and raises
+        # JSONDecodeError. Bracket with barriers so every other rank waits for the
+        # single writer.
+        torch.distributed.barrier()
         config_json_file = save_directory + "/config.json"
-        if self._hf_quant_config and os.path.exists(config_json_file):
+        if (
+            is_last_stage_main_rank
+            and get_data_parallel_rank() == 0
+            and get_expert_model_parallel_rank() == 0
+            and self._hf_quant_config
+            and os.path.exists(config_json_file)
+        ):
             with open(config_json_file) as f:
                 config_dict = json.load(f)
             config_dict["quantization_config"] = convert_hf_quant_config_format(
@@ -410,6 +450,7 @@ class GPTModelExporter:
             )
             with open(config_json_file, "w") as f:
                 json.dump(config_dict, f, indent=4)
+        torch.distributed.barrier()
 
         # save_safetensors(state_dict, save_directory)
         save_safetensors_by_layer_index(
@@ -614,7 +655,7 @@ class GPTModelExporter:
                 )
                 single_safetensors_file = None
             except EntryNotFoundError:
-                # Model uses a single unsharded safetensors file — check it for MTP weights.
+                # Model uses a single unsharded safetensors file -- check it for MTP weights.
                 safetensors_index_file = None
                 try:
                     single_safetensors_file = Path(
@@ -1042,6 +1083,17 @@ class GPTModelExporter:
         quantization state from the module, then iterates over experts and saves each expert's
         weight (and scales if quantized) under the HF-style per-expert prefix.
 
+        Collective behavior (EP > 1):
+            When the expert-model-parallel world size is greater than 1, ``num_experts`` is the
+            number of *local* experts on this rank, and ``range(num_experts)`` numbers them
+            0..N-1, which collides with every other EP rank. This method translates local
+            expert ids to *global* ids (preferring ``module.local_expert_indices`` when
+            exposed, falling back to the standard Megatron contiguous layout
+            ``[ep_rank*N, (ep_rank+1)*N - 1]``) and ``all_gather_object`` the resulting
+            per-expert state across the EP process group so every rank in the EP group ends
+            up with the union of experts for this layer. All ranks in the EP group MUST call
+            this function for the same layer at the same logical step or the gather will hang.
+
         This is the reverse of _grouped_mlp_merging in the importer.
         """
         num_experts = module.num_gemms
@@ -1064,37 +1116,134 @@ class GPTModelExporter:
 
         state_dict = module.state_dict()
 
-        for expert_id in range(num_experts):
-            expert_prefix = prefix.format(expert_id) + "."
-            self._record_layer_quant_config(expert_prefix, qformat, block_size)
-            weight_key = f"weight{expert_id}"
+        ep_size = (
+            get_expert_model_parallel_world_size() if torch.distributed.is_initialized() else 1
+        )
+        ep_rank = get_expert_model_parallel_rank() if torch.distributed.is_initialized() else 0
 
-            if weight_key not in state_dict:
-                raise ValueError(f"Missing expected TEGroupedMLP expert weight: {weight_key}")
+        # Prefer the model's authoritative local-to-global expert mapping if exposed.
+        # The standard Megatron contiguous layout (rank r owns experts [r*N, (r+1)*N - 1])
+        # is the fallback when the module doesn't expose local_expert_indices.
+        #
+        # Normalize to a plain Python list of ints regardless of whether Megatron exposes
+        # this as a list, tuple, torch.Tensor, or numpy array. A bare `or` against the raw
+        # attribute trips `bool(tensor)` for multi-element tensors, and an empty list (or
+        # 0-d tensor) would silently fall through to the contiguous-layout fallback.
+        indices = getattr(module, "local_expert_indices", None)
+        if indices is None and getattr(module, "experts", None) is not None:
+            indices = getattr(module.experts, "local_expert_indices", None)
+        if indices is None:
+            local_expert_indices = [ep_rank * num_experts + i for i in range(num_experts)]
+        elif isinstance(indices, torch.Tensor):
+            local_expert_indices = indices.detach().cpu().tolist()
+        else:
+            local_expert_indices = [int(i) for i in indices]
+        if len(local_expert_indices) != num_experts:
+            raise ValueError(
+                f"local_expert_indices length {len(local_expert_indices)} doesn't match "
+                f"module.num_gemms {num_experts}"
+            )
+
+        # Collective-safe missing-key detection: every EP rank checks for its weight keys
+        # locally, then we all_reduce(MAX) over a 0/1 flag so a single rank's missing key
+        # surfaces on every rank. Tensor must be on the current CUDA device -- NCCL has no
+        # CPU backend on the EP process group.
+        local_missing = [
+            k for k in (f"weight{i}" for i in range(num_experts)) if k not in state_dict
+        ]
+        if ep_size > 1:
+            missing_flag = torch.tensor(
+                [1 if local_missing else 0],
+                dtype=torch.int32,
+                device=torch.cuda.current_device(),
+            )
+            torch.distributed.all_reduce(
+                missing_flag,
+                op=torch.distributed.ReduceOp.MAX,
+                group=get_expert_model_parallel_group(),
+            )
+            if missing_flag.item() != 0:
+                raise ValueError(
+                    f"TEGroupedMLP missing expert weights on at least one EP rank "
+                    f"(local missing on rank {ep_rank}: {local_missing})"
+                )
+        elif local_missing:
+            raise ValueError(f"TEGroupedMLP missing expert weights: {local_missing}")
+
+        # Scales / aux values are small and shared across local experts. Move to CPU once
+        # so the gather payload doesn't repeatedly clone GPU tensors.
+        weight_scale_cpu = weight_scale.detach().cpu().clone() if weight_scale is not None else None
+        weight_scale_2_cpu = (
+            weight_scale_2.detach().cpu().clone() if weight_scale_2 is not None else None
+        )
+        name_to_value_cpu = {
+            k: v.detach().cpu().clone() for k, v in name_to_value.items() if k != "output_scale"
+        }
+
+        # Record per-layer quant config for ALL global experts on every rank, not just
+        # the local slice -- `_per_layer_quant_config` is a local in-memory dict that
+        # later gets serialized into hf_quant_config.json; if we only recorded the
+        # local 1/EP slice, the writer rank's dict would be missing (EP-1)/EP of the
+        # routed-expert entries. Within a single TEGroupedMLP layer all routed experts
+        # share the same qformat / block_size by construction (one quantizer pattern
+        # in the recipe matches the whole `*mixer.experts.*` glob), so it's safe to
+        # use the local qformat/block_size for the global record.
+        num_total_experts = num_experts * ep_size
+        for global_id in range(num_total_experts):
+            self._record_layer_quant_config(prefix.format(global_id) + ".", qformat, block_size)
+
+        local_expert_state: dict[str, torch.Tensor] = {}
+
+        for local_id in range(num_experts):
+            global_id = local_expert_indices[local_id]
+            expert_prefix = prefix.format(global_id) + "."
+            weight_key = f"weight{local_id}"
 
             weight = state_dict[weight_key].to(self.dtype).cpu()
 
-            if weight_scale is None:
-                self._state_dict[expert_prefix + "weight"] = weight
+            if weight_scale_cpu is None:
+                local_expert_state[expert_prefix + "weight"] = weight
             else:
-                self._state_dict[expert_prefix + "weight"] = to_quantized_weight(
+                local_expert_state[expert_prefix + "weight"] = to_quantized_weight(
                     weight,
-                    weight_scale,
+                    weight_scale_cpu,
                     qformat,
-                    weight_scale_2,
+                    weight_scale_2_cpu,
                     block_size,
                 )
-                self._state_dict[expert_prefix + "weight_scale"] = weight_scale.detach().clone()
+                local_expert_state[expert_prefix + "weight_scale"] = weight_scale_cpu.clone()
 
-            if weight_scale_2 is not None:
-                self._state_dict[expert_prefix + "weight_scale_2"] = weight_scale_2.detach().clone()
+            if weight_scale_2_cpu is not None:
+                local_expert_state[expert_prefix + "weight_scale_2"] = weight_scale_2_cpu.clone()
 
-        for key, val in name_to_value.items():
-            if key == "output_scale":
-                continue
-            for expert_id in range(num_experts):
-                expert_prefix = prefix.format(expert_id) + "."
-                self._state_dict[expert_prefix + key] = val.detach().clone()
+            for key, val in name_to_value_cpu.items():
+                local_expert_state[expert_prefix + key] = val.clone()
+
+        if ep_size > 1:
+            # all_gather_object can pickle Python objects but trips on quantized uint8
+            # tensors whose UntypedStorage has no dtype attr. Round-trip through
+            # torch.save's byte stream -- PyTorch's own tensor codec handles them.
+            _buf = io.BytesIO()
+            torch.save(local_expert_state, _buf)
+            local_bytes = _buf.getvalue()
+            del _buf
+            gathered_bytes: list = [None] * ep_size
+            torch.distributed.all_gather_object(
+                gathered_bytes, local_bytes, group=get_expert_model_parallel_group()
+            )
+            del local_bytes
+            for b in gathered_bytes:
+                # weights_only=False: payload is generated by us via torch.save in this
+                # same function on a sibling rank in the EP process group of this job
+                # -- it never leaves the cluster's collective and is not user-supplied.
+                # weights_only=True would refuse to deserialize the dict[str, Tensor]
+                # because quantized uint8 tensors store custom storage metadata that
+                # the safe-loader allowlist doesn't cover.
+                s = torch.load(io.BytesIO(b), map_location="cpu", weights_only=False)
+                self._state_dict.update(s)
+            del gathered_bytes
+        else:
+            self._state_dict.update(local_expert_state)
 
     def _qkv_slicing(
         self,

--- a/modelopt/torch/export/unified_export_megatron.py
+++ b/modelopt/torch/export/unified_export_megatron.py
@@ -264,6 +264,20 @@ class GPTModelExporter:
 
         torch.distributed.barrier()
 
+    @staticmethod
+    def _is_sidecar_writer_rank(is_last_stage_main_rank: bool) -> bool:
+        """The one rank that writes sidecar/config files.
+
+        Multiple ranks may satisfy ``is_last_stage_main_rank`` at DP>1 or EP>1;
+        pinning to DP0/EP0 ensures a single writer so peers never observe a
+        partial read-modify-write on save_directory.
+        """
+        return (
+            is_last_stage_main_rank
+            and get_data_parallel_rank() == 0
+            and get_expert_model_parallel_rank() == 0
+        )
+
     def save_pretrained(
         self,
         save_directory: str | os.PathLike,
@@ -284,6 +298,9 @@ class GPTModelExporter:
         # We use the last PP rank to write the config because
         # medusa_heads and eagle_module only exist in the last stage.
         is_last_stage_main_rank = pp_rank == pp_size - 1 and tp_rank == 0
+        # At DP>1 or EP>1 several ranks satisfy is_last_stage_main_rank; further
+        # pinning to DP0/EP0 ensures exactly one writer for sidecar/config files.
+        is_writer_rank = self._is_sidecar_writer_rank(is_last_stage_main_rank)
 
         # Main export process
         layer_state_dicts = self.layer_state_dicts
@@ -302,22 +319,11 @@ class GPTModelExporter:
         elif quantization_format == QUANTIZATION_W4A16_NVFP4:
             quantization = "W4A16_NVFP4"
 
-        # We use the last PP rank and the 1st EP rank to write the config because
-        # medusa_heads and eagle_module only exist in the last stage.
         if is_last_stage_main_rank:
-            # Sidecar file writes (tokenizer, generation_config, hf_config,
-            # preprocessor, etc.) all target the same save_directory. At DP > 1
-            # or EP > 1 there are multiple `is_last_stage_main_rank` ranks; if
-            # they all race on these writes the contents stay correct (last
-            # writer wins with identical bytes) but partial-write windows can
-            # still corrupt a concurrent read by another rank. Pin to one rank.
-            if get_data_parallel_rank() == 0 and get_expert_model_parallel_rank() == 0:
-                # Baseline: for a local source, copy every non-safetensors file
-                # (tokenizer, remote_code *.py, README, etc.); for a Hub-ID source,
-                # snapshot_download just the *.py sidecars (tokenizer comes via the
-                # AutoTokenizer fallback below). modelopt-owned files (config.json,
-                # generation_config.json, hf_quant_config.json, preprocessor_config.json)
-                # are overwritten below.
+            if is_writer_rank:
+                # Local dir source: copy every non-safetensors file (tokenizer, *.py, README).
+                # Hub-ID source: snapshot_download the *.py sidecars (tokenizer via
+                # AutoTokenizer below). modelopt-owned files are overwritten below.
                 if self._hf_pretrained_model_name is not None:
                     if os.path.isdir(self._hf_pretrained_model_name):
                         copy_non_safetensor_files_from_ckpt(
@@ -356,10 +362,8 @@ class GPTModelExporter:
                 except (OSError, ValueError, ImportError):
                     pass
 
-            # MTP load is in-memory per-rank state (mutates this rank's
-            # layer_state_dicts that feeds the per-rank safetensors save
-            # later); it must run on every last-stage main rank, not just
-            # the single writer.
+            # MTP load mutates this rank's layer_state_dicts (per-rank state) so it
+            # must run on every last-stage main rank, not just the writer.
             mtp_state_dict = self._get_mtp_state_dict()
             if len(mtp_state_dict) > 0:
                 layer_state_dicts[self.model.config.num_layers].update(mtp_state_dict)
@@ -370,17 +374,9 @@ class GPTModelExporter:
         # kv_cache_dtype is only set on attention-owning ranks; writer rank may not be one.
         gathered_kv_cache_dtype = self._gather_kv_cache_dtype()
 
-        # Pin hf_quant_config.json assembly + write to a single rank for the same
-        # reason as the sidecar block above (and for symmetry with the config.json
-        # patch below). Self._hf_quant_config remains empty on non-writer ranks,
-        # which makes the config.json gate at the bottom of this method naturally
-        # a no-op on them.
-        if (
-            is_last_stage_main_rank
-            and get_data_parallel_rank() == 0
-            and get_expert_model_parallel_rank() == 0
-            and quantization is not None
-        ):
+        # _hf_quant_config stays empty on non-writer ranks, which makes the
+        # config.json gate below a natural no-op on them.
+        if is_writer_rank and quantization is not None:
             if combined_layer_config_dict:
                 quantization_config = process_layer_quant_config(combined_layer_config_dict)
                 quantization_config["exclude_modules"] = combined_exclude_modules
@@ -423,26 +419,14 @@ class GPTModelExporter:
                 )
                 layer_state_dicts[first_layer_key].update(vision_state_dict)
 
-        # Barrier to ensure the export_dir has been created.
+        # Barrier to ensure the export_dir has been created (also opens the
+        # bracket for the single-writer config.json read-modify-write below).
         torch.distributed.barrier()
 
-        # Newer versions of VLLM expect config.json with hf_quant_config.
-        # Pin the writer to a single rank: last PP stage, TP rank 0 (handled by
-        # `is_last_stage_main_rank`), DP rank 0, EP rank 0. Without the DP/EP gates,
-        # multiple ranks satisfy `is_last_stage_main_rank` simultaneously (one per
-        # DPxEP cell), read-modify-write the same file, and any pair can interleave
-        # such that another rank reads a truncated mid-write file and raises
-        # JSONDecodeError. Bracket with barriers so every other rank waits for the
-        # single writer.
-        torch.distributed.barrier()
+        # Newer VLLM expects config.json with hf_quant_config. Close the bracket
+        # after the write so peers never see a truncated file mid-write.
         config_json_file = save_directory + "/config.json"
-        if (
-            is_last_stage_main_rank
-            and get_data_parallel_rank() == 0
-            and get_expert_model_parallel_rank() == 0
-            and self._hf_quant_config
-            and os.path.exists(config_json_file)
-        ):
+        if is_writer_rank and self._hf_quant_config and os.path.exists(config_json_file):
             with open(config_json_file) as f:
                 config_dict = json.load(f)
             config_dict["quantization_config"] = convert_hf_quant_config_format(
@@ -1076,25 +1060,15 @@ class GPTModelExporter:
                 self._state_dict[up_proj_key] = val.detach().clone()
 
     def _grouped_mlp_slicing(self, module, prefix, parallel_config=None):
-        """Export TEGroupedMLP weights by splitting per-expert weights into individual HF weights.
+        """Export TEGroupedMLP weights, one HF-style per-expert entry per local expert.
 
-        TEGroupedMLP (via TEGroupedLinear) stores weights as weight0, weight1, ..., weight{N-1}
-        in its state_dict, where each weight{i} corresponds to one expert. This method extracts
-        quantization state from the module, then iterates over experts and saves each expert's
-        weight (and scales if quantized) under the HF-style per-expert prefix.
+        TEGroupedMLP stores weights as weight0..weight{N-1}, one per local expert. At EP>1
+        each rank only owns a slice, so local ids are mapped to global via
+        ``module.local_expert_indices`` (fallback: Megatron contiguous ``[ep_rank*N, ...]``)
+        and the resulting per-expert state is ``all_gather_object``-ed across the EP group.
+        All EP ranks MUST enter this method for the same layer in lockstep or the gather hangs.
 
-        Collective behavior (EP > 1):
-            When the expert-model-parallel world size is greater than 1, ``num_experts`` is the
-            number of *local* experts on this rank, and ``range(num_experts)`` numbers them
-            0..N-1, which collides with every other EP rank. This method translates local
-            expert ids to *global* ids (preferring ``module.local_expert_indices`` when
-            exposed, falling back to the standard Megatron contiguous layout
-            ``[ep_rank*N, (ep_rank+1)*N - 1]``) and ``all_gather_object`` the resulting
-            per-expert state across the EP process group so every rank in the EP group ends
-            up with the union of experts for this layer. All ranks in the EP group MUST call
-            this function for the same layer at the same logical step or the gather will hang.
-
-        This is the reverse of _grouped_mlp_merging in the importer.
+        Reverse of _grouped_mlp_merging in the importer.
         """
         num_experts = module.num_gemms
 
@@ -1121,14 +1095,9 @@ class GPTModelExporter:
         )
         ep_rank = get_expert_model_parallel_rank() if torch.distributed.is_initialized() else 0
 
-        # Prefer the model's authoritative local-to-global expert mapping if exposed.
-        # The standard Megatron contiguous layout (rank r owns experts [r*N, (r+1)*N - 1])
-        # is the fallback when the module doesn't expose local_expert_indices.
-        #
-        # Normalize to a plain Python list of ints regardless of whether Megatron exposes
-        # this as a list, tuple, torch.Tensor, or numpy array. A bare `or` against the raw
-        # attribute trips `bool(tensor)` for multi-element tensors, and an empty list (or
-        # 0-d tensor) would silently fall through to the contiguous-layout fallback.
+        # Prefer module.local_expert_indices; fall back to Megatron's contiguous layout
+        # [ep_rank*N, (ep_rank+1)*N - 1]. Normalize to list[int] -- Megatron may expose
+        # this as a tensor and `bool(tensor)` on a multi-element tensor would raise.
         indices = getattr(module, "local_expert_indices", None)
         if indices is None and getattr(module, "experts", None) is not None:
             indices = getattr(module.experts, "local_expert_indices", None)
@@ -1144,10 +1113,9 @@ class GPTModelExporter:
                 f"module.num_gemms {num_experts}"
             )
 
-        # Collective-safe missing-key detection: every EP rank checks for its weight keys
-        # locally, then we all_reduce(MAX) over a 0/1 flag so a single rank's missing key
-        # surfaces on every rank. Tensor must be on the current CUDA device -- NCCL has no
-        # CPU backend on the EP process group.
+        # Collective-safe missing-key check: all_reduce(MAX) over a local 0/1 flag
+        # so any rank's missing key surfaces everywhere. Flag lives on the current
+        # CUDA device -- NCCL has no CPU backend on the EP group.
         local_missing = [
             k for k in (f"weight{i}" for i in range(num_experts)) if k not in state_dict
         ]
@@ -1170,7 +1138,7 @@ class GPTModelExporter:
         elif local_missing:
             raise ValueError(f"TEGroupedMLP missing expert weights: {local_missing}")
 
-        # Scales / aux values are small and shared across local experts. Move to CPU once
+        # Scales / aux values are shared across local experts -- move to CPU once
         # so the gather payload doesn't repeatedly clone GPU tensors.
         weight_scale_cpu = weight_scale.detach().cpu().clone() if weight_scale is not None else None
         weight_scale_2_cpu = (
@@ -1180,14 +1148,11 @@ class GPTModelExporter:
             k: v.detach().cpu().clone() for k, v in name_to_value.items() if k != "output_scale"
         }
 
-        # Record per-layer quant config for ALL global experts on every rank, not just
-        # the local slice -- `_per_layer_quant_config` is a local in-memory dict that
-        # later gets serialized into hf_quant_config.json; if we only recorded the
-        # local 1/EP slice, the writer rank's dict would be missing (EP-1)/EP of the
-        # routed-expert entries. Within a single TEGroupedMLP layer all routed experts
-        # share the same qformat / block_size by construction (one quantizer pattern
-        # in the recipe matches the whole `*mixer.experts.*` glob), so it's safe to
-        # use the local qformat/block_size for the global record.
+        # Record per-layer quant config for ALL global experts on every rank -- the
+        # writer's _per_layer_quant_config is serialized into hf_quant_config.json and
+        # would otherwise be missing (EP-1)/EP of the routed experts. Within one
+        # TEGroupedMLP layer all experts share qformat/block_size (one quantizer
+        # pattern matches `*mixer.experts.*`), so local values apply globally.
         num_total_experts = num_experts * ep_size
         for global_id in range(num_total_experts):
             self._record_layer_quant_config(prefix.format(global_id) + ".", qformat, block_size)
@@ -1220,9 +1185,8 @@ class GPTModelExporter:
                 local_expert_state[expert_prefix + key] = val.clone()
 
         if ep_size > 1:
-            # all_gather_object can pickle Python objects but trips on quantized uint8
-            # tensors whose UntypedStorage has no dtype attr. Round-trip through
-            # torch.save's byte stream -- PyTorch's own tensor codec handles them.
+            # all_gather_object pickles trip on quantized uint8 tensors whose
+            # UntypedStorage has no dtype attr -- round-trip through torch.save bytes.
             _buf = io.BytesIO()
             torch.save(local_expert_state, _buf)
             local_bytes = _buf.getvalue()
@@ -1233,12 +1197,9 @@ class GPTModelExporter:
             )
             del local_bytes
             for b in gathered_bytes:
-                # weights_only=False: payload is generated by us via torch.save in this
-                # same function on a sibling rank in the EP process group of this job
-                # -- it never leaves the cluster's collective and is not user-supplied.
-                # weights_only=True would refuse to deserialize the dict[str, Tensor]
-                # because quantized uint8 tensors store custom storage metadata that
-                # the safe-loader allowlist doesn't cover.
+                # weights_only=False: bytes are our own torch.save output from a sibling
+                # EP rank in this job's collective, not user-supplied. weights_only=True
+                # rejects quantized uint8 tensors (custom storage outside the allowlist).
                 s = torch.load(io.BytesIO(b), map_location="cpu", weights_only=False)
                 self._state_dict.update(s)
             del gathered_bytes

--- a/modelopt/torch/export/unified_export_megatron.py
+++ b/modelopt/torch/export/unified_export_megatron.py
@@ -266,12 +266,7 @@ class GPTModelExporter:
 
     @staticmethod
     def _is_sidecar_writer_rank(is_last_stage_main_rank: bool) -> bool:
-        """The one rank that writes sidecar/config files.
-
-        Multiple ranks may satisfy ``is_last_stage_main_rank`` at DP>1 or EP>1;
-        pinning to DP0/EP0 ensures a single writer so peers never observe a
-        partial read-modify-write on save_directory.
-        """
+        """True only for the DP0/EP0 last-stage-main rank (single writer for save_directory)."""
         return (
             is_last_stage_main_rank
             and get_data_parallel_rank() == 0
@@ -298,8 +293,6 @@ class GPTModelExporter:
         # We use the last PP rank to write the config because
         # medusa_heads and eagle_module only exist in the last stage.
         is_last_stage_main_rank = pp_rank == pp_size - 1 and tp_rank == 0
-        # At DP>1 or EP>1 several ranks satisfy is_last_stage_main_rank; further
-        # pinning to DP0/EP0 ensures exactly one writer for sidecar/config files.
         is_writer_rank = self._is_sidecar_writer_rank(is_last_stage_main_rank)
 
         # Main export process
@@ -321,9 +314,6 @@ class GPTModelExporter:
 
         if is_last_stage_main_rank:
             if is_writer_rank:
-                # Local dir source: copy every non-safetensors file (tokenizer, *.py, README).
-                # Hub-ID source: snapshot_download the *.py sidecars (tokenizer via
-                # AutoTokenizer below). modelopt-owned files are overwritten below.
                 if self._hf_pretrained_model_name is not None:
                     if os.path.isdir(self._hf_pretrained_model_name):
                         copy_non_safetensor_files_from_ckpt(
@@ -362,8 +352,7 @@ class GPTModelExporter:
                 except (OSError, ValueError, ImportError):
                     pass
 
-            # MTP load mutates this rank's layer_state_dicts (per-rank state) so it
-            # must run on every last-stage main rank, not just the writer.
+            # MTP load mutates per-rank layer_state_dicts, so it runs on every last-stage main rank.
             mtp_state_dict = self._get_mtp_state_dict()
             if len(mtp_state_dict) > 0:
                 layer_state_dicts[self.model.config.num_layers].update(mtp_state_dict)
@@ -374,8 +363,6 @@ class GPTModelExporter:
         # kv_cache_dtype is only set on attention-owning ranks; writer rank may not be one.
         gathered_kv_cache_dtype = self._gather_kv_cache_dtype()
 
-        # _hf_quant_config stays empty on non-writer ranks, which makes the
-        # config.json gate below a natural no-op on them.
         if is_writer_rank and quantization is not None:
             if combined_layer_config_dict:
                 quantization_config = process_layer_quant_config(combined_layer_config_dict)
@@ -419,12 +406,9 @@ class GPTModelExporter:
                 )
                 layer_state_dicts[first_layer_key].update(vision_state_dict)
 
-        # Barrier to ensure the export_dir has been created (also opens the
-        # bracket for the single-writer config.json read-modify-write below).
+        # Bracket the writer's config.json read-modify-write with barriers so peers
+        # never observe a truncated file (also ensures export_dir exists).
         torch.distributed.barrier()
-
-        # Newer VLLM expects config.json with hf_quant_config. Close the bracket
-        # after the write so peers never see a truncated file mid-write.
         config_json_file = save_directory + "/config.json"
         if is_writer_rank and self._hf_quant_config and os.path.exists(config_json_file):
             with open(config_json_file) as f:
@@ -1060,13 +1044,11 @@ class GPTModelExporter:
                 self._state_dict[up_proj_key] = val.detach().clone()
 
     def _grouped_mlp_slicing(self, module, prefix, parallel_config=None):
-        """Export TEGroupedMLP weights, one HF-style per-expert entry per local expert.
+        """Export TEGroupedMLP weight0..weight{N-1} as one HF-style entry per expert.
 
-        TEGroupedMLP stores weights as weight0..weight{N-1}, one per local expert. At EP>1
-        each rank only owns a slice, so local ids are mapped to global via
-        ``module.local_expert_indices`` (fallback: Megatron contiguous ``[ep_rank*N, ...]``)
-        and the resulting per-expert state is ``all_gather_object``-ed across the EP group.
-        All EP ranks MUST enter this method for the same layer in lockstep or the gather hangs.
+        At EP>1, local ids are mapped to global via ``module.local_expert_indices``
+        and per-expert state is ``all_gather_object``-ed across the EP group. All EP ranks
+        MUST enter this method for the same layer in lockstep or the gather hangs.
 
         Reverse of _grouped_mlp_merging in the importer.
         """
@@ -1095,9 +1077,8 @@ class GPTModelExporter:
         )
         ep_rank = get_expert_model_parallel_rank() if torch.distributed.is_initialized() else 0
 
-        # Prefer module.local_expert_indices; fall back to Megatron's contiguous layout
-        # [ep_rank*N, (ep_rank+1)*N - 1]. Normalize to list[int] -- Megatron may expose
-        # this as a tensor and `bool(tensor)` on a multi-element tensor would raise.
+        # Prefer module.local_expert_indices; fall back to Megatron's contiguous layout.
+        # Normalize to list[int] since Megatron may expose this as a torch.Tensor.
         indices = getattr(module, "local_expert_indices", None)
         if indices is None and getattr(module, "experts", None) is not None:
             indices = getattr(module.experts, "local_expert_indices", None)
@@ -1138,8 +1119,7 @@ class GPTModelExporter:
         elif local_missing:
             raise ValueError(f"TEGroupedMLP missing expert weights: {local_missing}")
 
-        # Scales / aux values are shared across local experts -- move to CPU once
-        # so the gather payload doesn't repeatedly clone GPU tensors.
+        # Move shared scales/aux to CPU once so the gather payload avoids GPU clones.
         weight_scale_cpu = weight_scale.detach().cpu().clone() if weight_scale is not None else None
         weight_scale_2_cpu = (
             weight_scale_2.detach().cpu().clone() if weight_scale_2 is not None else None
@@ -1148,11 +1128,9 @@ class GPTModelExporter:
             k: v.detach().cpu().clone() for k, v in name_to_value.items() if k != "output_scale"
         }
 
-        # Record per-layer quant config for ALL global experts on every rank -- the
-        # writer's _per_layer_quant_config is serialized into hf_quant_config.json and
-        # would otherwise be missing (EP-1)/EP of the routed experts. Within one
-        # TEGroupedMLP layer all experts share qformat/block_size (one quantizer
-        # pattern matches `*mixer.experts.*`), so local values apply globally.
+        # Record quant config for ALL global experts on every rank; otherwise the writer's
+        # hf_quant_config.json would miss (EP-1)/EP of the routed experts. All experts in
+        # a TEGroupedMLP layer share qformat/block_size, so local values apply globally.
         num_total_experts = num_experts * ep_size
         for global_id in range(num_total_experts):
             self._record_layer_quant_config(prefix.format(global_id) + ".", qformat, block_size)

--- a/tests/gpu_megatron/torch/export/test_unified_export_megatron.py
+++ b/tests/gpu_megatron/torch/export/test_unified_export_megatron.py
@@ -540,3 +540,80 @@ def test_mtp_state_dict_index_file(tmp_path):
     assert "mtp.0.hnorm.weight" in mtp_state_dict
     assert torch.allclose(mtp_state_dict["mtp.0.hnorm.weight"], torch.full((32,), 3.0))
     assert "mtp*" in exporter.exclude_modules
+
+
+class _FakeTEGroupedMLP:
+    """Minimal TEGroupedMLP stand-in exposing num_gemms, weight{i}, and state_dict()."""
+
+    def __init__(self, num_gemms: int, hidden: int = 8, ffn: int = 16, local_expert_indices=None):
+        self.num_gemms = num_gemms
+        self._weights = {
+            f"weight{i}": torch.randn(ffn, hidden, dtype=torch.bfloat16) for i in range(num_gemms)
+        }
+        for k, v in self._weights.items():
+            setattr(self, k, v)
+        if local_expert_indices is not None:
+            self.local_expert_indices = local_expert_indices
+
+    def state_dict(self):
+        return dict(self._weights)
+
+
+def _make_exporter_for_grouped_mlp() -> GPTModelExporter:
+    exporter = object.__new__(GPTModelExporter)
+    exporter.dtype = torch.bfloat16
+    exporter._state_dict = {}
+    exporter._get_quantized_state = lambda *a, **k: ({}, None, 0)
+    exporter._get_weight_scales = lambda *a, **k: (None, None)
+    exporter._record_layer_quant_config = lambda *a, **k: None
+    return exporter
+
+
+def test_grouped_mlp_slicing_maps_local_to_global_expert_ids():
+    """EP>1 fix: local expert IDs must be remapped to global via module.local_expert_indices,
+    otherwise every EP rank would write experts.0..N-1 and collide on the writer's state_dict.
+    """
+    exporter = _make_exporter_for_grouped_mlp()
+    # Simulate EP rank 2 of an EP=4 job: this rank owns global experts 4 and 5.
+    module = _FakeTEGroupedMLP(num_gemms=2, local_expert_indices=[4, 5])
+
+    exporter._grouped_mlp_slicing(module, "experts.{}.gate_up_proj")
+
+    assert "experts.4.gate_up_proj.weight" in exporter._state_dict
+    assert "experts.5.gate_up_proj.weight" in exporter._state_dict
+    # Local indices 0/1 must NOT leak into the exported state_dict.
+    assert "experts.0.gate_up_proj.weight" not in exporter._state_dict
+    assert "experts.1.gate_up_proj.weight" not in exporter._state_dict
+
+
+def test_grouped_mlp_slicing_raises_on_missing_expert_weight():
+    """Corrupted module.state_dict (weight{i} missing) must raise ValueError on the local rank."""
+    exporter = _make_exporter_for_grouped_mlp()
+    module = _FakeTEGroupedMLP(num_gemms=2)
+    module.state_dict = lambda: {"weight0": module.weight0}  # drop weight1
+
+    with pytest.raises(ValueError, match="missing expert weights"):
+        exporter._grouped_mlp_slicing(module, "experts.{}.gate_up_proj")
+
+
+def test_is_sidecar_writer_rank_pins_to_dp0_ep0(monkeypatch):
+    """DP>1 fix: only the DP0/EP0 rank among is_last_stage_main_rank writes sidecar files."""
+    import modelopt.torch.export.unified_export_megatron as uem
+
+    # is_last_stage_main_rank=False is never a writer, regardless of DP/EP.
+    monkeypatch.setattr(uem, "get_data_parallel_rank", lambda: 0)
+    monkeypatch.setattr(uem, "get_expert_model_parallel_rank", lambda: 0)
+    assert GPTModelExporter._is_sidecar_writer_rank(False) is False
+
+    # DP0/EP0 is the writer.
+    assert GPTModelExporter._is_sidecar_writer_rank(True) is True
+
+    # DP rank != 0 loses the writer role even if is_last_stage_main_rank.
+    monkeypatch.setattr(uem, "get_data_parallel_rank", lambda: 1)
+    monkeypatch.setattr(uem, "get_expert_model_parallel_rank", lambda: 0)
+    assert GPTModelExporter._is_sidecar_writer_rank(True) is False
+
+    # EP rank != 0 loses the writer role.
+    monkeypatch.setattr(uem, "get_data_parallel_rank", lambda: 0)
+    monkeypatch.setattr(uem, "get_expert_model_parallel_rank", lambda: 1)
+    assert GPTModelExporter._is_sidecar_writer_rank(True) is False

--- a/tests/gpu_megatron/torch/export/test_unified_export_megatron.py
+++ b/tests/gpu_megatron/torch/export/test_unified_export_megatron.py
@@ -570,8 +570,8 @@ def _make_exporter_for_grouped_mlp() -> GPTModelExporter:
 
 
 def test_grouped_mlp_slicing_maps_local_to_global_expert_ids():
-    """EP>1 fix: local expert IDs must be remapped to global via module.local_expert_indices,
-    otherwise every EP rank would write experts.0..N-1 and collide on the writer's state_dict.
+    """EP>1 fix: without global remapping, every EP rank would write experts.0..N-1 and
+    collide on the writer's state_dict.
     """
     exporter = _make_exporter_for_grouped_mlp()
     # Simulate EP rank 2 of an EP=4 job: this rank owns global experts 4 and 5.
@@ -586,18 +586,43 @@ def test_grouped_mlp_slicing_maps_local_to_global_expert_ids():
     assert "experts.1.gate_up_proj.weight" not in exporter._state_dict
 
 
-def test_grouped_mlp_slicing_raises_on_missing_expert_weight():
-    """Corrupted module.state_dict (weight{i} missing) must raise ValueError on the local rank."""
+def test_grouped_mlp_slicing_normalizes_tensor_local_expert_indices():
+    """local_expert_indices may arrive as a torch.Tensor (Megatron path). It must be
+    normalized to list[int] -- a naive `bool(tensor)` on a multi-element tensor raises.
+    """
     exporter = _make_exporter_for_grouped_mlp()
-    module = _FakeTEGroupedMLP(num_gemms=2)
-    module.state_dict = lambda: {"weight0": module.weight0}  # drop weight1
+    module = _FakeTEGroupedMLP(
+        num_gemms=2, local_expert_indices=torch.tensor([6, 7], dtype=torch.long)
+    )
 
-    with pytest.raises(ValueError, match="missing expert weights"):
+    exporter._grouped_mlp_slicing(module, "experts.{}.gate_up_proj")
+
+    assert "experts.6.gate_up_proj.weight" in exporter._state_dict
+    assert "experts.7.gate_up_proj.weight" in exporter._state_dict
+
+
+def test_grouped_mlp_slicing_collects_all_missing_expert_weights():
+    """New collect-then-raise behavior: the error message must name every missing
+    weight{i}, not just the first one hit.
+    """
+    exporter = _make_exporter_for_grouped_mlp()
+    module = _FakeTEGroupedMLP(num_gemms=3)
+    # Drop weight0 AND weight2; only weight1 remains.
+    module.state_dict = lambda: {"weight1": module.weight1}
+
+    with pytest.raises(ValueError) as exc_info:
         exporter._grouped_mlp_slicing(module, "experts.{}.gate_up_proj")
+
+    msg = str(exc_info.value)
+    assert "weight0" in msg and "weight2" in msg, (
+        f"error should list all missing weights, got: {msg}"
+    )
 
 
 def test_is_sidecar_writer_rank_pins_to_dp0_ep0(monkeypatch):
-    """DP>1 fix: only the DP0/EP0 rank among is_last_stage_main_rank writes sidecar files."""
+    """DP>1 fix predicate: only the DP0/EP0 rank among is_last_stage_main_rank writes
+    sidecar files. Guards the predicate used at three sites in save_pretrained.
+    """
     import modelopt.torch.export.unified_export_megatron as uem
 
     # is_last_stage_main_rank=False is never a writer, regardless of DP/EP.


### PR DESCRIPTION
## Summary

Two related bugs surface when exporting a Megatron-Core Mamba-MoE checkpoint (e.g., Nemotron 3 Ultra) to HuggingFace with non-trivial expert and data parallelism.

### 1. TEGroupedMLP expert-id collision at EP > 1

`_grouped_mlp_slicing` iterates `range(num_experts)`, but `num_experts == module.num_gemms` is the *local* expert count on each EP rank. Using local ids `0..N-1` for the saved HF key prefix means every EP rank emits the same key set (`experts.0..N-1.*`), and the last writer wins for each layer — at EP=8 this silently loses **7/8 of every MoE layer's experts**.

The fix:

- Reads the authoritative local-to-global mapping from `module.local_expert_indices` (or `module.experts.local_expert_indices`) when exposed; falls back to the standard Megatron contiguous layout `[ep_rank*N, (ep_rank+1)*N − 1]`.
- Saves each expert under its **global** id so key sets are disjoint across EP ranks.
- Adds a collective-safe missing-key check via `all_reduce(MAX)` over a **CUDA-resident** int32 flag — CPU tensors trip `RuntimeError: No backend type associated with device type cpu` on the NCCL-backed EP process group.
- Builds the per-rank state dict locally, then byte-stream all-gathers it across the EP group via `torch.save` → `all_gather_object` → `torch.load`. `all_gather_object` pickling fails on quantized uint8 weights because their `UntypedStorage` has no `dtype` attr; the byte-stream round-trip uses PyTorch's own tensor codec to sidestep this.
- Pre-moves shared scales / aux tensors to CPU once so the gather payload doesn't repeatedly clone GPU tensors.

When EP == 1 the gather is skipped and behavior is identical to the original loop modulo the global-id rename (a no-op when local_expert_indices is the trivial 0..N-1).

### 2. `config.json` race at DP > 1

The post-save block that injects `quantization_config` into `config.json` had no DP-rank gating. With DP > 1 there are multiple last-stage main ranks; all of them read-then-write the same file, and any interleaving can leave another rank reading a truncated file, raising `JSONDecodeError`. Guarded with `is_last_stage_main_rank AND get_data_parallel_rank() == 0` and bracketed with `torch.distributed.barrier()`s so every PP/DP rank waits for the single writer.

Two new imports (`get_data_parallel_rank`, `get_expert_model_parallel_*`) and an `io` import are added at the module level.

## Repro

Without this patch, exporting Nemotron 3 Ultra (108-layer Mamba-MoE hybrid, 512 routed experts) at `--pp 9 --tp 1 --ep 8` produces a HuggingFace checkpoint where only 64 of 512 experts per MoE layer are present, and the `config.json` write races to a JSONDecodeError on DP=8. With this patch both succeed and vLLM loads the resulting checkpoint and serves real generations.

## Test plan

- [x] Exported a 108-layer 512-expert Nemotron-3-Ultra MoE checkpoint at PP=9 TP=1 EP=8 DP=8 (72 ranks across 9 nodes × 8 GPUs). Inspected `model.safetensors.index.json` and confirmed all 512 experts per MoE layer are present in the HF shards.
- [x] Sanity-loaded the checkpoint with `vllm serve` and verified end-to-end generation (no `KeyError` on weight loading, real model output).
- [x] Pre-existing unrelated ruff RUF059 warnings on the same file (lines 1453, 1473) are untouched by this PR.
- [ ] No new unit-test coverage added — the bug requires a multi-node EP/DP > 1 distributed run and is non-trivial to mock. Open to suggestions on a CI-friendly regression test.

## Follow-up

The `SequentialMLP` path in `_get_transformer_layer_state_dict` (iterating `local_experts.linear_fc{1,2}`) has the same local-id-collision issue and will need an equivalent global-id + EP-gather treatment when MoE recipes start exercising that spec. Not addressed here because the recipes in current Megatron-Bridge mostly use `TEGroupedMLP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: James Shen <yueshen@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent corruption during distributed model export by coordinating writes and gating sidecar/config file updates to a single writer rank with barriers.

* **Improvements**
  * Made multi-rank expert-parallel export collective-safe with consistent global expert indexing and cross-rank verification of missing pieces.
  * Reduced memory pressure by moving large quantization/auxiliary tensors to CPU and using safe per-rank serialization and exchange for final exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->