### PR TITLE
Add NVFP4 fakequant for attention BMMs

### DIFF
--- a/examples/vllm_serve/README.md
+++ b/examples/vllm_serve/README.md
@@ -114,7 +114,25 @@ Workflow:
    python vllm_serve_sparse_attn.py <EXPORT_DIR> --enforce-eager -tp 8 --host 0.0.0.0 --port 8000
    ```
 
-If the checkpoint has no `sparse_attention_config`, the worker logs a message and passes through — vLLM runs unchanged. Quant-only flows are handled by `vllm_serve_fakequant.py`; combined sparse + quant will land in a follow-up PR.
+If the checkpoint has no `sparse_attention_config`, the worker logs a message and passes through — vLLM runs unchanged.
+
+### Attention quantization knobs (env-driven, no re-export)
+
+For attention-numerics accuracy studies you can toggle **NVFP4 attention BMMs**, a **mixed-precision softmax datapath**, and **N:M sparse softmax** on a *single served checkpoint* via env vars — mirroring the env-driven `vllm_serve_fakequant.py` flow (no re-export, no `sparse_attention_config` required; the worker force-swaps the ModelOpt sparse impl when any are set):
+
+| Env var | Example | Effect |
+|---------|---------|--------|
+| `MODELOPT_ATTN_NVFP4` | `q,k,p,v` (or `kv`, `qkpv`) | fake-quant those BMM operands to NVFP4 (`k,v` = NVFP4 KV$; all four = full BMM1+BMM2) |
+| `MODELOPT_ATTN_FP16_SOFTMAX` | `1` | FP16 softmax at all DIFF/EXP2/ACC points |
+| `MODELOPT_ATTN_SOFTMAX_QUANT` | `diff:fp16_rz,exp2:bf16_rne,acc:fp16` | per-point softmax-datapath precision (overrides the FP16 shortcut) |
+| `MODELOPT_ATTN_SPARSITY_NM` | `2:4` | N:M sparse softmax (prefill) |
+
+```bash
+MODELOPT_ATTN_NVFP4=q,k,p,v MODELOPT_ATTN_FP16_SOFTMAX=1 \
+  python vllm_serve_sparse_attn.py <CKPT> --enforce-eager -tp 8 --host 0.0.0.0 --port 8000
+```
+
+These apply to both prefill and decode (the decode kernel runs them too), and the NVFP4 numerics are bit-exact to the customized-vLLM attention-quant reference. The fakequant `tl.dot` still runs in bf16/fp32 — this measures accuracy, not throughput.
 
 Limitations:
 

--- a/examples/vllm_serve/sparse_attn_worker.py
+++ b/examples/vllm_serve/sparse_attn_worker.py
@@ -89,7 +89,7 @@ def _replace_attention_impl(worker):
             "sparsity_n": env_q["sparsity_n"],
             "sparsity_m": env_q["sparsity_m"],
             "dense_sink_tokens": 0,
-            "dense_recent_tokens": 0,
+            "dense_recent_tokens": 128,
         }
         if "sparsity_n" in env_q
         else {}

--- a/examples/vllm_serve/sparse_attn_worker.py
+++ b/examples/vllm_serve/sparse_attn_worker.py
@@ -54,6 +54,7 @@ from modelopt.torch.sparsity.attention_sparsity.plugins.sparse_attn_config impor
 from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
     _build_sparse_kw,
     _clone_sparse_impl,
+    parse_attn_quant_env,
     select_sparse_impl_cls,
 )
 
@@ -62,21 +63,38 @@ def _replace_attention_impl(worker):
     """Replace the attention impl with the ModelOpt sparse impl on all Attention layers.
 
     Supports the FlashAttention and FlashInfer backends (the matching sparse impl
-    is selected per layer). The sole configuration source is the checkpoint's
-    ``sparse_attention_config`` metadata. No-op if the checkpoint has no such block.
+    is selected per layer). Configuration comes from the checkpoint's
+    ``sparse_attention_config`` metadata and/or the ``MODELOPT_ATTN_*`` env knobs
+    (NVFP4 BMMs / mixed-precision softmax / N:M sparse softmax) — the latter mirror
+    the env-driven ``vllm_serve_fakequant`` flow and let one served checkpoint toggle
+    configs with no re-export. No-op only if neither is present.
     """
     hf_config = getattr(worker.model_runner.model_config, "hf_config", None)
     detected = load_from_checkpoint_metadata(hf_config)
-    if detected is None:
+    env_q = parse_attn_quant_env()
+    if detected is None and not env_q:
         print(
-            "[ModelOpt] No sparse_attention_config found in the checkpoint; "
-            "skipping sparse attention. Run examples/llm_sparsity/"
-            "attention_sparsity/hf_sa.py to calibrate and export a checkpoint "
-            "with the config embedded."
+            "[ModelOpt] No sparse_attention_config and no MODELOPT_ATTN_* env knobs; "
+            "skipping sparse attention. Run examples/llm_sparsity/attention_sparsity/"
+            "hf_sa.py to export a config, or set e.g. MODELOPT_ATTN_NVFP4=q,k,p,v."
         )
         return
-    cfg, preset_name = detected
-    print(f"[ModelOpt] Sparse attention config: algo -> {preset_name}")
+    cfg, preset_name = detected if detected is not None else (None, "env-attn-quant")
+    print(f"[ModelOpt] Sparse attention config: algo -> {preset_name}; env knobs -> {env_q}")
+
+    # Env N:M sparse softmax (prefill) augments the per-layer kwargs; the NVFP4 /
+    # mixed-precision-softmax knobs ride on the impl as attn_quant_kw.
+    env_nm = (
+        {
+            "sparsity_n": env_q["sparsity_n"],
+            "sparsity_m": env_q["sparsity_m"],
+            "dense_sink_tokens": 0,
+            "dense_recent_tokens": 0,
+        }
+        if "sparsity_n" in env_q
+        else {}
+    )
+    env_attn_quant = {k: env_q[k] for k in ("nvfp4", "fp16_softmax", "softmax_quant") if k in env_q}
 
     model = worker.model_runner.model
     if hasattr(model, "unwrap"):
@@ -88,14 +106,17 @@ def _replace_attention_impl(worker):
         if not isinstance(module, VLLMAttention):
             continue
 
-        layer_cfg = match_sparse_config(name, cfg)
-        if layer_cfg is None or not layer_cfg.get("enable", True):
-            continue
+        if cfg is not None:
+            layer_cfg = match_sparse_config(name, cfg)
+            if layer_cfg is None or not layer_cfg.get("enable", True):
+                continue
+        else:
+            layer_cfg = {}  # env-only: apply the env knobs to every attention layer
 
         sparse_kw = _build_sparse_kw(layer_cfg)
-        if not sparse_kw:
-            # Keep vLLM's original impl when the exported layer config does not
-            # enable any sparse feature.
+        sparse_kw.update(env_nm)  # env N:M sparse softmax augments/overrides
+        if not sparse_kw and not env_attn_quant:
+            # Neither metadata nor env enables any sparse/quant feature here.
             continue
         new_cls = select_sparse_impl_cls(module.impl)
         if new_cls is None:
@@ -109,6 +130,7 @@ def _replace_attention_impl(worker):
             skipped_backends.add(type(module.impl).__name__)
             continue
         new_impl.sparse_kw = sparse_kw
+        new_impl.attn_quant_kw = env_attn_quant  # NVFP4 BMMs + mixed-precision softmax
         module.impl = new_impl
         patched += 1
     print(f"[ModelOpt] Sparse attention: replaced impl on {patched} attention layers")

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -62,6 +62,10 @@ from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import (
     fake_quant_fp4_k1,
     tensor_global_scale,
 )
+from modelopt.torch.kernels.quantization.attention.softmax_fakequant import (
+    resolve_softmax_mode,
+    softmax_round,
+)
 
 # Cap on the auto-chosen split count. Decode KV reads dominate, so a handful of
 # splits is enough to fill the SMs at small batch; more just fragments skipping.
@@ -108,7 +112,9 @@ def _attn_decode_split_fwd(
     NVFP4_K: tl.constexpr,  # fakequant K -> NVFP4 before BMM1 (= NVFP4 KV$ K side)
     NVFP4_P: tl.constexpr,  # fakequant softmax P -> NVFP4 before BMM2
     NVFP4_V: tl.constexpr,  # fakequant V -> NVFP4 before BMM2 (= NVFP4 KV$ V side)
-    FP16_SOFTMAX: tl.constexpr,  # compute the softmax exp in fp16 (mixed precision)
+    DIFF_QUANT: tl.constexpr,  # softmax-datapath modes: DIFF (pre-exp2), EXP2, ACC (sum)
+    EXP2_QUANT: tl.constexpr,
+    ACC_QUANT: tl.constexpr,
     q_global_scale,  # per-tensor NVFP4 global scales (amax/(6*448)), computed host-side
     k_global_scale,
     p_global_scale,
@@ -193,12 +199,11 @@ def _attn_decode_split_fwd(
 
         if not skip:
             m_new = tl.maximum(m_i, tile_max)
-            p = tl.math.exp2(scores - m_new)  # [BLOCK_N]
-            if FP16_SOFTMAX:
-                p = p.to(tl.float16).to(tl.float32)  # mixed-precision (fp16) softmax
+            s_shift = softmax_round(scores - m_new, DIFF_QUANT)  # DIFF: input to exp2
+            p = softmax_round(tl.math.exp2(s_shift), EXP2_QUANT)  # EXP2: output of exp2
             p = tl.where(kv_valid, p, 0.0)
             correction = tl.math.exp2(m_i - m_new)
-            l_i = l_i * correction + tl.sum(p, axis=0)
+            l_i = l_i * correction + softmax_round(tl.sum(p, axis=0), ACC_QUANT)  # ACC: sum
             acc = acc * correction
             # P operand of BMM2 -> NVFP4. NVFP4 is homogeneous (NVFP4(c*x)=c*NVFP4(x)),
             # so quantizing the unnormalized exp here equals quantizing normalized P,
@@ -312,6 +317,7 @@ def attention_decode(
     measure_sparsity: bool = False,
     nvfp4: set[str] | None = None,
     fp16_softmax: bool = False,
+    softmax_quant: dict | None = None,
 ) -> torch.Tensor:
     """Decode attention (one query token per request) over a paged KV cache.
 
@@ -372,6 +378,12 @@ def attention_decode(
     k_gs = tensor_global_scale(k_cache) if "k" in nvfp4 else 1.0
     v_gs = tensor_global_scale(v_cache) if "v" in nvfp4 else 1.0
     p_gs = (1.0 / (6.0 * 448.0) + 1e-30) if "p" in nvfp4 else 1.0  # unnormalized exp P max ~1
+    # Softmax-datapath modes (DIFF/EXP2/ACC); fp16_softmax = FP16-RNE at all three.
+    _sq = softmax_quant or {}
+    _sm_default = "fp16_rne" if fp16_softmax else None
+    diff_q = resolve_softmax_mode(_sq.get("diff", _sm_default))
+    exp2_q = resolve_softmax_mode(_sq.get("exp2", _sm_default))
+    acc_q = resolve_softmax_mode(_sq.get("acc", _sm_default))
 
     # Per-split partial softmax state, merged by the combine kernel.
     m_partial = torch.empty(batch, num_q_heads, num_kv_splits, dtype=torch.float32, device=q.device)
@@ -428,7 +440,9 @@ def attention_decode(
             NVFP4_K="k" in nvfp4,
             NVFP4_P="p" in nvfp4,
             NVFP4_V="v" in nvfp4,
-            FP16_SOFTMAX=fp16_softmax,
+            DIFF_QUANT=diff_q,
+            EXP2_QUANT=exp2_q,
+            ACC_QUANT=acc_q,
             q_global_scale=q_gs,
             k_global_scale=k_gs,
             p_global_scale=p_gs,

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -318,6 +318,7 @@ def attention_decode(
     nvfp4: set[str] | None = None,
     fp16_softmax: bool = False,
     softmax_quant: dict | None = None,
+    attn_global_scales: dict | None = None,
 ) -> torch.Tensor:
     """Decode attention (one query token per request) over a paged KV cache.
 
@@ -374,9 +375,12 @@ def attention_decode(
     assert nvfp4 <= {"q", "k", "p", "v"}, f"nvfp4 must be a subset of q/k/p/v, got {nvfp4}"
     assert BLOCK_D % 16 == 0 and BLOCK_N % 16 == 0, "NVFP4 needs dims divisible by 16"
     # Per-tensor NVFP4 global scales (host-side amax/(6*448)), aligned with mni/attnOpt.
-    q_gs = tensor_global_scale(q) if "q" in nvfp4 else 1.0
-    k_gs = tensor_global_scale(k_cache) if "k" in nvfp4 else 1.0
-    v_gs = tensor_global_scale(v_cache) if "v" in nvfp4 else 1.0
+    # Paged serving passes precomputed scales (from the small per-step q/k/v); scanning
+    # the full paged K/V cache here would upcast it to fp32 and OOM.
+    _gs = attn_global_scales or {}
+    q_gs = (_gs["q"] if "q" in _gs else tensor_global_scale(q)) if "q" in nvfp4 else 1.0
+    k_gs = (_gs["k"] if "k" in _gs else tensor_global_scale(k_cache)) if "k" in nvfp4 else 1.0
+    v_gs = (_gs["v"] if "v" in _gs else tensor_global_scale(v_cache)) if "v" in nvfp4 else 1.0
     p_gs = (1.0 / (6.0 * 448.0) + 1e-30) if "p" in nvfp4 else 1.0  # unnormalized exp P max ~1
     # Softmax-datapath modes (DIFF/EXP2/ACC); fp16_softmax = FP16-RNE at all three.
     _sq = softmax_quant or {}

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -57,11 +57,11 @@ from modelopt.torch.kernels.common.attention.triton_fa import (
     _load_paged_v_tile,
 )
 from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import (
-    nvfp4_qdq_1d,
-    nvfp4_qdq_axis0,
+    QUANT_NVFP4,
+    fake_quant_fp4_k0,
+    fake_quant_fp4_k1,
+    tensor_global_scale,
 )
-
-_NVFP4_BLK = 16  # NVFP4 block size (contraction-axis group)
 
 # Cap on the auto-chosen split count. Decode KV reads dominate, so a handful of
 # splits is enough to fill the SMs at small batch; more just fragments skipping.
@@ -109,8 +109,10 @@ def _attn_decode_split_fwd(
     NVFP4_P: tl.constexpr,  # fakequant softmax P -> NVFP4 before BMM2
     NVFP4_V: tl.constexpr,  # fakequant V -> NVFP4 before BMM2 (= NVFP4 KV$ V side)
     FP16_SOFTMAX: tl.constexpr,  # compute the softmax exp in fp16 (mixed precision)
-    NB_D: tl.constexpr,  # head-dim NVFP4 blocks = BLOCK_D // 16
-    NB_N: tl.constexpr,  # kv-tile NVFP4 blocks = BLOCK_N // 16
+    q_global_scale,  # per-tensor NVFP4 global scales (amax/(6*448)), computed host-side
+    k_global_scale,
+    p_global_scale,
+    v_global_scale,
 ):
     """One (request, head, KV split): partial GEMV attention with skip + optional NVFP4."""
     batch_idx = tl.program_id(0)
@@ -137,8 +139,13 @@ def _attn_decode_split_fwd(
     q = tl.load(
         Q + batch_idx * stride_qb + head_idx * stride_qh + dim_pos, mask=d_mask, other=0.0
     ).to(tl.float32)
-    if NVFP4_Q:
-        q = nvfp4_qdq_1d(q, NB_D, 16)  # BMM1 query operand -> NVFP4
+    if NVFP4_Q:  # BMM1 query (A-side, single row, GEMM-K = head dim)
+        q = tl.reshape(
+            fake_quant_fp4_k1(
+                tl.reshape(q, (1, BLOCK_D)), 1, BLOCK_D, 16, q_global_scale, QUANT_NVFP4
+            ),
+            (BLOCK_D,),
+        )
 
     m_i = -float("inf")  # running max (prefix, scalar) within this split
     l_i = 0.0  # running softmax denominator (scalar)
@@ -168,8 +175,8 @@ def _attn_decode_split_fwd(
             max_blocks_per_seq,
         )
         kt_f = kt.to(tl.float32)
-        if NVFP4_K:
-            kt_f = nvfp4_qdq_axis0(kt_f, NB_D, 16, BLOCK_N)  # BMM1 key operand -> NVFP4
+        if NVFP4_K:  # BMM1 key (B-side, K^T [BLOCK_D, BLOCK_N], GEMM-K = head dim = axis 0)
+            kt_f = fake_quant_fp4_k0(kt_f, BLOCK_D, BLOCK_N, 16, 1, k_global_scale, QUANT_NVFP4)
         scores = tl.sum(q[:, None] * kt_f, axis=0) * qk_scale  # [BLOCK_N], fp32 accum
         scores = tl.where(kv_valid, scores, -float("inf"))
 
@@ -196,7 +203,16 @@ def _attn_decode_split_fwd(
             # P operand of BMM2 -> NVFP4. NVFP4 is homogeneous (NVFP4(c*x)=c*NVFP4(x)),
             # so quantizing the unnormalized exp here equals quantizing normalized P,
             # since the final acc is divided by l_i in the combine kernel.
-            p_bmm = nvfp4_qdq_1d(p, NB_N, 16) if NVFP4_P else p
+            p_bmm = (
+                tl.reshape(
+                    fake_quant_fp4_k1(
+                        tl.reshape(p, (1, BLOCK_N)), 1, BLOCK_N, 16, p_global_scale, QUANT_NVFP4
+                    ),
+                    (BLOCK_N,),
+                )
+                if NVFP4_P
+                else p
+            )
             vt = _load_paged_v_tile(
                 V_cache,
                 Block_table,
@@ -216,8 +232,8 @@ def _attn_decode_split_fwd(
                 max_blocks_per_seq,
             )
             vt_f = vt.to(tl.float32)
-            if NVFP4_V:
-                vt_f = nvfp4_qdq_axis0(vt_f, NB_N, 16, BLOCK_D)  # BMM2 value operand -> NVFP4
+            if NVFP4_V:  # BMM2 value (B-side, V [BLOCK_N, BLOCK_D], GEMM-K = keys = axis 0)
+                vt_f = fake_quant_fp4_k0(vt_f, BLOCK_N, BLOCK_D, 16, 1, v_global_scale, QUANT_NVFP4)
             acc += tl.sum(p_bmm[:, None] * vt_f, axis=0)  # [BLOCK_D], fp32 accum
             m_i = m_new
 
@@ -351,6 +367,11 @@ def attention_decode(
     nvfp4 = nvfp4 or set()
     assert nvfp4 <= {"q", "k", "p", "v"}, f"nvfp4 must be a subset of q/k/p/v, got {nvfp4}"
     assert BLOCK_D % 16 == 0 and BLOCK_N % 16 == 0, "NVFP4 needs dims divisible by 16"
+    # Per-tensor NVFP4 global scales (host-side amax/(6*448)), aligned with mni/attnOpt.
+    q_gs = tensor_global_scale(q) if "q" in nvfp4 else 1.0
+    k_gs = tensor_global_scale(k_cache) if "k" in nvfp4 else 1.0
+    v_gs = tensor_global_scale(v_cache) if "v" in nvfp4 else 1.0
+    p_gs = (1.0 / (6.0 * 448.0) + 1e-30) if "p" in nvfp4 else 1.0  # unnormalized exp P max ~1
 
     # Per-split partial softmax state, merged by the combine kernel.
     m_partial = torch.empty(batch, num_q_heads, num_kv_splits, dtype=torch.float32, device=q.device)
@@ -408,8 +429,10 @@ def attention_decode(
             NVFP4_P="p" in nvfp4,
             NVFP4_V="v" in nvfp4,
             FP16_SOFTMAX=fp16_softmax,
-            NB_D=BLOCK_D // 16,
-            NB_N=BLOCK_N // 16,
+            q_global_scale=q_gs,
+            k_global_scale=k_gs,
+            p_global_scale=p_gs,
+            v_global_scale=v_gs,
             num_warps=4,
             num_stages=2,
         )

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -294,6 +294,254 @@ def _attn_decode_split_fwd(
 
 
 @triton.jit
+def _attn_decode_split_fwd_batched(
+    Q,  # [batch, num_q_heads, head_dim] — one query token per request
+    qk_scale,  # softmax_scale * log2(e)
+    B_seq_len_k,  # [batch] total KV length per request
+    M_partial,  # [batch, num_q_heads, num_kv_splits] per-split running max
+    L_partial,  # [batch, num_q_heads, num_kv_splits] per-split softmax denom
+    Acc_partial,  # [batch, num_q_heads, num_kv_splits, BLOCK_D] per-split weighted V sum
+    stride_qb,
+    stride_qh,
+    stride_mb,
+    stride_mh,
+    stride_ab,
+    stride_ah,
+    stride_as,
+    K_cache,  # [num_blocks, page_size, num_kv_heads, head_dim]
+    V_cache,
+    Block_table,  # [batch, max_blocks_per_seq]
+    stride_kc_block,
+    stride_kc_pos,
+    stride_kc_head,
+    stride_vc_block,
+    stride_vc_pos,
+    stride_vc_head,
+    Sparsity_total,  # optional int64 scalar (atomic) — total tiles
+    Sparsity_skipped,  # optional int64 scalar (atomic) — skipped tiles
+    kv_group_num: tl.constexpr,  # GQA ratio num_q_heads // num_kv_heads
+    BLOCK_H: tl.constexpr,  # query heads (M dim) processed together per KV head
+    BLOCK_D: tl.constexpr,  # next_power_of_2(head_dim)
+    BLOCK_N: tl.constexpr,  # KV tile size (128 to match the calibration granularity)
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    max_blocks_per_seq,
+    NUM_KV_SPLITS: tl.constexpr,
+    APPLY_SKIP: tl.constexpr,
+    SKIP_THRESHOLD_LOG2: tl.constexpr,  # log2(lambda) in the scaled-log2 score space
+    MEASURE_SPARSITY: tl.constexpr,
+    NVFP4_Q: tl.constexpr,  # fakequant Q -> NVFP4 before BMM1
+    NVFP4_K: tl.constexpr,  # fakequant K -> NVFP4 before BMM1 (= NVFP4 KV$ K side)
+    NVFP4_P: tl.constexpr,  # fakequant softmax P -> NVFP4 before BMM2
+    NVFP4_V: tl.constexpr,  # fakequant V -> NVFP4 before BMM2 (= NVFP4 KV$ V side)
+    DIFF_QUANT: tl.constexpr,  # softmax-datapath modes: DIFF (pre-exp2), EXP2, ACC (sum)
+    EXP2_QUANT: tl.constexpr,
+    ACC_QUANT: tl.constexpr,
+    MIXED_FP16: tl.constexpr,  # reference mixed-precision softmax (native fp16 MUFU)
+    K_CACHE_QUANTIZED: tl.constexpr,  # K cache pre-quantized (skip in-kernel K FQ entirely)
+    V_CACHE_QUANTIZED: tl.constexpr,  # V cache pre-quantized for COMPLETE 16-key blocks (FQ only tail)
+    PER_PAGE_SCALE: tl.constexpr,  # method 2: per-page (per-BLOCK_N-tile) NVFP4 global scale
+    # Per-tensor NVFP4 global scales (amax/(6*448)) as device 0-d tensors (pointers).
+    q_global_scale,
+    k_global_scale,
+    p_global_scale,
+    v_global_scale,
+):
+    """GQA-batched decode split: one (request, KV head tile, KV split).
+
+    Processes ``BLOCK_H`` query heads that share one KV head together, so the
+    paged K/V is loaded ONCE per KV head and BMM1/BMM2 run as ``tl.dot`` at
+    ``M=BLOCK_H`` on the tensor cores. The per-row online softmax (each query
+    head keeps its own running max/denom/acc) plus the per-row skip decision make
+    every head's partial-softmax state bit-identical to the per-head kernel; the
+    combine kernel then merges the splits exactly as before.
+
+    Grid: ``(batch, num_kv_heads * num_h_tiles, num_kv_splits)`` where
+    ``num_h_tiles = ceil(kv_group_num / BLOCK_H)``. Program ``id(1)`` selects
+    ``(kv_head, h_tile)`` and owns query heads
+    ``kv_head*kv_group_num + h_tile*BLOCK_H .. +BLOCK_H``. Rows that fall past the
+    group (when ``kv_group_num`` is not a multiple of ``BLOCK_H``) are masked off:
+    they neither write output nor veto the all-rows-skip fast path.
+    """
+    batch_idx = tl.program_id(0)
+    hk_idx = tl.program_id(1)  # flattened (kv_head, h_tile)
+    split_idx = tl.program_id(2)
+
+    NUM_H_TILES: tl.constexpr = (kv_group_num + BLOCK_H - 1) // BLOCK_H
+    kv_head_idx = hk_idx // NUM_H_TILES
+    h_tile = hk_idx % NUM_H_TILES
+
+    # Absolute query-head indices for the BLOCK_H rows of this tile.
+    h_local = tl.arange(0, BLOCK_H)  # 0..BLOCK_H-1 within the group
+    group_pos = h_tile * BLOCK_H + h_local  # position within the GQA group
+    head_pos = kv_head_idx * kv_group_num + group_pos  # absolute q-head index
+    head_valid = group_pos < kv_group_num  # rows past the group are padding
+
+    seq_len_kv = tl.load(B_seq_len_k + batch_idx)
+
+    v_dense_boundary = (seq_len_kv // 16) * 16
+    page_boundary = (seq_len_kv // BLOCK_N) * BLOCK_N
+
+    num_tiles = (seq_len_kv + BLOCK_N - 1) // BLOCK_N
+    tiles_per_split = (num_tiles + NUM_KV_SPLITS - 1) // NUM_KV_SPLITS
+    tile_lo = split_idx * tiles_per_split
+    tile_hi = tl.minimum(tile_lo + tiles_per_split, num_tiles)
+    kv_lo = tile_lo * BLOCK_N
+    kv_hi = tile_hi * BLOCK_N
+
+    dim_pos = tl.arange(0, BLOCK_D)
+    d_mask = dim_pos < HEAD_DIM
+    kv_pos = tl.arange(0, BLOCK_N)
+
+    q_gs = tl.load(q_global_scale) if NVFP4_Q else 1.0
+    k_gs = tl.load(k_global_scale) if NVFP4_K else 1.0
+    p_gs = tl.load(p_global_scale) if NVFP4_P else 1.0
+    v_gs = tl.load(v_global_scale) if NVFP4_V else 1.0
+
+    # Q tile [BLOCK_H, BLOCK_D]; invalid head rows read as 0 (masked out at store).
+    # Upcast to fp32: BMM1 (Q@K^T) runs with input_precision="tf32x3" (3-pass tf32 ~=
+    # fp32 accuracy on tensor cores), matching the per-head kernel's fp32 elementwise
+    # reduce within tolerance while still using tensor cores. BMM1 is precision-critical
+    # because its score error feeds the softmax — fp16 there shifts probabilities enough
+    # to break NVFP4 at short seq. (The QDQ helpers already compute in fp32; their
+    # dequantized output stays fp32 here. On sm_100 the fp32-operand dot maps to the
+    # native low-precision path.) BMM2 (P@V) instead uses the cache dtype — see below.
+    q_ptrs = batch_idx * stride_qb + head_pos[:, None] * stride_qh + dim_pos[None, :]
+    q = tl.load(Q + q_ptrs, mask=head_valid[:, None] & d_mask[None, :], other=0.0).to(tl.float32)
+    if NVFP4_Q:  # BMM1 query (A-side, GEMM-K = head dim = axis 1)
+        q = fake_quant_fp4_k1(q, BLOCK_H, BLOCK_D, 16, q_gs, QUANT_NVFP4)
+
+    m_i = tl.zeros([BLOCK_H], dtype=tl.float32) - float("inf")  # per-row running max
+    l_i = tl.zeros([BLOCK_H], dtype=tl.float32)  # per-row softmax denom
+    acc = tl.zeros([BLOCK_H, BLOCK_D], dtype=tl.float32)  # per-row weighted V sum
+
+    for kv_start in range(kv_lo, kv_hi, BLOCK_N):
+        kv_start = tl.multiple_of(kv_start, BLOCK_N)
+        kv_valid = (kv_start + kv_pos) < seq_len_kv
+
+        # K^T tile [BLOCK_D, BLOCK_N] (loaded ONCE for all BLOCK_H heads).
+        kt = _load_paged_k_tile(
+            K_cache,
+            Block_table,
+            batch_idx,
+            kv_head_idx,
+            kv_start,
+            kv_pos,
+            dim_pos,
+            seq_len_kv,
+            stride_kc_block,
+            stride_kc_pos,
+            stride_kc_head,
+            PAGE_SIZE,
+            BLOCK_N,
+            BLOCK_D,
+            HEAD_DIM,
+            max_blocks_per_seq,
+        )
+        kt_f = kt.to(tl.float32)
+        if NVFP4_K and (
+            (not K_CACHE_QUANTIZED) or (PER_PAGE_SCALE and kv_start + BLOCK_N > page_boundary)
+        ):
+            kgs_eff = (tl.max(tl.abs(kt_f)) / (6.0 * 448.0) + 1e-30) if PER_PAGE_SCALE else k_gs
+            kt_f = fake_quant_fp4_k0(kt_f, BLOCK_D, BLOCK_N, 16, 1, kgs_eff, QUANT_NVFP4)
+
+        # scores[BLOCK_H, BLOCK_N] = Q @ K^T on tensor cores, fp32 accum. tf32x3 keeps
+        # fp32-operand fidelity (matches the per-head fp32 reduce within tolerance).
+        scores = tl.dot(q, kt_f, input_precision="tf32x3") * qk_scale  # [BLOCK_H, BLOCK_N]
+        scores = tl.where(kv_valid[None, :], scores, -float("inf"))
+
+        tile_max = tl.max(scores, axis=1)  # [BLOCK_H] per-row tile max
+
+        # Per-row skip: identical criterion to the per-head kernel applied to each
+        # row independently. Invalid head rows are forced skippable so they never
+        # veto the all-rows-skip fast path.
+        if APPLY_SKIP:
+            row_skip = (tile_max < (m_i + SKIP_THRESHOLD_LOG2)) | (~head_valid)
+        else:
+            row_skip = ~head_valid  # only padding rows skip when skipping disabled
+        if MEASURE_SPARSITY:
+            # Match the per-head kernel's counts: one (head, tile) per valid row.
+            n_valid = tl.sum(head_valid.to(tl.int32))
+            n_skip = tl.sum((row_skip & head_valid).to(tl.int32))
+            tl.atomic_add(Sparsity_total, n_valid)
+            tl.atomic_add(Sparsity_skipped, n_skip)
+
+        # Whole-tile fast path: only load V + run BMM2 if at least one row keeps it.
+        any_keep = tl.min(row_skip.to(tl.int32)) == 0
+        if any_keep:
+            # Skip rows get m_new == m_i (correction == 1, p == 0) so their running
+            # state is left untouched — bit-identical to the per-head kernel skipping.
+            m_new = tl.where(row_skip, m_i, tl.maximum(m_i, tile_max))  # [BLOCK_H]
+            if MIXED_FP16:
+                p = ex2_fp16(scores - m_new[:, None])
+                p = tl.where(kv_valid[None, :], p, 0.0)
+                p = tl.where(row_skip[:, None], 0.0, p)
+                correction = ex2_fp16(m_i - m_new)
+                l_i = l_i * correction + tl.sum(p, axis=1)
+            else:
+                s_shift = softmax_round(scores - m_new[:, None], DIFF_QUANT)
+                p = softmax_round(tl.math.exp2(s_shift), EXP2_QUANT)
+                p = tl.where(kv_valid[None, :], p, 0.0)
+                p = tl.where(row_skip[:, None], 0.0, p)
+                correction = tl.math.exp2(m_i - m_new)
+                l_i = l_i * correction + softmax_round(tl.sum(p, axis=1), ACC_QUANT)
+            acc = acc * correction[:, None]
+            # P operand of BMM2 -> NVFP4 (A-side [BLOCK_H, BLOCK_N], GEMM-K = keys = axis 1).
+            p_bmm = fake_quant_fp4_k1(p, BLOCK_H, BLOCK_N, 16, p_gs, QUANT_NVFP4) if NVFP4_P else p
+
+            vt = _load_paged_v_tile(
+                V_cache,
+                Block_table,
+                batch_idx,
+                kv_head_idx,
+                kv_start,
+                kv_pos,
+                dim_pos,
+                seq_len_kv,
+                stride_vc_block,
+                stride_vc_pos,
+                stride_vc_head,
+                PAGE_SIZE,
+                BLOCK_N,
+                BLOCK_D,
+                HEAD_DIM,
+                max_blocks_per_seq,
+            )
+            # BMM2 (P @ V) runs in the cache dtype (fp16/bf16) with fp32 accumulation:
+            # the P@V product is dominated by small softmax probs, so fp16 inputs match
+            # the fp32 reference to ~2e-4 (verified) — unlike BMM1, whose score error
+            # would shift the softmax. Keeping V in cache dtype also halves the BMM2 SRAM
+            # (no fp32 V copy), which is what lets BLOCK_H=32 + NVFP4 fit the A6000.
+            vt_q = vt
+            if NVFP4_V:  # BMM2 value (B-side, V [BLOCK_N, BLOCK_D], GEMM-K = keys = axis 0)
+                v_bound = page_boundary if PER_PAGE_SCALE else v_dense_boundary
+                if (not V_CACHE_QUANTIZED) or (kv_start + BLOCK_N > v_bound):
+                    vgs_eff = (
+                        (tl.max(tl.abs(vt.to(tl.float32))) / (6.0 * 448.0) + 1e-30)
+                        if PER_PAGE_SCALE
+                        else v_gs
+                    )
+                    vt_q = fake_quant_fp4_k0(vt, BLOCK_N, BLOCK_D, 16, 1, vgs_eff, QUANT_NVFP4)
+            # acc[BLOCK_H, BLOCK_D] += P @ V on tensor cores, fp32 accum. P cast to the V
+            # dtype (mirrors prefill's tl.dot(p_dot.to(v.dtype), v, acc)).
+            acc = tl.dot(p_bmm.to(vt_q.dtype), vt_q, acc)
+            m_i = m_new
+        # else: every row skips this tile -> no V load, no BMM2, state unchanged.
+
+    # Store each row's partial softmax state at its absolute query head.
+    off_ml = batch_idx * stride_mb + head_pos * stride_mh + split_idx
+    tl.store(M_partial + off_ml, m_i, mask=head_valid)
+    tl.store(L_partial + off_ml, l_i, mask=head_valid)
+    off_a = (
+        batch_idx * stride_ab
+        + head_pos[:, None] * stride_ah
+        + split_idx * stride_as
+        + dim_pos[None, :]
+    )
+    tl.store(Acc_partial + off_a, acc, mask=head_valid[:, None] & d_mask[None, :])
+
+
+@triton.jit
 def _attn_decode_combine(
     M_partial,  # [batch, num_q_heads, num_kv_splits]
     L_partial,
@@ -365,6 +613,11 @@ def attention_decode(
     k_cache_quantized: bool = False,  # K cache holds fake-quantized values (skip in-kernel K FQ)
     v_cache_quantized: bool = False,  # V cache pre-quantized for complete 16-key blocks (FQ tail only)
     per_page_scale: bool = False,  # method 2: per-page (per-tile) NVFP4 global scale (see kernel)
+    gqa_batched: bool = False,  # opt-in: batch GQA group (M=BLOCK_H tensor-core tl.dot). Numerically
+    # equivalent (validated max_abs 4.9e-4 on sm_86+sm_100), but on GB300/sm_100 the per-head path is
+    # as-fast-or-faster at common seq lens (tf32x3 BMM1 + L2-cached KV negate the batching win); the
+    # batched path's single-K/V-load only wins at very long context (>~50K, e.g. RULER-1M). Default off.
+    block_h: int | None = None,  # query heads per program in the batched path (default: clamp 16)
 ) -> torch.Tensor:
     """Decode attention (one query token per request) over a paged KV cache.
 
@@ -471,60 +724,132 @@ def attention_decode(
         sparsity_total = None
         sparsity_skipped = None
 
+    # GQA-batched path needs >1 query head per KV head; with group==1 there is
+    # nothing to batch, so fall back to the per-head kernel (still correct).
+    use_batched = gqa_batched and kv_group_num > 1
+
     with torch.cuda.device(q.device):
-        _attn_decode_split_fwd[(batch, num_q_heads, num_kv_splits)](
-            q,
-            qk_scale,
-            b_seq_len_k,
-            m_partial,
-            l_partial,
-            acc_partial,
-            q.stride(0),
-            q.stride(1),
-            m_partial.stride(0),
-            m_partial.stride(1),
-            acc_partial.stride(0),
-            acc_partial.stride(1),
-            acc_partial.stride(2),
-            k_cache,
-            v_cache,
-            block_table,
-            k_cache.stride(0),
-            k_cache.stride(1),
-            k_cache.stride(2),
-            v_cache.stride(0),
-            v_cache.stride(1),
-            v_cache.stride(2),
-            sparsity_total,
-            sparsity_skipped,
-            kv_group_num=kv_group_num,
-            BLOCK_D=BLOCK_D,
-            BLOCK_N=BLOCK_N,
-            HEAD_DIM=head_dim,
-            PAGE_SIZE=page_size,
-            max_blocks_per_seq=block_table.shape[1],
-            NUM_KV_SPLITS=num_kv_splits,
-            APPLY_SKIP=apply_skip,
-            SKIP_THRESHOLD_LOG2=skip_threshold_log2,
-            MEASURE_SPARSITY=do_measure,
-            NVFP4_Q="q" in nvfp4,
-            NVFP4_K="k" in nvfp4,
-            NVFP4_P="p" in nvfp4,
-            NVFP4_V="v" in nvfp4,
-            DIFF_QUANT=diff_q,
-            EXP2_QUANT=exp2_q,
-            ACC_QUANT=acc_q,
-            MIXED_FP16=_mixed_fp16,
-            K_CACHE_QUANTIZED=k_cache_quantized,
-            V_CACHE_QUANTIZED=v_cache_quantized,
-            PER_PAGE_SCALE=per_page_scale,
-            q_global_scale=q_gs,
-            k_global_scale=k_gs,
-            p_global_scale=p_gs,
-            v_global_scale=v_gs,
-            num_warps=4,
-            num_stages=2,
-        )
+        if use_batched:
+            # BLOCK_H query heads per program; clamp to [16, next_pow2(group)] so the
+            # tl.dot M dim is tensor-core sized and <= the group (no all-padding tiles).
+            if block_h is None:
+                block_h_eff = min(16, triton.next_power_of_2(kv_group_num))
+            else:
+                block_h_eff = block_h
+            block_h_eff = max(16, triton.next_power_of_2(block_h_eff))
+            block_h_eff = min(block_h_eff, triton.next_power_of_2(kv_group_num))
+            num_h_tiles = (kv_group_num + block_h_eff - 1) // block_h_eff
+            _attn_decode_split_fwd_batched[(batch, num_kv_heads * num_h_tiles, num_kv_splits)](
+                q,
+                qk_scale,
+                b_seq_len_k,
+                m_partial,
+                l_partial,
+                acc_partial,
+                q.stride(0),
+                q.stride(1),
+                m_partial.stride(0),
+                m_partial.stride(1),
+                acc_partial.stride(0),
+                acc_partial.stride(1),
+                acc_partial.stride(2),
+                k_cache,
+                v_cache,
+                block_table,
+                k_cache.stride(0),
+                k_cache.stride(1),
+                k_cache.stride(2),
+                v_cache.stride(0),
+                v_cache.stride(1),
+                v_cache.stride(2),
+                sparsity_total,
+                sparsity_skipped,
+                kv_group_num=kv_group_num,
+                BLOCK_H=block_h_eff,
+                BLOCK_D=BLOCK_D,
+                BLOCK_N=BLOCK_N,
+                HEAD_DIM=head_dim,
+                PAGE_SIZE=page_size,
+                max_blocks_per_seq=block_table.shape[1],
+                NUM_KV_SPLITS=num_kv_splits,
+                APPLY_SKIP=apply_skip,
+                SKIP_THRESHOLD_LOG2=skip_threshold_log2,
+                MEASURE_SPARSITY=do_measure,
+                NVFP4_Q="q" in nvfp4,
+                NVFP4_K="k" in nvfp4,
+                NVFP4_P="p" in nvfp4,
+                NVFP4_V="v" in nvfp4,
+                DIFF_QUANT=diff_q,
+                EXP2_QUANT=exp2_q,
+                ACC_QUANT=acc_q,
+                MIXED_FP16=_mixed_fp16,
+                K_CACHE_QUANTIZED=k_cache_quantized,
+                V_CACHE_QUANTIZED=v_cache_quantized,
+                PER_PAGE_SCALE=per_page_scale,
+                q_global_scale=q_gs,
+                k_global_scale=k_gs,
+                p_global_scale=p_gs,
+                v_global_scale=v_gs,
+                num_warps=4,
+                # M=BLOCK_H tiles already fill the dot; num_stages=1 keeps the fp32
+                # K/V tiles (BLOCK_N x BLOCK_D) within the A6000's 99KB SRAM at
+                # BLOCK_H=32. (B200/GB300 have ample SRAM for deeper pipelining.)
+                num_stages=1,
+            )
+        else:
+            _attn_decode_split_fwd[(batch, num_q_heads, num_kv_splits)](
+                q,
+                qk_scale,
+                b_seq_len_k,
+                m_partial,
+                l_partial,
+                acc_partial,
+                q.stride(0),
+                q.stride(1),
+                m_partial.stride(0),
+                m_partial.stride(1),
+                acc_partial.stride(0),
+                acc_partial.stride(1),
+                acc_partial.stride(2),
+                k_cache,
+                v_cache,
+                block_table,
+                k_cache.stride(0),
+                k_cache.stride(1),
+                k_cache.stride(2),
+                v_cache.stride(0),
+                v_cache.stride(1),
+                v_cache.stride(2),
+                sparsity_total,
+                sparsity_skipped,
+                kv_group_num=kv_group_num,
+                BLOCK_D=BLOCK_D,
+                BLOCK_N=BLOCK_N,
+                HEAD_DIM=head_dim,
+                PAGE_SIZE=page_size,
+                max_blocks_per_seq=block_table.shape[1],
+                NUM_KV_SPLITS=num_kv_splits,
+                APPLY_SKIP=apply_skip,
+                SKIP_THRESHOLD_LOG2=skip_threshold_log2,
+                MEASURE_SPARSITY=do_measure,
+                NVFP4_Q="q" in nvfp4,
+                NVFP4_K="k" in nvfp4,
+                NVFP4_P="p" in nvfp4,
+                NVFP4_V="v" in nvfp4,
+                DIFF_QUANT=diff_q,
+                EXP2_QUANT=exp2_q,
+                ACC_QUANT=acc_q,
+                MIXED_FP16=_mixed_fp16,
+                K_CACHE_QUANTIZED=k_cache_quantized,
+                V_CACHE_QUANTIZED=v_cache_quantized,
+                PER_PAGE_SCALE=per_page_scale,
+                q_global_scale=q_gs,
+                k_global_scale=k_gs,
+                p_global_scale=p_gs,
+                v_global_scale=v_gs,
+                num_warps=4,
+                num_stages=2,
+            )
         _attn_decode_combine[(batch, num_q_heads)](
             m_partial,
             l_partial,

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -63,6 +63,7 @@ from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import (
     tensor_global_scale_device,
 )
 from modelopt.torch.kernels.quantization.attention.softmax_fakequant import (
+    ex2_fp16,
     resolve_softmax_mode,
     softmax_round,
 )
@@ -115,6 +116,7 @@ def _attn_decode_split_fwd(
     DIFF_QUANT: tl.constexpr,  # softmax-datapath modes: DIFF (pre-exp2), EXP2, ACC (sum)
     EXP2_QUANT: tl.constexpr,
     ACC_QUANT: tl.constexpr,
+    MIXED_FP16: tl.constexpr,  # reference mixed-precision softmax (native fp16 MUFU)
     # Per-tensor NVFP4 global scales (amax/(6*448)) as device 0-d tensors (pointers);
     # read via tl.load so no host .item() sync is needed (CUDA-graph-safe).
     q_global_scale,
@@ -206,11 +208,18 @@ def _attn_decode_split_fwd(
 
         if not skip:
             m_new = tl.maximum(m_i, tile_max)
-            s_shift = softmax_round(scores - m_new, DIFF_QUANT)  # DIFF: input to exp2
-            p = softmax_round(tl.math.exp2(s_shift), EXP2_QUANT)  # EXP2: output of exp2
-            p = tl.where(kv_valid, p, 0.0)
-            correction = tl.math.exp2(m_i - m_new)
-            l_i = l_i * correction + softmax_round(tl.sum(p, axis=0), ACC_QUANT)  # ACC: sum
+            if MIXED_FP16:
+                # Reference mixed-precision softmax: native fp16 MUFU exp + fp32 unrounded sum.
+                p = ex2_fp16(scores - m_new)  # FHADD2 -> fp16 ; MUFU.ex2.fp16 -> P fp16
+                p = tl.where(kv_valid, p, 0.0)
+                correction = ex2_fp16(m_i - m_new)  # fp16 correction factor
+                l_i = l_i * correction + tl.sum(p, axis=0)  # row_sum in fp32 (unrounded)
+            else:
+                s_shift = softmax_round(scores - m_new, DIFF_QUANT)  # DIFF: input to exp2
+                p = softmax_round(tl.math.exp2(s_shift), EXP2_QUANT)  # EXP2: output of exp2
+                p = tl.where(kv_valid, p, 0.0)
+                correction = tl.math.exp2(m_i - m_new)
+                l_i = l_i * correction + softmax_round(tl.sum(p, axis=0), ACC_QUANT)  # ACC: sum
             acc = acc * correction
             # P operand of BMM2 -> NVFP4. NVFP4 is homogeneous (NVFP4(c*x)=c*NVFP4(x)),
             # so quantizing the unnormalized exp here equals quantizing normalized P,
@@ -350,7 +359,13 @@ def attention_decode(
             to NVFP4 (E2M1) before the dot. ``{"k", "v"}`` == NVFP4 KV$; the full set
             == NVFP4 BMM1+BMM2. ``None`` disables (exact). Accuracy sim only — the dot
             still runs in fp32.
-        fp16_softmax: compute the softmax exp in fp16 (mixed precision) instead of fp32.
+        fp16_softmax: engage the reference mixed-precision softmax — both exp2s (the softmax exp
+            and the online correction) run in native fp16 (``ex2.approx.ftz.f16``) with the
+            denominator accumulated in fp32 (P fp16-in, sum unrounded). The matmul accumulators
+            stay fp32. Ignored when ``softmax_quant`` is given (that selects per-point round-based
+            datapath quant instead).
+        softmax_quant: optional per-point datapath quant ``{"diff"/"exp2"/"acc": mode}`` for the
+            round-based experiments (fp8/bf16/fp16-round); takes precedence over ``fp16_softmax``.
 
     Returns:
         ``[batch, num_q_heads, head_dim]`` attention output.
@@ -396,8 +411,11 @@ def attention_decode(
     # uniformity. Built copy-free with new_full (device-side fill) — torch.tensor(const,
     # device=cuda) does a host->device copy that is illegal during CUDA-graph capture.
     p_gs = q.new_full((), 1.0 / (6.0 * 448.0) + 1e-30, dtype=torch.float32) if "p" in nvfp4 else 1.0
-    # Softmax-datapath modes (DIFF/EXP2/ACC); fp16_softmax = FP16-RNE at all three.
+    # Softmax-datapath modes. ``fp16_softmax`` (with no per-point override) engages the reference
+    # mixed-precision design (native fp16 MUFU exp + fp32 unrounded sum); a ``softmax_quant`` dict
+    # instead selects per-point round-based datapath quant and takes precedence.
     _sq = softmax_quant or {}
+    _mixed_fp16 = bool(fp16_softmax) and not _sq
     _sm_default = "fp16_rne" if fp16_softmax else None
     diff_q = resolve_softmax_mode(_sq.get("diff", _sm_default))
     exp2_q = resolve_softmax_mode(_sq.get("exp2", _sm_default))
@@ -461,6 +479,7 @@ def attention_decode(
             DIFF_QUANT=diff_q,
             EXP2_QUANT=exp2_q,
             ACC_QUANT=acc_q,
+            MIXED_FP16=_mixed_fp16,
             q_global_scale=q_gs,
             k_global_scale=k_gs,
             p_global_scale=p_gs,

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -56,6 +56,12 @@ from modelopt.torch.kernels.common.attention.triton_fa import (
     _load_paged_k_tile,
     _load_paged_v_tile,
 )
+from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import (
+    nvfp4_qdq_1d,
+    nvfp4_qdq_axis0,
+)
+
+_NVFP4_BLK = 16  # NVFP4 block size (contraction-axis group)
 
 # Cap on the auto-chosen split count. Decode KV reads dominate, so a handful of
 # splits is enough to fill the SMs at small batch; more just fragments skipping.
@@ -98,8 +104,15 @@ def _attn_decode_split_fwd(
     APPLY_SKIP: tl.constexpr,
     SKIP_THRESHOLD_LOG2: tl.constexpr,  # log2(lambda) in the scaled-log2 score space
     MEASURE_SPARSITY: tl.constexpr,
+    NVFP4_Q: tl.constexpr,  # fakequant Q -> NVFP4 before BMM1
+    NVFP4_K: tl.constexpr,  # fakequant K -> NVFP4 before BMM1 (= NVFP4 KV$ K side)
+    NVFP4_P: tl.constexpr,  # fakequant softmax P -> NVFP4 before BMM2
+    NVFP4_V: tl.constexpr,  # fakequant V -> NVFP4 before BMM2 (= NVFP4 KV$ V side)
+    FP16_SOFTMAX: tl.constexpr,  # compute the softmax exp in fp16 (mixed precision)
+    NB_D: tl.constexpr,  # head-dim NVFP4 blocks = BLOCK_D // 16
+    NB_N: tl.constexpr,  # kv-tile NVFP4 blocks = BLOCK_N // 16
 ):
-    """One (request, head, KV split): partial GEMV attention with skip."""
+    """One (request, head, KV split): partial GEMV attention with skip + optional NVFP4."""
     batch_idx = tl.program_id(0)
     head_idx = tl.program_id(1)
     split_idx = tl.program_id(2)
@@ -124,6 +137,8 @@ def _attn_decode_split_fwd(
     q = tl.load(
         Q + batch_idx * stride_qb + head_idx * stride_qh + dim_pos, mask=d_mask, other=0.0
     ).to(tl.float32)
+    if NVFP4_Q:
+        q = nvfp4_qdq_1d(q, NB_D, 16)  # BMM1 query operand -> NVFP4
 
     m_i = -float("inf")  # running max (prefix, scalar) within this split
     l_i = 0.0  # running softmax denominator (scalar)
@@ -152,7 +167,10 @@ def _attn_decode_split_fwd(
             HEAD_DIM,
             max_blocks_per_seq,
         )
-        scores = tl.sum(q[:, None] * kt.to(tl.float32), axis=0) * qk_scale  # [BLOCK_N], fp32 accum
+        kt_f = kt.to(tl.float32)
+        if NVFP4_K:
+            kt_f = nvfp4_qdq_axis0(kt_f, NB_D, 16, BLOCK_N)  # BMM1 key operand -> NVFP4
+        scores = tl.sum(q[:, None] * kt_f, axis=0) * qk_scale  # [BLOCK_N], fp32 accum
         scores = tl.where(kv_valid, scores, -float("inf"))
 
         tile_max = tl.max(scores, axis=0)  # scalar
@@ -169,10 +187,16 @@ def _attn_decode_split_fwd(
         if not skip:
             m_new = tl.maximum(m_i, tile_max)
             p = tl.math.exp2(scores - m_new)  # [BLOCK_N]
+            if FP16_SOFTMAX:
+                p = p.to(tl.float16).to(tl.float32)  # mixed-precision (fp16) softmax
             p = tl.where(kv_valid, p, 0.0)
             correction = tl.math.exp2(m_i - m_new)
             l_i = l_i * correction + tl.sum(p, axis=0)
             acc = acc * correction
+            # P operand of BMM2 -> NVFP4. NVFP4 is homogeneous (NVFP4(c*x)=c*NVFP4(x)),
+            # so quantizing the unnormalized exp here equals quantizing normalized P,
+            # since the final acc is divided by l_i in the combine kernel.
+            p_bmm = nvfp4_qdq_1d(p, NB_N, 16) if NVFP4_P else p
             vt = _load_paged_v_tile(
                 V_cache,
                 Block_table,
@@ -191,7 +215,10 @@ def _attn_decode_split_fwd(
                 HEAD_DIM,
                 max_blocks_per_seq,
             )
-            acc += tl.sum(p[:, None] * vt.to(tl.float32), axis=0)  # [BLOCK_D], fp32 accum
+            vt_f = vt.to(tl.float32)
+            if NVFP4_V:
+                vt_f = nvfp4_qdq_axis0(vt_f, NB_N, 16, BLOCK_D)  # BMM2 value operand -> NVFP4
+            acc += tl.sum(p_bmm[:, None] * vt_f, axis=0)  # [BLOCK_D], fp32 accum
             m_i = m_new
 
     # Store this split's partial softmax state (undivided acc + max + denom).
@@ -267,6 +294,8 @@ def attention_decode(
     page_size: int = 16,
     num_kv_splits: int | None = None,
     measure_sparsity: bool = False,
+    nvfp4: set[str] | None = None,
+    fp16_softmax: bool = False,
 ) -> torch.Tensor:
     """Decode attention (one query token per request) over a paged KV cache.
 
@@ -287,6 +316,11 @@ def attention_decode(
             skipping maximally effective.
         measure_sparsity: when skipping is active, count total/skipped tiles and
             attach them as ``_sparsity_total`` / ``_sparsity_skipped`` on the output.
+        nvfp4: subset of ``{"q", "k", "p", "v"}`` whose BMM operands are fake-quantized
+            to NVFP4 (E2M1) before the dot. ``{"k", "v"}`` == NVFP4 KV$; the full set
+            == NVFP4 BMM1+BMM2. ``None`` disables (exact). Accuracy sim only — the dot
+            still runs in fp32.
+        fp16_softmax: compute the softmax exp in fp16 (mixed precision) instead of fp32.
 
     Returns:
         ``[batch, num_q_heads, head_dim]`` attention output.
@@ -313,6 +347,10 @@ def attention_decode(
     if num_kv_splits is None:
         num_kv_splits = _auto_num_kv_splits(q.device, batch * num_q_heads)
     num_kv_splits = max(1, num_kv_splits)
+
+    nvfp4 = nvfp4 or set()
+    assert nvfp4 <= {"q", "k", "p", "v"}, f"nvfp4 must be a subset of q/k/p/v, got {nvfp4}"
+    assert BLOCK_D % 16 == 0 and BLOCK_N % 16 == 0, "NVFP4 needs dims divisible by 16"
 
     # Per-split partial softmax state, merged by the combine kernel.
     m_partial = torch.empty(batch, num_q_heads, num_kv_splits, dtype=torch.float32, device=q.device)
@@ -365,6 +403,13 @@ def attention_decode(
             APPLY_SKIP=apply_skip,
             SKIP_THRESHOLD_LOG2=skip_threshold_log2,
             MEASURE_SPARSITY=do_measure,
+            NVFP4_Q="q" in nvfp4,
+            NVFP4_K="k" in nvfp4,
+            NVFP4_P="p" in nvfp4,
+            NVFP4_V="v" in nvfp4,
+            FP16_SOFTMAX=fp16_softmax,
+            NB_D=BLOCK_D // 16,
+            NB_N=BLOCK_N // 16,
             num_warps=4,
             num_stages=2,
         )

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -60,7 +60,7 @@ from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import (
     QUANT_NVFP4,
     fake_quant_fp4_k0,
     fake_quant_fp4_k1,
-    tensor_global_scale,
+    tensor_global_scale_device,
 )
 from modelopt.torch.kernels.quantization.attention.softmax_fakequant import (
     resolve_softmax_mode,
@@ -115,7 +115,9 @@ def _attn_decode_split_fwd(
     DIFF_QUANT: tl.constexpr,  # softmax-datapath modes: DIFF (pre-exp2), EXP2, ACC (sum)
     EXP2_QUANT: tl.constexpr,
     ACC_QUANT: tl.constexpr,
-    q_global_scale,  # per-tensor NVFP4 global scales (amax/(6*448)), computed host-side
+    # Per-tensor NVFP4 global scales (amax/(6*448)) as device 0-d tensors (pointers);
+    # read via tl.load so no host .item() sync is needed (CUDA-graph-safe).
+    q_global_scale,
     k_global_scale,
     p_global_scale,
     v_global_scale,
@@ -140,6 +142,13 @@ def _attn_decode_split_fwd(
     d_mask = dim_pos < HEAD_DIM
     kv_pos = tl.arange(0, BLOCK_N)
 
+    # NVFP4 global scales: read on-device once (no host sync); only dereferenced when
+    # the matching operand is quantized, else an unused scalar.
+    q_gs = tl.load(q_global_scale) if NVFP4_Q else 1.0
+    k_gs = tl.load(k_global_scale) if NVFP4_K else 1.0
+    p_gs = tl.load(p_global_scale) if NVFP4_P else 1.0
+    v_gs = tl.load(v_global_scale) if NVFP4_V else 1.0
+
     # Single query vector [BLOCK_D] for this (request, head); stays in registers.
     # Upcast to fp32 so the QK dot product accumulates in fp32 (matches torch matmul).
     q = tl.load(
@@ -147,9 +156,7 @@ def _attn_decode_split_fwd(
     ).to(tl.float32)
     if NVFP4_Q:  # BMM1 query (A-side, single row, GEMM-K = head dim)
         q = tl.reshape(
-            fake_quant_fp4_k1(
-                tl.reshape(q, (1, BLOCK_D)), 1, BLOCK_D, 16, q_global_scale, QUANT_NVFP4
-            ),
+            fake_quant_fp4_k1(tl.reshape(q, (1, BLOCK_D)), 1, BLOCK_D, 16, q_gs, QUANT_NVFP4),
             (BLOCK_D,),
         )
 
@@ -182,7 +189,7 @@ def _attn_decode_split_fwd(
         )
         kt_f = kt.to(tl.float32)
         if NVFP4_K:  # BMM1 key (B-side, K^T [BLOCK_D, BLOCK_N], GEMM-K = head dim = axis 0)
-            kt_f = fake_quant_fp4_k0(kt_f, BLOCK_D, BLOCK_N, 16, 1, k_global_scale, QUANT_NVFP4)
+            kt_f = fake_quant_fp4_k0(kt_f, BLOCK_D, BLOCK_N, 16, 1, k_gs, QUANT_NVFP4)
         scores = tl.sum(q[:, None] * kt_f, axis=0) * qk_scale  # [BLOCK_N], fp32 accum
         scores = tl.where(kv_valid, scores, -float("inf"))
 
@@ -211,7 +218,7 @@ def _attn_decode_split_fwd(
             p_bmm = (
                 tl.reshape(
                     fake_quant_fp4_k1(
-                        tl.reshape(p, (1, BLOCK_N)), 1, BLOCK_N, 16, p_global_scale, QUANT_NVFP4
+                        tl.reshape(p, (1, BLOCK_N)), 1, BLOCK_N, 16, p_gs, QUANT_NVFP4
                     ),
                     (BLOCK_N,),
                 )
@@ -238,7 +245,7 @@ def _attn_decode_split_fwd(
             )
             vt_f = vt.to(tl.float32)
             if NVFP4_V:  # BMM2 value (B-side, V [BLOCK_N, BLOCK_D], GEMM-K = keys = axis 0)
-                vt_f = fake_quant_fp4_k0(vt_f, BLOCK_N, BLOCK_D, 16, 1, v_global_scale, QUANT_NVFP4)
+                vt_f = fake_quant_fp4_k0(vt_f, BLOCK_N, BLOCK_D, 16, 1, v_gs, QUANT_NVFP4)
             acc += tl.sum(p_bmm[:, None] * vt_f, axis=0)  # [BLOCK_D], fp32 accum
             m_i = m_new
 
@@ -374,14 +381,21 @@ def attention_decode(
     nvfp4 = nvfp4 or set()
     assert nvfp4 <= {"q", "k", "p", "v"}, f"nvfp4 must be a subset of q/k/p/v, got {nvfp4}"
     assert BLOCK_D % 16 == 0 and BLOCK_N % 16 == 0, "NVFP4 needs dims divisible by 16"
-    # Per-tensor NVFP4 global scales (host-side amax/(6*448)), aligned with mni/attnOpt.
-    # Paged serving passes precomputed scales (from the small per-step q/k/v); scanning
-    # the full paged K/V cache here would upcast it to fp32 and OOM.
+    # Per-tensor NVFP4 global scales (amax/(6*448)) as 0-d device tensors, read in-kernel
+    # via tl.load (no host .item()). Paged serving passes precomputed scales (from the
+    # small per-step q/k/v); scanning the full paged K/V cache here would OOM.
     _gs = attn_global_scales or {}
-    q_gs = (_gs["q"] if "q" in _gs else tensor_global_scale(q)) if "q" in nvfp4 else 1.0
-    k_gs = (_gs["k"] if "k" in _gs else tensor_global_scale(k_cache)) if "k" in nvfp4 else 1.0
-    v_gs = (_gs["v"] if "v" in _gs else tensor_global_scale(v_cache)) if "v" in nvfp4 else 1.0
-    p_gs = (1.0 / (6.0 * 448.0) + 1e-30) if "p" in nvfp4 else 1.0  # unnormalized exp P max ~1
+    q_gs = (_gs["q"] if "q" in _gs else tensor_global_scale_device(q)) if "q" in nvfp4 else 1.0
+    k_gs = (
+        (_gs["k"] if "k" in _gs else tensor_global_scale_device(k_cache)) if "k" in nvfp4 else 1.0
+    )
+    v_gs = (
+        (_gs["v"] if "v" in _gs else tensor_global_scale_device(v_cache)) if "v" in nvfp4 else 1.0
+    )
+    # P global is a fixed constant (unnormalized exp P max ~1); 0-d device tensor for
+    # uniformity. Built copy-free with new_full (device-side fill) — torch.tensor(const,
+    # device=cuda) does a host->device copy that is illegal during CUDA-graph capture.
+    p_gs = q.new_full((), 1.0 / (6.0 * 448.0) + 1e-30, dtype=torch.float32) if "p" in nvfp4 else 1.0
     # Softmax-datapath modes (DIFF/EXP2/ACC); fp16_softmax = FP16-RNE at all three.
     _sq = softmax_quant or {}
     _sm_default = "fp16_rne" if fp16_softmax else None

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -117,6 +117,8 @@ def _attn_decode_split_fwd(
     EXP2_QUANT: tl.constexpr,
     ACC_QUANT: tl.constexpr,
     MIXED_FP16: tl.constexpr,  # reference mixed-precision softmax (native fp16 MUFU)
+    K_CACHE_QUANTIZED: tl.constexpr,  # K cache pre-quantized (skip in-kernel K FQ entirely)
+    V_CACHE_QUANTIZED: tl.constexpr,  # V cache pre-quantized for COMPLETE 16-key blocks (FQ only tail)
     # Per-tensor NVFP4 global scales (amax/(6*448)) as device 0-d tensors (pointers);
     # read via tl.load so no host .item() sync is needed (CUDA-graph-safe).
     q_global_scale,
@@ -131,6 +133,11 @@ def _attn_decode_split_fwd(
     kv_head_idx = head_idx // kv_group_num
 
     seq_len_kv = tl.load(B_seq_len_k + batch_idx)
+
+    # Quantize-on-write: K is fully fake-quantized in the cache and V is fake-quantized for
+    # every COMPLETE 16-key NVFP4 block; only the in-progress tail block (the last
+    # ``seq_len_kv % 16`` keys) is still raw and must be fakequantized in-kernel.
+    v_dense_boundary = (seq_len_kv // 16) * 16
 
     # Partition whole BLOCK_N tiles (calibration-aligned) evenly across splits.
     num_tiles = (seq_len_kv + BLOCK_N - 1) // BLOCK_N
@@ -190,7 +197,8 @@ def _attn_decode_split_fwd(
             max_blocks_per_seq,
         )
         kt_f = kt.to(tl.float32)
-        if NVFP4_K:  # BMM1 key (B-side, K^T [BLOCK_D, BLOCK_N], GEMM-K = head dim = axis 0)
+        if NVFP4_K and not K_CACHE_QUANTIZED:  # pre-quantized K read as-is (every key's
+            # head-dim block is complete at write time, so the whole cache is already on-grid)
             kt_f = fake_quant_fp4_k0(kt_f, BLOCK_D, BLOCK_N, 16, 1, k_gs, QUANT_NVFP4)
         scores = tl.sum(q[:, None] * kt_f, axis=0) * qk_scale  # [BLOCK_N], fp32 accum
         scores = tl.where(kv_valid, scores, -float("inf"))
@@ -254,7 +262,10 @@ def _attn_decode_split_fwd(
             )
             vt_f = vt.to(tl.float32)
             if NVFP4_V:  # BMM2 value (B-side, V [BLOCK_N, BLOCK_D], GEMM-K = keys = axis 0)
-                vt_f = fake_quant_fp4_k0(vt_f, BLOCK_N, BLOCK_D, 16, 1, v_gs, QUANT_NVFP4)
+                # Pre-quantized completed V blocks read as-is; only tiles reaching the raw tail
+                # (kv_start+BLOCK_N > boundary) are fakequantized. Without on-write, FQ every tile.
+                if (not V_CACHE_QUANTIZED) or (kv_start + BLOCK_N > v_dense_boundary):
+                    vt_f = fake_quant_fp4_k0(vt_f, BLOCK_N, BLOCK_D, 16, 1, v_gs, QUANT_NVFP4)
             acc += tl.sum(p_bmm[:, None] * vt_f, axis=0)  # [BLOCK_D], fp32 accum
             m_i = m_new
 
@@ -335,6 +346,8 @@ def attention_decode(
     fp16_softmax: bool = False,
     softmax_quant: dict | None = None,
     attn_global_scales: dict | None = None,
+    k_cache_quantized: bool = False,  # K cache holds fake-quantized values (skip in-kernel K FQ)
+    v_cache_quantized: bool = False,  # V cache pre-quantized for complete 16-key blocks (FQ tail only)
 ) -> torch.Tensor:
     """Decode attention (one query token per request) over a paged KV cache.
 
@@ -480,6 +493,8 @@ def attention_decode(
             EXP2_QUANT=exp2_q,
             ACC_QUANT=acc_q,
             MIXED_FP16=_mixed_fp16,
+            K_CACHE_QUANTIZED=k_cache_quantized,
+            V_CACHE_QUANTIZED=v_cache_quantized,
             q_global_scale=q_gs,
             k_global_scale=k_gs,
             p_global_scale=p_gs,
@@ -511,4 +526,104 @@ def attention_decode(
     return out
 
 
-__all__ = ["attention_decode"]
+@triton.jit
+def _prequant_kv_kernel(
+    K,  # flat [total_keys, n_kv_heads, head_dim] (head_dim contiguous)
+    V,
+    seq_len,  # per-request KV length (uniform across requests here)
+    stride_req,  # element stride between consecutive requests' key blocks
+    stride_key,
+    stride_head,
+    k_global_scale,
+    v_global_scale,
+    NVFP4_K: tl.constexpr,
+    NVFP4_V: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+):
+    """Fake-quantize a (contiguous) paged KV cache in place = the quantize-on-write op.
+
+    K: every key's head-dim 16-block is complete at write time → fakequant ALL keys.
+    V: NVFP4 blocks span 16 keys → fakequant only tiles whose keys are all in COMPLETE blocks
+    (``kv_start + BLOCK_N <= (seq_len // 16) * 16``); the in-progress tail tile is left raw for the
+    decode kernel to fakequant on read. This partitions the cache so the decode kernel with
+    ``KV_CACHE_QUANTIZED=True`` reproduces fakequant-on-read exactly (same op, same global scale).
+    """
+    r = tl.program_id(0)
+    h = tl.program_id(1)
+    t = tl.program_id(2)
+    kv_start = t * BLOCK_N
+    key_off = tl.arange(0, BLOCK_N)
+    dim_off = tl.arange(0, BLOCK_D)
+    d_mask = dim_off < HEAD_DIM
+    key_valid = (kv_start + key_off) < seq_len
+    mask = key_valid[:, None] & d_mask[None, :]
+    base = r * stride_req + kv_start * stride_key + h * stride_head
+    ptr = base + key_off[:, None] * stride_key + dim_off[None, :]
+    if NVFP4_K:
+        k_gs = tl.load(k_global_scale)
+        kt = tl.load(K + ptr, mask=mask, other=0.0).to(tl.float32)
+        kq = fake_quant_fp4_k1(
+            kt, BLOCK_N, BLOCK_D, 16, k_gs, QUANT_NVFP4
+        )  # per-key head-dim blocks
+        tl.store(K + ptr, kq.to(K.dtype.element_ty), mask=mask)
+    if NVFP4_V:
+        v_dense_boundary = (seq_len // 16) * 16
+        if kv_start + BLOCK_N <= v_dense_boundary:  # whole tile is complete 16-key blocks
+            v_gs = tl.load(v_global_scale)
+            vt = tl.load(V + ptr, mask=mask, other=0.0).to(tl.float32)
+            vq = fake_quant_fp4_k0(vt, BLOCK_N, BLOCK_D, 16, 1, v_gs, QUANT_NVFP4)
+            tl.store(V + ptr, vq.to(V.dtype.element_ty), mask=mask)
+
+
+def fake_quant_kv_cache(
+    k_cache: torch.Tensor,  # [num_blocks, page_size, n_kv_heads, head_dim]
+    v_cache: torch.Tensor,
+    seq_len: int,  # uniform per-request KV length
+    num_requests: int,
+    blocks_per_req: int,
+    *,
+    page_size: int = 16,
+    k_global_scale=None,
+    v_global_scale=None,
+    nvfp4: set[str] | None = None,
+) -> None:
+    """In-place quantize-on-write over a *contiguous* paged cache (block_table = arange).
+
+    The serving path performs this incrementally per token; this batch form is the reference /
+    test entrypoint. K is fully fake-quantized; V only for complete 16-key blocks (tail left raw).
+    """
+    nvfp4 = nvfp4 or set()
+    if not ({"k", "v"} & nvfp4):
+        return
+    nb, ps, nkv, hd = k_cache.shape
+    assert ps == page_size
+    kf = k_cache.view(nb * ps, nkv, hd)
+    vf = v_cache.view(nb * ps, nkv, hd)
+    BLOCK_D = triton.next_power_of_2(hd)
+    BLOCK_N = 128
+    stride_req = blocks_per_req * ps * kf.stride(0)
+    n_tiles = (seq_len + BLOCK_N - 1) // BLOCK_N
+    kgs = k_global_scale if k_global_scale is not None else kf.new_full((), 1.0)
+    vgs = v_global_scale if v_global_scale is not None else kf.new_full((), 1.0)
+    with torch.cuda.device(kf.device):
+        _prequant_kv_kernel[(num_requests, nkv, n_tiles)](
+            kf,
+            vf,
+            seq_len,
+            stride_req,
+            kf.stride(0),
+            kf.stride(1),
+            kgs,
+            vgs,
+            NVFP4_K="k" in nvfp4,
+            NVFP4_V="v" in nvfp4,
+            BLOCK_N=BLOCK_N,
+            BLOCK_D=BLOCK_D,
+            HEAD_DIM=hd,
+            num_warps=4,
+        )
+
+
+__all__ = ["attention_decode", "fake_quant_kv_cache"]

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -626,4 +626,151 @@ def fake_quant_kv_cache(
         )
 
 
-__all__ = ["attention_decode", "fake_quant_kv_cache"]
+@triton.jit
+def _onwrite_fq_paged_kernel(
+    K_cache,
+    V_cache,
+    Block_table,
+    K_lo,  # [batch] per-request K quant range [lo, hi) in logical key positions
+    K_hi,
+    V_lo,  # [batch] per-request V quant range (block-aligned, complete 16-key blocks)
+    V_hi,
+    stride_kc_block,
+    stride_kc_pos,
+    stride_kc_head,
+    stride_vc_block,
+    stride_vc_pos,
+    stride_vc_head,
+    tile0,  # first tile index covered by the grid (keys >= tile0*BLOCK_N)
+    k_global_scale,
+    v_global_scale,
+    NVFP4_K: tl.constexpr,
+    NVFP4_V: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    max_blocks_per_seq,
+):
+    """In-place fake-quant of a paged KV cache over per-request key ranges (quantize-on-write).
+
+    K range = newly-written keys (head-dim 16-blocks, per key). V range = newly-COMPLETE 16-key
+    blocks (keys 16-blocks). Reads the tile, fakequants with the SAME ``fake_quant_fp4_k0`` the
+    decode kernel would use, and stores back only the in-range valid keys via the block table.
+    """
+    batch_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    tile = tile0 + tl.program_id(2)
+    kv_start = tile * BLOCK_N
+    kv_pos = tl.arange(0, BLOCK_N)
+    dim_pos = tl.arange(0, BLOCK_D)
+    d_mask = dim_pos < HEAD_DIM
+    kv_abs = kv_start + kv_pos
+
+    klo = tl.load(K_lo + batch_idx)
+    khi = tl.load(K_hi + batch_idx)
+    vlo = tl.load(V_lo + batch_idx)
+    vhi = tl.load(V_hi + batch_idx)
+
+    page_local = kv_abs // PAGE_SIZE
+    offset_in_page = kv_abs % PAGE_SIZE
+    in_any = ((kv_abs >= klo) & (kv_abs < khi)) | ((kv_abs >= vlo) & (kv_abs < vhi))
+    page_global = tl.load(
+        Block_table + batch_idx * max_blocks_per_seq + page_local, mask=in_any, other=0
+    )
+
+    if NVFP4_K:
+        k_gs = tl.load(k_global_scale)
+        k_ptrs = (
+            page_global[None, :].to(tl.int64) * stride_kc_block
+            + offset_in_page[None, :] * stride_kc_pos
+            + head_idx * stride_kc_head
+            + dim_pos[:, None]
+        )
+        k_in = (kv_abs >= klo) & (kv_abs < khi)
+        kt = tl.load(K_cache + k_ptrs, mask=k_in[None, :] & d_mask[:, None], other=0.0).to(
+            tl.float32
+        )
+        kq = fake_quant_fp4_k0(kt, BLOCK_D, BLOCK_N, 16, 1, k_gs, QUANT_NVFP4)
+        tl.store(
+            K_cache + k_ptrs, kq.to(K_cache.dtype.element_ty), mask=k_in[None, :] & d_mask[:, None]
+        )
+
+    if NVFP4_V:
+        v_gs = tl.load(v_global_scale)
+        v_ptrs = (
+            page_global[:, None].to(tl.int64) * stride_vc_block
+            + offset_in_page[:, None] * stride_vc_pos
+            + head_idx * stride_vc_head
+            + dim_pos[None, :]
+        )
+        v_in = (kv_abs >= vlo) & (kv_abs < vhi)
+        vt = tl.load(V_cache + v_ptrs, mask=v_in[:, None] & d_mask[None, :], other=0.0).to(
+            tl.float32
+        )
+        vq = fake_quant_fp4_k0(vt, BLOCK_N, BLOCK_D, 16, 1, v_gs, QUANT_NVFP4)
+        tl.store(
+            V_cache + v_ptrs, vq.to(V_cache.dtype.element_ty), mask=v_in[:, None] & d_mask[None, :]
+        )
+
+
+def fake_quant_kv_onwrite(
+    k_cache,  # [num_blocks, page_size, n_kv_heads, head_dim]
+    v_cache,
+    block_table,  # [batch, max_blocks_per_seq]
+    k_lo,  # [batch] int32 per-request K range [lo, hi)
+    k_hi,
+    v_lo,  # [batch] int32 per-request V range (16-block-aligned)
+    v_hi,
+    *,
+    page_size: int = 16,
+    k_global_scale=None,
+    v_global_scale=None,
+    nvfp4: set[str] | None = None,
+) -> None:
+    """Paged quantize-on-write: fakequant K (k_lo:k_hi) and V (v_lo:v_hi) per request in place."""
+    nvfp4 = nvfp4 or set()
+    if not ({"k", "v"} & nvfp4):
+        return
+    batch, max_blocks = block_table.shape
+    nkv, hd = k_cache.shape[2], k_cache.shape[3]
+    BLOCK_D = triton.next_power_of_2(hd)
+    BLOCK_N = 128
+    hi = int(max(int(k_hi.max().item()), int(v_hi.max().item())))
+    lo = int(min(int(k_lo.min().item()), int(v_lo.min().item())))
+    if hi <= lo:
+        return
+    tile0 = lo // BLOCK_N
+    n_tiles = (hi + BLOCK_N - 1) // BLOCK_N - tile0
+    kgs = k_global_scale if k_global_scale is not None else k_cache.new_full((), 1.0)
+    vgs = v_global_scale if v_global_scale is not None else k_cache.new_full((), 1.0)
+    with torch.cuda.device(k_cache.device):
+        _onwrite_fq_paged_kernel[(batch, nkv, n_tiles)](
+            k_cache,
+            v_cache,
+            block_table,
+            k_lo,
+            k_hi,
+            v_lo,
+            v_hi,
+            k_cache.stride(0),
+            k_cache.stride(1),
+            k_cache.stride(2),
+            v_cache.stride(0),
+            v_cache.stride(1),
+            v_cache.stride(2),
+            tile0,
+            kgs,
+            vgs,
+            NVFP4_K="k" in nvfp4,
+            NVFP4_V="v" in nvfp4,
+            PAGE_SIZE=page_size,
+            BLOCK_N=BLOCK_N,
+            BLOCK_D=BLOCK_D,
+            HEAD_DIM=hd,
+            max_blocks_per_seq=max_blocks,
+            num_warps=4,
+        )
+
+
+__all__ = ["attention_decode", "fake_quant_kv_cache", "fake_quant_kv_onwrite"]

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -641,7 +641,6 @@ def _onwrite_fq_paged_kernel(
     stride_vc_block,
     stride_vc_pos,
     stride_vc_head,
-    tile0,  # first tile index covered by the grid (keys >= tile0*BLOCK_N)
     k_global_scale,
     v_global_scale,
     NVFP4_K: tl.constexpr,
@@ -657,20 +656,26 @@ def _onwrite_fq_paged_kernel(
     K range = newly-written keys (head-dim 16-blocks, per key). V range = newly-COMPLETE 16-key
     blocks (keys 16-blocks). Reads the tile, fakequants with the SAME ``fake_quant_fp4_k0`` the
     decode kernel would use, and stores back only the in-range valid keys via the block table.
+
+    The tile each program touches is derived *per request* from on-device bounds
+    (``base_tile = min(k_lo, v_lo) // BLOCK_N``, then ``+ program_id(2)``), so the launch grid
+    never depends on a host ``.item()``. A pure-decode step appends one key whose tile also holds
+    the at-most-one just-completed 128-block, so a fixed grid of ``(batch, n_kv, 1)`` covers it and
+    is CUDA-graph-capturable.
     """
     batch_idx = tl.program_id(0)
     head_idx = tl.program_id(1)
-    tile = tile0 + tl.program_id(2)
+    klo = tl.load(K_lo + batch_idx)
+    khi = tl.load(K_hi + batch_idx)
+    vlo = tl.load(V_lo + batch_idx)
+    vhi = tl.load(V_hi + batch_idx)
+    base_tile = tl.minimum(klo, vlo) // BLOCK_N
+    tile = base_tile + tl.program_id(2)
     kv_start = tile * BLOCK_N
     kv_pos = tl.arange(0, BLOCK_N)
     dim_pos = tl.arange(0, BLOCK_D)
     d_mask = dim_pos < HEAD_DIM
     kv_abs = kv_start + kv_pos
-
-    klo = tl.load(K_lo + batch_idx)
-    khi = tl.load(K_hi + batch_idx)
-    vlo = tl.load(V_lo + batch_idx)
-    vhi = tl.load(V_hi + batch_idx)
 
     page_local = kv_abs // PAGE_SIZE
     offset_in_page = kv_abs % PAGE_SIZE
@@ -727,8 +732,14 @@ def fake_quant_kv_onwrite(
     k_global_scale=None,
     v_global_scale=None,
     nvfp4: set[str] | None = None,
+    decode: bool = False,
 ) -> None:
-    """Paged quantize-on-write: fakequant K (k_lo:k_hi) and V (v_lo:v_hi) per request in place."""
+    """Paged quantize-on-write: fakequant K (k_lo:k_hi) and V (v_lo:v_hi) per request in place.
+
+    Set ``decode=True`` for a pure single-token decode step: the grid is fixed to one tile per
+    request, so the launch needs no host ``.item()`` and is CUDA-graph-capturable. ``decode=False``
+    (prefill / mixed batch, run eager) sizes the grid to the largest per-request span.
+    """
     nvfp4 = nvfp4 or set()
     if not ({"k", "v"} & nvfp4):
         return
@@ -736,12 +747,17 @@ def fake_quant_kv_onwrite(
     nkv, hd = k_cache.shape[2], k_cache.shape[3]
     BLOCK_D = triton.next_power_of_2(hd)
     BLOCK_N = 128
-    hi = int(max(int(k_hi.max().item()), int(v_hi.max().item())))
-    lo = int(min(int(k_lo.min().item()), int(v_lo.min().item())))
-    if hi <= lo:
-        return
-    tile0 = lo // BLOCK_N
-    n_tiles = (hi + BLOCK_N - 1) // BLOCK_N - tile0
+    if decode:
+        # One appended key per request; its tile also holds the at-most-one just-completed
+        # 128-block, so a single per-request tile suffices. Fixed grid => graph-safe (no sync).
+        n_tiles = 1
+    else:
+        # Eager prefill/mixed: span the largest per-request range (base = min(k_lo,v_lo)//BLOCK_N).
+        base = torch.minimum(k_lo, v_lo) // BLOCK_N
+        span = int((torch.maximum(k_hi, v_hi) - base * BLOCK_N).max().item())
+        if span <= 0:
+            return
+        n_tiles = (span + BLOCK_N - 1) // BLOCK_N
     kgs = k_global_scale if k_global_scale is not None else k_cache.new_full((), 1.0)
     vgs = v_global_scale if v_global_scale is not None else k_cache.new_full((), 1.0)
     with torch.cuda.device(k_cache.device):
@@ -759,7 +775,6 @@ def fake_quant_kv_onwrite(
             v_cache.stride(0),
             v_cache.stride(1),
             v_cache.stride(2),
-            tile0,
             kgs,
             vgs,
             NVFP4_K="k" in nvfp4,

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -119,6 +119,9 @@ def _attn_decode_split_fwd(
     MIXED_FP16: tl.constexpr,  # reference mixed-precision softmax (native fp16 MUFU)
     K_CACHE_QUANTIZED: tl.constexpr,  # K cache pre-quantized (skip in-kernel K FQ entirely)
     V_CACHE_QUANTIZED: tl.constexpr,  # V cache pre-quantized for COMPLETE 16-key blocks (FQ only tail)
+    PER_PAGE_SCALE: tl.constexpr,  # method 2: per-page (per-BLOCK_N-tile) NVFP4 global scale —
+    # complete tiles are baked with their own amax; the trailing (in-progress) tile is FQ'd on read
+    # from its own in-kernel amax (the raw-bf16 "master pool"). Overrides the passed k/v_global_scale.
     # Per-tensor NVFP4 global scales (amax/(6*448)) as device 0-d tensors (pointers);
     # read via tl.load so no host .item() sync is needed (CUDA-graph-safe).
     q_global_scale,
@@ -138,6 +141,9 @@ def _attn_decode_split_fwd(
     # every COMPLETE 16-key NVFP4 block; only the in-progress tail block (the last
     # ``seq_len_kv % 16`` keys) is still raw and must be fakequantized in-kernel.
     v_dense_boundary = (seq_len_kv // 16) * 16
+    # Per-page mode: a tile is "complete" (baked) iff it ends at/below the last whole-tile
+    # boundary; the trailing tile (the in-progress page) is FQ'd on read from its own amax.
+    page_boundary = (seq_len_kv // BLOCK_N) * BLOCK_N
 
     # Partition whole BLOCK_N tiles (calibration-aligned) evenly across splits.
     num_tiles = (seq_len_kv + BLOCK_N - 1) // BLOCK_N
@@ -197,9 +203,14 @@ def _attn_decode_split_fwd(
             max_blocks_per_seq,
         )
         kt_f = kt.to(tl.float32)
-        if NVFP4_K and not K_CACHE_QUANTIZED:  # pre-quantized K read as-is (every key's
-            # head-dim block is complete at write time, so the whole cache is already on-grid)
-            kt_f = fake_quant_fp4_k0(kt_f, BLOCK_D, BLOCK_N, 16, 1, k_gs, QUANT_NVFP4)
+        if NVFP4_K and (
+            (not K_CACHE_QUANTIZED) or (PER_PAGE_SCALE and kv_start + BLOCK_N > page_boundary)
+        ):
+            # Frozen mode: pre-quantized K read as-is (every key's head-dim block is complete at
+            # write). Per-page mode: complete tiles read as-is; only the trailing (raw) tile is
+            # FQ'd here, with its own per-tile amax (recomputed each step from the bf16 master).
+            kgs_eff = (tl.max(tl.abs(kt_f)) / (6.0 * 448.0) + 1e-30) if PER_PAGE_SCALE else k_gs
+            kt_f = fake_quant_fp4_k0(kt_f, BLOCK_D, BLOCK_N, 16, 1, kgs_eff, QUANT_NVFP4)
         scores = tl.sum(q[:, None] * kt_f, axis=0) * qk_scale  # [BLOCK_N], fp32 accum
         scores = tl.where(kv_valid, scores, -float("inf"))
 
@@ -264,8 +275,13 @@ def _attn_decode_split_fwd(
             if NVFP4_V:  # BMM2 value (B-side, V [BLOCK_N, BLOCK_D], GEMM-K = keys = axis 0)
                 # Pre-quantized completed V blocks read as-is; only tiles reaching the raw tail
                 # (kv_start+BLOCK_N > boundary) are fakequantized. Without on-write, FQ every tile.
-                if (not V_CACHE_QUANTIZED) or (kv_start + BLOCK_N > v_dense_boundary):
-                    vt_f = fake_quant_fp4_k0(vt_f, BLOCK_N, BLOCK_D, 16, 1, v_gs, QUANT_NVFP4)
+                v_bound = page_boundary if PER_PAGE_SCALE else v_dense_boundary
+                if (not V_CACHE_QUANTIZED) or (kv_start + BLOCK_N > v_bound):
+                    # Per-page: the trailing tile's scale = its own amax (bf16-master re-quant).
+                    vgs_eff = (
+                        (tl.max(tl.abs(vt_f)) / (6.0 * 448.0) + 1e-30) if PER_PAGE_SCALE else v_gs
+                    )
+                    vt_f = fake_quant_fp4_k0(vt_f, BLOCK_N, BLOCK_D, 16, 1, vgs_eff, QUANT_NVFP4)
             acc += tl.sum(p_bmm[:, None] * vt_f, axis=0)  # [BLOCK_D], fp32 accum
             m_i = m_new
 
@@ -348,6 +364,7 @@ def attention_decode(
     attn_global_scales: dict | None = None,
     k_cache_quantized: bool = False,  # K cache holds fake-quantized values (skip in-kernel K FQ)
     v_cache_quantized: bool = False,  # V cache pre-quantized for complete 16-key blocks (FQ tail only)
+    per_page_scale: bool = False,  # method 2: per-page (per-tile) NVFP4 global scale (see kernel)
 ) -> torch.Tensor:
     """Decode attention (one query token per request) over a paged KV cache.
 
@@ -414,12 +431,17 @@ def attention_decode(
     # small per-step q/k/v); scanning the full paged K/V cache here would OOM.
     _gs = attn_global_scales or {}
     q_gs = (_gs["q"] if "q" in _gs else tensor_global_scale_device(q)) if "q" in nvfp4 else 1.0
-    k_gs = (
-        (_gs["k"] if "k" in _gs else tensor_global_scale_device(k_cache)) if "k" in nvfp4 else 1.0
-    )
-    v_gs = (
-        (_gs["v"] if "v" in _gs else tensor_global_scale_device(v_cache)) if "v" in nvfp4 else 1.0
-    )
+    if per_page_scale:
+        # The K/V global scale is computed per tile in-kernel from the cache content; the passed
+        # k/v scales are unused. Pass cheap 0-d placeholders (never tl.load'd on the per-page path)
+        # and skip the cache-wide amax scan that would OOM on a large paged cache.
+        k_gs = q.new_full((), 1.0) if "k" in nvfp4 else 1.0
+        v_gs = q.new_full((), 1.0) if "v" in nvfp4 else 1.0
+    else:
+        # Default (no explicit scale) = constant 1.0. The old whole-cache amax fallback both OOMs on
+        # a large paged cache and, used as a frozen scale, saturates on long context — deprecated.
+        k_gs = (_gs["k"] if "k" in _gs else k_cache.new_full((), 1.0)) if "k" in nvfp4 else 1.0
+        v_gs = (_gs["v"] if "v" in _gs else v_cache.new_full((), 1.0)) if "v" in nvfp4 else 1.0
     # P global is a fixed constant (unnormalized exp P max ~1); 0-d device tensor for
     # uniformity. Built copy-free with new_full (device-side fill) — torch.tensor(const,
     # device=cuda) does a host->device copy that is illegal during CUDA-graph capture.
@@ -495,6 +517,7 @@ def attention_decode(
             MIXED_FP16=_mixed_fp16,
             K_CACHE_QUANTIZED=k_cache_quantized,
             V_CACHE_QUANTIZED=v_cache_quantized,
+            PER_PAGE_SCALE=per_page_scale,
             q_global_scale=q_gs,
             k_global_scale=k_gs,
             p_global_scale=p_gs,
@@ -645,6 +668,7 @@ def _onwrite_fq_paged_kernel(
     v_global_scale,
     NVFP4_K: tl.constexpr,
     NVFP4_V: tl.constexpr,
+    PER_PAGE_SCALE: tl.constexpr,  # derive the global scale per tile from its own amax (method 2)
     PAGE_SIZE: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_D: tl.constexpr,
@@ -685,7 +709,6 @@ def _onwrite_fq_paged_kernel(
     )
 
     if NVFP4_K:
-        k_gs = tl.load(k_global_scale)
         k_ptrs = (
             page_global[None, :].to(tl.int64) * stride_kc_block
             + offset_in_page[None, :] * stride_kc_pos
@@ -696,13 +719,19 @@ def _onwrite_fq_paged_kernel(
         kt = tl.load(K_cache + k_ptrs, mask=k_in[None, :] & d_mask[:, None], other=0.0).to(
             tl.float32
         )
+        # Per-page: this tile is a complete page (the plugin restricts the range to whole tiles),
+        # so bake it with its own amax. Frozen: use the passed per-tensor scale.
+        k_gs = (
+            (tl.max(tl.abs(kt)) / (6.0 * 448.0) + 1e-30)
+            if PER_PAGE_SCALE
+            else tl.load(k_global_scale)
+        )
         kq = fake_quant_fp4_k0(kt, BLOCK_D, BLOCK_N, 16, 1, k_gs, QUANT_NVFP4)
         tl.store(
             K_cache + k_ptrs, kq.to(K_cache.dtype.element_ty), mask=k_in[None, :] & d_mask[:, None]
         )
 
     if NVFP4_V:
-        v_gs = tl.load(v_global_scale)
         v_ptrs = (
             page_global[:, None].to(tl.int64) * stride_vc_block
             + offset_in_page[:, None] * stride_vc_pos
@@ -712,6 +741,11 @@ def _onwrite_fq_paged_kernel(
         v_in = (kv_abs >= vlo) & (kv_abs < vhi)
         vt = tl.load(V_cache + v_ptrs, mask=v_in[:, None] & d_mask[None, :], other=0.0).to(
             tl.float32
+        )
+        v_gs = (
+            (tl.max(tl.abs(vt)) / (6.0 * 448.0) + 1e-30)
+            if PER_PAGE_SCALE
+            else tl.load(v_global_scale)
         )
         vq = fake_quant_fp4_k0(vt, BLOCK_N, BLOCK_D, 16, 1, v_gs, QUANT_NVFP4)
         tl.store(
@@ -733,12 +767,17 @@ def fake_quant_kv_onwrite(
     v_global_scale=None,
     nvfp4: set[str] | None = None,
     decode: bool = False,
+    per_page_scale: bool = False,
 ) -> None:
     """Paged quantize-on-write: fakequant K (k_lo:k_hi) and V (v_lo:v_hi) per request in place.
 
     Set ``decode=True`` for a pure single-token decode step: the grid is fixed to one tile per
     request, so the launch needs no host ``.item()`` and is CUDA-graph-capturable. ``decode=False``
     (prefill / mixed batch, run eager) sizes the grid to the largest per-request span.
+
+    ``per_page_scale=True`` (method 2) derives each tile's NVFP4 global scale from its own amax in
+    the kernel (the passed ``k/v_global_scale`` are then unused); the caller must restrict
+    ``[k_lo,k_hi)``/``[v_lo,v_hi)`` to whole BLOCK_N tiles so only complete pages are baked.
     """
     nvfp4 = nvfp4 or set()
     if not ({"k", "v"} & nvfp4):
@@ -779,6 +818,7 @@ def fake_quant_kv_onwrite(
             vgs,
             NVFP4_K="k" in nvfp4,
             NVFP4_V="v" in nvfp4,
+            PER_PAGE_SCALE=per_page_scale,
             PAGE_SIZE=page_size,
             BLOCK_N=BLOCK_N,
             BLOCK_D=BLOCK_D,

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -1086,6 +1086,14 @@ class _Attention(torch.autograd.Function):
                     num_warps=_MEASURE_NUM_WARPS,
                     num_stages=_MEASURE_NUM_STAGES,
                 )
+            elif per_page_scale:
+                # Per-page bakes 128-key pages; the prefill KV tile MUST equal that page so the
+                # trailing page's amax is computed over the FULL 128-page (matching decode/on-write),
+                # not a 64-wide sub-tile. Pin BLOCK_N=128; small BLOCK_M + num_stages=1 keeps shared
+                # memory in budget (bf16 serve ~84KB on A6000's 99KB; ample on GB300/B200).
+                _attn_fwd.fn[grid](
+                    *fwd_args, **fwd_kwargs, BLOCK_M=16, BLOCK_N=128, num_warps=4, num_stages=1
+                )
             else:
                 _attn_fwd[grid](
                     *fwd_args,

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -306,6 +306,11 @@ def _attn_fwd(
     EXP2_QUANT: tl.constexpr = 0,
     ACC_QUANT: tl.constexpr = 0,
     MIXED_FP16: tl.constexpr = False,  # reference mixed-precision softmax (native fp16 MUFU)
+    PER_PAGE_SCALE: tl.constexpr = False,  # method 2: derive K/V global scale per tile from its own
+    # amax (overrides the passed k/v_global_scale); complete tiles read as-is (baked), tail FQ'd.
+    SCALE_PAGE: tl.constexpr = 128,  # per-page granularity = the on-write bake tile (128). The page
+    # boundary uses THIS, not BLOCK_N, so a smaller autotuned BLOCK_N still reads baked 128-pages
+    # correctly. (The trailing-page amax is then over BLOCK_N, a finer-but-consistent sub-page scale.)
     # Per-tensor NVFP4 global scales (amax/(6*448)). When the matching NVFP4_* flag is
     # set these are device 0-d tensors (pointers), read via ``tl.load`` so no host
     # ``.item()`` sync is needed (CUDA-graph-safe); otherwise an unused float default.
@@ -328,6 +333,10 @@ def _attn_fwd(
     seq_len_kv = tl.load(b_seq_len_k + batch_idx)
     q_offset = tl.load(b_start_loc + batch_idx)
     kv_offset = tl.load(b_start_loc_k + batch_idx)
+    # Per-page: tiles ending at/below this boundary are complete pages (baked on write -> read
+    # as-is); only the trailing in-progress page is fakequantized on read, from its own amax. The
+    # boundary is the 128-key bake page (SCALE_PAGE), independent of the autotuned BLOCK_N.
+    page_boundary = (seq_len_kv // SCALE_PAGE) * SCALE_PAGE
 
     if tile_q * BLOCK_M >= seq_len_q:
         return  # This Q tile is past the sequence end
@@ -401,8 +410,13 @@ def _attn_fwd(
                 other=0.0,
             )
 
-        if NVFP4_K:  # BMM1 key operand (B-side, K^T [BLOCK_D, BLOCK_N], GEMM-K = axis 0)
-            k = fake_quant_fp4_k0(k, BLOCK_D, BLOCK_N, 16, 1, k_gs, QUANT_NVFP4)
+        if NVFP4_K and (  # BMM1 key operand (B-side, K^T [BLOCK_D, BLOCK_N], GEMM-K = axis 0)
+            (not PER_PAGE_SCALE) or (not IS_PAGED) or (kv_start + BLOCK_N > page_boundary)
+        ):
+            # Per-page: complete tiles are baked (read as-is); only the trailing tile is FQ'd,
+            # with its own per-tile amax. Frozen: every tile FQ'd with the per-tensor k_gs.
+            kgs_eff = (tl.max(tl.abs(k)) / (6.0 * 448.0) + 1e-30) if PER_PAGE_SCALE else k_gs
+            k = fake_quant_fp4_k0(k, BLOCK_D, BLOCK_N, 16, 1, kgs_eff, QUANT_NVFP4)
 
         # scores = Q @ K^T * scale  [BLOCK_M, BLOCK_N]
         scores = tl.dot(q, k) * qk_scale
@@ -485,8 +499,12 @@ def _attn_fwd(
                     mask=((kv_start + kv_pos[:, None]) < seq_len_kv) & d_mask[None, :],
                     other=0.0,
                 )
-            if NVFP4_V:  # BMM2 value operand (B-side, V [BLOCK_N, BLOCK_D], GEMM-K = keys = axis 0)
-                v = fake_quant_fp4_k0(v, BLOCK_N, BLOCK_D, 16, 1, v_gs, QUANT_NVFP4)
+            if NVFP4_V and (  # BMM2 value operand (B-side, V [BLOCK_N, BLOCK_D], GEMM-K = axis 0)
+                (not PER_PAGE_SCALE) or (not IS_PAGED) or (kv_start + BLOCK_N > page_boundary)
+            ):
+                # Per-page: complete tiles baked (read as-is); trailing tile FQ'd from its own amax.
+                vgs_eff = (tl.max(tl.abs(v)) / (6.0 * 448.0) + 1e-30) if PER_PAGE_SCALE else v_gs
+                v = fake_quant_fp4_k0(v, BLOCK_N, BLOCK_D, 16, 1, vgs_eff, QUANT_NVFP4)
             # BMM2 prob operand (A-side, P [BLOCK_M, BLOCK_N], GEMM-K = keys = axis 1) with a
             # per-tensor p_global_scale, matching mni/attnOpt: quantize the *unnormalized* exp
             # P tile, accumulate, normalize acc by row_sum after the loop. (Across KV tiles the
@@ -897,6 +915,7 @@ class _Attention(torch.autograd.Function):
         fp16_softmax=False,
         softmax_quant=None,
         attn_global_scales=None,
+        per_page_scale=False,
     ):
         HEAD_DIM = q.shape[2]
         num_q_heads = q.shape[1]
@@ -980,10 +999,6 @@ class _Attention(torch.autograd.Function):
         _nvfp4 = nvfp4 or set()
         assert _nvfp4 <= {"q", "k", "p", "v"}, f"nvfp4 must be a subset of q/k/p/v, got {nvfp4}"
         _diff_q, _exp2_q, _acc_q, _mixed_fp16 = _resolve_softmax_modes(fp16_softmax, softmax_quant)
-        # Per-tensor NVFP4 global scales (host-side amax/(6*448)), aligned with the
-        # mni/attnOpt convention (tensor_scale). K/V are read from the paged cache.
-        _k_src = k_cache if is_paged else k
-        _v_src = v_cache if is_paged else v
         # P global is a fixed constant (unnormalized exp P has per-row max ~1); keep it
         # as a 0-d device tensor so every scale enters the kernel uniformly by pointer.
         # Built copy-free with new_full (device-side fill) — torch.tensor(const,
@@ -994,6 +1009,10 @@ class _Attention(torch.autograd.Function):
         # K/V cache here would upcast it to fp32 and OOM. Eager/test launches leave
         # ``attn_global_scales`` unset and compute from the (small) q/k/v operands.
         _gs = attn_global_scales or {}
+        # K/V NVFP4 global scale: DEFAULT = constant 1.0. The deprecated whole-cache amax scan OOMs
+        # on a paged cache and, used as a frozen scale, saturates long context. per_page_scale derives
+        # it per tile in-kernel (the passed scale is then ignored). Either way pass this cheap 0-d 1.0.
+        _one_gs = q.new_full((), 1.0, dtype=torch.float32)
         fwd_kwargs = {
             "N_CTX": max_input_len,
             "kv_group_num": kv_group_num,
@@ -1036,13 +1055,14 @@ class _Attention(torch.autograd.Function):
             "q_global_scale": (_gs["q"] if "q" in _gs else tensor_global_scale_device(q))
             if "q" in _nvfp4
             else 1.0,
-            "k_global_scale": (_gs["k"] if "k" in _gs else tensor_global_scale_device(_k_src))
+            "k_global_scale": (_one_gs if per_page_scale else _gs.get("k", _one_gs))
             if "k" in _nvfp4
             else 1.0,
             "p_global_scale": _p_global if "p" in _nvfp4 else 1.0,
-            "v_global_scale": (_gs["v"] if "v" in _gs else tensor_global_scale_device(_v_src))
+            "v_global_scale": (_one_gs if per_page_scale else _gs.get("v", _one_gs))
             if "v" in _nvfp4
             else 1.0,
+            "PER_PAGE_SCALE": per_page_scale,
         }
 
         # Grid: (batch, q_heads, q_tiles). Uses a function because BLOCK_M is autotuned.
@@ -1239,6 +1259,7 @@ class _Attention(torch.autograd.Function):
             None,  # fp16_softmax
             None,  # softmax_quant
             None,  # attn_global_scales
+            None,  # per_page_scale
         )
 
 
@@ -1269,6 +1290,7 @@ def attention(
     v_cache: torch.Tensor | None = None,
     block_table: torch.Tensor | None = None,
     page_size: int = 16,
+    per_page_scale: bool = False,
 ) -> torch.Tensor:
     """Variable-length flash attention with GQA, autograd, optional sparsity, and paged KV.
 
@@ -1353,6 +1375,7 @@ def attention(
         fp16_softmax,
         softmax_quant,
         attn_global_scales,
+        per_page_scale,
     )
 
 

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -280,7 +280,7 @@ def _attn_fwd(
     SPARSITY_N: tl.constexpr = 0,  # N:M sparsity — keep top-N of every M elements (0 = disabled)
     SPARSITY_M: tl.constexpr = 4,  # N:M sparsity — group size (4 or 8)
     DENSE_SINK_TOKENS: tl.constexpr = 0,  # Leading KV tokens kept dense (attention sinks)
-    DENSE_RECENT_TOKENS: tl.constexpr = 64,  # Recent KV tokens kept dense (BLOCK_N-independent)
+    DENSE_RECENT_TOKENS: tl.constexpr = 128,  # Recent KV tokens kept dense (BLOCK_N-independent)
     APPLY_SKIP_SOFTMAX: tl.constexpr = False,  # Skip KV tiles with negligible scores
     SKIP_THRESHOLD_LOG2: tl.constexpr = 0.0,  # log2(lambda) in the kernel's scaled log2 score space
     Sparsity_total=None,  # Optional int64 scalar for counting total tiles (atomic)
@@ -597,7 +597,7 @@ def _attn_bwd_dq(
     SPARSITY_N: tl.constexpr = 0,
     SPARSITY_M: tl.constexpr = 4,
     DENSE_SINK_TOKENS: tl.constexpr = 0,
-    DENSE_RECENT_TOKENS: tl.constexpr = 64,
+    DENSE_RECENT_TOKENS: tl.constexpr = 128,
     APPLY_SKIP_SOFTMAX: tl.constexpr = False,
     SKIP_THRESHOLD_LOG2: tl.constexpr = 0.0,
 ):
@@ -748,7 +748,7 @@ def _attn_bwd_dkdv(
     SPARSITY_N: tl.constexpr = 0,
     SPARSITY_M: tl.constexpr = 4,
     DENSE_SINK_TOKENS: tl.constexpr = 0,
-    DENSE_RECENT_TOKENS: tl.constexpr = 64,
+    DENSE_RECENT_TOKENS: tl.constexpr = 128,
     APPLY_SKIP_SOFTMAX: tl.constexpr = False,
     SKIP_THRESHOLD_LOG2: tl.constexpr = 0.0,
 ):
@@ -1258,7 +1258,7 @@ def attention(
     sparsity_n: int = 0,
     sparsity_m: int = 4,
     dense_sink_tokens: int = 0,
-    dense_recent_tokens: int = 64,
+    dense_recent_tokens: int = 128,
     skip_softmax_threshold: float | None = None,
     measure_sparsity: bool = False,
     nvfp4: set[str] | None = None,

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -34,7 +34,7 @@ from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import (
     QUANT_NVFP4,
     fake_quant_fp4_k0,
     fake_quant_fp4_k1,
-    tensor_global_scale,
+    tensor_global_scale_device,
 )
 from modelopt.torch.kernels.quantization.attention.softmax_fakequant import (
     resolve_softmax_mode,
@@ -298,7 +298,10 @@ def _attn_fwd(
     DIFF_QUANT: tl.constexpr = 0,  # softmax-datapath modes: DIFF (pre-exp2), EXP2, ACC (sum)
     EXP2_QUANT: tl.constexpr = 0,
     ACC_QUANT: tl.constexpr = 0,
-    q_global_scale=1.0,  # per-tensor NVFP4 global scales (amax/(6*448)), computed host-side
+    # Per-tensor NVFP4 global scales (amax/(6*448)). When the matching NVFP4_* flag is
+    # set these are device 0-d tensors (pointers), read via ``tl.load`` so no host
+    # ``.item()`` sync is needed (CUDA-graph-safe); otherwise an unused float default.
+    q_global_scale=1.0,
     k_global_scale=1.0,
     p_global_scale=1.0,
     v_global_scale=1.0,
@@ -327,11 +330,19 @@ def _attn_fwd(
     dim_pos = tl.arange(0, BLOCK_D)  # Head dimension positions
     d_mask = dim_pos < HEAD_DIM  # Mask for non-power-of-2 head dims
 
+    # --- NVFP4 global scales: read on-device (no host sync) once, reuse in the KV loop.
+    # The matching constexpr guard means the arg is only dereferenced when that operand
+    # is actually quantized; otherwise it is an unused scalar default.
+    q_gs = tl.load(q_global_scale) if NVFP4_Q else 1.0
+    k_gs = tl.load(k_global_scale) if NVFP4_K else 1.0
+    p_gs = tl.load(p_global_scale) if NVFP4_P else 1.0
+    v_gs = tl.load(v_global_scale) if NVFP4_V else 1.0
+
     # --- Load Q tile [BLOCK_M, BLOCK_D]: stays in SRAM for the entire KV loop ---
     q_ptrs = (q_offset + q_pos[:, None]) * stride_qbs + head_idx * stride_qh + dim_pos[None, :]
     q = tl.load(Q + q_ptrs, mask=(q_pos[:, None] < seq_len_q) & d_mask[None, :], other=0.0)
     if NVFP4_Q:  # BMM1 query operand (A-side, GEMM-K = head dim = axis 1)
-        q = fake_quant_fp4_k1(q, BLOCK_M, BLOCK_D, 16, q_global_scale, QUANT_NVFP4)
+        q = fake_quant_fp4_k1(q, BLOCK_M, BLOCK_D, 16, q_gs, QUANT_NVFP4)
 
     # Base pointers for K and V at this KV head (per-tile offset added in loop)
     k_base = K + kv_head_idx * stride_kh
@@ -383,7 +394,7 @@ def _attn_fwd(
             )
 
         if NVFP4_K:  # BMM1 key operand (B-side, K^T [BLOCK_D, BLOCK_N], GEMM-K = axis 0)
-            k = fake_quant_fp4_k0(k, BLOCK_D, BLOCK_N, 16, 1, k_global_scale, QUANT_NVFP4)
+            k = fake_quant_fp4_k0(k, BLOCK_D, BLOCK_N, 16, 1, k_gs, QUANT_NVFP4)
 
         # scores = Q @ K^T * scale  [BLOCK_M, BLOCK_N]
         scores = tl.dot(q, k) * qk_scale
@@ -458,17 +469,13 @@ def _attn_fwd(
                     other=0.0,
                 )
             if NVFP4_V:  # BMM2 value operand (B-side, V [BLOCK_N, BLOCK_D], GEMM-K = keys = axis 0)
-                v = fake_quant_fp4_k0(v, BLOCK_N, BLOCK_D, 16, 1, v_global_scale, QUANT_NVFP4)
+                v = fake_quant_fp4_k0(v, BLOCK_N, BLOCK_D, 16, 1, v_gs, QUANT_NVFP4)
             # BMM2 prob operand (A-side, P [BLOCK_M, BLOCK_N], GEMM-K = keys = axis 1) with a
             # per-tensor p_global_scale, matching mni/attnOpt: quantize the *unnormalized* exp
             # P tile, accumulate, normalize acc by row_sum after the loop. (Across KV tiles the
             # online-softmax rescaling makes this an approximation of full-P NVFP4 — same as
             # their flash kernel; the materialized/eager path is the exact reference.)
-            p_dot = (
-                fake_quant_fp4_k1(p, BLOCK_M, BLOCK_N, 16, p_global_scale, QUANT_NVFP4)
-                if NVFP4_P
-                else p
-            )
+            p_dot = fake_quant_fp4_k1(p, BLOCK_M, BLOCK_N, 16, p_gs, QUANT_NVFP4) if NVFP4_P else p
             acc = tl.dot(p_dot.to(v.dtype), v, acc)
             row_max = m_new
         # else: tile skipped — no softmax, no V load, no BMM2 for this tile
@@ -960,7 +967,11 @@ class _Attention(torch.autograd.Function):
         # mni/attnOpt convention (tensor_scale). K/V are read from the paged cache.
         _k_src = k_cache if is_paged else k
         _v_src = v_cache if is_paged else v
-        _p_global = 1.0 / (6.0 * 448.0) + 1e-30  # unnormalized exp P has per-row max ~1
+        # P global is a fixed constant (unnormalized exp P has per-row max ~1); keep it
+        # as a 0-d device tensor so every scale enters the kernel uniformly by pointer.
+        # Built copy-free with new_full (device-side fill) — torch.tensor(const,
+        # device=cuda) does a host->device copy that is illegal during CUDA-graph capture.
+        _p_global = q.new_full((), 1.0 / (6.0 * 448.0) + 1e-30, dtype=torch.float32)
         # In paged serving the caller passes precomputed per-tensor global scales
         # (from the small per-step q/k/v); falling back to scanning the full paged
         # K/V cache here would upcast it to fp32 and OOM. Eager/test launches leave
@@ -1001,14 +1012,17 @@ class _Attention(torch.autograd.Function):
             "DIFF_QUANT": _diff_q,
             "EXP2_QUANT": _exp2_q,
             "ACC_QUANT": _acc_q,
-            "q_global_scale": (_gs["q"] if "q" in _gs else tensor_global_scale(q))
+            # Device 0-d tensors (pointers) when quantized — read via tl.load in-kernel,
+            # no host .item(). The caller's precomputed scales (paged serving) are also
+            # device tensors; the fallback computes from the small q/k/v operands.
+            "q_global_scale": (_gs["q"] if "q" in _gs else tensor_global_scale_device(q))
             if "q" in _nvfp4
             else 1.0,
-            "k_global_scale": (_gs["k"] if "k" in _gs else tensor_global_scale(_k_src))
+            "k_global_scale": (_gs["k"] if "k" in _gs else tensor_global_scale_device(_k_src))
             if "k" in _nvfp4
             else 1.0,
             "p_global_scale": _p_global if "p" in _nvfp4 else 1.0,
-            "v_global_scale": (_gs["v"] if "v" in _gs else tensor_global_scale(_v_src))
+            "v_global_scale": (_gs["v"] if "v" in _gs else tensor_global_scale_device(_v_src))
             if "v" in _nvfp4
             else 1.0,
         }

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -36,6 +36,26 @@ from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import (
     fake_quant_fp4_k1,
     tensor_global_scale,
 )
+from modelopt.torch.kernels.quantization.attention.softmax_fakequant import (
+    resolve_softmax_mode,
+    softmax_round,
+)
+
+
+def _resolve_softmax_modes(fp16_softmax, softmax_quant):
+    """(fp16_softmax bool, per-point dict) -> (DIFF, EXP2, ACC) integer modes.
+
+    ``fp16_softmax=True`` is a shortcut for FP16-RNE at all three points; the optional
+    ``softmax_quant`` dict ({"diff"/"exp2"/"acc": mode}) overrides per point.
+    """
+    sq = softmax_quant or {}
+    default = "fp16_rne" if fp16_softmax else None
+    return (
+        resolve_softmax_mode(sq.get("diff", default)),
+        resolve_softmax_mode(sq.get("exp2", default)),
+        resolve_softmax_mode(sq.get("acc", default)),
+    )
+
 
 # Helpers for optional N:M sparsity and sink/window-aware dense regions live
 # in the sparsity package. The baseline forward kernel below calls them
@@ -272,7 +292,9 @@ def _attn_fwd(
     NVFP4_K: tl.constexpr = False,  # fakequant K -> NVFP4 before BMM1 (= NVFP4 KV$ K side)
     NVFP4_P: tl.constexpr = False,  # fakequant softmax P -> NVFP4 before BMM2
     NVFP4_V: tl.constexpr = False,  # fakequant V -> NVFP4 before BMM2 (= NVFP4 KV$ V side)
-    FP16_SOFTMAX: tl.constexpr = False,  # compute softmax exp in fp16 (mixed precision)
+    DIFF_QUANT: tl.constexpr = 0,  # softmax-datapath modes: DIFF (pre-exp2), EXP2, ACC (sum)
+    EXP2_QUANT: tl.constexpr = 0,
+    ACC_QUANT: tl.constexpr = 0,
     q_global_scale=1.0,  # per-tensor NVFP4 global scales (amax/(6*448)), computed host-side
     k_global_scale=1.0,
     p_global_scale=1.0,
@@ -396,12 +418,11 @@ def _attn_fwd(
             )
 
         if not skip_tile:
-            # --- Online softmax update ---
+            # --- Online softmax update (with optional mixed-precision datapath quant) ---
             m_new = tl.maximum(row_max, tl.max(scores, 1))
-            p = tl.math.exp2(scores - m_new[:, None])
-            if FP16_SOFTMAX:  # mixed-precision (fp16) softmax
-                p = p.to(tl.float16).to(tl.float32)
-            l_new = tl.sum(p, 1)
+            s_shift = softmax_round(scores - m_new[:, None], DIFF_QUANT)  # DIFF: input to exp2
+            p = softmax_round(tl.math.exp2(s_shift), EXP2_QUANT)  # EXP2: output of exp2
+            l_new = softmax_round(tl.sum(p, 1), ACC_QUANT)  # ACC: running softmax denom
             correction = tl.math.exp2(row_max - m_new)
             row_sum = row_sum * correction + l_new
             acc = acc * correction[:, None]
@@ -847,6 +868,7 @@ class _Attention(torch.autograd.Function):
         page_size,
         nvfp4=None,
         fp16_softmax=False,
+        softmax_quant=None,
     ):
         HEAD_DIM = q.shape[2]
         num_q_heads = q.shape[1]
@@ -929,6 +951,7 @@ class _Attention(torch.autograd.Function):
         )
         _nvfp4 = nvfp4 or set()
         assert _nvfp4 <= {"q", "k", "p", "v"}, f"nvfp4 must be a subset of q/k/p/v, got {nvfp4}"
+        _diff_q, _exp2_q, _acc_q = _resolve_softmax_modes(fp16_softmax, softmax_quant)
         # Per-tensor NVFP4 global scales (host-side amax/(6*448)), aligned with the
         # mni/attnOpt convention (tensor_scale). K/V are read from the paged cache.
         _k_src = k_cache if is_paged else k
@@ -966,7 +989,9 @@ class _Attention(torch.autograd.Function):
             "NVFP4_K": "k" in _nvfp4,
             "NVFP4_P": "p" in _nvfp4,
             "NVFP4_V": "v" in _nvfp4,
-            "FP16_SOFTMAX": fp16_softmax,
+            "DIFF_QUANT": _diff_q,
+            "EXP2_QUANT": _exp2_q,
+            "ACC_QUANT": _acc_q,
             "q_global_scale": tensor_global_scale(q) if "q" in _nvfp4 else 1.0,
             "k_global_scale": tensor_global_scale(_k_src) if "k" in _nvfp4 else 1.0,
             "p_global_scale": _p_global if "p" in _nvfp4 else 1.0,
@@ -1165,6 +1190,7 @@ class _Attention(torch.autograd.Function):
             None,  # page_size
             None,  # nvfp4
             None,  # fp16_softmax
+            None,  # softmax_quant
         )
 
 
@@ -1189,6 +1215,7 @@ def attention(
     measure_sparsity: bool = False,
     nvfp4: set[str] | None = None,
     fp16_softmax: bool = False,
+    softmax_quant: dict | None = None,
     k_cache: torch.Tensor | None = None,
     v_cache: torch.Tensor | None = None,
     block_table: torch.Tensor | None = None,
@@ -1269,6 +1296,7 @@ def attention(
         page_size,
         nvfp4,
         fp16_softmax,
+        softmax_quant,
     )
 
 

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -154,7 +154,7 @@ def _load_paged_k_tile(
     # Load K values: K_cache[page_global, offset_in_page, kv_head_idx, dim]
     # K^T layout [BLOCK_D, BLOCK_N] for Q @ K^T matmul
     k_ptrs = (
-        # int64: real KV pools have >2**31/stride blocks, so page_global*stride_kc_block
+        # int64: real KV pools have >2^31/stride blocks, so page_global*stride_kc_block
         # overflows int32 at high block IDs -> negative offset -> illegal memory access.
         page_global[None, :].to(tl.int64) * stride_kc_block
         + offset_in_page[None, :] * stride_kc_pos
@@ -872,6 +872,7 @@ class _Attention(torch.autograd.Function):
         nvfp4=None,
         fp16_softmax=False,
         softmax_quant=None,
+        attn_global_scales=None,
     ):
         HEAD_DIM = q.shape[2]
         num_q_heads = q.shape[1]
@@ -960,6 +961,11 @@ class _Attention(torch.autograd.Function):
         _k_src = k_cache if is_paged else k
         _v_src = v_cache if is_paged else v
         _p_global = 1.0 / (6.0 * 448.0) + 1e-30  # unnormalized exp P has per-row max ~1
+        # In paged serving the caller passes precomputed per-tensor global scales
+        # (from the small per-step q/k/v); falling back to scanning the full paged
+        # K/V cache here would upcast it to fp32 and OOM. Eager/test launches leave
+        # ``attn_global_scales`` unset and compute from the (small) q/k/v operands.
+        _gs = attn_global_scales or {}
         fwd_kwargs = {
             "N_CTX": max_input_len,
             "kv_group_num": kv_group_num,
@@ -995,10 +1001,16 @@ class _Attention(torch.autograd.Function):
             "DIFF_QUANT": _diff_q,
             "EXP2_QUANT": _exp2_q,
             "ACC_QUANT": _acc_q,
-            "q_global_scale": tensor_global_scale(q) if "q" in _nvfp4 else 1.0,
-            "k_global_scale": tensor_global_scale(_k_src) if "k" in _nvfp4 else 1.0,
+            "q_global_scale": (_gs["q"] if "q" in _gs else tensor_global_scale(q))
+            if "q" in _nvfp4
+            else 1.0,
+            "k_global_scale": (_gs["k"] if "k" in _gs else tensor_global_scale(_k_src))
+            if "k" in _nvfp4
+            else 1.0,
             "p_global_scale": _p_global if "p" in _nvfp4 else 1.0,
-            "v_global_scale": tensor_global_scale(_v_src) if "v" in _nvfp4 else 1.0,
+            "v_global_scale": (_gs["v"] if "v" in _gs else tensor_global_scale(_v_src))
+            if "v" in _nvfp4
+            else 1.0,
         }
 
         # Grid: (batch, q_heads, q_tiles). Uses a function because BLOCK_M is autotuned.
@@ -1194,6 +1206,7 @@ class _Attention(torch.autograd.Function):
             None,  # nvfp4
             None,  # fp16_softmax
             None,  # softmax_quant
+            None,  # attn_global_scales
         )
 
 
@@ -1219,6 +1232,7 @@ def attention(
     nvfp4: set[str] | None = None,
     fp16_softmax: bool = False,
     softmax_quant: dict | None = None,
+    attn_global_scales: dict | None = None,
     k_cache: torch.Tensor | None = None,
     v_cache: torch.Tensor | None = None,
     block_table: torch.Tensor | None = None,
@@ -1300,6 +1314,7 @@ def attention(
         nvfp4,
         fp16_softmax,
         softmax_quant,
+        attn_global_scales,
     )
 
 

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -154,7 +154,9 @@ def _load_paged_k_tile(
     # Load K values: K_cache[page_global, offset_in_page, kv_head_idx, dim]
     # K^T layout [BLOCK_D, BLOCK_N] for Q @ K^T matmul
     k_ptrs = (
-        page_global[None, :] * stride_kc_block
+        # int64: real KV pools have >2**31/stride blocks, so page_global*stride_kc_block
+        # overflows int32 at high block IDs -> negative offset -> illegal memory access.
+        page_global[None, :].to(tl.int64) * stride_kc_block
         + offset_in_page[None, :] * stride_kc_pos
         + kv_head_idx * stride_kc_head
         + dim_pos[:, None]
@@ -196,7 +198,8 @@ def _load_paged_v_tile(
 
     # V layout [BLOCK_N, BLOCK_D]
     v_ptrs = (
-        page_global[:, None] * stride_vc_block
+        # int64: see _load_paged_k_tile — avoid int32 overflow at high block IDs.
+        page_global[:, None].to(tl.int64) * stride_vc_block
         + offset_in_page[:, None] * stride_vc_pos
         + kv_head_idx * stride_vc_head
         + dim_pos[None, :]

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -1014,7 +1014,14 @@ class _Attention(torch.autograd.Function):
         # it per tile in-kernel (the passed scale is then ignored). Either way pass this cheap 0-d 1.0.
         _one_gs = q.new_full((), 1.0, dtype=torch.float32)
         fwd_kwargs = {
-            "N_CTX": max_input_len,
+            # Bucket the autotune key to a power-of-2 length REGIME, not the exact
+            # seq len: keying on exact max_input_len re-ran autotune (benchmark all
+            # _FWD_CONFIGS) per unique prefill length — ~149 re-tunes on a varying-
+            # length workload (random bench / agentic GDPval), the bulk of the TTFT
+            # blowup. next_power_of_2 collapses that to one tune per length regime,
+            # each still getting a length-appropriate config. (N_CTX is key-only,
+            # never used in compute — see the kernel arg comment.)
+            "N_CTX": triton.next_power_of_2(max(1, max_input_len)),
             "kv_group_num": kv_group_num,
             "BLOCK_D": BLOCK_D,
             "IS_CAUSAL": is_causal,

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -37,23 +37,30 @@ from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import (
     tensor_global_scale_device,
 )
 from modelopt.torch.kernels.quantization.attention.softmax_fakequant import (
+    ex2_fp16,
     resolve_softmax_mode,
     softmax_round,
 )
 
 
 def _resolve_softmax_modes(fp16_softmax, softmax_quant):
-    """(fp16_softmax bool, per-point dict) -> (DIFF, EXP2, ACC) integer modes.
+    """(fp16_softmax bool, per-point dict) -> (DIFF, EXP2, ACC, MIXED_FP16).
 
-    ``fp16_softmax=True`` is a shortcut for FP16-RNE at all three points; the optional
-    ``softmax_quant`` dict ({"diff"/"exp2"/"acc": mode}) overrides per point.
+    ``fp16_softmax=True`` engages the reference mixed-precision softmax design: both exp2s (the
+    softmax exp and the online correction) run in native fp16 (``ex2.approx.ftz.f16``) and the
+    denominator accumulates the fp16 P in fp32 (unrounded). The optional ``softmax_quant`` dict
+    ({"diff"/"exp2"/"acc": mode}) instead selects per-point round-based datapath quant (the
+    fp8/bf16/fp16-round experiments) and takes precedence when given.
     """
     sq = softmax_quant or {}
+    if fp16_softmax and not sq:
+        return (0, 0, 0, True)
     default = "fp16_rne" if fp16_softmax else None
     return (
         resolve_softmax_mode(sq.get("diff", default)),
         resolve_softmax_mode(sq.get("exp2", default)),
         resolve_softmax_mode(sq.get("acc", default)),
+        False,
     )
 
 
@@ -298,6 +305,7 @@ def _attn_fwd(
     DIFF_QUANT: tl.constexpr = 0,  # softmax-datapath modes: DIFF (pre-exp2), EXP2, ACC (sum)
     EXP2_QUANT: tl.constexpr = 0,
     ACC_QUANT: tl.constexpr = 0,
+    MIXED_FP16: tl.constexpr = False,  # reference mixed-precision softmax (native fp16 MUFU)
     # Per-tensor NVFP4 global scales (amax/(6*448)). When the matching NVFP4_* flag is
     # set these are device 0-d tensors (pointers), read via ``tl.load`` so no host
     # ``.item()`` sync is needed (CUDA-graph-safe); otherwise an unused float default.
@@ -434,10 +442,19 @@ def _attn_fwd(
         if not skip_tile:
             # --- Online softmax update (with optional mixed-precision datapath quant) ---
             m_new = tl.maximum(row_max, tl.max(scores, 1))
-            s_shift = softmax_round(scores - m_new[:, None], DIFF_QUANT)  # DIFF: input to exp2
-            p = softmax_round(tl.math.exp2(s_shift), EXP2_QUANT)  # EXP2: output of exp2
-            l_new = softmax_round(tl.sum(p, 1), ACC_QUANT)  # ACC: running softmax denom
-            correction = tl.math.exp2(row_max - m_new)
+            if MIXED_FP16:
+                # Reference mixed-precision softmax: fp16 datapath, fp32 reductions. The exp2
+                # input (scores - max) and the correction delta are converted to fp16 inside
+                # ex2_fp16 (cvt.rn.f16.f32) and exponentiated by the native fp16 MUFU; P comes
+                # out fp16-valued, and the denominator sums it in fp32 (unrounded).
+                p = ex2_fp16(scores - m_new[:, None])  # FHADD2 -> fp16 ; MUFU.ex2.fp16 -> P fp16
+                l_new = tl.sum(p, 1)  # row_sum accumulates fp16 P in fp32 (unrounded)
+                correction = ex2_fp16(row_max - m_new)  # fp16 correction factor
+            else:
+                s_shift = softmax_round(scores - m_new[:, None], DIFF_QUANT)  # DIFF: input to exp2
+                p = softmax_round(tl.math.exp2(s_shift), EXP2_QUANT)  # EXP2: output of exp2
+                l_new = softmax_round(tl.sum(p, 1), ACC_QUANT)  # ACC: running softmax denom
+                correction = tl.math.exp2(row_max - m_new)
             row_sum = row_sum * correction + l_new
             acc = acc * correction[:, None]
 
@@ -962,7 +979,7 @@ class _Attention(torch.autograd.Function):
         )
         _nvfp4 = nvfp4 or set()
         assert _nvfp4 <= {"q", "k", "p", "v"}, f"nvfp4 must be a subset of q/k/p/v, got {nvfp4}"
-        _diff_q, _exp2_q, _acc_q = _resolve_softmax_modes(fp16_softmax, softmax_quant)
+        _diff_q, _exp2_q, _acc_q, _mixed_fp16 = _resolve_softmax_modes(fp16_softmax, softmax_quant)
         # Per-tensor NVFP4 global scales (host-side amax/(6*448)), aligned with the
         # mni/attnOpt convention (tensor_scale). K/V are read from the paged cache.
         _k_src = k_cache if is_paged else k
@@ -1012,6 +1029,7 @@ class _Attention(torch.autograd.Function):
             "DIFF_QUANT": _diff_q,
             "EXP2_QUANT": _exp2_q,
             "ACC_QUANT": _acc_q,
+            "MIXED_FP16": _mixed_fp16,
             # Device 0-d tensors (pointers) when quantized — read via tl.load in-kernel,
             # no host .item(). The caller's precomputed scales (paged serving) are also
             # device tensors; the fallback computes from the small q/k/v operands.
@@ -1291,6 +1309,12 @@ def attention(
         block_table: Page table [batch, max_blocks_per_seq] mapping sequence
             block indices to global page IDs.
         page_size: Number of tokens per page in the KV cache.
+        fp16_softmax: Engage the reference mixed-precision softmax — both exp2s (the softmax
+            exp and the online correction) run in native fp16 (``ex2.approx.ftz.f16``) and the
+            denominator accumulates the fp16 P in fp32 (P fp16-in, sum unrounded). The matmul
+            accumulators stay fp32. Ignored when ``softmax_quant`` is given.
+        softmax_quant: Optional per-point datapath quant ``{"diff"/"exp2"/"acc": mode}`` for the
+            round-based experiments (fp8/bf16/fp16-round); takes precedence over ``fp16_softmax``.
 
     Returns:
         Output tensor [total_q_tokens, num_q_heads, head_dim].

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -31,9 +31,10 @@ import triton
 import triton.language as tl
 
 from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import (
-    nvfp4_qdq_axis0,
-    nvfp4_qdq_lastdim_2d,
-    nvfp4_qdq_lastdim_2d_perrow,
+    QUANT_NVFP4,
+    fake_quant_fp4_k0,
+    fake_quant_fp4_k1,
+    tensor_global_scale,
 )
 
 # Helpers for optional N:M sparsity and sink/window-aware dense regions live
@@ -272,6 +273,10 @@ def _attn_fwd(
     NVFP4_P: tl.constexpr = False,  # fakequant softmax P -> NVFP4 before BMM2
     NVFP4_V: tl.constexpr = False,  # fakequant V -> NVFP4 before BMM2 (= NVFP4 KV$ V side)
     FP16_SOFTMAX: tl.constexpr = False,  # compute softmax exp in fp16 (mixed precision)
+    q_global_scale=1.0,  # per-tensor NVFP4 global scales (amax/(6*448)), computed host-side
+    k_global_scale=1.0,
+    p_global_scale=1.0,
+    v_global_scale=1.0,
 ):
     # --- Grid: (batch, num_q_heads, num_q_tiles) ---
     # Example: batch=2, num_q_heads=32, seq_len=256, BLOCK_M=128
@@ -300,8 +305,8 @@ def _attn_fwd(
     # --- Load Q tile [BLOCK_M, BLOCK_D]: stays in SRAM for the entire KV loop ---
     q_ptrs = (q_offset + q_pos[:, None]) * stride_qbs + head_idx * stride_qh + dim_pos[None, :]
     q = tl.load(Q + q_ptrs, mask=(q_pos[:, None] < seq_len_q) & d_mask[None, :], other=0.0)
-    if NVFP4_Q:  # BMM1 query operand -> NVFP4 (contraction = head dim)
-        q = nvfp4_qdq_lastdim_2d(q.to(tl.float32), BLOCK_M, BLOCK_D // 16, 16).to(q.dtype)
+    if NVFP4_Q:  # BMM1 query operand (A-side, GEMM-K = head dim = axis 1)
+        q = fake_quant_fp4_k1(q, BLOCK_M, BLOCK_D, 16, q_global_scale, QUANT_NVFP4)
 
     # Base pointers for K and V at this KV head (per-tile offset added in loop)
     k_base = K + kv_head_idx * stride_kh
@@ -352,8 +357,8 @@ def _attn_fwd(
                 other=0.0,
             )
 
-        if NVFP4_K:  # BMM1 key operand -> NVFP4 (K^T [BLOCK_D, BLOCK_N], contraction = head dim)
-            k = nvfp4_qdq_axis0(k.to(tl.float32), BLOCK_D // 16, 16, BLOCK_N).to(k.dtype)
+        if NVFP4_K:  # BMM1 key operand (B-side, K^T [BLOCK_D, BLOCK_N], GEMM-K = axis 0)
+            k = fake_quant_fp4_k0(k, BLOCK_D, BLOCK_N, 16, 1, k_global_scale, QUANT_NVFP4)
 
         # scores = Q @ K^T * scale  [BLOCK_M, BLOCK_N]
         scores = tl.dot(q, k) * qk_scale
@@ -428,15 +433,18 @@ def _attn_fwd(
                     mask=((kv_start + kv_pos[:, None]) < seq_len_kv) & d_mask[None, :],
                     other=0.0,
                 )
-            if NVFP4_V:  # BMM2 value operand -> NVFP4 (V [BLOCK_N, BLOCK_D], contraction = keys)
-                v = nvfp4_qdq_axis0(v.to(tl.float32), BLOCK_N // 16, 16, BLOCK_D).to(v.dtype)
-            # BMM2 prob operand -> NVFP4 (contraction = keys), per-row (per-query-token)
-            # global. NVFP4 is homogeneous, so quantizing the unnormalized exp with a
-            # per-row global equals quantizing the normalized P (row_sum normalization is
-            # applied to acc after the loop). NOTE: exact only within a KV tile; across
-            # tiles the online-softmax rescaling makes multi-tile P-NVFP4 approximate —
-            # the faithful full-P NVFP4 is the materialized (eager) path.
-            p_dot = nvfp4_qdq_lastdim_2d_perrow(p, BLOCK_M, BLOCK_N // 16, 16) if NVFP4_P else p
+            if NVFP4_V:  # BMM2 value operand (B-side, V [BLOCK_N, BLOCK_D], GEMM-K = keys = axis 0)
+                v = fake_quant_fp4_k0(v, BLOCK_N, BLOCK_D, 16, 1, v_global_scale, QUANT_NVFP4)
+            # BMM2 prob operand (A-side, P [BLOCK_M, BLOCK_N], GEMM-K = keys = axis 1) with a
+            # per-tensor p_global_scale, matching mni/attnOpt: quantize the *unnormalized* exp
+            # P tile, accumulate, normalize acc by row_sum after the loop. (Across KV tiles the
+            # online-softmax rescaling makes this an approximation of full-P NVFP4 — same as
+            # their flash kernel; the materialized/eager path is the exact reference.)
+            p_dot = (
+                fake_quant_fp4_k1(p, BLOCK_M, BLOCK_N, 16, p_global_scale, QUANT_NVFP4)
+                if NVFP4_P
+                else p
+            )
             acc = tl.dot(p_dot.to(v.dtype), v, acc)
             row_max = m_new
         # else: tile skipped — no softmax, no V load, no BMM2 for this tile
@@ -921,6 +929,11 @@ class _Attention(torch.autograd.Function):
         )
         _nvfp4 = nvfp4 or set()
         assert _nvfp4 <= {"q", "k", "p", "v"}, f"nvfp4 must be a subset of q/k/p/v, got {nvfp4}"
+        # Per-tensor NVFP4 global scales (host-side amax/(6*448)), aligned with the
+        # mni/attnOpt convention (tensor_scale). K/V are read from the paged cache.
+        _k_src = k_cache if is_paged else k
+        _v_src = v_cache if is_paged else v
+        _p_global = 1.0 / (6.0 * 448.0) + 1e-30  # unnormalized exp P has per-row max ~1
         fwd_kwargs = {
             "N_CTX": max_input_len,
             "kv_group_num": kv_group_num,
@@ -954,6 +967,10 @@ class _Attention(torch.autograd.Function):
             "NVFP4_P": "p" in _nvfp4,
             "NVFP4_V": "v" in _nvfp4,
             "FP16_SOFTMAX": fp16_softmax,
+            "q_global_scale": tensor_global_scale(q) if "q" in _nvfp4 else 1.0,
+            "k_global_scale": tensor_global_scale(_k_src) if "k" in _nvfp4 else 1.0,
+            "p_global_scale": _p_global if "p" in _nvfp4 else 1.0,
+            "v_global_scale": tensor_global_scale(_v_src) if "v" in _nvfp4 else 1.0,
         }
 
         # Grid: (batch, q_heads, q_tiles). Uses a function because BLOCK_M is autotuned.

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -30,6 +30,12 @@ import torch
 import triton
 import triton.language as tl
 
+from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import (
+    nvfp4_qdq_axis0,
+    nvfp4_qdq_lastdim_2d,
+    nvfp4_qdq_lastdim_2d_perrow,
+)
+
 # Helpers for optional N:M sparsity and sink/window-aware dense regions live
 # in the sparsity package. The baseline forward kernel below calls them
 # conditionally under constexpr guards, so the unified single-kernel design
@@ -261,6 +267,11 @@ def _attn_fwd(
     stride_vc_head=0,
     PAGE_SIZE: tl.constexpr = 16,
     max_blocks_per_seq=0,
+    NVFP4_Q: tl.constexpr = False,  # fakequant Q -> NVFP4 before BMM1
+    NVFP4_K: tl.constexpr = False,  # fakequant K -> NVFP4 before BMM1 (= NVFP4 KV$ K side)
+    NVFP4_P: tl.constexpr = False,  # fakequant softmax P -> NVFP4 before BMM2
+    NVFP4_V: tl.constexpr = False,  # fakequant V -> NVFP4 before BMM2 (= NVFP4 KV$ V side)
+    FP16_SOFTMAX: tl.constexpr = False,  # compute softmax exp in fp16 (mixed precision)
 ):
     # --- Grid: (batch, num_q_heads, num_q_tiles) ---
     # Example: batch=2, num_q_heads=32, seq_len=256, BLOCK_M=128
@@ -289,6 +300,8 @@ def _attn_fwd(
     # --- Load Q tile [BLOCK_M, BLOCK_D]: stays in SRAM for the entire KV loop ---
     q_ptrs = (q_offset + q_pos[:, None]) * stride_qbs + head_idx * stride_qh + dim_pos[None, :]
     q = tl.load(Q + q_ptrs, mask=(q_pos[:, None] < seq_len_q) & d_mask[None, :], other=0.0)
+    if NVFP4_Q:  # BMM1 query operand -> NVFP4 (contraction = head dim)
+        q = nvfp4_qdq_lastdim_2d(q.to(tl.float32), BLOCK_M, BLOCK_D // 16, 16).to(q.dtype)
 
     # Base pointers for K and V at this KV head (per-tile offset added in loop)
     k_base = K + kv_head_idx * stride_kh
@@ -339,6 +352,9 @@ def _attn_fwd(
                 other=0.0,
             )
 
+        if NVFP4_K:  # BMM1 key operand -> NVFP4 (K^T [BLOCK_D, BLOCK_N], contraction = head dim)
+            k = nvfp4_qdq_axis0(k.to(tl.float32), BLOCK_D // 16, 16, BLOCK_N).to(k.dtype)
+
         # scores = Q @ K^T * scale  [BLOCK_M, BLOCK_N]
         scores = tl.dot(q, k) * qk_scale
         scores = _apply_mask(scores, q_pos, kv_pos, seq_len_q, seq_len_kv, kv_start, IS_CAUSAL)
@@ -378,6 +394,8 @@ def _attn_fwd(
             # --- Online softmax update ---
             m_new = tl.maximum(row_max, tl.max(scores, 1))
             p = tl.math.exp2(scores - m_new[:, None])
+            if FP16_SOFTMAX:  # mixed-precision (fp16) softmax
+                p = p.to(tl.float16).to(tl.float32)
             l_new = tl.sum(p, 1)
             correction = tl.math.exp2(row_max - m_new)
             row_sum = row_sum * correction + l_new
@@ -410,7 +428,16 @@ def _attn_fwd(
                     mask=((kv_start + kv_pos[:, None]) < seq_len_kv) & d_mask[None, :],
                     other=0.0,
                 )
-            acc = tl.dot(p.to(v.dtype), v, acc)
+            if NVFP4_V:  # BMM2 value operand -> NVFP4 (V [BLOCK_N, BLOCK_D], contraction = keys)
+                v = nvfp4_qdq_axis0(v.to(tl.float32), BLOCK_N // 16, 16, BLOCK_D).to(v.dtype)
+            # BMM2 prob operand -> NVFP4 (contraction = keys), per-row (per-query-token)
+            # global. NVFP4 is homogeneous, so quantizing the unnormalized exp with a
+            # per-row global equals quantizing the normalized P (row_sum normalization is
+            # applied to acc after the loop). NOTE: exact only within a KV tile; across
+            # tiles the online-softmax rescaling makes multi-tile P-NVFP4 approximate —
+            # the faithful full-P NVFP4 is the materialized (eager) path.
+            p_dot = nvfp4_qdq_lastdim_2d_perrow(p, BLOCK_M, BLOCK_N // 16, 16) if NVFP4_P else p
+            acc = tl.dot(p_dot.to(v.dtype), v, acc)
             row_max = m_new
         # else: tile skipped — no softmax, no V load, no BMM2 for this tile
 
@@ -810,6 +837,8 @@ class _Attention(torch.autograd.Function):
         v_cache,
         block_table,
         page_size,
+        nvfp4=None,
+        fp16_softmax=False,
     ):
         HEAD_DIM = q.shape[2]
         num_q_heads = q.shape[1]
@@ -890,6 +919,8 @@ class _Attention(torch.autograd.Function):
             lse.stride(0),
             lse.stride(1),
         )
+        _nvfp4 = nvfp4 or set()
+        assert _nvfp4 <= {"q", "k", "p", "v"}, f"nvfp4 must be a subset of q/k/p/v, got {nvfp4}"
         fwd_kwargs = {
             "N_CTX": max_input_len,
             "kv_group_num": kv_group_num,
@@ -918,6 +949,11 @@ class _Attention(torch.autograd.Function):
             "stride_vc_head": v_cache.stride(2) if is_paged else 0,
             "PAGE_SIZE": page_size,
             "max_blocks_per_seq": block_table.shape[1] if is_paged else 0,
+            "NVFP4_Q": "q" in _nvfp4,
+            "NVFP4_K": "k" in _nvfp4,
+            "NVFP4_P": "p" in _nvfp4,
+            "NVFP4_V": "v" in _nvfp4,
+            "FP16_SOFTMAX": fp16_softmax,
         }
 
         # Grid: (batch, q_heads, q_tiles). Uses a function because BLOCK_M is autotuned.
@@ -1110,6 +1146,8 @@ class _Attention(torch.autograd.Function):
             None,  # v_cache
             None,  # block_table
             None,  # page_size
+            None,  # nvfp4
+            None,  # fp16_softmax
         )
 
 
@@ -1132,6 +1170,8 @@ def attention(
     dense_recent_tokens: int = 64,
     skip_softmax_threshold: float | None = None,
     measure_sparsity: bool = False,
+    nvfp4: set[str] | None = None,
+    fp16_softmax: bool = False,
     k_cache: torch.Tensor | None = None,
     v_cache: torch.Tensor | None = None,
     block_table: torch.Tensor | None = None,
@@ -1210,6 +1250,8 @@ def attention(
         v_cache,
         block_table,
         page_size,
+        nvfp4,
+        fp16_softmax,
     )
 
 

--- a/modelopt/torch/kernels/quantization/attention/nvfp4_fakequant.py
+++ b/modelopt/torch/kernels/quantization/attention/nvfp4_fakequant.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: N803 — Triton kernels use uppercase for constexpr by convention
+
+"""In-kernel NVFP4 (E2M1) fake quantization for attention BMM operands.
+
+Tile-level wrappers over the scalar FP4 device functions in
+``kernels/quantization/gemm/nvfp4_quant.py`` (the single source of truth for the
+E2M1 decision-boundary rounding). They quantize a Triton tile to NVFP4 along its
+*contraction* axis in groups of ``BLK`` (= 16, the NVFP4 block size): a per-block
+FP8-E4M3 scale plus a per-tile global scale (``global_amax / (6 * 448)``), exactly
+as ModelOpt's NVFP4 quantizer does.
+
+This is *fake* quantization: values are rounded to the NVFP4 grid and dequantized
+back to fp32, so the downstream ``tl.dot`` still runs in bf16/fp32 — the intent is
+to measure the *accuracy* impact of NVFP4 attention BMMs, not to accelerate them.
+
+The per-block E4M3 scale is computed with an exact fp32 emulation of E4M3 (rather
+than ``tl.float8e4nv``) so the kernel runs on pre-sm_89 GPUs as well; the emulation
+is bit-exact to ``torch.float8_e4m3fn``. The global scale is computed per tile
+(dynamic), which captures the dominant FP4-rounding error; a calibrated per-tensor
+global scale is a follow-up (would be passed in).
+"""
+
+import triton
+import triton.language as tl
+from triton.language.extra.cuda import libdevice
+
+from modelopt.torch.kernels.quantization.gemm.nvfp4_quant import nvfp4_scalar_quant
+
+# NVFP4 second-level normalizer: E2M1 max (6.0) * FP8-E4M3 max (448.0). Must use the
+# tl.constexpr(...) instantiation form so Triton @jit functions can read it as a global.
+_NVFP4_GLOBAL_NORM = tl.constexpr(6.0 * 448.0)
+
+
+@triton.jit
+def e4m3_emulate(x):
+    """Round ``x`` to the nearest E4M3 (E4M3fn, max 448) value in fp32.
+
+    Hardware-free equivalent of ``x.to(float8_e4m3fn).to(float32)`` — bit-exact to
+    ``torch.float8_e4m3fn`` over the representable range, so the NVFP4 block scale
+    can be quantized on GPUs without native fp8 (pre-sm_89).
+    """
+    ax = tl.minimum(tl.abs(x), 448.0)
+    nz = ax > 0.0
+    safe = tl.where(nz, ax, 1.0)  # avoid log2(0)
+    exp = tl.maximum(tl.floor(tl.log2(safe)), -6.0)  # clamp to min normal exponent
+    step = tl.exp2(exp - 3.0)  # 3 mantissa bits -> ulp = 2^(exp-3)
+    q = libdevice.nearbyint(safe / step) * step  # round-half-to-even (matches torch)
+    q = tl.minimum(tl.where(nz, q, 0.0), 448.0)
+    return tl.where(x >= 0, q, -q)
+
+
+@triton.jit
+def _nvfp4_block_scale(block_amax, global_scale):
+    """Per-block NVFP4 scale: E4M3-quantized ``block_amax/6`` with the global scale."""
+    scale_in_fp8_range = tl.minimum(block_amax / (6.0 * global_scale), 448.0)
+    return e4m3_emulate(scale_in_fp8_range) * global_scale
+
+
+@triton.jit
+def nvfp4_qdq_1d(x, NB: tl.constexpr, BLK: tl.constexpr):
+    """NVFP4 fake-quantize a 1-D tile ``x`` of length ``NB*BLK`` along its only axis."""
+    global_scale = tl.max(tl.abs(x)) / _NVFP4_GLOBAL_NORM
+    xr = tl.reshape(x, (NB, BLK))
+    block_amax = tl.max(tl.abs(xr), axis=1, keep_dims=True)  # [NB, 1]
+    scale = _nvfp4_block_scale(block_amax, global_scale)  # [NB, 1], broadcasts over BLK
+    xq = nvfp4_scalar_quant(xr, scale, BLK)
+    return tl.reshape(xq, (NB * BLK,))
+
+
+@triton.jit
+def nvfp4_qdq_lastdim_2d(x, M: tl.constexpr, NB: tl.constexpr, BLK: tl.constexpr):
+    """NVFP4 fake-quantize a 2-D tile ``x`` ``[M, NB*BLK]`` along axis 1 (contraction).
+
+    Used for operands whose contraction dimension is the column dimension, e.g. the
+    query tile ``[BLOCK_M, head_dim]`` (contract over head_dim) and the probability
+    tile ``[BLOCK_M, BLOCK_N]`` (contract over BLOCK_N) — each row is quantized
+    independently in blocks of ``BLK`` columns.
+    """
+    global_scale = tl.max(tl.abs(x)) / _NVFP4_GLOBAL_NORM
+    xr = tl.reshape(x, (M, NB, BLK))
+    block_amax = tl.max(tl.abs(xr), axis=2, keep_dims=True)  # [M, NB, 1]
+    scale = _nvfp4_block_scale(block_amax, global_scale)  # [M, NB, 1], broadcasts over BLK
+    xq = nvfp4_scalar_quant(xr, scale, BLK)
+    return tl.reshape(xq, (M, NB * BLK))
+
+
+@triton.jit
+def nvfp4_qdq_lastdim_2d_perrow(x, M: tl.constexpr, NB: tl.constexpr, BLK: tl.constexpr):
+    """NVFP4 fake-quantize ``[M, NB*BLK]`` along axis 1 with a *per-row* global scale.
+
+    Used for the softmax probabilities P: a flash kernel quantizes the unnormalized
+    ``exp`` and divides the output by the row sum afterward. Because NVFP4 is
+    homogeneous (``NVFP4(c*x) = c*NVFP4(x)``), a *per-row* global makes that equal to
+    quantizing the normalized P — but only with a per-row (per-query-token) global,
+    since each query row has its own normalizer. (A per-tile global would mix rows
+    with different row-sums and not commute with the deferred normalization.)
+    """
+    row_amax = tl.max(tl.abs(x), axis=1, keep_dims=True)  # [M, 1] per-row global
+    global_scale = row_amax / _NVFP4_GLOBAL_NORM
+    xr = tl.reshape(x, (M, NB, BLK))
+    block_amax = tl.max(tl.abs(xr), axis=2, keep_dims=True)  # [M, NB, 1]
+    scale = _nvfp4_block_scale(block_amax, global_scale[:, :, None])  # broadcasts over NB, BLK
+    xq = nvfp4_scalar_quant(xr, scale, BLK)
+    return tl.reshape(xq, (M, NB * BLK))
+
+
+@triton.jit
+def nvfp4_qdq_axis0(x, NB: tl.constexpr, BLK: tl.constexpr, M: tl.constexpr):
+    """NVFP4 fake-quantize a 2-D tile ``x`` ``[NB*BLK, M]`` along axis 0 (contraction).
+
+    Used for operands whose contraction dimension is the row dimension, e.g. K^T
+    ``[head_dim, BLOCK_N]`` (contract over head_dim) and V ``[BLOCK_N, head_dim]``
+    (contract over BLOCK_N) — each column is quantized independently in blocks of
+    ``BLK`` rows.
+    """
+    global_scale = tl.max(tl.abs(x)) / _NVFP4_GLOBAL_NORM
+    xr = tl.reshape(x, (NB, BLK, M))
+    block_amax = tl.max(tl.abs(xr), axis=1, keep_dims=True)  # [NB, 1, M]
+    scale = _nvfp4_block_scale(block_amax, global_scale)  # [NB, 1, M], broadcasts over BLK
+    xq = nvfp4_scalar_quant(xr, scale, BLK)
+    return tl.reshape(xq, (NB * BLK, M))

--- a/modelopt/torch/kernels/quantization/attention/nvfp4_fakequant.py
+++ b/modelopt/torch/kernels/quantization/attention/nvfp4_fakequant.py
@@ -57,8 +57,12 @@ def tensor_global_scale(tensor, scale_type: int = 2) -> float:
 
     Computed host-side and passed into the kernels as a constant. ``scale_type`` is
     accepted for signature parity; only NVFP4/SFP32 use a global (others ignore it).
+
+    Reduces in the tensor's native dtype (``abs().amax()``) rather than upcasting the
+    whole tensor to fp32 — the fp32 materialization would OOM when called on a large
+    paged KV cache. Serving passes the small per-step q/k/v here, never the cache.
     """
-    return tensor.float().abs().max().item() / (E2M1_MAX * FP8_E4M3_MAX) + 1e-30
+    return tensor.abs().amax().float().item() / (E2M1_MAX * FP8_E4M3_MAX) + 1e-30
 
 
 @triton.jit

--- a/modelopt/torch/kernels/quantization/attention/nvfp4_fakequant.py
+++ b/modelopt/torch/kernels/quantization/attention/nvfp4_fakequant.py
@@ -27,9 +27,10 @@ the mirror of their ``tensor_scale``), the same block-scale formula
 
 Two intentional portability tweaks (numerically identical to theirs):
   - ``A-side``/``B-side`` use ``k1``/``k0`` for Q,P / K,V (GEMM-K = axis 1 / 0).
-  - the E4M3 per-block scale is computed with an fp32 E4M3 emulation that is
-    bit-exact to ``torch.float8_e4m3fn`` (== their ``.to(tl.float8e4nv)``), so the
-    NVFP4 path also runs on pre-sm_89 GPUs where ``tl.float8e4nv`` is unsupported;
+  - the E4M3 per-block scale uses native ``tl.float8e4nv`` on sm_89+ (matching
+    their ``.to(tl.float8e4nv)``) and an fp32 E4M3 emulation — bit-exact to
+    ``torch.float8_e4m3fn`` — as the fallback on pre-sm_89 GPUs (e.g. A6000) where
+    ``tl.float8e4nv`` is unsupported (identical numerics either way);
     the E2M1 value rounding uses their PTX ``cvt`` on sm_100 and the portable
     ``>=`` fallback elsewhere.
 
@@ -84,11 +85,17 @@ def tensor_global_scale_device(tensor):
 
 @triton.jit
 def e4m3_emulate(x):
-    """fp32 round to nearest E4M3 (E4M3fn, max 448) — bit-exact to torch.float8_e4m3fn.
+    """Round-trip ``x`` through E4M3 (E4M3fn, max 448) for the per-block scale.
 
-    Portable equivalent of ``x.to(tl.float8e4nv).to(tl.float32)`` for the per-block
-    scale, so the NVFP4 path runs on GPUs without native fp8 (pre-sm_89).
+    Native ``x.to(tl.float8e4nv).to(tl.float32)`` on sm_89+ (Ada/Hopper/Blackwell,
+    matching mni/attnOpt); an fp32 emulation — bit-exact to ``torch.float8_e4m3fn``,
+    which *is* ``tl.float8e4nv`` — as the fallback on pre-sm_89 GPUs (e.g. A6000/sm_86)
+    where ``tl.float8e4nv`` is unsupported. Numerically identical either way; the
+    capability gate only swaps the SFU-heavy emulation (``log2``/``exp2``) for a
+    hardware ``cvt`` where it exists.
     """
+    if cuda_capability_geq(8, 9):
+        return x.to(tl.float8e4nv).to(tl.float32)
     ax = tl.minimum(tl.abs(x), 448.0)
     nz = ax > 0.0
     safe = tl.where(nz, ax, 1.0)
@@ -151,7 +158,8 @@ def _round_e2m1(x_s):
 def _block_scale(scale_f32, global_scale, SCALE_TYPE: tl.constexpr):
     """Quantize the per-block scale per SCALE_TYPE (mirror of mni/attnOpt)."""
     if SCALE_TYPE == QUANT_NVFP4:
-        # E4M3 block scale relative to the FP32 global (emulated E4M3 == fp8e4nv).
+        # E4M3 block scale relative to the FP32 global (native fp8e4nv on sm_89+,
+        # bit-exact fp32 emulation as the pre-sm_89 fallback — see e4m3_emulate).
         return e4m3_emulate(scale_f32 / global_scale) * global_scale
     elif SCALE_TYPE == QUANT_MXFP4_RUP:
         return tl.exp2(tl.ceil(tl.log2(scale_f32)))

--- a/modelopt/torch/kernels/quantization/attention/nvfp4_fakequant.py
+++ b/modelopt/torch/kernels/quantization/attention/nvfp4_fakequant.py
@@ -13,124 +13,174 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ruff: noqa: N803 — Triton kernels use uppercase for constexpr by convention
+# ruff: noqa: N803, N806 — Triton kernels use uppercase for constexpr by convention
 
-"""In-kernel NVFP4 (E2M1) fake quantization for attention BMM operands.
+"""In-kernel FP4 fake quantization for attention BMM operands.
 
-Tile-level wrappers over the scalar FP4 device functions in
-``kernels/quantization/gemm/nvfp4_quant.py`` (the single source of truth for the
-E2M1 decision-boundary rounding). They quantize a Triton tile to NVFP4 along its
-*contraction* axis in groups of ``BLK`` (= 16, the NVFP4 block size): a per-block
-FP8-E4M3 scale plus a per-tile global scale (``global_amax / (6 * 448)``), exactly
-as ModelOpt's NVFP4 quantizer does.
+**Design-aligned with the customized vLLM** ``mni/attnOpt`` attention-quant
+framework (``vllm/v1/attention/ops/triton_quant/triton_quant_utils.py``): same
+``_fake_quant_fp4_k1`` / ``_fake_quant_fp4_k0`` signatures, the same per-tensor
+``global_scale`` convention (computed host-side by :func:`tensor_global_scale`,
+the mirror of their ``tensor_scale``), the same block-scale formula
+(``absmax/6 + 1e-30``), the same E2M1 ``>=`` decision boundaries, and the same
+``SCALE_TYPE`` enum. So our NVFP4 numerics match theirs bit-for-bit.
 
-This is *fake* quantization: values are rounded to the NVFP4 grid and dequantized
-back to fp32, so the downstream ``tl.dot`` still runs in bf16/fp32 — the intent is
-to measure the *accuracy* impact of NVFP4 attention BMMs, not to accelerate them.
+Two intentional portability tweaks (numerically identical to theirs):
+  - ``A-side``/``B-side`` use ``k1``/``k0`` for Q,P / K,V (GEMM-K = axis 1 / 0).
+  - the E4M3 per-block scale is computed with an fp32 E4M3 emulation that is
+    bit-exact to ``torch.float8_e4m3fn`` (== their ``.to(tl.float8e4nv)``), so the
+    NVFP4 path also runs on pre-sm_89 GPUs where ``tl.float8e4nv`` is unsupported;
+    the E2M1 value rounding uses their PTX ``cvt`` on sm_100 and the portable
+    ``>=`` fallback elsewhere.
 
-The per-block E4M3 scale is computed with an exact fp32 emulation of E4M3 (rather
-than ``tl.float8e4nv``) so the kernel runs on pre-sm_89 GPUs as well; the emulation
-is bit-exact to ``torch.float8_e4m3fn``. The global scale is computed per tile
-(dynamic), which captures the dominant FP4-rounding error; a calibrated per-tensor
-global scale is a follow-up (would be passed in).
+This is *fake* quantization: operands are rounded to the FP4 grid and dequantized
+to fp32; the ``tl.dot`` still runs in bf16/fp32 (accuracy study, not speed).
 """
 
 import triton
 import triton.language as tl
 from triton.language.extra.cuda import libdevice
+from triton.language.target_info import cuda_capability_geq
 
-from modelopt.torch.kernels.quantization.gemm.nvfp4_quant import nvfp4_scalar_quant
+# SCALE_TYPE enum — values mirror mni/attnOpt's triton_quant_utils for parity.
+QUANT_NVFP4 = tl.constexpr(2)  # FP4 E2M1, E4M3 per-block scale x FP32 global (true NVFP4)
+QUANT_MXFP4_RUP = tl.constexpr(3)  # FP4 E2M1, E8M0 per-block scale, round up
+QUANT_MXFP4_RNE = tl.constexpr(4)  # FP4 E2M1, E8M0 per-block scale, round to nearest
+QUANT_NVFP4_SFP32 = tl.constexpr(6)  # FP4 E2M1, full FP32 per-block scale (no scale quant)
 
-# NVFP4 second-level normalizer: E2M1 max (6.0) * FP8-E4M3 max (448.0). Must use the
-# tl.constexpr(...) instantiation form so Triton @jit functions can read it as a global.
-_NVFP4_GLOBAL_NORM = tl.constexpr(6.0 * 448.0)
+E2M1_MAX = 6.0
+FP8_E4M3_MAX = 448.0
+
+
+def tensor_global_scale(tensor, scale_type: int = 2) -> float:
+    """Per-tensor NVFP4 global scale ``amax / (6*448)`` (mirror of their ``tensor_scale``).
+
+    Computed host-side and passed into the kernels as a constant. ``scale_type`` is
+    accepted for signature parity; only NVFP4/SFP32 use a global (others ignore it).
+    """
+    return tensor.float().abs().max().item() / (E2M1_MAX * FP8_E4M3_MAX) + 1e-30
 
 
 @triton.jit
 def e4m3_emulate(x):
-    """Round ``x`` to the nearest E4M3 (E4M3fn, max 448) value in fp32.
+    """fp32 round to nearest E4M3 (E4M3fn, max 448) — bit-exact to torch.float8_e4m3fn.
 
-    Hardware-free equivalent of ``x.to(float8_e4m3fn).to(float32)`` — bit-exact to
-    ``torch.float8_e4m3fn`` over the representable range, so the NVFP4 block scale
-    can be quantized on GPUs without native fp8 (pre-sm_89).
+    Portable equivalent of ``x.to(tl.float8e4nv).to(tl.float32)`` for the per-block
+    scale, so the NVFP4 path runs on GPUs without native fp8 (pre-sm_89).
     """
     ax = tl.minimum(tl.abs(x), 448.0)
     nz = ax > 0.0
-    safe = tl.where(nz, ax, 1.0)  # avoid log2(0)
-    exp = tl.maximum(tl.floor(tl.log2(safe)), -6.0)  # clamp to min normal exponent
-    step = tl.exp2(exp - 3.0)  # 3 mantissa bits -> ulp = 2^(exp-3)
-    q = libdevice.nearbyint(safe / step) * step  # round-half-to-even (matches torch)
+    safe = tl.where(nz, ax, 1.0)
+    exp = tl.maximum(tl.floor(tl.log2(safe)), -6.0)
+    step = tl.exp2(exp - 3.0)
+    q = libdevice.nearbyint(safe / step) * step
     q = tl.minimum(tl.where(nz, q, 0.0), 448.0)
     return tl.where(x >= 0, q, -q)
 
 
 @triton.jit
-def _nvfp4_block_scale(block_amax, global_scale):
-    """Per-block NVFP4 scale: E4M3-quantized ``block_amax/6`` with the global scale."""
-    scale_in_fp8_range = tl.minimum(block_amax / (6.0 * global_scale), 448.0)
-    return e4m3_emulate(scale_in_fp8_range) * global_scale
+def _round_e2m1(x_s):
+    """Round x_s (= value / scale) to the nearest FP4 E2M1 magnitude (signed).
 
-
-@triton.jit
-def nvfp4_qdq_1d(x, NB: tl.constexpr, BLK: tl.constexpr):
-    """NVFP4 fake-quantize a 1-D tile ``x`` of length ``NB*BLK`` along its only axis."""
-    global_scale = tl.max(tl.abs(x)) / _NVFP4_GLOBAL_NORM
-    xr = tl.reshape(x, (NB, BLK))
-    block_amax = tl.max(tl.abs(xr), axis=1, keep_dims=True)  # [NB, 1]
-    scale = _nvfp4_block_scale(block_amax, global_scale)  # [NB, 1], broadcasts over BLK
-    xq = nvfp4_scalar_quant(xr, scale, BLK)
-    return tl.reshape(xq, (NB * BLK,))
-
-
-@triton.jit
-def nvfp4_qdq_lastdim_2d(x, M: tl.constexpr, NB: tl.constexpr, BLK: tl.constexpr):
-    """NVFP4 fake-quantize a 2-D tile ``x`` ``[M, NB*BLK]`` along axis 1 (contraction).
-
-    Used for operands whose contraction dimension is the column dimension, e.g. the
-    query tile ``[BLOCK_M, head_dim]`` (contract over head_dim) and the probability
-    tile ``[BLOCK_M, BLOCK_N]`` (contract over BLOCK_N) — each row is quantized
-    independently in blocks of ``BLK`` columns.
+    PTX ``cvt.rn.satfinite.e2m1x2.f32`` on sm_100+ (matches mni/attnOpt); portable
+    ``>=`` decision-boundary fallback elsewhere (identical grid + tie direction).
     """
-    global_scale = tl.max(tl.abs(x)) / _NVFP4_GLOBAL_NORM
-    xr = tl.reshape(x, (M, NB, BLK))
-    block_amax = tl.max(tl.abs(xr), axis=2, keep_dims=True)  # [M, NB, 1]
-    scale = _nvfp4_block_scale(block_amax, global_scale)  # [M, NB, 1], broadcasts over BLK
-    xq = nvfp4_scalar_quant(xr, scale, BLK)
-    return tl.reshape(xq, (M, NB * BLK))
+    if cuda_capability_geq(10, 0):
+        return tl.inline_asm_elementwise(
+            """{
+                .reg .b8 e2m1;
+                .reg .b32 f16x2;
+                .reg .b16 lo, hi;
+                cvt.rn.satfinite.e2m1x2.f32 e2m1, $2, $3;
+                cvt.rn.f16x2.e2m1x2 f16x2, e2m1;
+                mov.b32 {lo, hi}, f16x2;
+                cvt.f32.f16 $0, hi;
+                cvt.f32.f16 $1, lo;
+            }""",
+            "=r,=r,r,r",
+            args=[x_s],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=2,
+        )
+    a = tl.abs(x_s)
+    sgn = tl.where(x_s >= 0.0, 1.0, -1.0)
+    return sgn * tl.where(
+        a >= 5.0,
+        6.0,
+        tl.where(
+            a >= 3.5,
+            4.0,
+            tl.where(
+                a >= 2.5,
+                3.0,
+                tl.where(
+                    a >= 1.75,
+                    2.0,
+                    tl.where(
+                        a >= 1.25, 1.5, tl.where(a >= 0.75, 1.0, tl.where(a >= 0.25, 0.5, 0.0))
+                    ),
+                ),
+            ),
+        ),
+    )
 
 
 @triton.jit
-def nvfp4_qdq_lastdim_2d_perrow(x, M: tl.constexpr, NB: tl.constexpr, BLK: tl.constexpr):
-    """NVFP4 fake-quantize ``[M, NB*BLK]`` along axis 1 with a *per-row* global scale.
-
-    Used for the softmax probabilities P: a flash kernel quantizes the unnormalized
-    ``exp`` and divides the output by the row sum afterward. Because NVFP4 is
-    homogeneous (``NVFP4(c*x) = c*NVFP4(x)``), a *per-row* global makes that equal to
-    quantizing the normalized P — but only with a per-row (per-query-token) global,
-    since each query row has its own normalizer. (A per-tile global would mix rows
-    with different row-sums and not commute with the deferred normalization.)
-    """
-    row_amax = tl.max(tl.abs(x), axis=1, keep_dims=True)  # [M, 1] per-row global
-    global_scale = row_amax / _NVFP4_GLOBAL_NORM
-    xr = tl.reshape(x, (M, NB, BLK))
-    block_amax = tl.max(tl.abs(xr), axis=2, keep_dims=True)  # [M, NB, 1]
-    scale = _nvfp4_block_scale(block_amax, global_scale[:, :, None])  # broadcasts over NB, BLK
-    xq = nvfp4_scalar_quant(xr, scale, BLK)
-    return tl.reshape(xq, (M, NB * BLK))
+def _block_scale(scale_f32, global_scale, SCALE_TYPE: tl.constexpr):
+    """Quantize the per-block scale per SCALE_TYPE (mirror of mni/attnOpt)."""
+    if SCALE_TYPE == QUANT_NVFP4:
+        # E4M3 block scale relative to the FP32 global (emulated E4M3 == fp8e4nv).
+        return e4m3_emulate(scale_f32 / global_scale) * global_scale
+    elif SCALE_TYPE == QUANT_MXFP4_RUP:
+        return tl.exp2(tl.ceil(tl.log2(scale_f32)))
+    elif SCALE_TYPE == QUANT_MXFP4_RNE:
+        return tl.exp2(tl.floor(tl.log2(scale_f32) + 0.5))
+    else:  # QUANT_NVFP4_SFP32: full fp32 per-block scale
+        return scale_f32
 
 
 @triton.jit
-def nvfp4_qdq_axis0(x, NB: tl.constexpr, BLK: tl.constexpr, M: tl.constexpr):
-    """NVFP4 fake-quantize a 2-D tile ``x`` ``[NB*BLK, M]`` along axis 0 (contraction).
+def fake_quant_fp4_k1(
+    x,
+    M: tl.constexpr,
+    K: tl.constexpr,
+    K_BLOCK: tl.constexpr,
+    global_scale,
+    SCALE_TYPE: tl.constexpr,
+):
+    """Fake-quantize ``x [M, K]`` to FP4 E2M1, 1×K_BLOCK blocks along K (axis 1).
 
-    Used for operands whose contraction dimension is the row dimension, e.g. K^T
-    ``[head_dim, BLOCK_N]`` (contract over head_dim) and V ``[BLOCK_N, head_dim]``
-    (contract over BLOCK_N) — each column is quantized independently in blocks of
-    ``BLK`` rows.
+    A-side operands (Q, P) where the GEMM-K dim is axis 1. Per-tensor ``global_scale``.
     """
-    global_scale = tl.max(tl.abs(x)) / _NVFP4_GLOBAL_NORM
-    xr = tl.reshape(x, (NB, BLK, M))
-    block_amax = tl.max(tl.abs(xr), axis=1, keep_dims=True)  # [NB, 1, M]
-    scale = _nvfp4_block_scale(block_amax, global_scale)  # [NB, 1, M], broadcasts over BLK
-    xq = nvfp4_scalar_quant(xr, scale, BLK)
-    return tl.reshape(xq, (NB * BLK, M))
+    NG: tl.constexpr = K // K_BLOCK
+    x_r = tl.reshape(x.to(tl.float32), (M, NG, K_BLOCK))
+    scale_f32 = tl.max(tl.abs(x_r), axis=2) / 6.0 + 1e-30  # [M, NG]
+    scale = _block_scale(scale_f32, global_scale, SCALE_TYPE)
+    scale = tl.broadcast_to(tl.expand_dims(scale, 2), (M, NG, K_BLOCK))
+    x_q = _round_e2m1(x_r / scale)
+    return tl.reshape(x_q * scale, (M, K)).to(x.dtype)
+
+
+@triton.jit
+def fake_quant_fp4_k0(
+    x,
+    K: tl.constexpr,
+    N: tl.constexpr,
+    K_BLOCK: tl.constexpr,
+    N_BLOCK: tl.constexpr,
+    global_scale,
+    SCALE_TYPE: tl.constexpr,
+):
+    """Fake-quantize ``x [K, N]`` to FP4 E2M1, K_BLOCK×N_BLOCK blocks.
+
+    B-side operands (K^T, V) where the GEMM-K dim is axis 0. ``N_BLOCK=1`` for NVFP4.
+    """
+    KG: tl.constexpr = K // K_BLOCK
+    NG: tl.constexpr = N // N_BLOCK
+    x_r = tl.reshape(x.to(tl.float32), (KG, K_BLOCK, NG, N_BLOCK))
+    scale_f32 = tl.max(tl.max(tl.abs(x_r), axis=3), axis=1) / 6.0 + 1e-30  # [KG, NG]
+    scale = _block_scale(scale_f32, global_scale, SCALE_TYPE)
+    scale = tl.broadcast_to(tl.expand_dims(tl.expand_dims(scale, 1), 3), (KG, K_BLOCK, NG, N_BLOCK))
+    x_q = _round_e2m1(x_r / scale)
+    return tl.reshape(x_q * scale, (K, N)).to(x.dtype)

--- a/modelopt/torch/kernels/quantization/attention/nvfp4_fakequant.py
+++ b/modelopt/torch/kernels/quantization/attention/nvfp4_fakequant.py
@@ -61,8 +61,25 @@ def tensor_global_scale(tensor, scale_type: int = 2) -> float:
     Reduces in the tensor's native dtype (``abs().amax()``) rather than upcasting the
     whole tensor to fp32 — the fp32 materialization would OOM when called on a large
     paged KV cache. Serving passes the small per-step q/k/v here, never the cache.
+
+    Prefer :func:`tensor_global_scale_device` on the serving hot path — the ``.item()``
+    here is a blocking host sync that both stalls decode and forces ``--enforce-eager``.
     """
     return tensor.abs().amax().float().item() / (E2M1_MAX * FP8_E4M3_MAX) + 1e-30
+
+
+def tensor_global_scale_device(tensor):
+    """Per-tensor NVFP4 global scale ``amax/(6*448)`` as a 0-d **device** tensor.
+
+    Identical value to :func:`tensor_global_scale` but kept on-device — no ``.item()``
+    host sync. The kernels read it via ``tl.load`` (pointer arg), so the whole
+    amax → scale → quant chain stays on the GPU. That removes the per-step CPU↔GPU
+    serialization (~3 syncs × every attention layer × every decode step) and, because
+    no data-dependent host value is produced mid-forward, lets vLLM capture CUDA graphs
+    (drop ``--enforce-eager``). Numerically equivalent: the value ``tl.load`` reads is
+    exactly what the host float used to be.
+    """
+    return tensor.abs().amax().float() / (E2M1_MAX * FP8_E4M3_MAX) + 1e-30
 
 
 @triton.jit

--- a/modelopt/torch/kernels/quantization/attention/softmax_fakequant.py
+++ b/modelopt/torch/kernels/quantization/attention/softmax_fakequant.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: N803 — Triton kernels use uppercase for constexpr by convention
+
+"""Softmax-datapath fake quantization for attention (mixed-precision softmax).
+
+Design-aligned, mode-value-identical with the customized vLLM ``mni/attnOpt``
+framework: the softmax internal datapath can be rounded to FP16/BF16 (RNE/RZ, with
+optional flush-to-zero) at separate points — **DIFF** (input to exp2), **EXP2**
+(output of exp2), and **ACC** (the running sum) — to model the hardware MUFU/PTX
+softmax precision rather than the conservative FP32 reference.
+
+The per-mode rounding functions are bit-exact copies of theirs (same PTX
+``cvt.rz``/``cvt.rn.ftz`` and Triton casts), so a "mixed-FP16 softmax" run here
+matches theirs at each point. Mode integer values mirror their enum exactly.
+"""
+
+import triton
+import triton.language as tl
+
+# Mode enum — values identical to mni/attnOpt triton_quant_utils (QUANT_NONE / SMQUANT_*).
+SMQUANT_NONE = tl.constexpr(0)
+SMQUANT_BF16_RZ = tl.constexpr(9)
+SMQUANT_FP16_RZ = tl.constexpr(10)
+SMQUANT_BF16_RNE = tl.constexpr(12)
+SMQUANT_FP16_RNE = tl.constexpr(13)
+SMQUANT_FP16_RNE_FTZ = tl.constexpr(17)
+SMQUANT_FP16_RZ_FTZ = tl.constexpr(18)
+SMQUANT_BF16_RNE_FTZ = tl.constexpr(19)
+SMQUANT_BF16_RZ_FTZ = tl.constexpr(20)
+
+# Python-side string -> mode map (mirror of their _SMQUANT_ALL_MODES subset).
+SOFTMAX_MODE_MAP = {
+    None: 0,
+    "none": 0,
+    "fp32": 0,
+    "bypass": 0,
+    "bf16_rz": 9,
+    "fp16_rz": 10,
+    "bf16": 12,
+    "fp16": 13,
+    "fp16_ftz": 17,
+    "fp16_rz_ftz": 18,
+    "bf16_ftz": 19,
+    "bf16_rz_ftz": 20,
+    # convenience aliases
+    "fp16_rne": 13,
+    "bf16_rne": 12,
+}
+
+
+@triton.jit
+def _rz_bf16(x):
+    return tl.inline_asm_elementwise(
+        "{ .reg .b16 b; cvt.rz.bf16.f32 b, $1; cvt.f32.bf16 $0, b; }",
+        "=r,r",
+        args=[x],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _rz_fp16(x):
+    return tl.inline_asm_elementwise(
+        "{ .reg .b16 h; cvt.rz.f16.f32 h, $1; cvt.f32.f16 $0, h; }",
+        "=r,r",
+        args=[x],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _rne_bf16_ftz(x):
+    return tl.inline_asm_elementwise(
+        "{ .reg .b16 b; cvt.rn.ftz.bf16.f32 b, $1; cvt.f32.bf16 $0, b; }",
+        "=r,r",
+        args=[x],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _rz_bf16_ftz(x):
+    return tl.inline_asm_elementwise(
+        "{ .reg .b16 b; cvt.rz.ftz.bf16.f32 b, $1; cvt.f32.bf16 $0, b; }",
+        "=r,r",
+        args=[x],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _rne_fp16_ftz(x):
+    return tl.inline_asm_elementwise(
+        "{ .reg .b16 h; cvt.rn.ftz.f16.f32 h, $1; cvt.f32.f16 $0, h; }",
+        "=r,r",
+        args=[x],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def _rz_fp16_ftz(x):
+    return tl.inline_asm_elementwise(
+        "{ .reg .b16 h; cvt.rz.ftz.f16.f32 h, $1; cvt.f32.f16 $0, h; }",
+        "=r,r",
+        args=[x],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
+def softmax_round(x, MODE: tl.constexpr):
+    """Round ``x`` per the softmax-datapath MODE (no-op for MODE==0/NONE)."""
+    if MODE == SMQUANT_FP16_RNE:
+        return (x.to(tl.float16)).to(tl.float32)  # Triton RNE cast
+    elif MODE == SMQUANT_BF16_RNE:
+        return (x.to(tl.bfloat16)).to(tl.float32)
+    elif MODE == SMQUANT_FP16_RZ:
+        return _rz_fp16(x)
+    elif MODE == SMQUANT_BF16_RZ:
+        return _rz_bf16(x)
+    elif MODE == SMQUANT_FP16_RNE_FTZ:
+        return _rne_fp16_ftz(x)
+    elif MODE == SMQUANT_FP16_RZ_FTZ:
+        return _rz_fp16_ftz(x)
+    elif MODE == SMQUANT_BF16_RNE_FTZ:
+        return _rne_bf16_ftz(x)
+    elif MODE == SMQUANT_BF16_RZ_FTZ:
+        return _rz_bf16_ftz(x)
+    else:
+        return x  # NONE / fp32 — no rounding
+
+
+def resolve_softmax_mode(mode) -> int:
+    """Map a softmax-quant mode string (or None) to its integer enum value."""
+    if isinstance(mode, int):
+        return mode
+    if mode not in SOFTMAX_MODE_MAP:
+        valid = sorted(k for k in SOFTMAX_MODE_MAP if isinstance(k, str))
+        raise ValueError(f"Unknown softmax quant mode {mode!r}; choose from {valid}")
+    return SOFTMAX_MODE_MAP[mode]

--- a/modelopt/torch/kernels/quantization/attention/softmax_fakequant.py
+++ b/modelopt/torch/kernels/quantization/attention/softmax_fakequant.py
@@ -135,6 +135,27 @@ def _rz_fp16_ftz(x):
 
 
 @triton.jit
+def ex2_fp16(x):
+    """Native fp16 base-2 exp — the hardware ``MUFU.ex2.fp16`` (PTX ``ex2.approx.f16``).
+
+    Converts the fp32 input to fp16, runs the fp16 transcendental, and returns fp32, so the
+    exponential itself uses the fp16 unit's polynomial (not an fp32 ``exp2`` rounded afterward)
+    while the surrounding fp32 reductions are unaffected. This is the reference mixed-precision
+    softmax: used for both ``exp2(scores - max)`` and the online correction ``exp2(old_max - new_max)``.
+    The ``cvt.rn.f16.f32`` is also the exp2-input fp16 conversion (the deck's ``FHADD2 → fp16`` step).
+    (``.ftz`` is not a legal modifier on the f16 ``ex2`` — the fp16 unit handles subnormals itself.)
+    """
+    return tl.inline_asm_elementwise(
+        "{ .reg .b16 h; cvt.rn.f16.f32 h, $1; ex2.approx.f16 h, h; cvt.f32.f16 $0, h; }",
+        "=r,r",
+        args=[x],
+        dtype=tl.float32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@triton.jit
 def softmax_round(x, MODE: tl.constexpr):
     """Round ``x`` per the softmax-datapath MODE (no-op for MODE==0/NONE)."""
     if MODE == SMQUANT_FP16_RNE:

--- a/modelopt/torch/sparsity/attention_sparsity/config.py
+++ b/modelopt/torch/sparsity/attention_sparsity/config.py
@@ -126,11 +126,11 @@ class SparseAttentionAttributeConfig(ModeloptBaseConfig):
     )
 
     dense_recent_tokens: int = ModeloptField(
-        default=64,
+        default=128,
         title="Dense recent tokens.",
         description=(
             "Number of recent KV tokens excluded from N:M sparsity and kept dense. "
-            "Default 64. Used by triton_sparse_softmax, or exported for vLLM restore "
+            "Default 128. Used by triton_sparse_softmax, or exported for vLLM restore "
             "when export_sparse_softmax is True."
         ),
     )

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -40,7 +40,10 @@ from vllm.v1.attention.backends.flash_attn import (
     FlashAttentionMetadata,
 )
 
-from modelopt.torch.kernels.common.attention.decode_attention import attention_decode
+from modelopt.torch.kernels.common.attention.decode_attention import (
+    attention_decode,
+    fake_quant_kv_onwrite,
+)
 from modelopt.torch.kernels.common.attention.triton_fa import attention as triton_attention
 from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import tensor_global_scale_device
 from modelopt.torch.kernels.sparsity.attention.calibrate import attention_calibrate
@@ -309,19 +312,39 @@ class _SparseCalibrationMixin:
                 self._nvfp4_gs_cache = gs_cache
 
             def _running_max(name, tensor):
-                s = tensor_global_scale_device(tensor[:num_actual_tokens])  # 0-d device tensor
+                # FROZEN scale: quantize-on-write requires a fixed per-tensor scale (write-time ==
+                # read-time), else previously-written cache entries drift. The first prefill seeds a
+                # representative scale and it is reused thereafter (graph-safe persistent buffer).
                 buf = gs_cache.get(name)
                 if buf is None:
-                    buf = s.detach().clone()  # persistent buffer, allocated on first call
+                    buf = tensor_global_scale_device(tensor[:num_actual_tokens]).detach().clone()
                     gs_cache[name] = buf
-                else:
-                    torch.maximum(buf, s, out=buf)  # in-place running max — graph-safe
                 attn_global_scales[name] = buf
 
             if "k" in nvfp4 and new_key is not None:
                 _running_max("k", new_key)
             if "v" in nvfp4 and new_value is not None:
                 _running_max("v", new_value)
+            # Quantize-KV-on-write: fake-quantize the newly-written K/V in the paged cache once
+            # (frozen scale) so the decode kernel reads them pre-quantized instead of re-FQ'ing the
+            # whole cache every step. K = new keys [prev, seq); V = newly-complete 128-tiles. Prefill
+            # re-FQ's idempotently on read; decode (flags below) skips it -> the 8-18x decode speedup.
+            if {"k", "v"} & nvfp4:
+                prev = (seq_lens - b_seq_len).to(torch.int32)
+                seqk32 = seq_lens.to(torch.int32)
+                fake_quant_kv_onwrite(
+                    key_cache,
+                    value_cache,
+                    block_table,
+                    prev,
+                    seqk32,
+                    (prev // 128) * 128,
+                    (seqk32 // 128) * 128,
+                    page_size=page_size,
+                    k_global_scale=attn_global_scales.get("k"),
+                    v_global_scale=attn_global_scales.get("v"),
+                    nvfp4=nvfp4,
+                )
         _resolve_skip_softmax_calibration(
             sparse_kw, is_prefill=not is_decode_only, max_seq_len=max_seq_len
         )
@@ -348,6 +371,8 @@ class _SparseCalibrationMixin:
                 fp16_softmax=fp16_softmax,
                 softmax_quant=softmax_quant,
                 attn_global_scales=attn_global_scales,
+                k_cache_quantized=("k" in nvfp4),
+                v_cache_quantized=("v" in nvfp4),
                 output=output,
             )
         if not sparse_kw and not quant_active:
@@ -400,6 +425,8 @@ class _SparseCalibrationMixin:
         fp16_softmax: bool = False,
         softmax_quant: dict | None = None,
         attn_global_scales: dict | None = None,
+        k_cache_quantized: bool = False,
+        v_cache_quantized: bool = False,
     ) -> torch.Tensor:
         """Decode via the dedicated paged decode kernel (skip-softmax and/or NVFP4).
 
@@ -425,6 +452,8 @@ class _SparseCalibrationMixin:
             fp16_softmax=fp16_softmax,
             softmax_quant=softmax_quant,
             attn_global_scales=attn_global_scales,
+            k_cache_quantized=k_cache_quantized,
+            v_cache_quantized=v_cache_quantized,
         )
         output[:num_actual_tokens] = decode_out
         return output

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -30,6 +30,7 @@ live in ``plugins/sparse_attn_config.py`` and are unit-testable without vLLM.
 import functools
 import inspect
 import math
+import os
 import warnings
 
 import torch
@@ -94,6 +95,41 @@ def _resolve_skip_softmax_calibration(
         )
         return
     sparse_kw["skip_softmax_threshold"] = threshold
+
+
+def parse_attn_quant_env() -> dict:
+    """Read ``MODELOPT_ATTN_*`` env knobs into an attention-quant config.
+
+    Mirrors the env-driven ``vllm_serve_fakequant`` flow (``QUANT_CFG``/``KV_QUANT_CFG``):
+    lets a single served checkpoint toggle NVFP4 attention BMMs, mixed-precision softmax,
+    and N:M sparse softmax at serve time, with no re-export. Returns ``{}`` if none set.
+
+    Env knobs:
+      ``MODELOPT_ATTN_NVFP4``        e.g. ``"q,k,p,v"`` | ``"kv"`` | ``"qkpv"`` — BMM operands -> NVFP4
+      ``MODELOPT_ATTN_FP16_SOFTMAX`` ``"1"`` -> FP16 softmax (all DIFF/EXP2/ACC points)
+      ``MODELOPT_ATTN_SOFTMAX_QUANT`` e.g. ``"diff:fp16_rz,exp2:bf16_rne,acc:fp16"``
+      ``MODELOPT_ATTN_SPARSITY_NM``  e.g. ``"2:4"`` — N:M sparse softmax (prefill)
+    """
+    cfg: dict = {}
+    nv = os.environ.get("MODELOPT_ATTN_NVFP4", "")
+    ops = {ch for tok in nv.replace(" ", "").split(",") for ch in tok if ch in "qkpv"}
+    if ops:
+        cfg["nvfp4"] = ops
+    if os.environ.get("MODELOPT_ATTN_FP16_SOFTMAX", "0").lower() in ("1", "true", "yes"):
+        cfg["fp16_softmax"] = True
+    sq = os.environ.get("MODELOPT_ATTN_SOFTMAX_QUANT", "")
+    sq_map = {}
+    for pair in sq.split(","):
+        key, sep, val = pair.partition(":")
+        if sep and key.strip() and val.strip():
+            sq_map[key.strip()] = val.strip()
+    if sq_map:
+        cfg["softmax_quant"] = sq_map
+    nm = os.environ.get("MODELOPT_ATTN_SPARSITY_NM", "")
+    if ":" in nm:
+        n, m = nm.split(":", 1)
+        cfg["sparsity_n"], cfg["sparsity_m"] = int(n), int(m)
+    return cfg
 
 
 def _build_sparse_kw(layer_cfg: dict) -> dict:
@@ -243,6 +279,12 @@ class _SparseCalibrationMixin:
         disabled sparsity).
         """
         sparse_kw = dict(getattr(self, "sparse_kw", {}))
+        # Attention-quant knobs (env-harness): NVFP4 BMMs + mixed-precision softmax.
+        aq = getattr(self, "attn_quant_kw", {}) or {}
+        nvfp4 = aq.get("nvfp4")
+        fp16_softmax = aq.get("fp16_softmax", False)
+        softmax_quant = aq.get("softmax_quant")
+        quant_active = bool(nvfp4) or fp16_softmax or bool(softmax_quant)
         _resolve_skip_softmax_calibration(
             sparse_kw, is_prefill=not is_decode_only, max_seq_len=max_seq_len
         )
@@ -251,11 +293,11 @@ class _SparseCalibrationMixin:
             for name in ("sparsity_n", "sparsity_m", "dense_sink_tokens", "dense_recent_tokens"):
                 sparse_kw.pop(name, None)
             threshold = sparse_kw.get("skip_softmax_threshold")
-            if threshold is None:
-                # No decode sparsity active for this launch.
+            if threshold is None and not quant_active:
+                # No decode sparsity and no attention quant active for this launch.
                 return dense_fallback()
-            # Decode-only skip-softmax runs on the dedicated decode kernel
-            # (one query vector per request, split-K), not the prefill kernel.
+            # Decode runs on the dedicated decode kernel (one query vector per request,
+            # split-K). It applies skip-softmax and/or NVFP4 + mixed-precision softmax.
             return self._forward_sparse_decode(
                 query=query,
                 key_cache=key_cache,
@@ -265,9 +307,12 @@ class _SparseCalibrationMixin:
                 block_table=block_table,
                 num_actual_tokens=num_actual_tokens,
                 skip_softmax_threshold=threshold,
+                nvfp4=nvfp4,
+                fp16_softmax=fp16_softmax,
+                softmax_quant=softmax_quant,
                 output=output,
             )
-        if not sparse_kw:
+        if not sparse_kw and not quant_active:
             # Dynamic calibration can disable sparse work for a launch (e.g. a
             # short-prefill threshold outside the valid lambda range).
             return dense_fallback()
@@ -292,6 +337,9 @@ class _SparseCalibrationMixin:
             v_cache=value_cache,
             block_table=block_table,
             page_size=page_size,
+            nvfp4=nvfp4,
+            fp16_softmax=fp16_softmax,
+            softmax_quant=softmax_quant,
             **sparse_kw,
         )
         output[:num_actual_tokens] = triton_out
@@ -307,10 +355,13 @@ class _SparseCalibrationMixin:
         seq_lens: torch.Tensor,
         block_table: torch.Tensor,
         num_actual_tokens: int,
-        skip_softmax_threshold: float,
         output: torch.Tensor,
+        skip_softmax_threshold: float | None = None,
+        nvfp4: set[str] | None = None,
+        fp16_softmax: bool = False,
+        softmax_quant: dict | None = None,
     ) -> torch.Tensor:
-        """Decode-only skip-softmax via the dedicated paged decode kernel.
+        """Decode via the dedicated paged decode kernel (skip-softmax and/or NVFP4).
 
         Standard decode schedules exactly one query token per request, so the
         ``num_actual_tokens`` query rows are the per-request decode queries. The
@@ -330,6 +381,9 @@ class _SparseCalibrationMixin:
             softmax_scale=self.scale,
             skip_softmax_threshold=skip_softmax_threshold,
             page_size=page_size,
+            nvfp4=nvfp4,
+            fp16_softmax=fp16_softmax,
+            softmax_quant=softmax_quant,
         )
         output[:num_actual_tokens] = decode_out
         return output

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -42,6 +42,7 @@ from vllm.v1.attention.backends.flash_attn import (
 
 from modelopt.torch.kernels.common.attention.decode_attention import attention_decode
 from modelopt.torch.kernels.common.attention.triton_fa import attention as triton_attention
+from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import tensor_global_scale
 from modelopt.torch.kernels.sparsity.attention.calibrate import attention_calibrate
 
 
@@ -267,6 +268,8 @@ class _SparseCalibrationMixin:
         is_causal: bool,
         output: torch.Tensor,
         dense_fallback,
+        new_key: torch.Tensor | None = None,
+        new_value: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Run the ModelOpt sparse Triton kernel over the paged cache, or delegate.
 
@@ -285,6 +288,34 @@ class _SparseCalibrationMixin:
         fp16_softmax = aq.get("fp16_softmax", False)
         softmax_quant = aq.get("softmax_quant")
         quant_active = bool(nvfp4) or fp16_softmax or bool(softmax_quant)
+        # Precompute NVFP4 per-tensor global scales from the small per-step q/k/v
+        # operands. The kernels otherwise derive them from the full paged K/V cache,
+        # which upcasts the whole cache to fp32 and OOMs (P is a fixed constant).
+        # Q is scaled per-step (Q rows = exactly what is quantized this launch). K/V
+        # are quantized over the *whole* cache in the kernel, but only this step's new
+        # tokens are visible here, so keep a running max on the impl — prefill seeds a
+        # representative scale and decode steps only raise it.
+        attn_global_scales = None
+        if nvfp4:
+            attn_global_scales = {}
+            if "q" in nvfp4:
+                attn_global_scales["q"] = tensor_global_scale(query[:num_actual_tokens])
+            gs_cache = getattr(self, "_nvfp4_gs_cache", None)
+            if gs_cache is None:
+                gs_cache = {}
+                self._nvfp4_gs_cache = gs_cache
+
+            def _running_max(name, tensor):
+                s = tensor_global_scale(tensor[:num_actual_tokens])
+                prev = gs_cache.get(name)
+                s = s if prev is None else max(prev, s)
+                gs_cache[name] = s
+                attn_global_scales[name] = s
+
+            if "k" in nvfp4 and new_key is not None:
+                _running_max("k", new_key)
+            if "v" in nvfp4 and new_value is not None:
+                _running_max("v", new_value)
         _resolve_skip_softmax_calibration(
             sparse_kw, is_prefill=not is_decode_only, max_seq_len=max_seq_len
         )
@@ -310,6 +341,7 @@ class _SparseCalibrationMixin:
                 nvfp4=nvfp4,
                 fp16_softmax=fp16_softmax,
                 softmax_quant=softmax_quant,
+                attn_global_scales=attn_global_scales,
                 output=output,
             )
         if not sparse_kw and not quant_active:
@@ -340,6 +372,7 @@ class _SparseCalibrationMixin:
             nvfp4=nvfp4,
             fp16_softmax=fp16_softmax,
             softmax_quant=softmax_quant,
+            attn_global_scales=attn_global_scales,
             **sparse_kw,
         )
         output[:num_actual_tokens] = triton_out
@@ -360,6 +393,7 @@ class _SparseCalibrationMixin:
         nvfp4: set[str] | None = None,
         fp16_softmax: bool = False,
         softmax_quant: dict | None = None,
+        attn_global_scales: dict | None = None,
     ) -> torch.Tensor:
         """Decode via the dedicated paged decode kernel (skip-softmax and/or NVFP4).
 
@@ -384,6 +418,7 @@ class _SparseCalibrationMixin:
             nvfp4=nvfp4,
             fp16_softmax=fp16_softmax,
             softmax_quant=softmax_quant,
+            attn_global_scales=attn_global_scales,
         )
         output[:num_actual_tokens] = decode_out
         return output
@@ -509,6 +544,8 @@ class ModelOptSparseAttentionImpl(_SparseCalibrationMixin, FlashAttentionImpl):
             is_decode_only=is_decode_only,
             is_causal=is_causal,
             output=output,
+            new_key=key,
+            new_value=value,
             dense_fallback=lambda: self._forward_vllm_flash_attn(
                 layer,
                 query,
@@ -732,6 +769,8 @@ def get_flashinfer_sparse_impl_cls() -> type:
                 is_decode_only=is_decode_only,
                 is_causal=not is_decode_only,
                 output=output,
+                new_key=key,
+                new_value=value,
                 dense_fallback=dense,
             )
 

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -141,7 +141,7 @@ def _build_sparse_kw(layer_cfg: dict) -> dict:
         sparse_kw["sparsity_n"] = sparsity_n
         sparse_kw["sparsity_m"] = layer_cfg.get("sparsity_m", 4)
         sparse_kw["dense_sink_tokens"] = layer_cfg.get("dense_sink_tokens", 0)
-        sparse_kw["dense_recent_tokens"] = layer_cfg.get("dense_recent_tokens", 64)
+        sparse_kw["dense_recent_tokens"] = layer_cfg.get("dense_recent_tokens", 128)
 
     threshold = layer_cfg.get("skip_softmax_threshold")
     if threshold is not None:

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -42,7 +42,7 @@ from vllm.v1.attention.backends.flash_attn import (
 
 from modelopt.torch.kernels.common.attention.decode_attention import attention_decode
 from modelopt.torch.kernels.common.attention.triton_fa import attention as triton_attention
-from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import tensor_global_scale
+from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import tensor_global_scale_device
 from modelopt.torch.kernels.sparsity.attention.calibrate import attention_calibrate
 
 
@@ -289,28 +289,34 @@ class _SparseCalibrationMixin:
         softmax_quant = aq.get("softmax_quant")
         quant_active = bool(nvfp4) or fp16_softmax or bool(softmax_quant)
         # Precompute NVFP4 per-tensor global scales from the small per-step q/k/v
-        # operands. The kernels otherwise derive them from the full paged K/V cache,
-        # which upcasts the whole cache to fp32 and OOMs (P is a fixed constant).
+        # operands, kept as 0-d *device* tensors so the kernels read them via tl.load
+        # (no host .item()). The kernels otherwise derive them from the full paged K/V
+        # cache, which materializes the whole cache and OOMs (P is a fixed constant).
         # Q is scaled per-step (Q rows = exactly what is quantized this launch). K/V
         # are quantized over the *whole* cache in the kernel, but only this step's new
         # tokens are visible here, so keep a running max on the impl — prefill seeds a
-        # representative scale and decode steps only raise it.
+        # representative scale and decode steps only raise it. The running max is an
+        # in-place update of a persistent device buffer (stable address, no host sync),
+        # so it is safe to capture in a CUDA graph and accumulates across replays.
         attn_global_scales = None
         if nvfp4:
             attn_global_scales = {}
             if "q" in nvfp4:
-                attn_global_scales["q"] = tensor_global_scale(query[:num_actual_tokens])
+                attn_global_scales["q"] = tensor_global_scale_device(query[:num_actual_tokens])
             gs_cache = getattr(self, "_nvfp4_gs_cache", None)
             if gs_cache is None:
                 gs_cache = {}
                 self._nvfp4_gs_cache = gs_cache
 
             def _running_max(name, tensor):
-                s = tensor_global_scale(tensor[:num_actual_tokens])
-                prev = gs_cache.get(name)
-                s = s if prev is None else max(prev, s)
-                gs_cache[name] = s
-                attn_global_scales[name] = s
+                s = tensor_global_scale_device(tensor[:num_actual_tokens])  # 0-d device tensor
+                buf = gs_cache.get(name)
+                if buf is None:
+                    buf = s.detach().clone()  # persistent buffer, allocated on first call
+                    gs_cache[name] = buf
+                else:
+                    torch.maximum(buf, s, out=buf)  # in-place running max — graph-safe
+                attn_global_scales[name] = buf
 
             if "k" in nvfp4 and new_key is not None:
                 _running_max("k", new_key)

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -110,6 +110,7 @@ def parse_attn_quant_env() -> dict:
 
     Env knobs:
       ``MODELOPT_ATTN_NVFP4``        e.g. ``"q,k,p,v"`` | ``"kv"`` | ``"qkpv"`` — BMM operands -> NVFP4
+      ``MODELOPT_ATTN_NVFP4_PER_PAGE_SCALE`` ``"1"`` -> per-page NVFP4 KV$ global scale (method 2)
       ``MODELOPT_ATTN_FP16_SOFTMAX`` ``"1"`` -> FP16 softmax (all DIFF/EXP2/ACC points)
       ``MODELOPT_ATTN_SOFTMAX_QUANT`` e.g. ``"diff:fp16_rz,exp2:bf16_rne,acc:fp16"``
       ``MODELOPT_ATTN_SPARSITY_NM``  e.g. ``"2:4"`` — N:M sparse softmax (prefill)
@@ -121,6 +122,11 @@ def parse_attn_quant_env() -> dict:
         cfg["nvfp4"] = ops
     if os.environ.get("MODELOPT_ATTN_FP16_SOFTMAX", "0").lower() in ("1", "true", "yes"):
         cfg["fp16_softmax"] = True
+    if os.environ.get("MODELOPT_ATTN_NVFP4_PER_PAGE_SCALE", "0").lower() in ("1", "true", "yes"):
+        # Method 2: per-page NVFP4 global scale (per BLOCK_N tile) instead of one frozen
+        # per-tensor scale — complete pages baked with their own amax, the in-progress page
+        # re-quantized from its bf16 master each step. Better dynamic range on long-context/math/code.
+        cfg["per_page_scale"] = True
     sq = os.environ.get("MODELOPT_ATTN_SOFTMAX_QUANT", "")
     sq_map = {}
     for pair in sq.split(","):
@@ -291,60 +297,57 @@ class _SparseCalibrationMixin:
         fp16_softmax = aq.get("fp16_softmax", False)
         softmax_quant = aq.get("softmax_quant")
         quant_active = bool(nvfp4) or fp16_softmax or bool(softmax_quant)
-        # Precompute NVFP4 per-tensor global scales from the small per-step q/k/v
-        # operands, kept as 0-d *device* tensors so the kernels read them via tl.load
-        # (no host .item()). The kernels otherwise derive them from the full paged K/V
-        # cache, which materializes the whole cache and OOMs (P is a fixed constant).
-        # Q is scaled per-step (Q rows = exactly what is quantized this launch). K/V
-        # are quantized over the *whole* cache in the kernel, but only this step's new
-        # tokens are visible here, so keep a running max on the impl — prefill seeds a
-        # representative scale and decode steps only raise it. The running max is an
-        # in-place update of a persistent device buffer (stable address, no host sync),
-        # so it is safe to capture in a CUDA graph and accumulates across replays.
+        # NVFP4 per-tensor global scales (0-d *device* tensors, read in-kernel via tl.load — no host
+        # .item()). Q is scaled per-step (the Q rows are exactly what is quantized this launch).
+        #
+        # K/V global scale DEFAULT = constant 1.0. The previous default — a per-tensor scale frozen
+        # on the FIRST prefill chunk — saturated the E4M3 block scales whenever later context exceeded
+        # the prompt (large long-context accuracy loss), so it is deprecated. 1.0 needs no calibration
+        # and E4M3's wide range absorbs typical KV magnitudes. Opt into the per-page scale
+        # (``MODELOPT_ATTN_NVFP4_PER_PAGE_SCALE=1``) for best fidelity — it derives a per-128-page
+        # scale in-kernel from the cache content (no saturation, fully causal).
+        per_page_scale = bool(aq.get("per_page_scale"))
         attn_global_scales = None
         if nvfp4:
             attn_global_scales = {}
             if "q" in nvfp4:
                 attn_global_scales["q"] = tensor_global_scale_device(query[:num_actual_tokens])
-            gs_cache = getattr(self, "_nvfp4_gs_cache", None)
-            if gs_cache is None:
-                gs_cache = {}
-                self._nvfp4_gs_cache = gs_cache
-
-            def _running_max(name, tensor):
-                # FROZEN scale: quantize-on-write requires a fixed per-tensor scale (write-time ==
-                # read-time), else previously-written cache entries drift. The first prefill seeds a
-                # representative scale and it is reused thereafter (graph-safe persistent buffer).
-                buf = gs_cache.get(name)
-                if buf is None:
-                    buf = tensor_global_scale_device(tensor[:num_actual_tokens]).detach().clone()
-                    gs_cache[name] = buf
-                attn_global_scales[name] = buf
-
-            if "k" in nvfp4 and new_key is not None:
-                _running_max("k", new_key)
-            if "v" in nvfp4 and new_value is not None:
-                _running_max("v", new_value)
+            # Default K/V scale = constant 1.0 (per_page_scale derives it per tile in-kernel instead).
+            if not per_page_scale:
+                one = query.new_full((), 1.0, dtype=torch.float32)
+                if "k" in nvfp4:
+                    attn_global_scales["k"] = one
+                if "v" in nvfp4:
+                    attn_global_scales["v"] = one
             # Quantize-KV-on-write: fake-quantize the newly-written K/V in the paged cache once
-            # (frozen scale) so the decode kernel reads them pre-quantized instead of re-FQ'ing the
+            # (fixed scale) so the decode kernel reads them pre-quantized instead of re-FQ'ing the
             # whole cache every step. K = new keys [prev, seq); V = newly-complete 128-tiles. Prefill
             # re-FQ's idempotently on read; decode (flags below) skips it -> the 8-18x decode speedup.
             if {"k", "v"} & nvfp4:
                 prev = (seq_lens - b_seq_len).to(torch.int32)
                 seqk32 = seq_lens.to(torch.int32)
+                if per_page_scale:
+                    # Per-page bakes only COMPLETE BLOCK_N tiles (with their own amax); K and V share
+                    # the same whole-tile range, and the in-progress page stays raw (bf16 master).
+                    k_lo = v_lo = (prev // 128) * 128
+                    k_hi = v_hi = (seqk32 // 128) * 128
+                else:
+                    k_lo, k_hi = prev, seqk32
+                    v_lo, v_hi = (prev // 128) * 128, (seqk32 // 128) * 128
                 fake_quant_kv_onwrite(
                     key_cache,
                     value_cache,
                     block_table,
-                    prev,
-                    seqk32,
-                    (prev // 128) * 128,
-                    (seqk32 // 128) * 128,
+                    k_lo,
+                    k_hi,
+                    v_lo,
+                    v_hi,
                     page_size=page_size,
                     k_global_scale=attn_global_scales.get("k"),
                     v_global_scale=attn_global_scales.get("v"),
                     nvfp4=nvfp4,
                     decode=is_decode_only,
+                    per_page_scale=per_page_scale,
                 )
         _resolve_skip_softmax_calibration(
             sparse_kw, is_prefill=not is_decode_only, max_seq_len=max_seq_len
@@ -374,6 +377,7 @@ class _SparseCalibrationMixin:
                 attn_global_scales=attn_global_scales,
                 k_cache_quantized=("k" in nvfp4),
                 v_cache_quantized=("v" in nvfp4),
+                per_page_scale=per_page_scale,
                 output=output,
             )
         if not sparse_kw and not quant_active:
@@ -405,6 +409,7 @@ class _SparseCalibrationMixin:
             fp16_softmax=fp16_softmax,
             softmax_quant=softmax_quant,
             attn_global_scales=attn_global_scales,
+            per_page_scale=per_page_scale,
             **sparse_kw,
         )
         output[:num_actual_tokens] = triton_out
@@ -428,6 +433,7 @@ class _SparseCalibrationMixin:
         attn_global_scales: dict | None = None,
         k_cache_quantized: bool = False,
         v_cache_quantized: bool = False,
+        per_page_scale: bool = False,
     ) -> torch.Tensor:
         """Decode via the dedicated paged decode kernel (skip-softmax and/or NVFP4).
 
@@ -455,6 +461,7 @@ class _SparseCalibrationMixin:
             attn_global_scales=attn_global_scales,
             k_cache_quantized=k_cache_quantized,
             v_cache_quantized=v_cache_quantized,
+            per_page_scale=per_page_scale,
         )
         output[:num_actual_tokens] = decode_out
         return output

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -344,6 +344,7 @@ class _SparseCalibrationMixin:
                     k_global_scale=attn_global_scales.get("k"),
                     v_global_scale=attn_global_scales.get("v"),
                     nvfp4=nvfp4,
+                    decode=is_decode_only,
                 )
         _resolve_skip_softmax_calibration(
             sparse_kw, is_prefill=not is_decode_only, max_seq_len=max_seq_len

--- a/test_method_comparison.py
+++ b/test_method_comparison.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: N803 — B/KV/NKV are batch/shape names by convention, matching the kernel files
+
+"""Compare NVFP4 KV-cache global-scale strategies against the no-fakequant bf16 baseline.
+
+All run the SAME decode kernel over the SAME bf16 cache, fakequanting {k,v} (Q/P left
+full-precision to isolate the KV$ scale effect); they differ only in the per-tensor NVFP4 global
+scale for K/V:
+
+  1. existing (1st-chunk frozen) : scale = amax(FIRST prefill chunk)/(6*448), frozen — this is what
+       the on-write plugin actually does (``_running_max`` seeds on the first launch and never
+       updates), so a later token/page bigger than the first chunk SATURATES the E4M3 block scales.
+  2. constant 1.0                : global scale fixed at 1.0 (no calibration) — the lower bound.
+  3. per-page                    : each 128-key page uses its own amax/(6*448) — method 2.
+  (ref) ideal frozen             : amax(WHOLE cache)/(6*448) — the best single scale (never
+       saturates); shown to separate "per-page vs a good frozen scale" from "vs the deployed one".
+
+Baseline = same kernel, nvfp4 disabled (no fakequant) on the bf16 cache. We report mean/max abs
+output error vs that baseline (smaller = more faithful). Regimes vary magnitude ACROSS pages: when
+the first chunk is representative (uniform) all are close; when later pages exceed it (growing /
+outlier) the 1st-chunk-frozen scale saturates and per-page pulls ahead.
+"""
+
+import torch
+
+from modelopt.torch.kernels.common.attention.decode_attention import attention_decode
+
+DEV, HEAD_DIM, NQ, NKV, PAGE = "cuda", 128, 64, 8, 16
+TILE = 128  # per-page scale granularity
+FIRST_CHUNK = 2 * TILE  # the prefill chunk that seeds the deployed frozen scale (256 tokens)
+SCALE = HEAD_DIM**-0.5
+KV_NVFP4 = {"k", "v"}
+torch.manual_seed(0)
+
+
+def _setup(B, KV, dtype=torch.bfloat16):
+    nblk = (KV + PAGE - 1) // PAGE
+    tb = B * nblk
+    q = torch.randn(B, NQ, HEAD_DIM, device=DEV, dtype=dtype)
+    kc = torch.randn(tb, PAGE, NKV, HEAD_DIM, device=DEV, dtype=dtype)
+    vc = torch.randn(tb, PAGE, NKV, HEAD_DIM, device=DEV, dtype=dtype)
+    bt = torch.arange(tb, device=DEV, dtype=torch.int32).view(B, nblk)
+    sk = torch.full((B,), KV, device=DEV, dtype=torch.int32)
+    return q, kc, vc, bt, sk
+
+
+def _flat(t, B):
+    return t.view(B, -1, NKV, HEAD_DIM)  # [B, KV_padded, NKV, HEAD_DIM] (contiguous arange bt)
+
+
+def _gscale(t):
+    return t.float().abs().amax() / (6 * 448) + 1e-30  # 0-d device tensor
+
+
+def _out(q, kc, vc, bt, sk, *, nvfp4=None, gs=None, per_page=False):
+    return attention_decode(
+        q,
+        kc.clone(),
+        vc.clone(),
+        bt,
+        sk,
+        softmax_scale=SCALE,
+        page_size=PAGE,
+        nvfp4=(nvfp4 or set()),
+        attn_global_scales=gs,
+        per_page_scale=per_page,
+    ).float()
+
+
+def _err(out, base):
+    d = (out - base).abs()
+    return d.mean().item(), d.max().item()
+
+
+def _compare(name, q, kc, vc, bt, sk, B):
+    base = _out(q, kc, vc, bt, sk)  # no fakequant, bf16 -> reference
+    fk, fv = _flat(kc, B), _flat(vc, B)
+    one = q.new_full((), 1.0, dtype=torch.float32)
+    fc = {"k": _gscale(fk[:, :FIRST_CHUNK]), "v": _gscale(fv[:, :FIRST_CHUNK])}  # 1st-chunk frozen
+    ideal = {"k": _gscale(kc), "v": _gscale(vc)}  # whole-cache frozen (never saturates)
+    rows = [
+        ("1 existing (1st-chunk frozen)", {"nvfp4": KV_NVFP4, "gs": fc}),
+        ("2 constant 1.0", {"nvfp4": KV_NVFP4, "gs": {"k": one, "v": one}}),
+        ("3 per-page", {"nvfp4": KV_NVFP4, "per_page": True}),
+        ("(ref) ideal frozen (whole-amax)", {"nvfp4": KV_NVFP4, "gs": ideal}),
+    ]
+    print(f"\n=== {name} | ref(no-FQ) mean|out|={base.abs().mean().item():.4e} ===")
+    print(f"  {'method':33s} {'mean|err|':>11s} {'max|err|':>11s} {'rel-mean':>9s}")
+    results = {}
+    for label, kw in rows:
+        mean, mx = _err(_out(q, kc, vc, bt, sk, **kw), base)  # type: ignore[arg-type]
+        results[label] = mean
+        print(f"  {label:33s} {mean:11.4e} {mx:11.4e} {mean / base.abs().mean().item():8.2%}")
+    return results
+
+
+if __name__ == "__main__":
+    print(
+        f"GPU {torch.cuda.get_device_name(0)} | head_dim={HEAD_DIM} q={NQ} kv={NKV} page={PAGE} (bf16)"
+    )
+    print(f"first prefill chunk (seeds the deployed frozen scale) = {FIRST_CHUNK} tokens")
+    B, KV = 2, 1024  # 8 pages of 128
+    npages = KV // TILE
+    summary = {}
+
+    # A: uniform N(0,1) — first chunk representative of the whole sequence. Expect all close.
+    q, kc, vc, bt, sk = _setup(B, KV)
+    summary["A uniform"] = _compare("A: uniform N(0,1)", q, kc, vc, bt, sk, B)
+
+    # B: magnitude GROWS with page position (page p scaled x2^p) — the first chunk (pages 0-1) is the
+    # smallest, so the deployed 1st-chunk scale is far too small for later pages -> saturation.
+    q, kc, vc, bt, sk = _setup(B, KV)
+    fk, fv = _flat(kc, B), _flat(vc, B)
+    for p in range(npages):
+        fk[:, p * TILE : (p + 1) * TILE] *= 2.0**p
+        fv[:, p * TILE : (p + 1) * TILE] *= 2.0**p
+    summary["B growing"] = _compare(
+        "B: magnitude grows with position (x2^page)", q, kc, vc, bt, sk, B
+    )
+
+    # C: a single large outlier page (x32) AFTER the first chunk — classic later-context outlier.
+    q, kc, vc, bt, sk = _setup(B, KV)
+    fk, fv = _flat(kc, B), _flat(vc, B)
+    fk[:, 6 * TILE : 7 * TILE] *= 32.0
+    fv[:, 6 * TILE : 7 * TILE] *= 32.0
+    summary["C late-outlier"] = _compare("C: late outlier page (x32, page 6)", q, kc, vc, bt, sk, B)
+
+    print("\n=== summary: mean|err| vs bf16 baseline (lower = better) ===")
+    print(
+        f"  {'regime':14s} {'1 existing':>12s} {'2 const1.0':>12s} {'3 per-page':>12s} {'ideal-frozen':>13s}"
+    )
+    for name, r in summary.items():
+        v = list(r.values())
+        print(f"  {name:14s} {v[0]:12.3e} {v[1]:12.3e} {v[2]:12.3e} {v[3]:13.3e}")
+    print(
+        "\nReading: per-page (3) tracks the IDEAL frozen scale (it never saturates either), and "
+        "beats the DEPLOYED 1st-chunk-frozen (1) + constant-1.0 (2) exactly when later pages exceed "
+        "the first chunk (B/C). Uniform (A) -> all comparable."
+    )

--- a/test_per_page_scale.py
+++ b/test_per_page_scale.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: N803 — B/KV/NKV are batch/shape names by convention, matching the kernel files
+
+"""Numerical correctness + accuracy benefit of per-page (method 2) NVFP4 KV$ scaling.
+
+Method 2 = each KV-cache page (one BLOCK_N=128 tile) carries its OWN global scale (amax/(6*448)):
+complete pages are baked once on write with their own amax; the in-progress (last) page stays raw
+bf16 (the "master pool") and is re-quantized on read each step from its own amax. Contrast with
+method 1 = a single per-tensor scale frozen after prefill.
+
+Test 1 (correctness): per-page on-WRITE+skip must equal per-page on-READ (every tile FQ'd with its
+own amax), since baking a complete tile is the SAME op the on-read path runs. Expect fp32 bit-exact;
+bf16 = pure storage residual (a real FP4 cache -> 0).
+
+Test 2 (benefit): with an outlier in a LATER page, a scale frozen from the FIRST page saturates the
+E4M3 block scales of the outlier page (method 1), while per-page (method 2) re-centers per page.
+Expect: per-page attention is CLOSER to the no-fakequant reference than the frozen scale.
+"""
+
+import torch
+
+from modelopt.torch.kernels.common.attention.decode_attention import (
+    attention_decode,
+    fake_quant_kv_onwrite,
+)
+from modelopt.torch.kernels.common.attention.triton_fa import attention as triton_attention
+
+DEV, HEAD_DIM, NQ, NKV, PAGE = "cuda", 128, 64, 8, 16
+TILE = 128  # the per-page (BLOCK_N) scale granularity in the kernels
+SCALE = HEAD_DIM**-0.5
+torch.manual_seed(0)
+
+
+def _setup(B, KV, dtype):
+    nblk = (KV + PAGE - 1) // PAGE
+    tb = B * nblk
+    q = torch.randn(B, NQ, HEAD_DIM, device=DEV, dtype=dtype)
+    kc = torch.randn(tb, PAGE, NKV, HEAD_DIM, device=DEV, dtype=dtype)
+    vc = torch.randn(tb, PAGE, NKV, HEAD_DIM, device=DEV, dtype=dtype)
+    bt = torch.arange(tb, device=DEV, dtype=torch.int32).view(B, nblk)
+    sk = torch.full((B,), KV, device=DEV, dtype=torch.int32)
+    return q, kc, vc, bt, sk, nblk
+
+
+def _bake_per_page(kc, vc, bt, KV, B, nvfp4):
+    """On-write: bake every COMPLETE 128-tile in place with its own per-tile amax (method 2)."""
+    lo = torch.zeros(B, device=DEV, dtype=torch.int32)
+    hi = torch.full((B,), (KV // TILE) * TILE, device=DEV, dtype=torch.int32)
+    fake_quant_kv_onwrite(
+        kc, vc, bt, lo, hi, lo, hi, page_size=PAGE, nvfp4=nvfp4, decode=False, per_page_scale=True
+    )
+
+
+def _run_correctness(dtype, B, KV, nvfp4):
+    q, kc, vc, bt, sk, _ = _setup(B, KV, dtype)
+    # Reference: per-page applied purely on READ (cache stays raw -> cache_quantized=False forces the
+    # decode kernel to FQ every tile, each with its own in-kernel amax).
+    ref = attention_decode(
+        q,
+        kc.clone(),
+        vc.clone(),
+        bt,
+        sk,
+        softmax_scale=SCALE,
+        page_size=PAGE,
+        nvfp4=nvfp4,
+        per_page_scale=True,
+    )
+    # Optimized: bake complete pages on write, then read them as-is (cache_quantized=True); only the
+    # trailing page is FQ'd on read.
+    kc2, vc2 = kc.clone(), vc.clone()
+    _bake_per_page(kc2, vc2, bt, KV, B, nvfp4 & {"k", "v"})
+    opt = attention_decode(
+        q,
+        kc2,
+        vc2,
+        bt,
+        sk,
+        softmax_scale=SCALE,
+        page_size=PAGE,
+        nvfp4=nvfp4,
+        per_page_scale=True,
+        k_cache_quantized=("k" in nvfp4),
+        v_cache_quantized=("v" in nvfp4),
+    )
+    d = (ref.float() - opt.float()).abs()
+    return d.max().item(), d.mean().item()
+
+
+def _attn_frozen(q, kc, vc, bt, sk, nvfp4, gk, gv):
+    """Method 1: single frozen per-tensor scale (gk/gv) applied on read (no baking)."""
+    return attention_decode(
+        q,
+        kc.clone(),
+        vc.clone(),
+        bt,
+        sk,
+        softmax_scale=SCALE,
+        page_size=PAGE,
+        nvfp4=nvfp4,
+        attn_global_scales={"k": gk, "v": gv},
+    )
+
+
+if __name__ == "__main__":
+    print(f"GPU {torch.cuda.get_device_name(0)} | head_dim={HEAD_DIM} q={NQ} kv={NKV} page={PAGE}")
+
+    # ---- Test 1: on-write+skip == on-read, per page ----
+    print("\n[1] per-page on-write+skip vs on-read (expect fp32 BIT-EXACT)")
+    cases = [
+        (1, 4096),
+        (4, 8192),
+        (8, 16384),
+        (1, 130),
+        (3, 200),
+        (2, 33),
+        (1, 127),
+        (1, 256),
+        (5, 4097),
+    ]
+    bad = 0
+    for nvfp4 in ({"k", "v"}, {"q", "k", "p", "v"}):
+        for dtype in (torch.float32, torch.bfloat16):
+            tag = "".join(sorted(nvfp4))
+            worst_max = worst_mean = 0.0
+            for B, KV in cases:
+                mx, mn = _run_correctness(dtype, B, KV, nvfp4)
+                worst_max, worst_mean = max(worst_max, mx), max(worst_mean, mn)
+            # fp32: bit-exact up to Triton FMA-context epsilon (~1 ULP = 2^-24); the ref/opt paths
+            # compile differently (K/V_CACHE_QUANTIZED False vs True) so the fp32 dot can reorder by
+            # 1 ULP. bf16: pure bf16-cache storage residual (a real FP4 cache -> 0).
+            gate = 1e-5 if dtype == torch.float32 else 5e-2
+            ok = worst_max <= gate
+            bad += not ok
+            kind = "bit-exact(<=1ULP)" if dtype == torch.float32 else "storage-residual"
+            print(
+                f"  nvfp4={tag:5s} {dtype!s:14s} max={worst_max:.3e} mean={worst_mean:.3e}"
+                f"  [{kind}] {'OK' if ok else 'FAIL'}"
+            )
+
+    # ---- Test 2: per-page beats a first-page-frozen scale under a later-page outlier ----
+    print("\n[2] later-page outlier: per-page should be CLOSER to no-FQ than a frozen scale")
+    B, KV, nvfp4 = 2, 512, {"k", "v"}  # 4 pages of 128
+    q, kc, vc, bt, sk, _ = _setup(B, KV, torch.float32)
+    # Inject a large outlier into the LAST page (keys [384, 512)) of both K and V.
+    last_lo = (KV // TILE - 1) * TILE
+    flat_k = kc.view(B, -1, NKV, HEAD_DIM)  # [B, KV, NKV, HEAD_DIM] (contiguous arange block_table)
+    flat_v = vc.view(B, -1, NKV, HEAD_DIM)
+    flat_k[:, last_lo:KV] *= 8.0
+    flat_v[:, last_lo:KV] *= 8.0
+    exact = attention_decode(q, kc.clone(), vc.clone(), bt, sk, softmax_scale=SCALE, page_size=PAGE)
+    # Method 1 frozen scale seeded from the FIRST page only (mimics freeze-on-first-chunk before the
+    # outlier page arrives).
+    gk = flat_k[:, :TILE].float().abs().max() / (6 * 448) + 1e-30
+    gv = flat_v[:, :TILE].float().abs().max() / (6 * 448) + 1e-30
+    frozen = _attn_frozen(q, kc, vc, bt, sk, nvfp4, gk, gv)
+    kc2, vc2 = kc.clone(), vc.clone()
+    _bake_per_page(kc2, vc2, bt, KV, B, nvfp4)
+    perpage = attention_decode(
+        q,
+        kc2,
+        vc2,
+        bt,
+        sk,
+        softmax_scale=SCALE,
+        page_size=PAGE,
+        nvfp4=nvfp4,
+        per_page_scale=True,
+        k_cache_quantized=True,
+        v_cache_quantized=True,
+    )
+    e_frozen = (exact - frozen).abs().mean().item()
+    e_perpage = (exact - perpage).abs().mean().item()
+    better = e_perpage < e_frozen
+    bad += not better
+    print(
+        f"  |exact-frozen|={e_frozen:.4e}  |exact-perpage|={e_perpage:.4e}"
+        f"  -> per-page {'BETTER' if better else 'NOT better'}"
+        f" ({e_frozen / max(e_perpage, 1e-30):.1f}x)"
+    )
+
+    # ---- Test 3: prefill per-page is consistent with decode per-page ----
+    # A single-token prefill over the same baked cache must match the (validated) decode path. The
+    # boundary page uses SCALE_PAGE=128 so prefill reads baked 128-pages as-is even with a smaller
+    # autotuned BLOCK_N. Compare on a 128-ALIGNED KV (no trailing page) so the only difference is
+    # tl.dot-vs-tl.sum kernel numerics; the unaligned case differs only on the <128-token tail page
+    # (prefill quantizes it per-BLOCK_N, a finer-but-consistent sub-page scale) and is reported FYI.
+    print("\n[3] prefill(per-page) vs decode(per-page): aligned must match (kernel numerics)")
+    torch.backends.cuda.matmul.allow_tf32 = False  # isolate per-page logic from TF32 dot error
+    for KV, gated in ((512, True), (600, False)):
+        q, kc, vc, bt, sk, _ = _setup(2, KV, torch.float32)
+        nvfp4 = {"k", "v"}
+        kc2, vc2 = kc.clone(), vc.clone()
+        _bake_per_page(kc2, vc2, bt, KV, 2, nvfp4)
+        dec = attention_decode(
+            q,
+            kc2.clone(),
+            vc2.clone(),
+            bt,
+            sk,
+            softmax_scale=SCALE,
+            page_size=PAGE,
+            nvfp4=nvfp4,
+            per_page_scale=True,
+            k_cache_quantized=True,
+            v_cache_quantized=True,
+        )
+        pre = triton_attention(
+            q,
+            k=torch.empty(0, NKV, HEAD_DIM, device=DEV),
+            v=torch.empty(0, NKV, HEAD_DIM, device=DEV),
+            b_start_loc=torch.arange(2, device=DEV, dtype=torch.int32),
+            b_seq_len=torch.ones(2, device=DEV, dtype=torch.int32),
+            max_input_len=1,
+            is_causal=False,
+            softmax_scale=SCALE,
+            b_start_loc_k=None,
+            b_seq_len_k=sk,
+            max_input_len_k=KV,
+            k_cache=kc2,
+            v_cache=vc2,
+            block_table=bt,
+            page_size=PAGE,
+            nvfp4=nvfp4,
+            per_page_scale=True,
+        )
+        d = (dec.float() - pre.float()).abs()
+        tail = "aligned (no tail)" if KV % TILE == 0 else f"tail={KV % TILE} (per-BLOCK_N, FYI)"
+        if gated:
+            ok = d.max().item() < 5e-3
+            bad += not ok
+            print(
+                f"  KV={KV} {tail}: max={d.max().item():.3e} mean={d.mean().item():.3e}"
+                f"  {'OK' if ok else 'FAIL'}"
+            )
+        else:
+            print(f"  KV={KV} {tail}: max={d.max().item():.3e} mean={d.mean().item():.3e}  [FYI]")
+
+    print(f"\n{'ALL PASS' if bad == 0 else f'{bad} FAILURE(S)'}")

--- a/test_per_page_scale.py
+++ b/test_per_page_scale.py
@@ -193,16 +193,16 @@ if __name__ == "__main__":
         f" ({e_frozen / max(e_perpage, 1e-30):.1f}x)"
     )
 
-    # ---- Test 3: prefill per-page is consistent with decode per-page ----
-    # A single-token prefill over the same baked cache must match the (validated) decode path. The
-    # boundary page uses SCALE_PAGE=128 so prefill reads baked 128-pages as-is even with a smaller
-    # autotuned BLOCK_N. Compare on a 128-ALIGNED KV (no trailing page) so the only difference is
-    # tl.dot-vs-tl.sum kernel numerics; the unaligned case differs only on the <128-token tail page
-    # (prefill quantizes it per-BLOCK_N, a finer-but-consistent sub-page scale) and is reported FYI.
-    print("\n[3] prefill(per-page) vs decode(per-page): aligned must match (kernel numerics)")
+    # ---- Test 3: prefill per-page == decode per-page, for aligned AND tail (the #4 fix) ----
+    # Per-page pins the prefill KV tile to BLOCK_N=128 = the page, so the trailing page's amax is over
+    # the FULL 128-page in BOTH prefill and decode (previously prefill used per-64 sub-tiles, an
+    # inconsistency: the tail diff was ~30x the aligned floor). After the fix, tail ≈ aligned. bf16
+    # because fp32 prefill@128 exceeds A6000 shared memory (bf16 is the serve dtype anyway); a
+    # single-token prefill over the same baked cache must match decode within bf16 + dot-vs-sum noise.
+    print("\n[3] prefill(per-page) vs decode(per-page): tail must match aligned floor (bf16)")
     torch.backends.cuda.matmul.allow_tf32 = False  # isolate per-page logic from TF32 dot error
-    for KV, gated in ((512, True), (600, False)):
-        q, kc, vc, bt, sk, _ = _setup(2, KV, torch.float32)
+    for KV in (512, 600):  # 512 = aligned (floor); 600 = 88-token tail (the #4 case)
+        q, kc, vc, bt, sk, _ = _setup(2, KV, torch.bfloat16)
         nvfp4 = {"k", "v"}
         kc2, vc2 = kc.clone(), vc.clone()
         _bake_per_page(kc2, vc2, bt, KV, 2, nvfp4)
@@ -221,8 +221,8 @@ if __name__ == "__main__":
         )
         pre = triton_attention(
             q,
-            k=torch.empty(0, NKV, HEAD_DIM, device=DEV),
-            v=torch.empty(0, NKV, HEAD_DIM, device=DEV),
+            k=torch.empty(0, NKV, HEAD_DIM, device=DEV, dtype=torch.bfloat16),
+            v=torch.empty(0, NKV, HEAD_DIM, device=DEV, dtype=torch.bfloat16),
             b_start_loc=torch.arange(2, device=DEV, dtype=torch.int32),
             b_seq_len=torch.ones(2, device=DEV, dtype=torch.int32),
             max_input_len=1,
@@ -239,15 +239,11 @@ if __name__ == "__main__":
             per_page_scale=True,
         )
         d = (dec.float() - pre.float()).abs()
-        tail = "aligned (no tail)" if KV % TILE == 0 else f"tail={KV % TILE} (per-BLOCK_N, FYI)"
-        if gated:
-            ok = d.max().item() < 5e-3
-            bad += not ok
-            print(
-                f"  KV={KV} {tail}: max={d.max().item():.3e} mean={d.mean().item():.3e}"
-                f"  {'OK' if ok else 'FAIL'}"
-            )
-        else:
-            print(f"  KV={KV} {tail}: max={d.max().item():.3e} mean={d.mean().item():.3e}  [FYI]")
+        tail = "aligned" if KV % TILE == 0 else f"tail={KV % TILE}"
+        ok = d.max().item() < 1.5e-2  # bf16 + tl.dot-vs-tl.sum kernel numerics (was ~2.5e-2 per-64)
+        bad += not ok
+        print(
+            f"  KV={KV} {tail}: max={d.max().item():.3e} mean={d.mean().item():.3e}  {'OK' if ok else 'FAIL'}"
+        )
 
     print(f"\n{'ALL PASS' if bad == 0 else f'{bad} FAILURE(S)'}")

--- a/tests/gpu/torch/kernels/quantization/attention/test_nvfp4_fakequant.py
+++ b/tests/gpu/torch/kernels/quantization/attention/test_nvfp4_fakequant.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: N803, N806 — Triton kernel args and attention dims use uppercase by convention
+
+"""GPU tests for in-kernel NVFP4 fake quantization of the attention BMM operands.
+
+Validates, against PyTorch references using ``torch.float8_e4m3fn``:
+  - the fp32 E4M3 emulation (block scale) is bit-exact to hardware fp8;
+  - the decode and prefill kernels' in-kernel NVFP4 reproduce a materialized NVFP4
+    attention for every operand subset {q, k, p, v}.
+"""
+
+import pytest
+import torch
+
+pytest.importorskip("triton")
+
+from modelopt.torch.kernels.common.attention import IS_AVAILABLE as TRITON_KERNEL_AVAILABLE
+
+if TRITON_KERNEL_AVAILABLE:
+    import triton
+    import triton.language as tl
+
+    from modelopt.torch.kernels.common.attention.decode_attention import attention_decode
+    from modelopt.torch.kernels.common.attention.triton_fa import attention
+    from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import e4m3_emulate
+
+    @triton.jit
+    def _e4m3_emulate_kernel(X, Y, N: tl.constexpr):
+        i = tl.arange(0, N)
+        tl.store(Y + i, e4m3_emulate(tl.load(X + i)))
+
+
+E2M1, FP8, BLK = 6.0, 448.0, 16
+
+
+# --- PyTorch NVFP4 reference (matches the kernels' E2M1 + E4M3-block + global scheme) ---
+def _e4m3(x):
+    ax = x.abs().clamp(max=FP8).float()
+    o = torch.zeros_like(ax)
+    nz = ax > 0
+    e = torch.floor(torch.log2(ax[nz])).clamp(min=-6.0)
+    s = torch.exp2(e - 3.0)
+    o[nz] = torch.round(ax[nz] / s) * s
+    return torch.sign(x) * o.clamp(max=FP8)
+
+
+def _e2m1(b):
+    return torch.where(
+        b <= 0.25,
+        0.0,
+        torch.where(
+            b < 0.75,
+            0.5,
+            torch.where(
+                b <= 1.25,
+                1.0,
+                torch.where(
+                    b < 1.75,
+                    1.5,
+                    torch.where(
+                        b <= 2.5, 2.0, torch.where(b < 3.5, 3.0, torch.where(b <= 5.0, 4.0, 6.0))
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def _qdq(x, axis, per_row=False):
+    xt = x.transpose(axis, -1).float()
+    gmax = xt.abs().amax(-1, keepdim=True) if per_row else xt.abs().max()
+    g = gmax / (E2M1 * FP8)
+    n = xt.shape[-1]
+    xr = xt.reshape(*xt.shape[:-1], n // BLK, BLK)
+    bamax = xr.abs().amax(-1, keepdim=True)
+    gb = g.unsqueeze(-1) if per_row else g
+    scale = _e4m3((bamax / (E2M1 * gb)).clamp(max=FP8)) * gb
+    scale = torch.where(scale > 0, scale, torch.ones_like(scale))
+    xq = torch.sign(xr) * _e2m1(xr.abs() / scale) * scale
+    return xq.reshape(xt.shape).transpose(axis, -1)
+
+
+@pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
+def test_e4m3_emulation_bit_exact():
+    """The fp32 E4M3 emulation used for the block scale matches torch.float8_e4m3fn."""
+    torch.manual_seed(0)
+    x = (torch.rand(4096, device="cuda") * 900 - 450).float()  # full range incl. >448
+    y = torch.empty_like(x)
+    _e4m3_emulate_kernel[(1,)](x, y, N=4096)
+    ref = x.clamp(-FP8, FP8).to(torch.float8_e4m3fn).to(torch.float32)
+    assert (y - ref).abs().max().item() == 0.0
+
+
+def _paged_decode(k, v, seq_len, page=16):
+    b, kvh, _, d = k.shape
+    nb = (seq_len + page - 1) // page
+    kc = torch.zeros(b * nb, page, kvh, d, device=k.device, dtype=k.dtype)
+    vc = torch.zeros_like(kc)
+    bt = torch.arange(b * nb, device=k.device, dtype=torch.int32).view(b, nb)
+    for bb in range(b):
+        for blk in range(nb):
+            ts, te = blk * page, min((blk + 1) * page, seq_len)
+            kc[bb * nb + blk, : te - ts] = k[bb, :, ts:te].transpose(0, 1)
+            vc[bb * nb + blk, : te - ts] = v[bb, :, ts:te].transpose(0, 1)
+    return kc, vc, bt
+
+
+@pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
+@pytest.mark.parametrize("ops", [(), ("k", "v"), ("q", "k"), ("p", "v"), ("q", "k", "p", "v")])
+def test_decode_kernel_nvfp4(ops):
+    """Decode kernel NVFP4 == materialized NVFP4 decode (single tile, num_kv_splits=1)."""
+    b, H, KVH, S, d = 2, 4, 2, 112, 64
+    sm = 1.0 / (d**0.5)
+    torch.manual_seed(0)
+    q = torch.randn(b, H, d, device="cuda", dtype=torch.float16)
+    k = torch.randn(b, KVH, S, d, device="cuda", dtype=torch.float16)
+    v = torch.randn(b, KVH, S, d, device="cuda", dtype=torch.float16)
+    kc, vc, bt = _paged_decode(k, v, S)
+    sl = torch.full((b,), S, device="cuda", dtype=torch.int32)
+    got = attention_decode(
+        q, kc, vc, bt, sl, softmax_scale=sm, page_size=16, num_kv_splits=1, nvfp4=set(ops)
+    )
+    g = H // KVH
+    ref = torch.empty_like(q)
+    for bb in range(b):
+        for h in range(H):
+            qh, kh, vh = q[bb, h].float(), k[bb, h // g].float(), v[bb, h // g].float()
+            if "q" in ops:
+                qh = _qdq(qh, 0)
+            if "k" in ops:
+                kh = _qdq(kh, -1)
+            p = torch.softmax((qh @ kh.t()) * sm, dim=-1)
+            if "p" in ops:
+                p = _qdq(p, 0)  # 1-D row -> per-row global
+            if "v" in ops:
+                vh = _qdq(vh, 0)
+            ref[bb, h] = (p @ vh).to(ref.dtype)
+    torch.testing.assert_close(got.float(), ref.float(), rtol=5e-3, atol=3e-3)
+
+
+@pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
+@pytest.mark.parametrize("ops", [(), ("k", "v"), ("q", "k"), ("p", "v"), ("q", "k", "p", "v")])
+def test_prefill_kernel_nvfp4(ops):
+    """Prefill kernel NVFP4 == materialized NVFP4 attention (single tile, non-causal)."""
+    S, H, KVH, d = 16, 4, 2, 64
+    sm = 1.0 / (d**0.5)
+    torch.manual_seed(0)
+    q = torch.randn(S, H, d, device="cuda", dtype=torch.float16)
+    k = torch.randn(S, KVH, d, device="cuda", dtype=torch.float16)
+    v = torch.randn(S, KVH, d, device="cuda", dtype=torch.float16)
+    bsl = torch.tensor([0], device="cuda", dtype=torch.int32)
+    bseq = torch.tensor([S], device="cuda", dtype=torch.int32)
+    got = attention(q, k, v, bsl, bseq, S, is_causal=False, softmax_scale=sm, nvfp4=set(ops))
+    g = H // KVH
+    ref = torch.empty_like(q)
+    for h in range(H):
+        qh, kh, vh = q[:, h].float(), k[:, h // g].float(), v[:, h // g].float()
+        if "q" in ops:
+            qh = _qdq(qh, -1)
+        if "k" in ops:
+            kh = _qdq(kh, -1)
+        sc = (qh.half().float() @ kh.half().float().t()) * sm
+        p = torch.softmax(sc, dim=-1)
+        if "p" in ops:
+            p = _qdq(p, -1, per_row=True)  # per-query-token global (flash homogeneity)
+        if "v" in ops:
+            vh = _qdq(vh, 0)
+        ref[:, h] = (p.half().float() @ vh.half().float()).to(ref.dtype)
+    torch.testing.assert_close(got.float(), ref.float(), rtol=5e-3, atol=5e-3)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/gpu/torch/kernels/quantization/attention/test_nvfp4_fakequant.py
+++ b/tests/gpu/torch/kernels/quantization/attention/test_nvfp4_fakequant.py
@@ -37,11 +37,17 @@ if TRITON_KERNEL_AVAILABLE:
     from modelopt.torch.kernels.common.attention.decode_attention import attention_decode
     from modelopt.torch.kernels.common.attention.triton_fa import attention
     from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import e4m3_emulate
+    from modelopt.torch.kernels.quantization.attention.softmax_fakequant import softmax_round
 
     @triton.jit
     def _e4m3_emulate_kernel(X, Y, N: tl.constexpr):
         i = tl.arange(0, N)
         tl.store(Y + i, e4m3_emulate(tl.load(X + i)))
+
+    @triton.jit
+    def _softmax_round_kernel(X, Y, N: tl.constexpr, MODE: tl.constexpr):
+        i = tl.arange(0, N)
+        tl.store(Y + i, softmax_round(tl.load(X + i), MODE))
 
 
 FP8, BLK = 448.0, 16
@@ -106,6 +112,19 @@ def test_e4m3_emulation_bit_exact():
     _e4m3_emulate_kernel[(1,)](x, y, N=4096)
     ref = x.clamp(-FP8, FP8).to(torch.float8_e4m3fn).to(torch.float32)
     assert (y - ref).abs().max().item() == 0.0
+
+
+@pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
+@pytest.mark.parametrize(("mode", "ref_dtype"), [(13, torch.float16), (12, torch.bfloat16)])
+def test_softmax_round_rne(mode, ref_dtype):
+    """softmax_round FP16/BF16 round-to-nearest == the torch cast; mode 0 is identity."""
+    torch.manual_seed(0)
+    x = (torch.rand(4096, device="cuda") * 8 - 4).float()
+    y = torch.empty_like(x)
+    _softmax_round_kernel[(1,)](x, y, N=4096, MODE=mode)
+    assert (y - x.to(ref_dtype).to(torch.float32)).abs().max().item() == 0.0
+    _softmax_round_kernel[(1,)](x, y, N=4096, MODE=0)  # NONE -> identity
+    assert (y - x).abs().max().item() == 0.0
 
 
 def _paged(k, v, S, page=16):

--- a/tests/gpu/torch/kernels/quantization/attention/test_nvfp4_fakequant.py
+++ b/tests/gpu/torch/kernels/quantization/attention/test_nvfp4_fakequant.py
@@ -17,10 +17,10 @@
 
 """GPU tests for in-kernel NVFP4 fake quantization of the attention BMM operands.
 
-Validates, against PyTorch references using ``torch.float8_e4m3fn``:
-  - the fp32 E4M3 emulation (block scale) is bit-exact to hardware fp8;
-  - the decode and prefill kernels' in-kernel NVFP4 reproduce a materialized NVFP4
-    attention for every operand subset {q, k, p, v}.
+The PyTorch reference mirrors the kernels' scheme, which is aligned with the
+customized vLLM ``mni/attnOpt`` framework: a per-tensor global scale
+(``amax/(6*448)``), block-16 E4M3 per-block scale, E2M1 ``>=`` decision boundaries,
+and (for P) quantizing the *unnormalized* exp then normalizing the accumulator.
 """
 
 import pytest
@@ -44,10 +44,10 @@ if TRITON_KERNEL_AVAILABLE:
         tl.store(Y + i, e4m3_emulate(tl.load(X + i)))
 
 
-E2M1, FP8, BLK = 6.0, 448.0, 16
+FP8, BLK = 448.0, 16
 
 
-# --- PyTorch NVFP4 reference (matches the kernels' E2M1 + E4M3-block + global scheme) ---
+# --- PyTorch reference mirroring the aligned kernel scheme ---
 def _e4m3(x):
     ax = x.abs().clamp(max=FP8).float()
     o = torch.zeros_like(ax)
@@ -58,21 +58,23 @@ def _e4m3(x):
     return torch.sign(x) * o.clamp(max=FP8)
 
 
-def _e2m1(b):
+def _e2m1(a):  # a = |x| / scale ; >= boundaries (matches mni/attnOpt + our kernel)
     return torch.where(
-        b <= 0.25,
-        0.0,
+        a >= 5.0,
+        6.0,
         torch.where(
-            b < 0.75,
-            0.5,
+            a >= 3.5,
+            4.0,
             torch.where(
-                b <= 1.25,
-                1.0,
+                a >= 2.5,
+                3.0,
                 torch.where(
-                    b < 1.75,
-                    1.5,
+                    a >= 1.75,
+                    2.0,
                     torch.where(
-                        b <= 2.5, 2.0, torch.where(b < 3.5, 3.0, torch.where(b <= 5.0, 4.0, 6.0))
+                        a >= 1.25,
+                        1.5,
+                        torch.where(a >= 0.75, 1.0, torch.where(a >= 0.25, 0.5, 0.0)),
                     ),
                 ),
             ),
@@ -80,40 +82,41 @@ def _e2m1(b):
     )
 
 
-def _qdq(x, axis, per_row=False):
+def _gscale(t):
+    return t.float().abs().max().item() / (6.0 * FP8) + 1e-30
+
+
+def _qdq(x, axis, gscale):
+    """NVFP4 fakequant: per-tensor gscale, block-16 along `axis`, E4M3 block scale, E2M1."""
     xt = x.transpose(axis, -1).float()
-    gmax = xt.abs().amax(-1, keepdim=True) if per_row else xt.abs().max()
-    g = gmax / (E2M1 * FP8)
     n = xt.shape[-1]
     xr = xt.reshape(*xt.shape[:-1], n // BLK, BLK)
-    bamax = xr.abs().amax(-1, keepdim=True)
-    gb = g.unsqueeze(-1) if per_row else g
-    scale = _e4m3((bamax / (E2M1 * gb)).clamp(max=FP8)) * gb
-    scale = torch.where(scale > 0, scale, torch.ones_like(scale))
+    scale_f32 = xr.abs().amax(-1, keepdim=True) / 6.0 + 1e-30
+    scale = _e4m3(scale_f32 / gscale) * gscale
     xq = torch.sign(xr) * _e2m1(xr.abs() / scale) * scale
     return xq.reshape(xt.shape).transpose(axis, -1)
 
 
 @pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
 def test_e4m3_emulation_bit_exact():
-    """The fp32 E4M3 emulation used for the block scale matches torch.float8_e4m3fn."""
+    """The fp32 E4M3 emulation (block scale) is bit-exact to torch.float8_e4m3fn."""
     torch.manual_seed(0)
-    x = (torch.rand(4096, device="cuda") * 900 - 450).float()  # full range incl. >448
+    x = (torch.rand(4096, device="cuda") * 900 - 450).float()
     y = torch.empty_like(x)
     _e4m3_emulate_kernel[(1,)](x, y, N=4096)
     ref = x.clamp(-FP8, FP8).to(torch.float8_e4m3fn).to(torch.float32)
     assert (y - ref).abs().max().item() == 0.0
 
 
-def _paged_decode(k, v, seq_len, page=16):
+def _paged(k, v, S, page=16):
     b, kvh, _, d = k.shape
-    nb = (seq_len + page - 1) // page
+    nb = (S + page - 1) // page
     kc = torch.zeros(b * nb, page, kvh, d, device=k.device, dtype=k.dtype)
     vc = torch.zeros_like(kc)
     bt = torch.arange(b * nb, device=k.device, dtype=torch.int32).view(b, nb)
     for bb in range(b):
         for blk in range(nb):
-            ts, te = blk * page, min((blk + 1) * page, seq_len)
+            ts, te = blk * page, min((blk + 1) * page, S)
             kc[bb * nb + blk, : te - ts] = k[bb, :, ts:te].transpose(0, 1)
             vc[bb * nb + blk, : te - ts] = v[bb, :, ts:te].transpose(0, 1)
     return kc, vc, bt
@@ -122,40 +125,43 @@ def _paged_decode(k, v, seq_len, page=16):
 @pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
 @pytest.mark.parametrize("ops", [(), ("k", "v"), ("q", "k"), ("p", "v"), ("q", "k", "p", "v")])
 def test_decode_kernel_nvfp4(ops):
-    """Decode kernel NVFP4 == materialized NVFP4 decode (single tile, num_kv_splits=1)."""
+    """Decode kernel NVFP4 == per-tensor-global materialized NVFP4 (single tile)."""
     b, H, KVH, S, d = 2, 4, 2, 112, 64
     sm = 1.0 / (d**0.5)
     torch.manual_seed(0)
     q = torch.randn(b, H, d, device="cuda", dtype=torch.float16)
     k = torch.randn(b, KVH, S, d, device="cuda", dtype=torch.float16)
     v = torch.randn(b, KVH, S, d, device="cuda", dtype=torch.float16)
-    kc, vc, bt = _paged_decode(k, v, S)
+    kc, vc, bt = _paged(k, v, S)
     sl = torch.full((b,), S, device="cuda", dtype=torch.int32)
     got = attention_decode(
         q, kc, vc, bt, sl, softmax_scale=sm, page_size=16, num_kv_splits=1, nvfp4=set(ops)
     )
+    qg, kg, vg = _gscale(q), _gscale(kc), _gscale(vc)
+    pg = 1.0 / (6.0 * FP8) + 1e-30
     g = H // KVH
     ref = torch.empty_like(q)
     for bb in range(b):
         for h in range(H):
             qh, kh, vh = q[bb, h].float(), k[bb, h // g].float(), v[bb, h // g].float()
             if "q" in ops:
-                qh = _qdq(qh, 0)
+                qh = _qdq(qh, 0, qg)
             if "k" in ops:
-                kh = _qdq(kh, -1)
-            p = torch.softmax((qh @ kh.t()) * sm, dim=-1)
-            if "p" in ops:
-                p = _qdq(p, 0)  # 1-D row -> per-row global
+                kh = _qdq(kh, -1, kg)  # block-16 along d, per key
+            scores = (qh @ kh.t()) * sm
+            p = torch.exp(scores - scores.max())  # unnormalized exp
+            denom = p.sum()
+            p_bmm = _qdq(p, 0, pg) if "p" in ops else p  # quantize unnormalized
             if "v" in ops:
-                vh = _qdq(vh, 0)
-            ref[bb, h] = (p @ vh).to(ref.dtype)
+                vh = _qdq(vh, 0, vg)  # block-16 along keys (axis 0)
+            ref[bb, h] = ((p_bmm @ vh) / denom).to(ref.dtype)
     torch.testing.assert_close(got.float(), ref.float(), rtol=5e-3, atol=3e-3)
 
 
 @pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
 @pytest.mark.parametrize("ops", [(), ("k", "v"), ("q", "k"), ("p", "v"), ("q", "k", "p", "v")])
 def test_prefill_kernel_nvfp4(ops):
-    """Prefill kernel NVFP4 == materialized NVFP4 attention (single tile, non-causal)."""
+    """Prefill kernel NVFP4 == per-tensor-global materialized NVFP4 (single tile, non-causal)."""
     S, H, KVH, d = 16, 4, 2, 64
     sm = 1.0 / (d**0.5)
     torch.manual_seed(0)
@@ -165,21 +171,23 @@ def test_prefill_kernel_nvfp4(ops):
     bsl = torch.tensor([0], device="cuda", dtype=torch.int32)
     bseq = torch.tensor([S], device="cuda", dtype=torch.int32)
     got = attention(q, k, v, bsl, bseq, S, is_causal=False, softmax_scale=sm, nvfp4=set(ops))
+    qg, kg, vg = _gscale(q), _gscale(k), _gscale(v)
+    pg = 1.0 / (6.0 * FP8) + 1e-30
     g = H // KVH
     ref = torch.empty_like(q)
     for h in range(H):
         qh, kh, vh = q[:, h].float(), k[:, h // g].float(), v[:, h // g].float()
         if "q" in ops:
-            qh = _qdq(qh, -1)
+            qh = _qdq(qh, -1, qg)  # block-16 along d, per query row
         if "k" in ops:
-            kh = _qdq(kh, -1)
-        sc = (qh.half().float() @ kh.half().float().t()) * sm
-        p = torch.softmax(sc, dim=-1)
-        if "p" in ops:
-            p = _qdq(p, -1, per_row=True)  # per-query-token global (flash homogeneity)
+            kh = _qdq(kh, -1, kg)
+        sc = (qh.half().float() @ kh.half().float().t()) * sm  # fp16 matmul
+        p = torch.exp(sc - sc.max(dim=-1, keepdim=True).values)  # unnormalized exp [S,S]
+        denom = p.sum(dim=-1, keepdim=True)
+        p_bmm = _qdq(p, -1, pg) if "p" in ops else p  # block-16 along keys, per query row
         if "v" in ops:
-            vh = _qdq(vh, 0)
-        ref[:, h] = (p.half().float() @ vh.half().float()).to(ref.dtype)
+            vh = _qdq(vh, 0, vg)
+        ref[:, h] = ((p_bmm.half().float() @ vh.half().float()) / denom).to(ref.dtype)
     torch.testing.assert_close(got.float(), ref.float(), rtol=5e-3, atol=5e-3)
 
 

--- a/tests/gpu/torch/sparsity/attention_sparsity/test_vllm_plugin.py
+++ b/tests/gpu/torch/sparsity/attention_sparsity/test_vllm_plugin.py
@@ -443,8 +443,24 @@ class TestModelOptSparseAttentionImpl:
             output=torch.empty_like(q),
         )
         kc, vc = kv_cache.unbind(0)
+        # The serving impl precomputes NVFP4 per-tensor global scales per-step from q/k/v
+        # (the cache-wide fp32 reduction OOMs), so the reference must use the same scales
+        # to match. Here key=value=q, so all three scales are tensor_global_scale(q).
+        from modelopt.torch.kernels.quantization.attention.nvfp4_fakequant import (
+            tensor_global_scale,
+        )
+
+        gs = tensor_global_scale(q)
         ref = attention_decode(
-            q, kc, vc, bt, kv_lens, softmax_scale=scale, page_size=ps, nvfp4={"q", "k", "p", "v"}
+            q,
+            kc,
+            vc,
+            bt,
+            kv_lens,
+            softmax_scale=scale,
+            page_size=ps,
+            nvfp4={"q", "k", "p", "v"},
+            attn_global_scales={"q": gs, "k": gs, "v": gs},
         )
         torch.testing.assert_close(out, ref, rtol=1e-3, atol=1e-3)
 

--- a/tests/gpu/torch/sparsity/attention_sparsity/test_vllm_plugin.py
+++ b/tests/gpu/torch/sparsity/attention_sparsity/test_vllm_plugin.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: N806 — attention dims (H, KVH, S, ...) use uppercase by convention
+
 """GPU tests for the vLLM sparse attention plugin (ModelOptSparseAttentionImpl).
 
 Covers the integration-critical metadata translation done in
@@ -43,6 +45,7 @@ from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
     enable_calibration,
     fit_calibration,
     get_flashinfer_sparse_impl_cls,
+    parse_attn_quant_env,
     patch_flashinfer_metadata_builder,
 )
 
@@ -382,6 +385,112 @@ class TestModelOptSparseAttentionImpl:
 
         ref = _dense_decode_ref(q, k, v, kv_start, kv_lens, num_heads, num_kv_heads, scale)
         torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-2)
+
+    def test_parse_attn_quant_env(self, monkeypatch):
+        """MODELOPT_ATTN_* env knobs parse into the expected attention-quant config."""
+        for k in ("NVFP4", "FP16_SOFTMAX", "SOFTMAX_QUANT", "SPARSITY_NM"):
+            monkeypatch.delenv(f"MODELOPT_ATTN_{k}", raising=False)
+        assert parse_attn_quant_env() == {}
+        monkeypatch.setenv("MODELOPT_ATTN_NVFP4", "q,k,p,v")
+        monkeypatch.setenv("MODELOPT_ATTN_FP16_SOFTMAX", "1")
+        monkeypatch.setenv("MODELOPT_ATTN_SOFTMAX_QUANT", "diff:fp16_rz,exp2:bf16_rne")
+        monkeypatch.setenv("MODELOPT_ATTN_SPARSITY_NM", "2:4")
+        cfg = parse_attn_quant_env()
+        assert cfg["nvfp4"] == {"q", "k", "p", "v"}
+        assert cfg["fp16_softmax"] is True
+        assert cfg["softmax_quant"] == {"diff": "fp16_rz", "exp2": "bf16_rne"}
+        assert (cfg["sparsity_n"], cfg["sparsity_m"]) == (2, 4)
+        monkeypatch.setenv("MODELOPT_ATTN_NVFP4", "kv")  # shorthand -> {k, v}
+        assert parse_attn_quant_env()["nvfp4"] == {"k", "v"}
+
+    def test_decode_nvfp4_via_attn_quant_kw(self, monkeypatch):
+        """Quant-only decode (NVFP4, no skip threshold) engages the decode kernel, not dense."""
+        from modelopt.torch.kernels.common.attention.decode_attention import attention_decode
+
+        batch = 2
+        kv_lens = torch.tensor([130, 200], device="cuda", dtype=torch.int32)
+        H, KVH, d, ps = 4, 2, 64, 16
+        scale = 1.0 / (d**0.5)
+        torch.manual_seed(5)
+        q = torch.randn(batch, H, d, device="cuda", dtype=torch.float16)
+        k = torch.randn(int(kv_lens.sum()), KVH, d, device="cuda", dtype=torch.float16)
+        v = torch.randn_like(k)
+        kv_start = torch.tensor([0, int(kv_lens[0].item())], device="cuda", dtype=torch.int32)
+        kv_cache, bt = _make_paged_cache(k, v, kv_start, kv_lens, KVH, d, ps)
+        meta = SimpleNamespace(
+            num_actual_tokens=batch,
+            max_query_len=1,
+            max_seq_len=int(kv_lens.max().item()),
+            query_start_loc=torch.tensor([0, 1, 2], device="cuda", dtype=torch.int32),
+            seq_lens=kv_lens,
+            block_table=bt,
+        )
+        monkeypatch.setattr(
+            FlashAttentionImpl,
+            "forward",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("quant-only must not delegate")),
+        )
+        impl = _make_impl(H, d, KVH)
+        impl.sparse_kw = {}  # no skip / N:M — quant only
+        impl.attn_quant_kw = {"nvfp4": {"q", "k", "p", "v"}}
+        out = impl.forward(
+            layer=None,
+            query=q,
+            key=q,
+            value=q,
+            kv_cache=kv_cache,
+            attn_metadata=meta,
+            output=torch.empty_like(q),
+        )
+        kc, vc = kv_cache.unbind(0)
+        ref = attention_decode(
+            q, kc, vc, bt, kv_lens, softmax_scale=scale, page_size=ps, nvfp4={"q", "k", "p", "v"}
+        )
+        torch.testing.assert_close(out, ref, rtol=1e-3, atol=1e-3)
+
+    def test_prefill_nvfp4_via_attn_quant_kw(self):
+        """Quant-only prefill (NVFP4, no sparse feature) engages the kernel (paged == contiguous)."""
+        S, H, KVH, d, ps = 64, 4, 2, 64, 16
+        scale = 1.0 / (d**0.5)
+        torch.manual_seed(6)
+        q = torch.randn(S, H, d, device="cuda", dtype=torch.float16)
+        k = torch.randn(S, KVH, d, device="cuda", dtype=torch.float16)
+        v = torch.randn_like(k)
+        seq = torch.tensor([S], device="cuda", dtype=torch.int32)
+        qsl = torch.tensor([0, S], device="cuda", dtype=torch.int32)
+        out_ref = triton_attention(
+            q,
+            k,
+            v,
+            qsl[:1],
+            seq,
+            S,
+            is_causal=True,
+            softmax_scale=scale,
+            nvfp4={"q", "k", "p", "v"},
+        )
+        kv_cache, bt = _make_paged_cache(k, v, qsl[:1], seq, KVH, d, ps)
+        meta = SimpleNamespace(
+            num_actual_tokens=S,
+            max_query_len=S,
+            max_seq_len=S,
+            query_start_loc=qsl,
+            seq_lens=seq,
+            block_table=bt,
+        )
+        impl = _make_impl(H, d, KVH)
+        impl.sparse_kw = {}
+        impl.attn_quant_kw = {"nvfp4": {"q", "k", "p", "v"}}
+        out = impl.forward(
+            layer=None,
+            query=q,
+            key=k,
+            value=v,
+            kv_cache=kv_cache,
+            attn_metadata=meta,
+            output=torch.empty_like(q),
+        )
+        torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=1e-2)
 
     def test_profiling_run_returns_zeros(self):
         """attn_metadata=None (vLLM profiling pass) must zero-fill output and return."""


### PR DESCRIPTION
### What does this PR do?

**Type of change:** new feature

Adds an in-kernel **NVFP4 (E2M1) fake-quantization path for the attention BMMs** (Q·Kᵀ and P·V) plus a **granular mixed-precision softmax datapath**, in both the prefill (`triton_fa._attn_fwd`) and decode (`decode_attention`) Triton kernels, and **wires them into the vLLM serve path** — for measuring the accuracy of NVFP4 attention (the `tl.dot` still runs in bf16/fp32). New helpers: `kernels/quantization/attention/nvfp4_fakequant.py` and `softmax_fakequant.py`.

**Numerically aligned (bit-exact) with the customized vLLM `mni/attnOpt` attention-quant framework**, so accuracy studies on either stack agree:
- **NVFP4:** per-tensor global scale, `absmax/6` E4M3 per-block scale, E2M1 `>=` boundaries — mirrors their `_fake_quant_fp4_k1/k0` + `tensor_scale`. Cross-checked vs their *actual* functions: **0.000e+00** for NVFP4_SFP32 / MXFP4-RNE / MXFP4-RUP (k1 & k0); the E4M3 block-scale cast is bit-exact to `torch.float8_e4m3fn` (= their `fp8e4nv`). E2M1 uses the PTX `cvt` on sm_100 and a portable fallback elsewhere; the E4M3 scale is fp32-emulated so the path also runs on pre-sm_89 GPUs.
- **Softmax datapath:** per-point quant at **DIFF** (pre-exp2), **EXP2** (post-exp2), **ACC** (sum), modes FP16/BF16 × RNE/RZ (+FTZ) — mode values + rounding bit-exact to theirs (**0.000e+00** all 8 modes).

### Serving (env-driven, no re-export)

The vLLM sparse serve path (`vllm_serve_sparse_attn.py` + `sparse_attn_worker.py` + `plugins/vllm.py`) now exposes these knobs via env vars, mirroring the env-driven `vllm_serve_fakequant.py` flow — so one served checkpoint can toggle configs with no re-export. The worker **force-swaps the ModelOpt sparse impl** when any knob is set (so pure-NVFP4 configs engage even without a `sparse_attention_config`), and the knobs are threaded through both the prefill and decode paths (a quant-only launch runs the kernel instead of delegating to dense).

| Env var | Example | Effect |
|---|---|---|
| `MODELOPT_ATTN_NVFP4` | `q,k,p,v` / `kv` / `qkpv` | NVFP4 on those BMM operands (`k,v` = NVFP4 KV$) |
| `MODELOPT_ATTN_FP16_SOFTMAX` | `1` | FP16 softmax (DIFF/EXP2/ACC) |
| `MODELOPT_ATTN_SOFTMAX_QUANT` | `diff:fp16_rz,exp2:bf16_rne,acc:fp16` | per-point softmax precision |
| `MODELOPT_ATTN_SPARSITY_NM` | `2:4` | N:M sparse softmax (prefill) |

```bash
MODELOPT_ATTN_NVFP4=q,k,p,v MODELOPT_ATTN_FP16_SOFTMAX=1 \
  python vllm_serve_sparse_attn.py <CKPT> --enforce-eager -tp 8 --host 0.0.0.0 --port 8000
