### PR TITLE
docs(skills): fix VLM PTQ ViT-quantization + AA eval judge/tool-call gaps

### DIFF
--- a/.agents/skills/evaluation/SKILL.md
+++ b/.agents/skills/evaluation/SKILL.md
@@ -186,6 +186,7 @@ Per-task `max_new_tokens` overrides are forbidden — set one top-level ceiling 
 2. Scan for any `max_tokens` / `max_new_tokens` / "output length" recommendation. Pick the **highest** value the card mentions (Qwen3.6: 32768 general + 81920 math-coding → use **81920**). Annotate with a citing comment.
 3. If the card is genuinely silent after a thorough read, fall back to: **65536** (reasoning), **16384** (non-reasoning); surface the silence to the user.
 4. **Forbidden:** writing `max_new_tokens: <generic_default>` with a "card not yet checked" comment. Either fetch and apply, or fetch and confirm silence.
+5. **A higher cap doesn't fix runaway reasoning.** On hard tasks (e.g. HLE) a non-terminating model just rambles to the larger cap (~80% length-capped at 131072), and the cap only helps if deployment `--max-model-len > prompt + max_new_tokens` (else generation is silently clipped — AA-LCR's ~120K input leaves little room). Treat such tasks as low-confidence.
 
 #### Quantization-aware benchmark defaults
 
@@ -260,7 +261,7 @@ Implications for the agent:
 
 4. Apply, show updated list, ask "Final, or more changes?" Loop until confirmed.
 
