### PR TITLE
Support MCore auto_quantize calibration updates

### DIFF
--- a/examples/llm_ptq/cast_mxfp4_to_nvfp4.py
+++ b/examples/llm_ptq/cast_mxfp4_to_nvfp4.py
@@ -297,8 +297,8 @@ def force_weight_quantizers_static(quant_cfg: list) -> None:
     The MXFP4 -> NVFP4 cast needs the per-block weight ``_amax`` to be recorded
     by max-cal (so it can be paired with the pinned global_amax later). Setting
     ``block_sizes['type'] = 'static'`` makes ``is_static_block_quant`` True so
-    ``promote_nvfp4_static_quantizers`` picks the entry up automatically at the
-    end of max_calibrate.
+    static NVFP4 finalization picks the entry up automatically at the end of
+    max_calibrate.
     """
     for i, entry in enumerate(quant_cfg):
         qname = entry.get("quantizer_name", "")

--- a/modelopt/torch/quantization/algorithms.py
+++ b/modelopt/torch/quantization/algorithms.py
@@ -291,13 +291,14 @@ class QuantRecipeHparam(Hparam):
                 total_score += importance.cpu().item()
                 continue
 
-            if parallel_state.expert_model_parallel_group.is_initialized():
-                # TODO: Support expert model parallelism for score estimation
-                warnings.warn("AutoQuantize does not support expert model parallelism yet.")
             importance = importance.cpu()
             importance = DistributedProcessGroup.get_dist_syncd_obj(
                 importance,
-                [parallel_state.tensor_parallel_group, parallel_state.data_parallel_group],
+                [
+                    parallel_state.tensor_parallel_group,
+                    parallel_state.data_parallel_group,
+                    parallel_state.expert_model_parallel_group,
+                ],
                 sum,
             )
             total_score += importance.item()
@@ -318,13 +319,12 @@ class QuantRecipeHparam(Hparam):
                 cost += weight_size * recipe.compression
                 continue
 
-            if parallel_state.expert_model_parallel_group.is_initialized():
-                # TODO: Support expert model parallelism
-                warnings.warn("AutoQuantize does not support expert model parallelism yet.")
-
             weight_size = DistributedProcessGroup.get_dist_syncd_obj(
                 weight_size,
-                [parallel_state.tensor_parallel_group],
+                [
+                    parallel_state.tensor_parallel_group,
+                    parallel_state.expert_model_parallel_group,
+                ],
                 sum,
             )
 
@@ -722,6 +722,15 @@ class _AutoQuantizeBaseSearcher(BaseSearcher, ABC):
             for module in modules
         )
 
+    @staticmethod
+    def _get_total_weight_size_from_candidate_stats(candidate_stats):
+        no_quant_recipe = QuantRecipe(quant_cfg=None)
+        total_weight_size = 0
+        for candidate_stat in candidate_stats.values():
+            no_quant_idx = candidate_stat["formats"].index(no_quant_recipe)
+            total_weight_size += candidate_stat["costs"][no_quant_idx]
+        return total_weight_size
+
     def _get_constraints_for_search(self, max_weight_size, lower_bound=None):
         constraints = {
             "weight_size_after_compression": (
@@ -744,7 +753,7 @@ class _AutoQuantizeBaseSearcher(BaseSearcher, ABC):
         )
 
         compression = self._get_formatted_weight_compression_constraint()
-        total_weight_size = self._get_total_weight_size(self.model.modules())
+        total_weight_size = self._get_total_weight_size_from_candidate_stats(self.candidate_stats)
         max_weight_size = total_weight_size * compression
 
         # Run the search with stats to get the best recipe and whether the constraints are satisfied
@@ -754,12 +763,16 @@ class _AutoQuantizeBaseSearcher(BaseSearcher, ABC):
         best_recipe = {}
         best_constraints, best_scores = 0, 0
         for name, best_hparam_recipe_info in best_recipe_info.items():
-            # Solvers could give different solutions for the same layer across DP/TP groups even though
-            # the scores and costs are the same. Lets make sure the same recipe is selected across DP/TP
+            # Solvers could give different solutions for the same layer across DP/TP/EP groups even though
+            # the scores and costs are the same. Lets make sure the same recipe is selected across DP/TP/EP
             _ps = self.model.get_submodule(name.split(".quant_recipe")[0]).parallel_state
             best_format = DistributedProcessGroup.get_dist_syncd_obj(
                 best_hparam_recipe_info["format"],
-                [_ps.data_parallel_group, _ps.tensor_parallel_group],
+                [
+                    _ps.data_parallel_group,
+                    _ps.tensor_parallel_group,
+                    _ps.expert_model_parallel_group,
+                ],
                 lambda a: a[0],
             )
 
@@ -1379,7 +1392,9 @@ def _resolve_best_recipe(search_state, constraints, verbose=False):
     effective_bits = constraints["effective_bits"]
     compression = effective_bits / 16.0
     candidate_stats = search_state["candidate_stats"]
-    total_weight_size = sum(s["costs"][-1] for s in candidate_stats.values())
+    total_weight_size = _AutoQuantizeBaseSearcher._get_total_weight_size_from_candidate_stats(
+        candidate_stats
+    )
     max_weight_size = total_weight_size * compression
     method = search_state["method"]
 

--- a/modelopt/torch/quantization/algorithms.py
+++ b/modelopt/torch/quantization/algorithms.py
@@ -956,7 +956,11 @@ class AutoQuantizeGradientSearcher(_AutoQuantizeBaseSearcher):
             return output
 
         def backward_hook(module, grad_input, grad_output):
-            for hparam, output_diff_dict in module.output_diff_dict.items():
+            output_diff_dict_by_hparam = getattr(module, "output_diff_dict", None)
+            if output_diff_dict_by_hparam is None:
+                return
+
+            for hparam, output_diff_dict in output_diff_dict_by_hparam.items():
                 for recipe, output_diff in output_diff_dict.items():
                     if hparam._importance_dict[recipe][module] is None:
                         hparam._importance_dict[recipe][module] = _get_auto_quantize_score(
@@ -964,8 +968,11 @@ class AutoQuantizeGradientSearcher(_AutoQuantizeBaseSearcher):
                         )
                     else:
                         _add_auto_quantize_score(
-                            grad_output[0], output_diff, hparam._importance_dict[recipe][module]
+                            grad_output[0],
+                            output_diff,
+                            hparam._importance_dict[recipe][module],
                         )
+            module.output_diff_dict = None
 
         def setup_params_for_score_estimation(name, param, params_metadata, enable_grad=True):
             # Let us delete the gradient as soon as they are computed to save memory

--- a/modelopt/torch/quantization/calib/mse.py
+++ b/modelopt/torch/quantization/calib/mse.py
@@ -178,9 +178,8 @@ class NVFP4MSECalibrator(MseCalibrator):
     Uses a fused Triton kernel as an internal fast path on the first ``collect`` call
     when (a) ``error_func is None``, (b) the input tensor is on CUDA in the standard
     blocked ``[n_blocks, block_size]`` layout, and (c) Triton + the kernel package are
-    importable. Falls back to the reference 126-step Python sweep otherwise (custom
-    ``error_func`` users, multi-``collect`` activation flows, CPU inputs, or when the
-    fast path is disabled via ``MODELOPT_NVFP4_TRITON_SWEEP=0``).
+    importable. Falls back to the reference 126-step Python sweep otherwise and caches
+    the final amax immediately, so this calibrator is one-shot between resets.
     """
 
     def __init__(
@@ -194,13 +193,16 @@ class NVFP4MSECalibrator(MseCalibrator):
         """Initialize NVFP4 MSE calibrator with per-block and global amax."""
         super().__init__(amax=amax, axis=axis, quant_func=quant_func, error_func=error_func)
         self._global_amax = global_amax
-        # Set by the Triton fast path on its (one-shot) collect; consumed by compute_amax.
+        # Set by collect() after either sweep path; consumed by compute_amax.
         self._best_amax_fast: torch.Tensor | None = None
 
     def _compute_candidate_amax(self, candidates: torch.Tensor) -> torch.Tensor:
+        candidates = candidates.to(dtype=torch.float32)
         if candidates.ndim != 0:  # Called during final compute amax
             candidates = candidates.view_as(self._initial_amax)
-        return torch.ones_like(self._initial_amax) * self._global_amax * candidates
+        return torch.ones_like(self._initial_amax, dtype=torch.float32) * (
+            self._global_amax.to(dtype=torch.float32) * candidates
+        )
 
     def _generate_candidates(self, device: torch.device) -> torch.Tensor:
         """Generate the 126 valid FP8 E4M3 scale candidates."""
@@ -235,35 +237,44 @@ class NVFP4MSECalibrator(MseCalibrator):
 
     @torch.no_grad()
     def collect(self, x: torch.Tensor):
-        """Collect input statistics. Uses the Triton fast path when eligible."""
+        """Collect input statistics and cache the final per-block amax."""
         if self._best_amax_fast is not None:
             raise RuntimeError(
-                "NVFP4MSECalibrator: the Triton fast path produced a final amax on a "
-                "previous collect() call; multi-collect after the fast path is not "
-                "supported. Call reset() to start a fresh cycle, set "
-                "MODELOPT_NVFP4_TRITON_SWEEP=0, or pass a non-None error_func to force "
-                "the reference path for activation-style accumulation."
+                "NVFP4MSECalibrator: a previous collect() call produced a final amax; "
+                "multi-collect is not supported. Call reset() to start a fresh cycle."
             )
-        # Fast path is eligible only on the first call, before the reference accumulator
-        # has produced any state.
-        if self._losses_sum is None and self._can_use_triton_fast_path(x):
+        if self._can_use_triton_fast_path(x):
             from modelopt.torch.kernels.quantization.gemm import nvfp4_fp8_scale_sweep
 
             best_flat = nvfp4_fp8_scale_sweep(x.detach(), self._global_amax, block_size=x.shape[-1])
-            # Match the original shape/dtype of the initial amax so downstream
-            # load_calib_amax behaves identically to the reference path.
+            # Store the selected amax in fp32; the fake-quant kernel still returns
+            # tensors in the requested output dtype.
             self._best_amax_fast = best_flat.reshape(self._initial_amax.shape).to(
-                self._initial_amax.dtype
+                dtype=torch.float32
             )
             return
+
+        self._run_reference_collect(x)
+
+    def _run_reference_collect(self, x: torch.Tensor):
         super().collect(x)
+        best_amax = super().compute_amax(verbose=False)
+        self._best_amax_fast = best_amax.to(dtype=torch.float32) if best_amax is not None else None
+        self._losses_sum = None
+        # Synchronize before calibrating another weight so reference MSE sweeps do
+        # not overlap. _losses_sum stores one fp32 reduced loss per candidate per
+        # block. With 16-element NVFP4 blocks and bf16 weights, this is roughly
+        # 128 / 16 * (4 / 2) = 16x the calibrated weight size.
+        if x.is_cuda:
+            torch.cuda.synchronize(x.device)
 
     @torch.no_grad()
     def compute_amax(self, verbose: bool = False):
-        """Return the per-block amax — from the fast path if it ran, else from the reference sweep."""
-        if self._best_amax_fast is not None:
-            return self._best_amax_fast
-        return super().compute_amax(verbose=verbose)
+        """Return the cached per-block amax."""
+        best_amax_fast = getattr(self, "_best_amax_fast", None)
+        if best_amax_fast is None:
+            return None
+        return best_amax_fast
 
     def reset(self):
         """Reset per-cycle state. Keep ``_initial_amax`` so the calibrator stays reusable.

--- a/modelopt/torch/quantization/config.py
+++ b/modelopt/torch/quantization/config.py
@@ -652,7 +652,7 @@ class MseCalibConfig(QuantizeAlgorithmConfig):
     Finds a scale s (via amax a, with s = a / q_max) that minimizes the
     reconstruction error of a tensor after uniform Q→DQ:
 
-        s* = argmin_s  E[(X - DQ(Q(X; s)))^2],   X ∈ {weights | activations}
+        s* = argmin_s  E[(W - DQ(Q(W; s)))^2],   W ∈ weights
 
     When fp8_scale_sweep is enabled, step_size is ignored.
     """
@@ -687,6 +687,12 @@ class MseCalibConfig(QuantizeAlgorithmConfig):
         description="If True, sweep all 128 FP8 E4M3 scale values instead of using multipliers. "
         "Only applies to NVFP4 weight quantization. When enabled, num_steps, step_size, "
         "start_multiplier, and stop_multiplier are ignored.",
+    )
+
+    apply_mse_nvfp_static_only: bool | None = ModeloptField(
+        default=False,
+        title="Apply MSE only to static NVFP4 weight quantizers.",
+        description="If True, non-static-NVFP4 weight quantizers keep their max-calibrated amax.",
     )
 
     distributed_sync: bool | None = ModeloptField(

--- a/modelopt/torch/quantization/model_calib.py
+++ b/modelopt/torch/quantization/model_calib.py
@@ -49,7 +49,6 @@ from .utils import (
     is_quantized_linear,
     is_quantized_row_parallel_linear,
     persistent_materialization,
-    promote_nvfp4_static_quantizers,
     quantizer_attr_names,
     reduce_amax,
 )
@@ -77,7 +76,7 @@ __all__ = [
 def _is_calibrated_nvfp4_static(q) -> bool:
     """True iff ``q`` is an enabled NVFP4-static weight quantizer with ``_amax`` set."""
     return (
-        isinstance(q, TensorQuantizer)
+        isinstance(q, NVFP4StaticQuantizer)
         and not q._disabled
         and q.is_nvfp4_static
         and getattr(q, "_amax", None) is not None
@@ -121,21 +120,16 @@ def _bootstrap_uncalibrated_static_weight_quantizers(model: nn.Module) -> int:
             continue
         with enable_weight_access_and_writeback(module, model, name_to_module):
             for weight, q in module.iter_weights_for_calibration():
-                if not isinstance(q, TensorQuantizer) or q._disabled or q._dynamic:
+                if (
+                    not isinstance(q, TensorQuantizer)
+                    or q._disabled
+                    or q._calibrator is None
+                    or not q.is_nvfp4_static
+                ):
                     continue
-                if q._calibrator is None:
+                if q.amax is not None and not torch.all(q.amax == 0):
                     continue
-                if getattr(q, "_amax", None) is not None and not torch.all(q._amax == 0):
-                    continue
-                q.disable_quant()
-                q.enable_calib()
-                q(weight)
-                if q._calibrator.compute_amax() is not None:
-                    q.load_calib_amax()
-                q.enable_quant()
-                q.disable_calib()
-                if hasattr(q._calibrator, "reset"):
-                    q._calibrator.reset()
+                _run_and_load_max_stats(q, lambda quantizer: quantizer(weight))
                 n += 1
     if n > 0:
         warnings.warn(
@@ -160,18 +154,31 @@ def _sync_grouped_weight_global_amax(model: nn.Module) -> int:
     # quant_utils imports back from this module; top-level would cycle.
     from modelopt.torch.export.quant_utils import preprocess_linear_fusion
 
-    wq_attr = quantizer_attr_names("weight").weight_quantizer
     n_groups = 0
     for group in _collect_grouped_linears(model):
-        for child in group:
-            wq = getattr(child, wq_attr)
-            if not isinstance(wq, NVFP4StaticQuantizer):
-                NVFP4StaticQuantizer.from_tensor_quantizer(
-                    wq, global_amax=reduce_amax(wq._amax, axis=None)
-                )
         preprocess_linear_fusion(group)
         n_groups += 1
     return n_groups
+
+
+@torch.no_grad()
+def _promote_nvfp4_static_quantizers_with_global_amax_sync(model: nn.Module) -> None:
+    """Promote static NVFP4 weight quantizers and sync grouped global amax."""
+    _bootstrap_uncalibrated_static_weight_quantizers(model)
+
+    for _name, module in list(model.named_modules()):
+        if not isinstance(module, TensorQuantizer) or not module.is_enabled:
+            continue
+        if not module.is_nvfp4_static:
+            continue
+        amax = module.amax
+        if amax is None:
+            continue
+
+        global_amax = reduce_amax(amax.clone().detach(), axis=None)
+        NVFP4StaticQuantizer.from_tensor_quantizer(module, global_amax=global_amax)
+
+    _sync_grouped_weight_global_amax(model)
 
 
 CalibratorFactory: TypeAlias = Callable[
@@ -210,6 +217,16 @@ def weight_only_quantize(model: nn.Module):
                 for weight, weight_quantizer in module.iter_weights_for_calibration():
                     weight_quantizer(weight)
         seen_modules.add(module)
+
+
+def _run_and_load_max_stats(model: nn.Module, forward_loop: ForwardLoop | None = None):
+    """Run max-stat collection and load collected stats without post-processing."""
+    enable_stats_collection(model)
+    if forward_loop is None:
+        weight_only_quantize(model)
+    else:
+        forward_loop(model)
+    finish_stats_collection(model)
 
 
 def _has_expert_parallelism(module: nn.Module) -> bool:
@@ -285,12 +302,7 @@ def max_calibrate(
     See :class:`MaxCalibConfig <modelopt.torch.quantization.config.MaxCalibConfig>` for
     details on the remaining arguments.
     """
-    enable_stats_collection(model)
-    if forward_loop is None:
-        weight_only_quantize(model)
-    else:
-        forward_loop(model)
-    finish_stats_collection(model)
+    _run_and_load_max_stats(model, forward_loop)
 
     # Sync quantizer amax across local experts within each rank (for SequentialMLP)
     for name, module in model.named_modules():
@@ -305,7 +317,7 @@ def max_calibrate(
     # two-level (per-block + global) scaling. Run before the ``distributed_sync`` early
     # return so single-process callers also get the promotion. No-op for dynamic-block
     # / non-NVFP4 configs.
-    promote_nvfp4_static_quantizers(model)
+    _promote_nvfp4_static_quantizers_with_global_amax_sync(model)
 
     if not distributed_sync:
         return
@@ -449,6 +461,58 @@ def _mse_quant_func(x, amax, quantizer):
     return xq
 
 
+def _make_weight_mse_calibrator(
+    weight_quantizer: TensorQuantizer,
+    step_size: float,
+    start_multiplier: float,
+    stop_multiplier: float,
+    fp8_scale_sweep: bool,
+    apply_mse_nvfp_static_only: bool,
+) -> _Calibrator | None:
+    """Create the MSE calibrator for one eligible weight quantizer."""
+    if (
+        not isinstance(weight_quantizer, TensorQuantizer)
+        or not weight_quantizer.is_enabled
+        or weight_quantizer._dynamic
+        or weight_quantizer._calibrator is None
+        or getattr(weight_quantizer, "_amax", None) is None
+    ):
+        return None
+
+    is_nvfp4_static = weight_quantizer.is_nvfp4_static
+    if apply_mse_nvfp_static_only and not is_nvfp4_static:
+        return None
+
+    initial_amax = weight_quantizer._amax.clone().detach()
+    axis = weight_quantizer._calibrator._axis
+    quant_func = partial(_mse_quant_func, quantizer=weight_quantizer)
+
+    if fp8_scale_sweep:
+        backend: str | None = getattr(weight_quantizer, "backend", None)
+        backend_factory = (
+            _FP8_SWEEP_CALIBRATOR_REGISTRY.get(backend) if backend is not None else None
+        )
+        if backend_factory is not None:
+            return backend_factory(initial_amax, axis, quant_func)
+
+    if fp8_scale_sweep and is_nvfp4_static:
+        return NVFP4MSECalibrator(
+            amax=initial_amax,
+            axis=axis,
+            global_amax=weight_quantizer.global_amax,
+            quant_func=quant_func,
+        )
+
+    return MseCalibrator(
+        amax=initial_amax,
+        axis=axis,
+        step_size=step_size,
+        start_multiplier=start_multiplier,
+        stop_multiplier=stop_multiplier,
+        quant_func=quant_func,
+    )
+
+
 @torch.no_grad()
 def mse_calibrate(
     model: nn.Module,
@@ -458,12 +522,13 @@ def mse_calibrate(
     start_multiplier: float = 0.25,
     stop_multiplier: float = 4.0,
     fp8_scale_sweep: bool = False,
+    apply_mse_nvfp_static_only: bool = False,
 ):
-    """Calibrate the model using MSE-based amax search.
+    """Calibrate weight quantizers using MSE-based amax search.
 
-    This calibration method first uses max calibration to get initial amax values,
-    then searches for better amax values by minimizing the MSE between original
-    and quantized tensors.
+    This calibration method first uses max calibration to initialize amax values for
+    all quantizers, then searches for better weight amax values by minimizing the MSE
+    between original and quantized weights.
 
     Args:
         model: Model to be calibrated.
@@ -477,134 +542,40 @@ def mse_calibrate(
             for NVFP4 per-block quantization instead of using multipliers.
             This is specifically designed for optimizing the FP8-quantized
             per-block scales in NVFP4 format (default: False).
+        apply_mse_nvfp_static_only: If True, only apply the MSE pass to static NVFP4
+            weight quantizers. Other weight quantizers keep their max-calibrated amax.
 
     See :class:`MseCalibConfig <modelopt.torch.quantization.config.MseCalibConfig>` for
     details on the remaining arguments.
     """
-    # Step 1: max calibrate, bootstrap dead-expert weight quantizers,
-    # unify grouped NVFP4 global_amax so MSE sees a consistent FP8 grid.
+    # max_calibrate initializes activations and weights; MSE only refines weights below.
     max_calibrate(model, forward_loop, distributed_sync)
-    _bootstrap_uncalibrated_static_weight_quantizers(model)
-    _sync_grouped_weight_global_amax(model)
-
-    # Step 2: replace calibrators with MseCalibrator for enabled quantizers.
-    skipped_non_nvfp4: dict[str, int] = {}
-    for name, module in list(model.named_modules()):
-        if isinstance(module, TensorQuantizer) and not module._disabled:
-            if module._calibrator is not None and not module._dynamic and hasattr(module, "_amax"):
-                bs = getattr(module, "block_sizes", None)
-                if not (
-                    getattr(module, "_num_bits", None) == (2, 1)
-                    and bs is not None
-                    and bs.get("scale_bits") == (4, 3)
-                ):
-                    fmt = f"num_bits={module._num_bits} block_sizes={bs}"
-                    skipped_non_nvfp4[fmt] = skipped_non_nvfp4.get(fmt, 0) + 1
-                    continue
-                initial_amax = module._amax.clone().detach()
-                is_nvfp4_static = module.is_nvfp4_static
-
-                # Promote standalone NVFP4-static quantizers; grouped siblings
-                # already promoted by _sync_grouped_weight_global_amax above.
-                if is_nvfp4_static and not isinstance(module, NVFP4StaticQuantizer):
-                    global_amax = reduce_amax(initial_amax, axis=None)
-                    NVFP4StaticQuantizer.from_tensor_quantizer(module, global_amax=global_amax)
-
-                if fp8_scale_sweep:
-                    # Check if backend has a registered custom calibrator factory.
-                    _backend: str | None = getattr(module, "backend", None)
-                    backend_factory = (
-                        _FP8_SWEEP_CALIBRATOR_REGISTRY.get(_backend)
-                        if _backend is not None
-                        else None
-                    )
-                    if backend_factory is not None:
-                        module._calibrator = backend_factory(
-                            initial_amax,
-                            module._calibrator._axis,
-                            partial(_mse_quant_func, quantizer=module),
-                        )
-                        continue
-
-                if fp8_scale_sweep and is_nvfp4_static:
-                    # NVFP4MSECalibrator internally selects a fused Triton kernel for
-                    # the standard squared-error sweep; set MODELOPT_NVFP4_TRITON_SWEEP=0
-                    # to force the reference Python sweep for debugging.
-                    module._calibrator = NVFP4MSECalibrator(
-                        amax=initial_amax,
-                        axis=module._calibrator._axis,
-                        global_amax=module.global_amax,
-                        quant_func=partial(_mse_quant_func, quantizer=module),
-                    )
-                    continue
-
-                # Create MSE calibrator with quant_func
-                module._calibrator = MseCalibrator(
-                    amax=initial_amax,
-                    axis=module._calibrator._axis,
-                    step_size=step_size,
-                    start_multiplier=start_multiplier,
-                    stop_multiplier=stop_multiplier,
-                    quant_func=partial(_mse_quant_func, quantizer=module),
-                )
-
-    if skipped_non_nvfp4:
-        formats = ", ".join(f"{n}x [{fmt}]" for fmt, n in skipped_non_nvfp4.items())
-        warnings.warn(
-            f"MSE calibration only meaningful for NVFP4; skipped {sum(skipped_non_nvfp4.values())} "
-            f"non-NVFP4 quantizer(s) — keeping max-calibrated amax: {formats}",
-            stacklevel=2,
-        )
-
-    # Step 3: calibrate weight quantizers via iter_weights_for_calibration.
     name_to_module = dict(model.named_modules())
     seen_modules: set[int] = set()
     pbar = tqdm(desc="MSE weight calibration")
-    n_calibrated = 0
     for parent_module in name_to_module.values():
         if id(parent_module) in seen_modules or not isinstance(parent_module, QuantModule):
             continue
         seen_modules.add(id(parent_module))
         with enable_weight_access_and_writeback(parent_module, model, name_to_module):
             for weight, weight_quantizer in parent_module.iter_weights_for_calibration():
-                if not (
-                    isinstance(weight_quantizer, TensorQuantizer)
-                    and weight_quantizer.is_enabled
-                    and getattr(weight_quantizer, "_calibrator", None) is not None
-                ):
+                cal = _make_weight_mse_calibrator(
+                    weight_quantizer,
+                    step_size,
+                    start_multiplier,
+                    stop_multiplier,
+                    fp8_scale_sweep,
+                    apply_mse_nvfp_static_only,
+                )
+                if cal is None:
                     continue
-                weight_quantizer.disable_quant()
-                weight_quantizer.enable_calib()
-                weight_quantizer(weight)
-
-                cal = weight_quantizer._calibrator
-                if cal.compute_amax() is not None:
-                    weight_quantizer.load_calib_amax()
-
-                weight_quantizer.enable_quant()
-                weight_quantizer.disable_calib()
-
-                if torch.cuda.is_available():
-                    for dev_id in range(torch.cuda.device_count()):
-                        torch.cuda.synchronize(torch.device(f"cuda:{dev_id}"))
-
+                weight_quantizer._calibrator = cal
+                _run_and_load_max_stats(weight_quantizer, lambda q: q(weight))
                 if hasattr(cal, "reset"):
                     cal.reset()
 
                 pbar.update(1)
-                n_calibrated += 1
-                if n_calibrated % 10 == 0 and torch.cuda.is_available():
-                    for dev_id in range(torch.cuda.device_count()):
-                        torch.cuda.synchronize(torch.device(f"cuda:{dev_id}"))
-                    torch.cuda.empty_cache()
     pbar.close()
-
-    if torch.cuda.is_available():
-        for dev_id in range(torch.cuda.device_count()):
-            torch.cuda.synchronize(torch.device(f"cuda:{dev_id}"))
-        torch.cuda.empty_cache()
-
-    # TODO: Sync amax across distributed processes
 
 
 @torch.no_grad()
@@ -751,8 +722,6 @@ def local_hessian_calibrate(
     # This calibrates both weight_quantizer and input_quantizer with max calibration
     print_rank_0("local_hessian: Running max calibration for all quantizers...")
     max_calibrate(model, forward_loop, distributed_sync)
-
-    _sync_grouped_weight_global_amax(model)
 
     # Setup helpers for all quantized linear modules
     name_to_module = dict(model.named_modules())
@@ -1905,7 +1874,6 @@ def gptq(
 
     # TODO: Add support for other scale setting strateiges like weight-mse or local-hessian
     max_calibrate(model, forward_loop=forward_loop)
-    promote_nvfp4_static_quantizers(model)
 
     quantized_layers = [
         (n, m)

--- a/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
+++ b/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
@@ -642,10 +642,12 @@ class TensorQuantizer(nn.Module):
                     err_msg
                     + " Passing 'strict=False' to `load_calib_amax()` will ignore the error."
                 )
-        if not hasattr(self, "_amax"):
-            self.register_buffer("_amax", calib_amax.clone().detach())
-        else:
-            self._amax.data.copy_(calib_amax.clone().detach())
+        if hasattr(self, "_amax"):
+            assert self._amax.shape == calib_amax.shape, (
+                "Changing shape when loading calibration amax is not allowed."
+            )
+        device = self._amax.device if hasattr(self, "_amax") else calib_amax.device
+        self._buffers["_amax"] = calib_amax.clone().detach().to(device=device)
 
     def load_calib_bias(self, *args, **kwargs):
         """Load affine bias for quantization."""

--- a/modelopt/torch/quantization/plugins/megatron.py
+++ b/modelopt/torch/quantization/plugins/megatron.py
@@ -18,6 +18,7 @@
 import logging
 import types
 import warnings
+from contextlib import contextmanager
 from typing import Any
 
 import megatron.core.parallel_state as mcore_parallel
@@ -775,3 +776,33 @@ if HAS_TE:
             # Affine KVCache Quant bias vector.
             state_dict = self.state_dict(prefix="", keep_vars=True)
             return make_sharded_tensors_for_checkpoint(state_dict, prefix, {}, sharded_offsets)
+
+
+def _is_supported_megatron_model(model: torch.nn.Module) -> bool:
+    return isinstance(model, MegatronModule)
+
+
+@contextmanager
+def _megatron_grad_ckpt_context(model: torch.nn.Module):
+    # Megatron configures activation recompute at model build time via TransformerConfig,
+    # so there is no runtime flag to flip here.
+    yield
+
+
+def _is_param_grad_enabled_for_megatron(pname: str, model: torch.nn.Module) -> bool:
+    return "embed" in pname
+
+
+def _register_auto_quantize_support() -> None:
+    # Local import breaks the circular path where algorithms imports model_calib,
+    # which imports _check_static_block_tp_supported from this plugin.
+    from ..algorithms import AutoQuantizeGradientSearcher
+
+    AutoQuantizeGradientSearcher.register_custom_support(
+        _is_supported_megatron_model,
+        _megatron_grad_ckpt_context,
+        _is_param_grad_enabled_for_megatron,
+    )
+
+
+_register_auto_quantize_support()

--- a/modelopt/torch/quantization/utils/core_utils.py
+++ b/modelopt/torch/quantization/utils/core_utils.py
@@ -940,26 +940,3 @@ def update_quant_cfg_with_kv_cache_quant(
         quant_cfg["algorithm"] = "max"
     print_rank_0(f"Updated quant_cfg with KV cache quantization: {quant_cfg}")
     return quant_cfg
-
-
-def promote_nvfp4_static_quantizers(model: nn.Module) -> int:
-    """Convert eligible TensorQuantizers to NVFP4StaticQuantizer in-place.
-
-    After max calibration sets per-block amax values, NVFP4 static quantizers
-    need to be promoted so they use the two-level scaling path (global amax +
-    per-block amax) instead of the generic E4M3 path.
-
-    Returns the number of quantizers converted.
-    """
-    from modelopt.torch.quantization.nn import NVFP4StaticQuantizer, TensorQuantizer
-
-    converted = 0
-    for _name, module in list(model.named_modules()):
-        if isinstance(module, TensorQuantizer) and not module._disabled:
-            if module._calibrator is not None and not module._dynamic and hasattr(module, "_amax"):
-                if module.is_nvfp4_static:
-                    initial_amax = module._amax.clone().detach()
-                    global_amax = reduce_amax(initial_amax, axis=None)
-                    NVFP4StaticQuantizer.from_tensor_quantizer(module, global_amax=global_amax)
-                    converted += 1
-    return converted

--- a/modelopt/torch/utils/dataset_utils.py
+++ b/modelopt/torch/utils/dataset_utils.py
@@ -26,7 +26,7 @@ from warnings import warn
 
 import requests
 import torch
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, DistributedSampler
 from tqdm import tqdm
 
 if TYPE_CHECKING:
@@ -109,6 +109,7 @@ SUPPORTED_DATASET_CONFIG: dict[str, Any] = {
 __all__ = [
     "create_forward_loop",
     "download_hf_dataset_as_jsonl",
+    "get_dataloader_from_dataset",
     "get_dataset_dataloader",
     "get_dataset_samples",
     "get_jsonl_text_samples",
@@ -423,6 +424,49 @@ class _CustomDataset(torch.utils.data.Dataset):
         return len(next(iter(self.encodings.values())))
 
 
+def get_dataloader_from_dataset(
+    dataset: torch.utils.data.Dataset,
+    batch_size: int = 1,
+    distributed: bool = False,
+    sampler_kwargs: dict[str, Any] | None = None,
+    dataloader_kwargs: dict[str, Any] | None = None,
+) -> DataLoader:
+    """Create a dataloader from an existing dataset.
+
+    Args:
+        dataset: Dataset to wrap in a dataloader.
+        batch_size: Batch size of the returned dataloader.
+        distributed: Whether to shard the dataset with ``DistributedSampler``.
+        sampler_kwargs: Optional keyword arguments for ``DistributedSampler``.
+        dataloader_kwargs: Optional keyword arguments for ``DataLoader``.
+
+    Returns:
+        An instance of dataloader.
+    """
+    sampler_kwargs = {"shuffle": False, "drop_last": False, **(sampler_kwargs or {})}
+    dataloader_kwargs = dataloader_kwargs or {}
+
+    if not distributed:
+        return DataLoader(
+            dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            **dataloader_kwargs,
+        )
+
+    sampler = DistributedSampler(
+        dataset,
+        **sampler_kwargs,
+    )
+    return DataLoader(
+        dataset,
+        batch_size=batch_size,
+        sampler=sampler,
+        shuffle=False,
+        **dataloader_kwargs,
+    )
+
+
 def get_dataset_dataloader(
     dataset_name: str | list[str] = "cnn_dailymail",
     tokenizer: "PreTrainedTokenizerBase | None" = None,
@@ -432,6 +476,10 @@ def get_dataset_dataloader(
     device: torch.device | None = None,
     include_labels: bool = False,
     apply_chat_template: bool = False,
+    distributed: bool = False,
+    sampler_kwargs: dict[str, Any] | None = None,
+    pad_to_max_length: bool = False,
+    warn_on_right_padding: bool = True,
 ) -> DataLoader:
     """Get a dataloader with the dataset name and tokenizer of the target model.
 
@@ -448,6 +496,10 @@ def get_dataset_dataloader(
         include_labels: Whether to include labels in the dataloader.
         apply_chat_template: Whether to apply the chat template to the samples
             (if supported by the dataset).
+        distributed: Whether to shard the dataset with ``DistributedSampler``.
+        sampler_kwargs: Optional keyword arguments for ``DistributedSampler``.
+        pad_to_max_length: Whether to pad every tokenized sample to ``max_sample_length``.
+        warn_on_right_padding: Whether to warn when the tokenizer uses right padding.
 
     Returns:
         An instance of dataloader.
@@ -456,7 +508,7 @@ def get_dataset_dataloader(
     # Tokenizer encoding may modify the tokenizer in place, so we need to clone it.
     tokenizer = copy.deepcopy(tokenizer)
 
-    if tokenizer.padding_side != "left":
+    if warn_on_right_padding and tokenizer.padding_side != "left":
         warn(
             "Tokenizer with the right padding_side may impact calibration accuracy. Recommend set to left"
         )
@@ -481,7 +533,7 @@ def get_dataset_dataloader(
     batch_encoded = tokenizer(
         all_samples,
         return_tensors="pt",
-        padding=True,
+        padding="max_length" if pad_to_max_length else True,
         truncation=True,
         max_length=max_sample_length,
     )
@@ -509,7 +561,12 @@ def get_dataset_dataloader(
             }
         )
 
-    calib_dataloader = DataLoader(tokenized_dataset, batch_size=batch_size, shuffle=False)
+    calib_dataloader = get_dataloader_from_dataset(
+        tokenized_dataset,
+        batch_size=batch_size,
+        distributed=distributed,
+        sampler_kwargs=sampler_kwargs,
+    )
 
     return calib_dataloader
 

--- a/modelopt_recipes/configs/ptq/presets/model/nvfp4_w4a4_weight_mse_fp8_sweep.yaml
+++ b/modelopt_recipes/configs/ptq/presets/model/nvfp4_w4a4_weight_mse_fp8_sweep.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# QuantizeConfig preset for NVFP4 W4A4 with static weight scales from MSE FP8-scale sweep.
+
+# modelopt-schema: modelopt.torch.quantization.config.QuantizeConfig
+imports:
+  base_disable_all: configs/ptq/units/base_disable_all
+  default_disabled_quantizers: configs/ptq/units/default_disabled_quantizers
+  nvfp4: configs/numerics/nvfp4
+  nvfp4_static: configs/numerics/nvfp4_static
+
+algorithm:
+  method: mse
+  fp8_scale_sweep: true
+  apply_mse_nvfp_static_only: true
+quant_cfg:
+  - $import: base_disable_all
+  - quantizer_name: '*weight_quantizer'
+    cfg:
+      $import: nvfp4_static
+  - quantizer_name: '*input_quantizer'
+    cfg:
+      $import: nvfp4
+  - $import: default_disabled_quantizers

--- a/tests/_test_utils/torch/quantization/quantize_common.py
+++ b/tests/_test_utils/torch/quantization/quantize_common.py
@@ -249,14 +249,28 @@ def data_tensor_context_parallel_test_helper(
         )
 
 
-def auto_quantize_helper(model):
+def auto_quantize_helper(
+    model,
+    data_loader=None,
+    forward_step=None,
+    forward_backward_step=None,
+    quantization_formats=None,
+):
+    if data_loader is None:
+        data_loader = [model.get_dummy_input().cuda() for _ in range(2)]
+    if forward_step is None:
+        forward_step = lambda model, batch: model(batch)  # noqa: E731
+    if forward_backward_step is None:
+        forward_backward_step = lambda model, batch: model(batch).sum().backward()  # noqa: E731
+    if quantization_formats is None:
+        quantization_formats = [mtq.INT4_BLOCKWISE_WEIGHT_ONLY_CFG, mtq.INT8_DEFAULT_CFG]
     model, search_state = mtq.auto_quantize(
         model,
         constraints={"effective_bits": 8.0},
-        quantization_formats=[mtq.INT4_BLOCKWISE_WEIGHT_ONLY_CFG, mtq.INT8_DEFAULT_CFG],
-        data_loader=[model.get_dummy_input().cuda() for _ in range(2)],
-        forward_step=lambda model, batch: model(batch),
-        forward_backward_step=lambda model, batch: model(batch).sum().backward(),
+        quantization_formats=quantization_formats,
+        data_loader=data_loader,
+        forward_step=forward_step,
+        forward_backward_step=forward_backward_step,
         num_calib_steps=2,
         num_score_steps=2,
         verbose=True,

--- a/tests/gpu/torch/quantization/test_gptq.py
+++ b/tests/gpu/torch/quantization/test_gptq.py
@@ -25,7 +25,6 @@ import modelopt.torch.quantization as mtq
 from modelopt.torch.export.unified_export_hf import _export_quantized_weight
 from modelopt.torch.quantization.model_calib import gptq
 from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
-from modelopt.torch.quantization.utils import promote_nvfp4_static_quantizers
 from modelopt.torch.quantization.utils.calib_utils import (
     compute_hessian_inverse,
     gptq_blockwise_update,
@@ -265,7 +264,6 @@ def _make_nvfp4_test_data(quant_block_size, out_features, dim):
     }
     inp = torch.randn(4, 32, dim, device="cuda")
     mtq.quantize(model, quant_cfg, forward_loop=lambda m: m(inp))
-    promote_nvfp4_static_quantizers(model)
 
     # Restore original weight (GPTQ operates on original weights)
     model.weight.data = weight.clone()

--- a/tests/gpu/torch/quantization/test_nvfp4_fp8_sweep_kernel.py
+++ b/tests/gpu/torch/quantization/test_nvfp4_fp8_sweep_kernel.py
@@ -31,6 +31,7 @@ import torch
 from conftest import requires_triton
 
 from modelopt.torch.quantization.calib import NVFP4MSECalibrator
+from modelopt.torch.quantization.nn import TensorQuantizer
 from modelopt.torch.quantization.tensor_quant import static_blockwise_fp4_fake_quant
 
 BLOCK_SIZE = 16
@@ -130,8 +131,30 @@ def test_quantized_output_matches():
 
 
 @requires_triton
+@pytest.mark.parametrize("triton_enabled", [True, False])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_sweep_stores_fp32_amax_and_preserves_output_dtype(dtype, triton_enabled):
+    """NVFP4 MSE stores selected amax in fp32 without changing fake-quant output dtype."""
+    torch.manual_seed(11)
+    device = "cuda"
+    num_blocks = 64
+    x = torch.randn(num_blocks, BLOCK_SIZE, device=device, dtype=dtype)
+    per_block_amax = x.abs().amax(dim=-1).to(dtype=dtype)
+    global_amax = per_block_amax.max()
+
+    with _force_sweep_path(triton_enabled=triton_enabled):
+        cal = _make_calibrator(per_block_amax, global_amax)
+        cal.collect(x)
+        amax = cal.compute_amax()
+
+    assert amax.dtype == torch.float32
+    xq = static_blockwise_fp4_fake_quant(x, amax, global_amax, True, x.dtype)
+    assert xq.dtype == x.dtype
+
+
+@requires_triton
 def test_reset_allows_recollect():
-    """After the fast path runs, a second collect() requires reset() in between."""
+    """After collect() caches an amax, a second collect() requires reset() in between."""
     torch.manual_seed(0)
     device = "cuda"
     num_blocks = 32
@@ -143,10 +166,10 @@ def test_reset_allows_recollect():
         cal = _make_calibrator(per_block_amax, global_amax)
         cal.collect(x)
         first = cal.compute_amax().clone()
-        assert cal._best_amax_fast is not None  # fast path was taken
+        assert cal._best_amax_fast is not None  # final amax was cached
 
-        # Second collect after the fast path is not allowed without a reset.
-        with pytest.raises(RuntimeError, match="multi-collect after the fast path"):
+        # Second collect after a final amax is cached is not allowed without a reset.
+        with pytest.raises(RuntimeError, match="multi-collect"):
             cal.collect(x)
 
         cal.reset()
@@ -198,7 +221,7 @@ def test_dispatch_fast_path_default():
 
 @requires_triton
 def test_dispatch_env_optout_falls_back():
-    """``MODELOPT_NVFP4_TRITON_SWEEP=0`` forces the reference 126-step sweep."""
+    """``MODELOPT_NVFP4_TRITON_SWEEP=0`` forces the cached reference sweep."""
     torch.manual_seed(0)
     num_blocks = 32
     x = torch.randn(num_blocks, BLOCK_SIZE, device="cuda", dtype=torch.float32)
@@ -208,8 +231,8 @@ def test_dispatch_env_optout_falls_back():
     with _force_sweep_path(triton_enabled=False):
         cal = _make_calibrator(per_block_amax, global_amax)
         cal.collect(x)
-        assert cal._best_amax_fast is None
-        assert cal._losses_sum is not None
+        assert cal._best_amax_fast is not None
+        assert cal._losses_sum is None
 
 
 @requires_triton
@@ -238,8 +261,8 @@ def test_dispatch_custom_error_func_falls_back():
             error_func=hessian_like_error,
         )
         cal.collect(x)
-        assert cal._best_amax_fast is None
-        assert cal._losses_sum is not None
+        assert cal._best_amax_fast is not None
+        assert cal._losses_sum is None
 
 
 @requires_triton
@@ -306,19 +329,30 @@ def test_mse_calibrate_end_to_end(monkeypatch):
                 m(batch)
 
         mtq.quantize(model, cfg, forward_loop=forward_loop)
+        amax_dtypes = {}
+        for name, module in model.named_modules():
+            if (
+                isinstance(module, TensorQuantizer)
+                and module.is_nvfp4_static
+                and module.amax is not None
+            ):
+                amax_dtypes[name] = module.amax.dtype
+        assert amax_dtypes
         # Run a deterministic input through and snapshot the output.
         torch.manual_seed(1)
         x = torch.randn(4, 16, device="cuda")
         with torch.no_grad():
             y = model(x).detach().clone()
-        return y, weight_snapshots
+        return y, weight_snapshots, amax_dtypes
 
-    y_default, w0 = _run_calibrated(env_value=None)
-    y_optout, w1 = _run_calibrated(env_value="0")
+    y_default, w0, dtypes_default = _run_calibrated(env_value=None)
+    y_optout, w1, dtypes_optout = _run_calibrated(env_value="0")
     # Both runs must start from the same weights (sanity: SimpleLinear is deterministic
     # under the same seed) before we compare post-calibration outputs.
     for name in w0:
         assert torch.equal(w0[name], w1[name]), name
+    assert all(dtype == torch.float32 for dtype in dtypes_default.values())
+    assert all(dtype == torch.float32 for dtype in dtypes_optout.values())
     assert torch.equal(y_default, y_optout)
 
 

--- a/tests/gpu/torch/quantization/test_nvfp4_static_quantizer_cuda.py
+++ b/tests/gpu/torch/quantization/test_nvfp4_static_quantizer_cuda.py
@@ -65,6 +65,27 @@ class TestNVFP4StaticQuantizer:
         quantizer.global_amax = None
         assert quantizer.global_amax is None
 
+    def test_load_calib_amax_preserves_fp32_result_dtype(self, device):
+        """Loading NVFP4 MSE amax should not cast fp32 results into an existing lower
+        dtype buffer."""
+        cfg = QuantizerAttributeConfig(
+            num_bits=(2, 1),
+            block_sizes={-1: 16, "type": "static", "scale_bits": (4, 3)},
+        )
+        quantizer = NVFP4StaticQuantizer(quant_attribute_cfg=cfg).to(device)
+        quantizer.amax = torch.ones(4, device=device, dtype=torch.float16)
+        expected = torch.arange(1, 5, device=device, dtype=torch.float32)
+
+        class Calibrator:
+            def compute_amax(self):
+                return expected
+
+        quantizer._calibrator = Calibrator()
+        quantizer.load_calib_amax()
+
+        assert quantizer.amax.dtype == torch.float32
+        torch.testing.assert_close(quantizer.amax, expected)
+
     def test_export_fp8_scale_no_nan_for_zero_amax_block(self, device):
         """Regression: export must not emit fp8 NaN bytes for an all-zero block.
 
@@ -168,6 +189,15 @@ class TestNVFP4MSECalibrator:
         assert cal._losses_sum is None
         assert cal._amax is None
 
+    def test_compute_amax_before_collect_returns_none(self, device):
+        """Test that compute_amax returns None before a final amax is cached."""
+        num_blocks = 4
+        amax = torch.ones(num_blocks, device=device)
+        global_amax = torch.tensor(10.0, device=device)
+        cal = NVFP4MSECalibrator(amax=amax, global_amax=global_amax)
+
+        assert cal.compute_amax() is None
+
     def test_fp8_candidates_generation(self, device):
         """Test that 126 valid FP8 candidates are generated."""
         num_blocks = 4
@@ -182,13 +212,7 @@ class TestNVFP4MSECalibrator:
         assert torch.all(candidates > 0)
 
     def test_collect_and_compute_amax(self, device, monkeypatch):
-        """Test reference-path collect and compute_amax workflow.
-
-        Pinned to the reference 126-step sweep (``MODELOPT_NVFP4_TRITON_SWEEP=0``)
-        because this test inspects ``_losses_sum``, which only the reference path
-        populates; the Triton fast path produces ``_best_amax_fast`` directly and
-        is covered separately in ``test_nvfp4_fp8_sweep_kernel.py``.
-        """
+        """Test reference-path collect caches the final amax immediately."""
         monkeypatch.setenv("MODELOPT_NVFP4_TRITON_SWEEP", "0")
         num_blocks = 8
         block_size = 16
@@ -207,8 +231,8 @@ class TestNVFP4MSECalibrator:
         x = torch.randn(num_blocks, block_size, device=device)
         cal.collect(x)
 
-        assert cal._losses_sum is not None
-        assert len(cal._losses_sum) == 126
+        assert cal._best_amax_fast is not None
+        assert cal._losses_sum is None
 
         amax = cal.compute_amax()
 
@@ -217,13 +241,8 @@ class TestNVFP4MSECalibrator:
         assert torch.all(torch.isfinite(amax))
         assert torch.all(amax > 0)
 
-    def test_multiple_collections(self, device, monkeypatch):
-        """Test that multiple collections accumulate correctly.
-
-        Multi-collect is reference-path-only — the Triton fast path is one-shot
-        and refuses a second ``collect()`` until ``reset()``. Forcing the env var
-        keeps this exercising the accumulator.
-        """
+    def test_reference_path_reset_allows_recollect(self, device, monkeypatch):
+        """Test that reference fallback is one-shot until reset."""
         monkeypatch.setenv("MODELOPT_NVFP4_TRITON_SWEEP", "0")
         num_blocks = 4
         block_size = 16
@@ -243,13 +262,16 @@ class TestNVFP4MSECalibrator:
         x2 = torch.randn(num_blocks, block_size, device=device)
 
         cal.collect(x1)
-        losses_after_first = [loss.clone() for loss in cal._losses_sum]
+        first = cal.compute_amax().clone()
+        assert cal._best_amax_fast is not None
+        assert cal._losses_sum is None
 
-        cal.collect(x2)
-        losses_after_second = cal._losses_sum
+        with pytest.raises(RuntimeError, match="multi-collect"):
+            cal.collect(x2)
 
-        for loss1, loss2 in zip(losses_after_first, losses_after_second):
-            assert torch.all(loss2 >= loss1 - 1e-6)
+        cal.reset()
+        cal.collect(x1)
+        assert torch.equal(first, cal.compute_amax())
 
     def test_per_block_independent_optimization(self, device):
         """Test that each block is optimized independently.

--- a/tests/gpu_megatron/torch/quantization/plugins/test_megatron.py
+++ b/tests/gpu_megatron/torch/quantization/plugins/test_megatron.py
@@ -26,6 +26,7 @@ from _test_utils.torch.megatron.models import (
 from _test_utils.torch.megatron.utils import (
     compare_amax_sync_across_expert_parallel,
     copy_weights_from_grouped_to_non_grouped,
+    get_batch,
     get_forward,
     initialize_for_megatron,
     run_mcore_inference,
@@ -692,6 +693,45 @@ def test_te_grouped_vs_sequential_quantize(dist_workers_size_4, quant_cfg):
     dist_workers_size_4.run(
         partial(_test_te_grouped_vs_sequential_quantize_helper, 1, 2, quant_cfg)
     )
+
+
+def _test_auto_quantize_moe_ep_helper(rank, size):
+    initialize_for_megatron(
+        tensor_model_parallel_size=1,
+        expert_model_parallel_size=size,
+        seed=SEED,
+    )
+    model = _gpt_model_provider(
+        tp_size=1,
+        ep_size=size,
+        hidden_size=32,
+        num_moe_experts=4,
+        moe_grouped_gemm=False,
+        transformer_impl="modelopt",
+    )
+
+    def forward_step(model, batch):
+        input_ids, labels, position_ids, attention_mask, loss_mask = batch
+        return model.forward(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            labels=labels,
+            loss_mask=loss_mask,
+        )
+
+    auto_quantize_helper(
+        model,
+        data_loader=[get_batch(model, batch_size=2) for _ in range(2)],
+        forward_step=forward_step,
+        forward_backward_step=lambda m, b: forward_step(m, b).mean().backward(),
+        quantization_formats=[mtq.NVFP4_DEFAULT_CFG, mtq.FP8_DEFAULT_CFG],
+    )
+
+
+def test_auto_quantize_moe_ep(dist_workers_size_2):
+    """auto_quantize must sum score/cost across EP ranks and pick a consistent recipe."""
+    dist_workers_size_2.run(_test_auto_quantize_moe_ep_helper)
 
 
 @pytest.mark.parametrize("ep_size", [1, 2])

--- a/tests/unit/torch/quantization/plugins/test_fused_experts.py
+++ b/tests/unit/torch/quantization/plugins/test_fused_experts.py
@@ -633,20 +633,15 @@ class TestFusedExpertsCalibration:
 
         self._cleanup_registry(expert_type)
 
-    def test_bootstrap_populates_dead_expert_quantizers(self):
-        """`_bootstrap_uncalibrated_weight_quantizers` fills `_amax` on experts the
-        forward pass never routed to.
+    def test_max_calibrate_populates_dead_static_nvfp4_expert_quantizers(self):
+        """max calibration fills static NVFP4 ``_amax`` on experts the forward never routed to.
 
         Regression for the dead-expert MSE skip: with partial routing during max
         calibration, never-routed experts' weight quantizers stay with
-        ``_amax=None``; bootstrap must run the calibrator on the per-expert weight
-        slice (via ``iter_weights_for_calibration``) to populate them so MSE
-        doesn't skip them.
+        ``_amax=None`` unless static NVFP4 finalization bootstraps them from the
+        per-expert weight slice.
         """
         import modelopt.torch.quantization as mtq
-        from modelopt.torch.quantization.model_calib import (
-            _bootstrap_uncalibrated_static_weight_quantizers,
-        )
 
         model = _TinyMoEModel()
         expert_type = type(model.moe.experts)
@@ -657,11 +652,17 @@ class TestFusedExpertsCalibration:
                 {"quantizer_name": "*", "enable": False},
                 {
                     "quantizer_name": "*gate_up_proj_weight_quantizer",
-                    "cfg": {"num_bits": 8, "axis": 0},
+                    "cfg": {
+                        "num_bits": (2, 1),
+                        "block_sizes": {-1: 16, "type": "static", "scale_bits": (4, 3)},
+                    },
                 },
                 {
                     "quantizer_name": "*down_proj_weight_quantizer",
-                    "cfg": {"num_bits": 8, "axis": 0},
+                    "cfg": {
+                        "num_bits": (2, 1),
+                        "block_sizes": {-1: 16, "type": "static", "scale_bits": (4, 3)},
+                    },
                 },
             ],
             "algorithm": "max",
@@ -688,41 +689,25 @@ class TestFusedExpertsCalibration:
 
         experts = model.moe.experts
 
-        # Pre-bootstrap: dead experts have no/zero _amax.
-        for idx in dead:
-            gu_q = experts.gate_up_proj_weight_quantizers[idx]
-            d_q = experts.down_proj_weight_quantizers[idx]
-            assert getattr(gu_q, "_amax", None) is None or torch.all(gu_q._amax == 0), (
-                f"Dead expert {idx} gate_up_proj should be uncalibrated pre-bootstrap"
-            )
-            assert getattr(d_q, "_amax", None) is None or torch.all(d_q._amax == 0), (
-                f"Dead expert {idx} down_proj should be uncalibrated pre-bootstrap"
-            )
-
-        n_bootstrapped = _bootstrap_uncalibrated_static_weight_quantizers(model)
-        assert n_bootstrapped >= 2 * len(dead), (
-            f"Expected ≥{2 * len(dead)} bootstrapped (gate_up + down per dead expert), "
-            f"got {n_bootstrapped}"
-        )
-
-        # Post-bootstrap: every expert has populated _amax matching max(|weight|).
+        # Static NVFP4 finalization in max_calibrate bootstraps every expert.
         for idx in range(NUM_EXPERTS):
             gu_q = experts.gate_up_proj_weight_quantizers[idx]
             d_q = experts.down_proj_weight_quantizers[idx]
             assert gu_q._amax is not None and not torch.all(gu_q._amax == 0), (
-                f"Expert {idx} gate_up_proj _amax not populated after bootstrap"
+                f"Expert {idx} gate_up_proj _amax not populated after max_calibrate"
             )
             assert d_q._amax is not None and not torch.all(d_q._amax == 0), (
-                f"Expert {idx} down_proj _amax not populated after bootstrap"
+                f"Expert {idx} down_proj _amax not populated after max_calibrate"
             )
 
-        # For dead experts, bootstrap reads max(|weight|). Sanity-check it matches
-        # the actual weight tensor's per-row max (axis=0 reduces over hidden_dim).
+        # For dead experts, bootstrap reads blockwise max(|weight|). Sanity-check it
+        # matches the actual weight tensor's per-block max over hidden_dim.
         for idx in dead:
-            expected = experts.gate_up_proj.data[idx].abs().amax(dim=1)
+            expected = experts.gate_up_proj.data[idx].reshape(2 * INTERMEDIATE_DIM, 2, 16)
+            expected = expected.abs().amax(dim=2).flatten()
             got = experts.gate_up_proj_weight_quantizers[idx]._amax.flatten()
             assert torch.allclose(got, expected, atol=1e-4), (
-                f"Expert {idx} bootstrap amax should equal per-row max(|weight|); "
+                f"Expert {idx} amax should equal blockwise max(|weight|); "
                 f"max diff {(got - expected).abs().max().item()}"
             )
 

--- a/tests/unit/torch/quantization/test_autoquant.py
+++ b/tests/unit/torch/quantization/test_autoquant.py
@@ -24,8 +24,10 @@ from _test_utils.torch.quantization.models import SimpleConv, SimpleConvLinear, 
 import modelopt.torch.opt as mto
 import modelopt.torch.quantization as mtq
 from modelopt.torch.quantization.algorithms import (
+    AutoQuantizeGradientSearcher,
     QuantRecipe,
     QuantRecipeHparam,
+    _AutoQuantizeBaseSearcher,
     estimate_quant_compression,
 )
 from modelopt.torch.quantization.config import _base_disable_all, _default_disabled_quantizer_cfg
@@ -303,6 +305,39 @@ def _test_data_parallel_auto_quantize(rank, size):
 
 def test_data_parallel_auto_quantize(skip_on_windows):
     spawn_multiprocess_job(4, _test_data_parallel_auto_quantize, backend="gloo")
+
+
+def test_auto_quantize_budget_uses_no_quant_candidate_cost(monkeypatch):
+    class _BudgetCaptureSearcher(AutoQuantizeGradientSearcher):
+        def run_search_with_stats(self, max_weight_size, verbose=False):
+            self.max_weight_size = max_weight_size
+            return {}, True
+
+    def _raise_local_total_weight_size(modules):
+        pytest.fail("run_search should derive total weight size from candidate costs")
+
+    monkeypatch.setattr(
+        _AutoQuantizeBaseSearcher,
+        "_get_total_weight_size",
+        staticmethod(_raise_local_total_weight_size),
+    )
+
+    searcher = _BudgetCaptureSearcher()
+    searcher.reset_search()
+    searcher.model = torch.nn.Module()
+    searcher.config = {"verbose": False}
+    searcher.constraints = {"effective_bits": 8.0}
+    searcher.candidate_stats = {
+        "local_expert.quant_recipe": {
+            "formats": [QuantRecipe(mtq.NVFP4_DEFAULT_CFG), QuantRecipe(None)],
+            "scores": [1.0, 0.0],
+            "costs": [25.0, 100.0],
+        }
+    }
+
+    searcher.run_search()
+
+    assert searcher.max_weight_size == 50.0
 
 
 def test_estimate_quant_compression():

--- a/tests/unit/torch/quantization/test_autoquant.py
+++ b/tests/unit/torch/quantization/test_autoquant.py
@@ -233,6 +233,30 @@ def test_auto_quantize_disabled_layers_no_poison():
     assert QuantRecipe(mtq.INT4_BLOCKWISE_WEIGHT_ONLY_CFG) in hparam.choices
 
 
+def test_auto_quantize_gradient_clears_output_diffs_after_backward():
+    model = SimpleLinear()
+
+    def forward_backward_step(model, batch):
+        model(batch).sum().backward()
+        leaked_modules = [
+            name
+            for name, module in model.named_modules()
+            if getattr(module, "output_diff_dict", None) is not None
+        ]
+        assert leaked_modules == []
+
+    mtq.auto_quantize(
+        model,
+        constraints={"effective_bits": 11.0},
+        quantization_formats=[mtq.INT8_SMOOTHQUANT_CFG],
+        data_loader=[model.get_input()],
+        forward_step=lambda model, batch: model(batch),
+        forward_backward_step=forward_backward_step,
+        num_calib_steps=1,
+        num_score_steps=1,
+    )
+
+
 INT4INT8_AWQ_CFG = {
     "quant_cfg": [
         {"quantizer_name": "*", "enable": False},

--- a/tests/unit/torch/quantization/test_mse_calibrator.py
+++ b/tests/unit/torch/quantization/test_mse_calibrator.py
@@ -19,7 +19,10 @@ import torch
 
 from modelopt.torch.quantization import calib
 from modelopt.torch.quantization.config import QuantizerAttributeConfig
-from modelopt.torch.quantization.nn import TensorQuantizer
+from modelopt.torch.quantization.model_calib import (
+    _promote_nvfp4_static_quantizers_with_global_amax_sync,
+)
+from modelopt.torch.quantization.nn import NVFP4StaticQuantizer, TensorQuantizer
 from modelopt.torch.quantization.utils import enable_fake_quant
 
 
@@ -551,32 +554,34 @@ class TestRegisterFP8SweepCalibrator:
         _QUANT_FUNCTIONAL_BACKENDS.clear()
         _QUANT_FUNCTIONAL_BACKENDS.update(self._orig_quant_backends)
 
-    def _quantize_and_calibrate(self, backend_name, fp8_scale_sweep=True):
+    def _quantize_and_calibrate(
+        self, backend_name, fp8_scale_sweep=True, apply_mse_nvfp_static_only=False
+    ):
         """Quantize a small Linear with the given backend and run mse_calibrate."""
         import modelopt.torch.quantization as mtq
         from modelopt.torch.quantization.model_calib import mse_calibrate
         from modelopt.torch.quantization.nn.modules.tensor_quantizer import register_quant_backend
 
         register_quant_backend(backend_name, lambda x, tq: x)
-        model = torch.nn.Linear(16, 8, bias=False)
-        inputs = torch.randn(1, 16)
+        model = torch.nn.Linear(8, 8, bias=False)
+        inputs = torch.randn(1, 8)
         config = {
             "quant_cfg": [
                 {"quantizer_name": "*", "enable": False},
                 {
                     "quantizer_name": "*weight_quantizer",
-                    "cfg": {
-                        "num_bits": (2, 1),
-                        "block_sizes": {-1: 16, "type": "static", "scale_bits": (4, 3)},
-                        "axis": None,
-                        "backend": backend_name,
-                    },
+                    "cfg": {"num_bits": 8, "axis": None, "backend": backend_name},
                 },
             ],
             "algorithm": "max",
         }
         mtq.quantize(model, config, forward_loop=lambda m: m(inputs))
-        mse_calibrate(model, lambda m: m(inputs), fp8_scale_sweep=fp8_scale_sweep)
+        mse_calibrate(
+            model,
+            lambda m: m(inputs),
+            fp8_scale_sweep=fp8_scale_sweep,
+            apply_mse_nvfp_static_only=apply_mse_nvfp_static_only,
+        )
         return model
 
     def test_register(self):
@@ -636,6 +641,25 @@ class TestRegisterFP8SweepCalibrator:
 
         assert len(factory_calls) == 0
 
+    def test_static_nvfp4_only_skips_registered_non_nvfp4_backend(self):
+        """Registry factory is not invoked for non-static-NVFP4 weights when requested."""
+        from modelopt.torch.quantization.model_calib import _register_fp8_sweep_calibrator
+
+        factory_calls: list = []
+
+        def my_factory(amax, axis, quant_func):
+            factory_calls.append(amax)
+            return calib.MseCalibrator(amax=amax, axis=axis, quant_func=quant_func)
+
+        _register_fp8_sweep_calibrator("_test_static_only_skip", my_factory)
+        self._quantize_and_calibrate(
+            "_test_static_only_skip",
+            fp8_scale_sweep=True,
+            apply_mse_nvfp_static_only=True,
+        )
+
+        assert len(factory_calls) == 0
+
     def test_unregistered_backend_uses_default_mse_calibrator(self):
         """A quantizer with an unregistered backend falls through to MseCalibrator."""
         from modelopt.torch.quantization.calib.mse import MseCalibrator
@@ -645,3 +669,38 @@ class TestRegisterFP8SweepCalibrator:
             if isinstance(module, TensorQuantizer) and module.is_enabled:
                 if getattr(module, "_calibrator", None) is not None:
                     assert isinstance(module._calibrator, MseCalibrator)
+
+
+class TestStaticNVFP4Promotion:
+    class _LinearLike(torch.nn.Module):
+        def __init__(self, amax):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.empty(1, 16))
+            cfg = QuantizerAttributeConfig(
+                num_bits=(2, 1),
+                block_sizes={-1: 16, "type": "static", "scale_bits": (4, 3)},
+                axis=None,
+            )
+            self.weight_quantizer = TensorQuantizer(quant_attribute_cfg=cfg, amax=amax)
+            self.input_quantizer = TensorQuantizer()
+            self.input_quantizer.disable()
+
+    def test_standalone_static_nvfp4_quantizer_is_promoted(self):
+        model = self._LinearLike(torch.tensor([1.0, 5.0]))
+
+        _promote_nvfp4_static_quantizers_with_global_amax_sync(model)
+
+        assert isinstance(model.weight_quantizer, NVFP4StaticQuantizer)
+        assert torch.equal(model.weight_quantizer.global_amax, torch.tensor(5.0))
+
+    def test_grouped_static_nvfp4_quantizers_share_global_amax(self):
+        model = torch.nn.Module()
+        model.q_proj = self._LinearLike(torch.tensor([1.0, 2.0]))
+        model.k_proj = self._LinearLike(torch.tensor([3.0, 4.0]))
+        model.v_proj = self._LinearLike(torch.tensor([5.0, 6.0]))
+
+        _promote_nvfp4_static_quantizers_with_global_amax_sync(model)
+
+        for child in (model.q_proj, model.k_proj, model.v_proj):
+            assert isinstance(child.weight_quantizer, NVFP4StaticQuantizer)
+            assert torch.equal(child.weight_quantizer.global_amax, torch.tensor(6.0))

--- a/tests/unit/torch/utils/test_dataset_utils.py
+++ b/tests/unit/torch/utils/test_dataset_utils.py
@@ -13,16 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from unittest.mock import Mock, patch
 
 import pytest
 import torch
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, DistributedSampler
 
+import modelopt.torch.utils.dataset_utils as dataset_utils
 from modelopt.torch.utils.dataset_utils import (
     _disable_use_cache,
     _forward_loop,
     _process_batch,
+    get_dataloader_from_dataset,
     get_dataset_dataloader,
     get_dataset_samples,
     get_max_batch_size,
@@ -231,6 +234,42 @@ def test_disable_use_cache_restores_on_exception():
         raise RuntimeError("boom")
 
     assert model.config.use_cache is True
+
+
+def test_get_dataloader_from_dataset_preserves_order_without_distributed():
+    dataset = torch.arange(5)
+
+    loader = get_dataloader_from_dataset(dataset, batch_size=2)
+
+    assert [batch.tolist() for batch in loader] == [[0, 1], [2, 3], [4]]
+
+
+def test_get_dataloader_from_dataset_uses_distributed_sampler_kwargs():
+    dataset = torch.arange(6)
+
+    loader = get_dataloader_from_dataset(
+        dataset,
+        batch_size=2,
+        distributed=True,
+        sampler_kwargs={"num_replicas": 2, "rank": 1},
+    )
+
+    assert isinstance(loader.sampler, DistributedSampler)
+    assert [batch.tolist() for batch in loader] == [[1, 3], [5]]
+
+
+def test_get_dataloader_from_dataset_sampler_kwargs_override_defaults():
+    dataset = torch.arange(6)
+
+    loader = get_dataloader_from_dataset(
+        dataset,
+        batch_size=2,
+        distributed=True,
+        sampler_kwargs={"num_replicas": 2, "rank": 1, "shuffle": True, "drop_last": True},
+    )
+
+    assert loader.sampler.shuffle is True
+    assert loader.sampler.drop_last is True
 
 
 def test_get_max_batch_size_oom_retry_shrinks_input():
@@ -517,7 +556,7 @@ class TestLocalJsonlLoading:
 class _FakeTokenizer:
     """Minimal callable tokenizer that mimics the HF tokenizer surface used by the dataloader.
 
-    Tokenizes by character ordinal and left-pads to the longest sample (capped at max_length).
+    Tokenizes by character ordinal and pads to the longest sample (capped at max_length).
     Avoids a hard dependency on ``transformers`` in the test environment.
     """
 
@@ -526,9 +565,13 @@ class _FakeTokenizer:
 
     def __call__(self, texts, return_tensors=None, padding=True, truncation=True, max_length=16):
         ids = [[ord(c) % 100 + 1 for c in t][:max_length] for t in texts]
-        n = max(len(x) for x in ids)
-        input_ids = [[self.pad_token_id] * (n - len(x)) + x for x in ids]
-        attention = [[0] * (n - len(x)) + [1] * len(x) for x in ids]
+        n = max_length if padding == "max_length" else max(len(x) for x in ids)
+        if self.padding_side == "left":
+            input_ids = [[self.pad_token_id] * (n - len(x)) + x for x in ids]
+            attention = [[0] * (n - len(x)) + [1] * len(x) for x in ids]
+        else:
+            input_ids = [x + [self.pad_token_id] * (n - len(x)) for x in ids]
+            attention = [[1] * len(x) + [0] * (n - len(x)) for x in ids]
         return {
             "input_ids": torch.tensor(input_ids, dtype=torch.long),
             "attention_mask": torch.tensor(attention, dtype=torch.long),
@@ -542,6 +585,71 @@ def pad_tokenizer():
 
 class TestGetDatasetDataloaderBlending:
     """``get_dataset_dataloader`` accepts a list of sources and concatenates them."""
+
+    def test_distributed_uses_distributed_sampler(self, monkeypatch, pad_tokenizer):
+        monkeypatch.setattr(
+            dataset_utils,
+            "get_dataset_samples",
+            lambda *args, **kwargs: ["a", "b", "c", "d"],
+        )
+
+        loader = get_dataset_dataloader(
+            dataset_name="dummy",
+            tokenizer=pad_tokenizer,
+            batch_size=2,
+            num_samples=4,
+            max_sample_length=16,
+            distributed=True,
+            sampler_kwargs={"num_replicas": 2, "rank": 1},
+        )
+
+        assert isinstance(loader.sampler, DistributedSampler)
+
+    def test_pad_to_max_length_uses_fixed_sequence_length(self, monkeypatch, pad_tokenizer):
+        monkeypatch.setattr(
+            dataset_utils,
+            "get_dataset_samples",
+            lambda *args, **kwargs: ["a", "abcd"],
+        )
+
+        loader = get_dataset_dataloader(
+            dataset_name="dummy",
+            tokenizer=pad_tokenizer,
+            batch_size=2,
+            num_samples=2,
+            max_sample_length=8,
+            pad_to_max_length=True,
+        )
+
+        batch = next(iter(loader))
+        assert batch["input_ids"].shape == (2, 8)
+        assert batch["attention_mask"].shape == (2, 8)
+
+    def test_right_padding_warning_can_be_disabled(self, monkeypatch, pad_tokenizer):
+        pad_tokenizer.padding_side = "right"
+        monkeypatch.setattr(
+            dataset_utils,
+            "get_dataset_samples",
+            lambda *args, **kwargs: ["a", "abcd"],
+        )
+
+        with pytest.warns(UserWarning, match="right padding_side"):
+            get_dataset_dataloader(
+                dataset_name="dummy",
+                tokenizer=pad_tokenizer,
+                num_samples=2,
+            )
+
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            get_dataset_dataloader(
+                dataset_name="dummy",
+                tokenizer=pad_tokenizer,
+                num_samples=2,
+                warn_on_right_padding=False,
+            )
+
+        assert not any("right padding_side" in str(record.message) for record in records)
 
     def test_single_jsonl(self, tmp_path, pad_tokenizer):
         pytest.importorskip("datasets")


### PR DESCRIPTION
### What does this PR do?

Type of change: new feature

- Supports `auto_quantize` for Megatron expert parallelism.
- Adds calibration dataloader options for auto-quantization workflows.
- Clears autoquant output diffs after backward.
- Refines static NVFP4 MSE calibration behavior and related tests.

### Usage

```python
# N/A: draft PR for quantization workflow updates.
```

### Testing

Not run during this PR creation step.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information

Draft PR. No reviewers or assignees requested.