```

### Usage (kernels)

```python
from modelopt.torch.kernels.common.attention.triton_fa import attention
from modelopt.torch.kernels.common.attention.decode_attention import attention_decode

out = attention(q, k, v, b_start_loc, b_seq_len, max_len, is_causal=True,
                nvfp4={"q", "k", "p", "v"}, fp16_softmax=True)
out = attention(..., softmax_quant={"diff": "fp16_rz", "exp2": "bf16_rne", "acc": "fp16"})
dec = attention_decode(q, k_cache, v_cache, block_table, b_seq_len_k,
                       nvfp4={"q", "k", "p", "v"}, fp16_softmax=True)
```

### Testing

- **GPU unit tests:** E4M3 emulation bit-exact; prefill & decode NVFP4 == materialized NVFP4 reference for every operand subset; softmax_round RNE modes; env-knob parsing; quant-only decode/prefill engage the kernel (not dense fallback) via the serve impl.
- **Bit-exact cross-check vs the vLLM `mni/attnOpt` actual functions** (NVFP4 k1/k0 + all 8 softmax rounding modes) — 0.000e+00 on A6000.
- **Accuracy (Qwen3-8B, perplexity):** full stack (NVFP4 BMM1+BMM2 + FP16 softmax + NVFP4 KV$ + 2:4) = **1.02×** dense.
- No regression on the existing sparse-attention path; 40+ GPU tests pass.

**Stacking:** based on `kaix/vllm_decode_skip_softmax` (the decode-wiring PR), which is based on the decode-kernel PR — the top of the stack.

Backward compatible: ✅ (NVFP4/softmax/env knobs default off). New tests: ✅.