-**Tasks that call an external judge / user-simulator / scoring endpoint.** Treat this as a general pattern, not a fixed list — HLE, AA-LCR, and Tau2 need one today, but other benchmarks may too (check each task's recipe). Their `model_id` / `url` are **config, not secrets**: substitute the **literal** values the user keeps in `.env` (keys per the task's recipe + `recipes/env.example`) into the task's `<VAR>` placeholders. Do **not** emit `${oc.env:...}` for these (it silently fails unless the var was exported with `set -a`). Only `api_key` stays an env-var *name* (e.g. `INFERENCE_API_KEY`), exported and read by the harness.
+**Tasks that call an external judge / user-simulator / scoring endpoint.** Treat this as a general pattern, not a fixed list — HLE, AA-LCR, and Tau2 need one today, but other benchmarks may too (check each task's recipe). Their `model_id` / `url` are **config, not secrets**: substitute the **literal** values the user keeps in `.env` (keys per the task's recipe + `recipes/env.example`) into the task's `<VAR>` placeholders. Do **not** emit `${oc.env:...}` for these (it silently fails unless the var was exported with `set -a`). Only `api_key` stays an env-var *name* (e.g. `INFERENCE_API_KEY`), exported and read by the harness. All nemo-skills/tau2 judges + user-sims (HLE, AA-LCR, Tau2) use one `INFERENCE_API_KEY` against one OpenAI-compatible host — *not* `build.nvidia.com`'s `JUDGE_API_KEY` (that's for simple-evals, e.g. AIME). Get the `*_MODEL_ID`/`*_URL` values from the `eval-config` skill if your org ships one, rather than guessing a host.
 
 **Known issue — nemo-skills self-deployment:** If using `nemo_skills.*` tasks (`ns_*`) with self-deployment (vLLM/SGLang/NIM), you need **both** of these:
 
@@ -339,6 +340,8 @@ nel run --config <path> --dry-run
 ```
 
 Fix unresolved `???`, bad Hydra overrides, missing env vars, invalid mounts, image issues, sbatch errors, obvious deployment errors before proceeding.
+
+> **Non-fatal noise:** "Failed to get manifest"/`401`/`404`, "Could not extract frame definition file", "proceeding with minimal task definition", "Found N unlisted task(s)" — expected for `ns_*`/recipe tasks and private (gitlab) containers; the task still runs in-container. Set `NEMO_EVALUATOR_TRUST_UNLISTED_TASKS=1`. Real blockers: unresolved `???`, interpolation errors, bad mounts, sbatch rejections.
 
 **Step 8.2 — Canary** (limited-samples, validates everything dry-run can't):
 

--- a/.agents/skills/evaluation/recipes/env.example
+++ b/.agents/skills/evaluation/recipes/env.example
@@ -40,6 +40,8 @@ NEMO_EVALUATOR_TRUST_PRE_CMD=1
 # substituted as literal model_id/url into the config (matching <VAR> placeholders in
 # the recipes) — they do NOT need to be exported; only INFERENCE_API_KEY is.
 # URL note: nemo-skills uses the /v1 base; tau2-bench needs the full /v1/chat/completions.
+# If your org ships an `eval-config` skill, it fills the model_id/url values
+# below — otherwise point them at your own OpenAI-compatible judge host.
 
 # HLE judge (ns_hle_aa) — recommended GPT-4o
 # HLE_JUDGE_MODEL_ID=<judge-model-id>

--- a/.agents/skills/evaluation/recipes/tasks/aa/tau2_bench_telecom.md
+++ b/.agents/skills/evaluation/recipes/tasks/aa/tau2_bench_telecom.md
@@ -24,6 +24,18 @@ errors from the judger/user endpoints, and ramp up if stable. The hard
 upper bound is 512. After choosing a value, recompute the deployment's
 `--max-num-seqs` per the rule in SKILL.md Step 3.
 
+## Deployment requirement — tool calling (mandatory)
+
+Tau2 is agentic tool use, so the served model MUST launch with
+`--enable-auto-tool-choice --tool-call-parser <parser>` — without it every trial
+returns `avg_reward 0.0` with zero `tool_calls`. Pick `<parser>` from the
+checkpoint's `chat_template.jinja`: XML `<tool_call><function=…>` → `qwen3_coder`
+(Qwen3/3.5); JSON `<tool_call>{"name":…}` → `hermes`.
+
+> With `--reasoning-parser` on, some turns emit only `<think>…</think>` and no
+> tool call → empty-response failures that depress the score; if frequent,
+> disable thinking for Tau2 (`enable_thinking: false`).
+
 ## YAML Fragment
 
 Use this inside the top-level `evaluation.tasks` list:

--- a/.agents/skills/ptq/SKILL.md
+++ b/.agents/skills/ptq/SKILL.md
@@ -48,9 +48,10 @@ If extra deps are needed:
 
 ```bash
 ls modelopt_recipes/models/ 2>/dev/null
+ls modelopt_recipes/huggingface/<model_type>/ptq/ 2>/dev/null  # per-arch; <model_type> from local config.json (Hub ID: AutoConfig.from_pretrained)
 ```
 
-If a model-specific recipe exists, use `--recipe <path>` — it may contain tuned settings.
+If a model-specific recipe exists, prefer `--recipe <path>` — but **inspect its include/exclude patterns** rather than assuming (e.g. for VLMs, confirm the vision tower is actually excluded).
 
 **If no model-specific recipe**, choose a format based on GPU (details in `examples/llm_ptq/README.md`):
 
@@ -60,6 +61,8 @@ If a model-specific recipe exists, use `--recipe <path>` — it may contain tune
 Use `--qformat <name>` (e.g., `--qformat nvfp4`). Format definitions: `modelopt/torch/quantization/config.py`. General PTQ recipes in `modelopt_recipes/general/ptq/` correspond to the same formats — `--qformat` is the simpler way to use them.
 
 Before running PTQ, sanity-check the selected qformat/recipe against the model structure. Inspect the recipe's include/exclude patterns and summarize which layer groups will be quantized and approximately how many modules/layers match (attention projections, MLP projections, experts, etc.). If the match count is 0, or far smaller than expected for the model, stop and fix the recipe or ask the user before launching calibration.
+
+**VLMs:** generic `*mlp*`/`*experts*` recipes also match the vision tower (`model.visual.*`); quantizing the ViT silently breaks image benchmarks. Use the `huggingface/<model_type>/ptq/` recipe or add `*visual*`/`*vision_tower*` excludes, then verify in Step 5 — see `references/checkpoint-validation.md`.
 
 If the source checkpoint is already quantized and the requested recipe/config reduces quantization coverage, confirm that intent with the user before running. For example, if an FP8 checkpoint is used as input and the recipe excludes some layers so they would fall back to BF16 instead of staying quantized, call out the affected layer groups and ask whether that FP8-to-BF16 fallback is intended.
 

--- a/.agents/skills/ptq/references/checkpoint-validation.md
+++ b/.agents/skills/ptq/references/checkpoint-validation.md
@@ -24,6 +24,33 @@ Stop instead of proceeding if:
 - Any layer group intended to be quantized has zero or unexpectedly low coverage.
 - Any layer has quantization metadata inconsistent with its declared precision.
 - Prompting, tokenizer, generation, architecture, context-length, or special-token metadata changed unexpectedly.
+- **VLM only:** any vision-tower weight (`model.visual.*`/`vision_tower.*`/`vision_model.*`) carries quantization scales (unless quantizing the ViT is intended). Generic `*mlp*`/`*experts*` recipes silently match the ViT MLPs → garbage image embeddings (~0% on MMMU-Pro) while text looks fine; the precision script above counts them as valid NVFP4, so run the VLM check below.
+
+## VLM check — vision tower must stay unquantized
+
+For multimodal checkpoints, confirm the vision branch carries no quantization scales (handles sharded and single-file exports):
+
+```bash
+python3 -c "
+import json, os, glob, struct
+output = '<output_path>'
+ix = os.path.join(output, 'model.safetensors.index.json')
+if os.path.exists(ix):
+    keys = list(json.load(open(ix))['weight_map'])
+else:  # non-sharded: read tensor names from each safetensors header
+    keys = []
+    for f in glob.glob(os.path.join(output, '*.safetensors')):
+        with open(f, 'rb') as fh:
+            n = struct.unpack('<Q', fh.read(8))[0]
+            keys += [k for k in json.loads(fh.read(n)) if k != '__metadata__']
+vis_q = [k for k in keys if any(t in k for t in ('model.visual', 'vision_tower', 'vision_model'))
+         and any(s in k for s in ('weight_scale', 'input_scale'))]
+print(f'Quantized vision-tower tensors: {len(vis_q)}  (expect 0)')
+for k in vis_q[:8]: print('  ', k)
+"
+```
+
+Nonzero → the ViT was quantized; re-quantize with the `huggingface/<model_type>/ptq/` recipe or add `*visual*`/`*vision_tower*` exclusions.
 
 ## Expected quantization patterns by recipe
 

--- a/.agents/skills/ptq/references/launcher-guide.md
+++ b/.agents/skills/ptq/references/launcher-guide.md
@@ -36,6 +36,10 @@ pipeline:
 > rejects the job with `QOSMinGRES` or `Requested node configuration is not
 > available`. e.g. GB300 nodes have 4 GPUs and require the full node → set
 > `gpus_per_node: 4`; B300/B200 nodes have 8. Check with `sinfo -o '%P %G'`.
+>
+> Also: the launcher emits `#SBATCH --mem=0` (all node RAM) with no override, so
+> clusters that scale RAM per GPU reject a partial-GPU alloc (`requested … RAM,
+> but only <N> GPUs`). Requesting the full node fixes it.
 
 > **`EXTRA_PIP_DEPS` must avoid shell metacharacters.** It is written into an
 > unquoted `export` in the generated sbatch script, so a value like
@@ -74,6 +78,12 @@ find tools/launcher/local_experiments -name "config.json" -path "*/exported_mode
 | Local Docker | `uv run launch.py --yaml <cfg> hf_local=<cache> --yes` |
 
 The launcher SSHes to `SLURM_HOST` via `nemo_run.SSHTunnel`. If `identity` is omitted, it uses `~/.ssh/id_rsa`.
+
+> **`SLURM_HF_LOCAL` — HF cache bind-mount.** `slurm_factory` mounts the host HF
+> cache at `/hf-local` from `$SLURM_HF_LOCAL` (default `/hf-local`). If that host
+> dir is missing, pyxis fails at container start (`enroot-mount: failed to mount:
+> /hf-local`). Export a real path (`SLURM_HF_LOCAL=/lustre/.../hf-local`); `ptq.sh`
+> reuses a model already there (skips the download).
 
 **If using `clusters.yaml`**: read the cluster config and map fields to launcher args:
 


### PR DESCRIPTION
### What does this PR do?

Type of change: documentation

Skill (`.claude/skills/`) doc fixes for gaps surfaced while running the AA
(Artificial Analysis) suite on Qwen3.5-9B (NVFP4 mlp-only) — each one cost real
debugging time that the skills should have prevented.

**`ptq` skill**
- **Step 3 (SKILL.md):** warn that generic `*mlp*` / `*experts*` recipes also
  match a VLM's vision-tower block MLPs (`model.visual.blocks.*.mlp`). Quantizing
  the ViT yields garbage image embeddings → ~0% on image benchmarks (MMMU-Pro:
  100% "no answer") while text benchmarks look fine and hide it. Steer to the
  `huggingface/<model_type>/ptq/` recipe (which excludes `*visual*`) or add the
  exclusion. Also point the model-specific-recipe check at `huggingface/<model_type>/ptq/`.
- **checkpoint-validation.md:** add a VLM gate — the existing precision script
  counts quantized ViT weights as legitimate NVFP4, so it does *not* catch this;
  add an explicit check/stop-condition for quantized `model.visual.*` /
  `vision_tower.*`.
- **launcher-guide.md:** document `SLURM_HF_LOCAL` (the `/hf-local` bind-mount host
  path; missing dir → pyxis `enroot-mount: failed`), and the `--mem=0` vs
  partial-GPU sbatch rejection.

**`evaluation` skill**
- **tau2_bench_telecom.md:** add the mandatory tool-calling deployment requirement
  (`--enable-auto-tool-choice --tool-call-parser`, parser chosen from the
  chat-template's tool-call format) — without it Tau2 returns `reward 0.0` with
  zero tool calls. Note the reasoning-parser empty-response conflict + mitigation.
- **SKILL.md / env.example:** clarify all nemo-skills/tau2 judges + user-sims use a
  *single* `INFERENCE_API_KEY` (not the `build.nvidia.com` `JUDGE_API_KEY`); point
  to an `eval-config` skill for endpoint values instead of trial-and-error; note
  the FDF "unlisted task" / "Failed to get manifest" warnings are non-fatal; note
  that a high `max_new_tokens` worsens runaway-reasoning truncation rather than
  fixing it.

### Usage

N/A — documentation only.

### Testing

Guidance was derived from and verified against a live AA run on aws cluster:
the ViT-exclusion re-quant took MMMU-Pro from 0% → 63.7%, the tool-call parser
took Tau2 from 0.0 → non-zero, and the corrected judge endpoint/key took AA-LCR
from 403/404 → scoring. No code paths changed.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A (docs only)
- Did you update [Changelog]?: N/A (skill docs)
- Did you get Claude approval on this PR?: ❌ (run `/claude review`)

### Additional Information

Docs only; no code or API changes. Follow-ups discussed but intentionally **not**
in this PR (need sign-off): (1) `tools/launcher/common/hf/ptq.sh` uses the removed
`huggingface-cli download` — `huggingface_hub>=1.0` (pulled by `transformers==5.5.0`)
drops that CLI, silently failing the model download; switch to `hf download`.
(2) Syncing the canonical judge-endpoint values into the internal `eval-config` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded evaluation guidance: token-limit behavior, external-judge configuration expectations, and handling of expected vs blocking validation failures
  * Added Tau2 Telecom deployment requirement: auto tool-calling and guidance to avoid empty-response failures
  * Clarified PTQ recipe selection with VLM-specific warnings and verification steps
  * Added vision-tower validation checks and launcher operational notes (SLURM/sbatch and cache-mount considerations)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->