### PR TITLE
[Feat]: Zero-disk hidden-state transfer for specdec streaming via NIXL RDMA

### DIFF
--- a/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
+++ b/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
@@ -54,6 +54,8 @@ from pathlib import Path
 from typing import TypedDict
 
 import httpx
+import base64
+import time
 import torch
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from safetensors import SafetensorError, safe_open
@@ -410,7 +412,90 @@ class EagleVllmStreamingDataset(StreamingDataset):
         self._rr += 1
         return url
 
+    # ---- RDMA transport (no-disk hidden states via NIXL) ----
+    def _rdma(self):
+        pid = os.getpid()
+        if getattr(self, "_nixl_pid", None) != pid:
+            from nixl._api import nixl_agent, nixl_agent_config
+            self._nixl = nixl_agent(f"hs-trainer-{pid}",
+                                    nixl_agent_config(backends=["UCX"]))
+            self._nixl_pid = pid
+            self._remote_by_host: dict = {}
+            self._recv = None
+            self._http_rdma = httpx.Client(
+                timeout=httpx.Timeout(self.config.request_timeout, connect=10.0))
+        return self._nixl
+
+    def _remote(self, host, port):
+        if host not in self._remote_by_host:
+            m = self._http_rdma.get(f"http://{host}:{port}/meta").json()["agent_metadata"]
+            self._remote_by_host[host] = self._nixl.add_remote_agent(base64.b64decode(m))
+        return self._remote_by_host[host]
+
+    def _fetch_rdma(self, sample: dict):
+        agent = self._rdma()
+        url = self._next_url()
+        host = url.split("://", 1)[-1].split(":")[0]
+        port = int(os.environ.get("HS_SIDECAR_PORT", "18999"))
+        r = self._http_rdma.post(
+            f"{url}/v1/completions",
+            json={"model": self.config.model, "prompt": sample["token_ids"],
+                  "max_tokens": 1, "temperature": 0})
+        r.raise_for_status()
+        rid = (r.json().get("kv_transfer_params") or {}).get("hs_req_id")
+        if rid is None:
+            warn_rank_0(f"[streaming] no hs_req_id for {sample['cid']}")
+            return None
+        remote = self._remote(host, port)
+        desc = None
+        deadline = time.time() + self.config.request_timeout
+        while time.time() < deadline:
+            rr = self._http_rdma.get(f"http://{host}:{port}/desc", params={"req_id": rid})
+            if rr.status_code == 200 and rr.json().get("ready"):
+                desc = rr.json(); break
+            time.sleep(0.002)
+        if desc is None:
+            warn_rank_0(f"[streaming] rdma desc timeout for {sample['cid']}")
+            return None
+        shape = tuple(desc["hs_shape"]); dtype = getattr(torch, desc["hs_dtype"])
+        feat = shape[1:]
+        maxtok = self.config.max_seq_len
+        if self._recv is None or self._recv.dtype != dtype or tuple(self._recv.shape[1:]) != feat:
+            self._recv = torch.empty((maxtok, *feat), dtype=dtype).pin_memory()
+            agent.register_memory([self._recv])
+        view = self._recv[:shape[0]]
+        ldescs = agent.get_xfer_descs([view])
+        rdescs = agent.deserialize_descs(base64.b64decode(desc["hs_descs"]))
+        h = agent.initialize_xfer("READ", ldescs, rdescs, remote)
+        agent.transfer(h)
+        while True:
+            st = agent.check_xfer_state(h)
+            if st == "DONE":
+                break
+            if st == "ERR":
+                agent.release_xfer_handle(h)
+                warn_rank_0(f"[streaming] rdma xfer ERR for {sample['cid']}")
+                return None
+            time.sleep(0.0002)
+        agent.release_xfer_handle(h)
+        try:
+            self._http_rdma.get(f"http://{host}:{port}/done", params={"req_id": rid})
+        except Exception:
+            pass
+        hidden_states = view.clone()
+        token_ids = torch.tensor(desc["token_ids"], dtype=torch.long)
+        client_ids = torch.as_tensor(sample["token_ids"], dtype=token_ids.dtype)
+        n = client_ids.shape[0]
+        if token_ids.shape[0] not in (n, n + 1) or not torch.equal(token_ids[:n], client_ids):
+            raise RuntimeError(
+                f"server token_ids drift for {sample['cid']}: client_len={n}, "
+                f"server_len={token_ids.shape[0]}")
+        loss_mask = self._align_loss_mask(sample["loss_mask"], token_ids.shape[0])
+        return {"token_ids": token_ids, "hidden_states": hidden_states, "loss_mask": loss_mask}
+
     def _fetch(self, sample: dict) -> EagleFetchPayload | None:
+        if os.environ.get("HS_TRANSPORT") == "rdma":
+            return self._fetch_rdma(sample)
         client = self._client()
         url = self._next_url()
         r = client.post(

--- a/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
+++ b/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
@@ -422,6 +422,8 @@ class EagleVllmStreamingDataset(StreamingDataset):
             self._nixl_pid = pid
             self._remote_by_host: dict = {}
             self._recv = None
+            _wi = torch.utils.data.get_worker_info()
+            self._rr = int(os.environ.get("RANK", "0")) * (_wi.num_workers if _wi else 1) + (_wi.id if _wi else 0)
             self._http_rdma = httpx.Client(
                 timeout=httpx.Timeout(self.config.request_timeout, connect=10.0))
         return self._nixl

--- a/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
+++ b/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
@@ -463,7 +463,10 @@ class EagleVllmStreamingDataset(StreamingDataset):
         feat = shape[1:]
         maxtok = self.config.max_seq_len
         if self._recv is None or self._recv.dtype != dtype or tuple(self._recv.shape[1:]) != feat:
-            self._recv = torch.empty((maxtok, *feat), dtype=dtype).pin_memory()
+            # plain (pageable) host tensor: NIXL/ibv_reg_mr pins the pages itself.
+            # Do NOT call .pin_memory() here — dataloader workers are forked and have no
+            # valid CUDA context (cudaHostAlloc -> CUDA initialization error).
+            self._recv = torch.empty((maxtok, *feat), dtype=dtype)
             agent.register_memory([self._recv])
         view = self._recv[:shape[0]]
         ldescs = agent.get_xfer_descs([view])

--- a/modelopt/torch/speculative/plugins/rdma_hidden_states_connector.py
+++ b/modelopt/torch/speculative/plugins/rdma_hidden_states_connector.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+"""RdmaHiddenStatesConnector (pooled) — no-disk hidden-states transfer over NIXL RDMA.
+
+Pooled variant: register ONE pinned buffer pool with NIXL at startup (the only
+ibv_reg_mr), assign each request a ring slot, copy its hidden states into that
+slot, and hand the consumer a transfer descriptor for the slot sub-region.
+No per-request memory registration; agent metadata is static (taken once after
+the pool is registered).
+
+Load out-of-tree:
+  --kv-transfer-config '{"kv_connector":"RdmaHiddenStatesConnector",
+     "kv_connector_module_path":"rdma_hidden_states_connector",
+     "kv_role":"kv_producer",
+     "kv_connector_extra_config":{"sidecar_port":"18999","pool_slots":"64","max_tokens":"512"}}'
+
+Scope: TP=1, host(pinned) memory (container UCX has no CUDA), ring-slot reuse
+(fine when in-flight requests < pool_slots; no credit protocol yet).
+"""
+import base64
+import json
+import socket
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from math import prod
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse, parse_qs
+
+import torch
+
+from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+    SupportsHMA,
+)
+from vllm.forward_context import get_forward_context
+from vllm.logger import init_logger
+from vllm.v1.attention.backend import AttentionMetadata
+from vllm.v1.core.sched.output import SchedulerOutput
+
+if TYPE_CHECKING:
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+
+def extract_from_kv_cache(kv_cache, slot_mapping, num_tokens):
+    block_size = kv_cache.shape[1]
+    return kv_cache[slot_mapping // block_size, slot_mapping % block_size][:num_tokens]
+
+
+@dataclass
+class ReqMeta:
+    req_id: str
+    token_ids: torch.Tensor
+    slot: int
+
+    @staticmethod
+    def make(req_id, token_ids, slot):
+        return ReqMeta(req_id=req_id, token_ids=torch.tensor(token_ids), slot=slot)
+
+
+@dataclass
+class RdmaConnMeta(KVConnectorMetadata):
+    requests: list = field(default_factory=list)
+
+    def add(self, req_id, token_ids, slot):
+        self.requests.append(ReqMeta.make(req_id, token_ids, slot))
+
+
+class _Sidecar(BaseHTTPRequestHandler):
+    connector = None
+
+    def log_message(self, *a):
+        pass
+
+    def _send(self, code, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        c = type(self).connector
+        u = urlparse(self.path)
+        if u.path == "/meta":
+            # static: pool was registered before we cached this
+            self._send(200, {"agent_metadata": base64.b64encode(c._agent_meta).decode()})
+            return
+        if u.path == "/desc":
+            rid = parse_qs(u.query).get("req_id", [None])[0]
+            e = c._bufs.get(rid)
+            if e is None:
+                self._send(404, {"error": "unknown", "req_id": rid})
+                return
+            if not e["event"].query():
+                self._send(202, {"ready": False})
+                return
+            self._send(200, {
+                "ready": True,
+                "hs_descs": base64.b64encode(e["descs"]).decode(),
+                "hs_shape": list(e["shape"]),
+                "hs_dtype": e["dtype"],
+                "token_ids": e["token_ids"],
+                "slot": e["slot"],
+            })
+            return
+        if u.path == "/done":
+            rid = parse_qs(u.query).get("req_id", [None])[0]
+            c._bufs.pop(rid, None)  # slot recycled by the ring; pool stays registered
+            self._send(200, {"freed": rid})
+            return
+        self._send(404, {"error": "not found"})
+
+
+class RdmaHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
+    @property
+    def prefer_cross_layer_blocks(self) -> bool:
+        return False
+
+    def __init__(self, vllm_config, role, kv_cache_config):
+        super().__init__(vllm_config=vllm_config, role=role,
+                         kv_cache_config=kv_cache_config)
+        self._role = role
+        ex = self._kv_transfer_config.get_from_extra_config
+        self._sidecar_port = int(ex("sidecar_port", "18999"))
+        self._pool_slots = int(ex("pool_slots", "64"))
+        self._max_tokens = int(ex("max_tokens", "512"))
+        self.cache_layers: list[str] = []
+        # worker state
+        self._copy_stream = None
+        self._nixl = None
+        self._agent_meta = b""
+        self._pool = None          # [pool_slots, slot_elems] pinned
+        self._slot_elems = 0
+        self._per_token_elems = 0
+        self._bufs: dict[str, dict] = {}
+        self._accum_finished: set[str] = set()
+        self._lock = threading.Lock()
+        # scheduler state
+        self._slot_ctr = 0
+        logger.info("RdmaHiddenStatesConnector role=%s slots=%d max_tokens=%d port=%d",
+                    role, self._pool_slots, self._max_tokens, self._sidecar_port)
+
+    def _cs(self):
+        if self._copy_stream is None:
+            self._copy_stream = torch.cuda.Stream()
+        return self._copy_stream
+
+    # ---------- worker ----------
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
+        from vllm.model_executor.models.extract_hidden_states import (
+            CacheOnlyAttentionLayer,
+        )
+        from nixl._api import nixl_agent, nixl_agent_config
+
+        layers = get_layers_from_vllm_config(
+            self._vllm_config, CacheOnlyAttentionLayer, list(kv_caches.keys()))
+        self.cache_layers = list(layers.keys())
+        assert len(self.cache_layers) == 1
+        kv = kv_caches[self.cache_layers[0]]
+        # per-token feature = everything past [num_blocks, block_size]
+        self._per_token_elems = int(prod(kv.shape[2:]))
+        self._feat_shape = tuple(kv.shape[2:])
+        self._dtype = kv.dtype
+        self._slot_elems = self._max_tokens * self._per_token_elems
+
+        self._nixl = nixl_agent(f"hs-producer-{uuid.uuid4()}",
+                                nixl_agent_config(backends=["UCX"]))
+        # ONE-TIME pool registration (the only ibv_reg_mr).
+        t0 = time.time()
+        self._pool = torch.empty((self._pool_slots, self._slot_elems),
+                                 dtype=self._dtype).pin_memory()
+        self._reg = self._nixl.register_memory([self._pool])
+        reg_ms = (time.time() - t0) * 1e3
+        self._agent_meta = self._nixl.get_agent_metadata()  # static after registration
+        gib = self._pool.numel() * self._pool.element_size() / 2**30
+        # pre-serialize a transfer descriptor per slot (cheap; no NIC registration)
+        self._slot_descs = [
+            self._nixl.get_serialized_descs(
+                self._nixl.get_xfer_descs([self._pool[s]]))
+            for s in range(self._pool_slots)
+        ]
+        self._start_sidecar()
+        logger.info("RDMA pool registered: %d slots x %d elems (%.2f GiB) in %.1f ms; "
+                    "per_token_elems=%d feat=%s dtype=%s",
+                    self._pool_slots, self._slot_elems, gib, reg_ms,
+                    self._per_token_elems, self._feat_shape, self._dtype)
+
+    def _start_sidecar(self):
+        h = type("H", (_Sidecar,), {"connector": self})
+        self._sidecar = ThreadingHTTPServer(("0.0.0.0", self._sidecar_port), h)
+        threading.Thread(target=self._sidecar.serve_forever, daemon=True).start()
+        logger.info("RDMA sidecar on %s:%d", socket.gethostname(), self._sidecar_port)
+
+    def start_load_kv(self, *a, **k): pass
+    def wait_for_layer_load(self, *a, **k): pass
+    def wait_for_save(self): pass
+
+    def save_kv_layer(self, layer_name, kv_layer, attn_metadata, **kwargs):
+        if layer_name not in self.cache_layers:
+            return
+        from vllm.model_executor.models.extract_hidden_states import (
+            CacheOnlyAttentionMetadata,
+        )
+        assert isinstance(attn_metadata, CacheOnlyAttentionMetadata)
+        md = self._get_connector_metadata()
+        assert isinstance(md, RdmaConnMeta)
+        cs = self._cs()
+        ready = torch.cuda.Event(); ready.record(); cs.wait_event(ready)
+        slot_mapping = get_forward_context().slot_mapping[layer_name]  # type: ignore
+        offset = 0
+        for req in md.requests:
+            n = req.token_ids.shape[0]
+            nelems = n * self._per_token_elems
+            slot = req.slot
+            with torch.cuda.stream(cs):
+                rsm = slot_mapping[offset:offset + n]
+                offset += n
+                hs_gpu = extract_from_kv_cache(kv_layer, rsm, n)  # [n, *feat]
+                # copy into the pre-registered pool slot (flattened)
+                self._pool[slot, :nelems].copy_(hs_gpu.reshape(-1), non_blocking=True)
+            ev = torch.cuda.Event(); ev.record(cs)
+            # descriptor for exactly this slot's used sub-region
+            sub = self._pool[slot, :nelems]
+            descs = self._nixl.get_serialized_descs(self._nixl.get_xfer_descs([sub]))
+            with self._lock:
+                self._bufs[req.req_id] = {
+                    "slot": slot, "descs": descs,
+                    "shape": (n, *self._feat_shape),
+                    "dtype": str(self._dtype).split(".")[-1],
+                    "token_ids": req.token_ids.tolist(),
+                    "event": ev,
+                }
+
+    # ---------- scheduler ----------
+    def get_num_new_matched_tokens(self, request, num_computed_tokens):
+        return 0, False
+
+    def update_state_after_alloc(self, request, blocks, num_external_tokens):
+        assert num_external_tokens == 0
+
+    def build_connector_meta(self, scheduler_output: SchedulerOutput) -> KVConnectorMetadata:
+        meta = RdmaConnMeta()
+        for nr in scheduler_output.scheduled_new_reqs:
+            slot = self._slot_ctr % self._pool_slots
+            self._slot_ctr += 1
+            meta.add(nr.req_id, token_ids=nr.prompt_token_ids or [], slot=slot)
+        return meta
+
+    def request_finished(self, request, block_ids):
+        return True, {"hs_req_id": request.request_id,
+                      "hs_sidecar_port": self._sidecar_port}
+
+    def request_finished_all_groups(self, request, block_ids):
+        return self.request_finished(request, block_ids[0])
+
+    def get_finished(self, finished_req_ids):
+        self._accum_finished.update(finished_req_ids)
+        done = set()
+        for rid in list(self._accum_finished):
+            e = self._bufs.get(rid)
+            if e is None or e["event"].query():
+                done.add(rid); self._accum_finished.discard(rid)
+        return (done or None), None
+
+    @classmethod
+    def get_required_kvcache_layout(cls, vllm_config):
+        if cls is KVConnectorBase_V1:
+            raise TypeError("not on base class")
+        return "NHD"

--- a/modelopt/torch/speculative/plugins/rdma_hidden_states_connector.py
+++ b/modelopt/torch/speculative/plugins/rdma_hidden_states_connector.py
@@ -13,8 +13,9 @@ Load out-of-tree:
      "kv_role":"kv_producer",
      "kv_connector_extra_config":{"sidecar_port":"18999","pool_slots":"64","max_tokens":"512"}}'
 
-Scope: TP=1, host(pinned) memory (container UCX has no CUDA), ring-slot reuse
-(fine when in-flight requests < pool_slots; no credit protocol yet).
+Scope: TP>=1 (hidden states are replicated across TP ranks; only rank 0 owns the
+pool + sidecar and serves them), host(pinned) memory (container UCX has no CUDA),
+ring-slot reuse (fine when in-flight requests < pool_slots; no credit protocol yet).
 """
 import base64
 import json
@@ -135,6 +136,11 @@ class RdmaHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         self._pool_slots = int(ex("pool_slots", "64"))
         self._max_tokens = int(ex("max_tokens", "512"))
         self.cache_layers: list[str] = []
+        # TP: hidden states are replicated across ranks, so only rank 0 owns the
+        # pool + sidecar (set for real in register_kv_caches). Default True so the
+        # scheduler-side instance and TP=1 behave exactly as before.
+        self._tp_rank = 0
+        self._owner = True
         # worker state
         self._copy_stream = None
         self._nixl = None
@@ -161,11 +167,26 @@ class RdmaHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
             CacheOnlyAttentionLayer,
         )
         from nixl._api import nixl_agent, nixl_agent_config
+        from vllm.distributed.parallel_state import get_tensor_model_parallel_rank
+
+        # TP: the captured hidden states are REPLICATED across TP ranks
+        # (CacheOnlyAttentionLayer is sized to the full hidden_size, never
+        # hidden_size/tp; the residual stream is all-reduced). So only TP rank 0
+        # registers the pool + runs the sidecar and serves the (identical) hidden
+        # states; other ranks no-op. This avoids the sidecar TCP-port collision
+        # and the TPx pinned-memory waste, and needs no trainer-side change.
+        self._tp_rank = get_tensor_model_parallel_rank()
+        self._owner = self._tp_rank == 0
 
         layers = get_layers_from_vllm_config(
             self._vllm_config, CacheOnlyAttentionLayer, list(kv_caches.keys()))
         self.cache_layers = list(layers.keys())
         assert len(self.cache_layers) == 1
+        if not self._owner:
+            logger.info("RdmaHiddenStatesConnector tp_rank=%d: non-owner, skipping "
+                        "pool/sidecar (hidden states are replicated on rank 0).",
+                        self._tp_rank)
+            return
         kv = kv_caches[self.cache_layers[0]]
         # per-token feature = everything past [num_blocks, block_size]
         self._per_token_elems = int(prod(kv.shape[2:]))
@@ -206,6 +227,8 @@ class RdmaHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
     def wait_for_save(self): pass
 
     def save_kv_layer(self, layer_name, kv_layer, attn_metadata, **kwargs):
+        if not self._owner:
+            return  # non-owner TP ranks hold an identical copy; rank 0 serves it
         if layer_name not in self.cache_layers:
             return
         from vllm.model_executor.models.extract_hidden_states import (
@@ -263,7 +286,19 @@ class RdmaHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
     def request_finished_all_groups(self, request, block_ids):
         return self.request_finished(request, block_ids[0])
 
+    def get_finished_count(self):
+        # Override KVOutputAggregator's default (world_size): only TP rank 0 (the
+        # owner) reports finished_sending, so a single completion frees a request.
+        # Without this the aggregator would wait for all TP workers and never free.
+        return 1
+
     def get_finished(self, finished_req_ids):
+        # Only the owner gates completion on its copy event. Non-owners have no
+        # _bufs and MUST report nothing — else (with get_finished_count==1) they
+        # would mark a request done before rank 0's DtoH copy lands, and the
+        # trainer would RDMA-read a stale/empty slot.
+        if not self._owner:
+            return None, None
         self._accum_finished.update(finished_req_ids)
         done = set()
         for rid in list(self._accum_finished):

--- a/tools/launcher/common/eagle3/train_eagle_streaming.sh
+++ b/tools/launcher/common/eagle3/train_eagle_streaming.sh
@@ -157,6 +157,11 @@ launch_vllm() {
     [ -n "${SERVE_MAX_NUM_SEQS:-}" ]   && opt_args+=(--max-num-seqs "$SERVE_MAX_NUM_SEQS")
     # --no-enable-chunked-prefill / --no-enable-prefix-caching: connector captures hidden states during prefill; both skip recomputing cached/partial prefixes, yielding short/empty hidden_states. Required.
     # --no-enable-flashinfer-autotune: on NVFP4 MoE the autotuner re-tunes on the first serving step and stalls a worker past vLLM's execute-model timeout, killing EngineCore.
+    if [ "${HS_TRANSPORT:-disk}" = "rdma" ]; then
+        KVCFG="{\"kv_connector\":\"RdmaHiddenStatesConnector\",\"kv_connector_module_path\":\"modelopt.torch.speculative.plugins.rdma_hidden_states_connector\",\"kv_role\":\"kv_producer\",\"kv_connector_extra_config\":{\"sidecar_port\":\"${HS_SIDECAR_PORT:-18999}\",\"pool_slots\":\"${HS_POOL_SLOTS:-16}\",\"max_tokens\":\"${HS_MAX_TOKENS:-4096}\"}}"
+    else
+        KVCFG="{\"kv_connector\":\"ExampleHiddenStatesConnector\",\"kv_role\":\"kv_producer\",\"kv_connector_extra_config\":{\"shared_storage_path\":\"$SERVE_SCRATCH\"}}"
+    fi
     "${gpu_env[@]}" vllm serve "$HF_MODEL_CKPT" \
         --host "$bind_host" \
         --port "$SERVE_PORT" \
@@ -177,11 +182,7 @@ launch_vllm() {
                 }
             }
         }" \
-        --kv-transfer-config "{
-            \"kv_connector\":\"ExampleHiddenStatesConnector\",
-            \"kv_role\":\"kv_producer\",
-            \"kv_connector_extra_config\":{\"shared_storage_path\":\"$SERVE_SCRATCH\"}
-        }" \
+        --kv-transfer-config "$KVCFG" \
         > "$SERVE_LOG" 2>&1 &
     SERVE_PID=$!
 }

--- a/tools/launcher/examples/Qwen/Qwen3-8B/perf_study/rdma_1n2g.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/perf_study/rdma_1n2g.yaml
@@ -1,0 +1,82 @@
+# EAGLE3 streaming (RDMA, no-disk) — INTRA-NODE co-located: 1 node, 2 GPU, 1 serve + 1 trainer.
+#
+# Topology (see common/eagle3/train_eagle_streaming.sh single-node branch):
+#   1 Slurm node, 2 GPU. NNODES<=1 -> vllm serve on SERVE_GPU=0, trainer on the
+#   remaining GPU (TRAIN_GPUS=1), serve bound to 127.0.0.1. Hidden states move
+#   serve(GPU0) -> NIXL RDMA over loopback/shm -> trainer(GPU1), no disk.
+#   Tests whether the RDMA path works co-located (add_remote_agent + READ on 127.0.0.1).
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/perf_study/rdma_1n2g.yaml --yes
+
+job_name: Qwen3-8B_EAGLE3_streaming_multi_node
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3-8B
+
+  task_0:
+    script: common/eagle3/make_dataset.sh
+    args:
+      - -f modules/Model-Optimizer/examples/dataset/example_data_config.yaml
+      - --full-conversations
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+
+  task_1:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.mode=streaming
+      - data.data_path=/scratchspace/data/train.jsonl
+      - training.output_dir=/scratchspace/eagle3
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+      - training.num_train_epochs=1
+      - eagle.eagle_use_torch_compile=false
+      - training.max_steps=200
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - EAGLE_CAPTURE_IDS: "[2,18,33,36]"
+      - SERVE_GPU: "0"
+      - SERVE_TP: "1"
+      - STREAMING_NUM_WORKERS: "4"
+      - HS_TRANSPORT: "rdma"
+      - HS_SIDECAR_PORT: "18999"
+      - HS_POOL_SLOTS: "16"
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:latest
+
+  task_2:
+    script: common/specdec_bench/quick_check.sh
+    args:
+      - --draft_model_dir /scratchspace/export
+      - --draft_length 3
+      - --output_length 4096
+      - --engine VLLM
+      - --tp_size 1
+      - --ep_size 1
+      - --speculative_algorithm EAGLE3
+      - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
+      - --concurrency 1
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: vllm/vllm-openai:latest

--- a/tools/launcher/examples/Qwen/Qwen3-8B/perf_study/rdma_1s1t.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/perf_study/rdma_1s1t.yaml
@@ -1,0 +1,88 @@
+# EAGLE3 streaming (RDMA, no-disk) — smallest cross-node config: 1 serve + 1 trainer.
+#
+# Topology (see common/eagle3/train_eagle_streaming.sh dispatch):
+#   2 Slurm nodes, 1 GPU each. SERVE_NODES=1 -> node 0 = 1 serve replica (TP=1),
+#   node 1 = 1 trainer (1 GPU). Trainer pulls hidden states from the serve over
+#   NIXL RDMA (no disk). The minimal end-to-end no-disk validation.
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/perf_study/rdma_1s1t.yaml --yes
+
+job_name: Qwen3-8B_EAGLE3_streaming_multi_node
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3-8B
+
+  # Step 1: Build input conversations
+  task_0:
+    script: common/eagle3/make_dataset.sh
+    args:
+      - -f modules/Model-Optimizer/examples/dataset/example_data_config.yaml
+      - --full-conversations
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+
+  # Step 2: Streaming EAGLE3 training — 2 serve replicas (TP=2) + 2 trainer nodes (2 GPU each).
+  # Capture ids: default_eagle_aux_layer_ids(36)=[1,17,32] +1, plus final layer 36.
+  task_1:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.mode=streaming
+      - data.data_path=/scratchspace/data/train.jsonl
+      - training.output_dir=/scratchspace/eagle3
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+      - training.num_train_epochs=1
+      - eagle.eagle_use_torch_compile=false
+      - training.max_steps=200
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # No spaces: nemo_run emits `export FOO=value` unquoted.
+      - EAGLE_CAPTURE_IDS: "[2,18,33,36]"
+      - SERVE_TP: "1"
+      # K serve replica nodes (Slurm nodes 0..K-1); the rest are trainers.
+      - SERVE_NODES: "1"
+      # Per-rank in-flight fetches; keep low so the cold NVFP4-MoE serve isn't flooded past its execute-model timeout (kills EngineCore).
+      - STREAMING_NUM_WORKERS: "4"
+      - HS_TRANSPORT: "rdma"
+      - HS_SIDECAR_PORT: "18999"
+      - HS_POOL_SLOTS: "16"
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 2
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: vllm/vllm-openai:latest
+
+  # Step 3: Benchmark speculative decoding (VLLM backend)
+  task_2:
+    script: common/specdec_bench/quick_check.sh
+    args:
+      - --draft_model_dir /scratchspace/export
+      - --draft_length 3
+      - --output_length 4096
+      - --engine VLLM
+      - --tp_size 1
+      - --ep_size 1
+      - --speculative_algorithm EAGLE3
+      - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
+      - --concurrency 1
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: vllm/vllm-openai:latest

--- a/tools/launcher/examples/Qwen/Qwen3-8B/perf_study/rdma_1s1t_tp2.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/perf_study/rdma_1s1t_tp2.yaml
@@ -1,0 +1,89 @@
+# EAGLE3 streaming (RDMA, no-disk) — serve-side TP>1: 1 node, serve TP=2 + 1 trainer.
+#
+# Topology (see common/eagle3/train_eagle_streaming.sh single-node branch):
+#   1 Slurm node, 3 GPU. NNODES<=1 -> vllm serve with SERVE_TP=2 on SERVE_GPU=0,1,
+#   trainer on the remaining GPU (TRAIN_GPUS=2), serve bound to 127.0.0.1. Hidden
+#   states move serve(GPU0/1, TP=2) -> NIXL RDMA over loopback/shm -> trainer(GPU2).
+#
+# Exercises serve-side tensor parallelism: the captured hidden states are REPLICATED
+# across TP ranks, so RdmaHiddenStatesConnector elects TP rank 0 as the sole owner of
+# the pinned pool + sidecar; other ranks no-op (avoids the sidecar TCP-port collision
+# and the TPx pinned-memory waste). No trainer-side change. Validated on oci-nrt H100:
+# serve comes up TP=2, only rank 0 registers a NIXL agent, training fetches over RDMA
+# with no port collision / desc-timeout / xfer-ERR, and the Training Acc curve tracks
+# the TP=1 baseline (rdma_1n2g) step-for-step.
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/perf_study/rdma_1s1t_tp2.yaml --yes
+
+job_name: Qwen3-8B_EAGLE3_streaming_tp2
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3-8B
+
+  task_0:
+    script: common/eagle3/make_dataset.sh
+    args:
+      - -f modules/Model-Optimizer/examples/dataset/example_data_config.yaml
+      - --full-conversations
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+
+  task_1:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.mode=streaming
+      - data.data_path=/scratchspace/data/train.jsonl
+      - training.output_dir=/scratchspace/eagle3
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+      - training.num_train_epochs=1
+      - eagle.eagle_use_torch_compile=false
+      - training.max_steps=200
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - EAGLE_CAPTURE_IDS: "[2,18,33,36]"
+      - SERVE_GPU: "0,1"
+      - SERVE_TP: "2"
+      - STREAMING_NUM_WORKERS: "4"
+      - HS_TRANSPORT: "rdma"
+      - HS_SIDECAR_PORT: "18999"
+      - HS_POOL_SLOTS: "16"
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 3
+      container: vllm/vllm-openai:latest
+
+  task_2:
+    script: common/specdec_bench/quick_check.sh
+    args:
+      - --draft_model_dir /scratchspace/export
+      - --draft_length 3
+      - --output_length 4096
+      - --engine VLLM
+      - --tp_size 1
+      - --ep_size 1
+      - --speculative_algorithm EAGLE3
+      - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
+      - --concurrency 1
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: vllm/vllm-openai:latest

--- a/tools/launcher/examples/Qwen/Qwen3-8B/perf_study/rdma_2s1t.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/perf_study/rdma_2s1t.yaml
@@ -1,0 +1,87 @@
+# EAGLE3 streaming (RDMA, no-disk) — MULTI-NODE validation: 2 serve + 1 trainer(8 rank).
+#
+# Topology (see common/eagle3/train_eagle_streaming.sh dispatch):
+#   3 Slurm nodes, 8 GPU each. SERVE_NODES=2 -> nodes 0,1 = independent serve replicas
+#   (each SERVE_TP=1, uses 1 of 8 GPUs; sidecar 18999, no collision across nodes).
+#   node 2 = single trainer node, 8 DDP ranks (all 8 GPUs). Trainer round-robins its
+#   fetches across the 2 serve URLs (data.streaming_server_url = comma-joined list),
+#   pulling hidden states over NIXL RDMA (no disk).
+#
+# Validates: DP serve fan-out + per-host add_remote_agent + per-(rank,worker) NIXL
+# agents/buffers. HS_POOL_SLOTS=64 >> peak in-flight per serve (8x4/2=16) to stay
+# clear of the ring-slot reuse race.
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/perf_study/rdma_2s1t.yaml --yes
+
+job_name: Qwen3-8B_EAGLE3_streaming_multi_node
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3-8B
+
+  task_0:
+    script: common/eagle3/make_dataset.sh
+    args:
+      - -f modules/Model-Optimizer/examples/dataset/example_data_config.yaml
+      - --full-conversations
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+
+  task_1:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.mode=streaming
+      - data.data_path=/scratchspace/data/train.jsonl
+      - training.output_dir=/scratchspace/eagle3
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+      - training.num_train_epochs=1
+      - eagle.eagle_use_torch_compile=false
+      - training.max_steps=200
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - EAGLE_CAPTURE_IDS: "[2,18,33,36]"
+      - SERVE_TP: "1"
+      - SERVE_NODES: "2"
+      - STREAMING_NUM_WORKERS: "4"
+      - HS_TRANSPORT: "rdma"
+      - HS_SIDECAR_PORT: "18999"
+      - HS_POOL_SLOTS: "64"
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 3
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      container: vllm/vllm-openai:latest
+
+  task_2:
+    script: common/specdec_bench/quick_check.sh
+    args:
+      - --draft_model_dir /scratchspace/export
+      - --draft_length 3
+      - --output_length 4096
+      - --engine VLLM
+      - --tp_size 1
+      - --ep_size 1
+      - --speculative_algorithm EAGLE3
+      - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
+      - --concurrency 1
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: vllm/vllm-openai:latest

--- a/tools/launcher/examples/Qwen/Qwen3-8B/perf_study/rdma_4s2t.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/perf_study/rdma_4s2t.yaml
@@ -1,0 +1,87 @@
+# EAGLE3 streaming (RDMA, no-disk) — MULTI-NODE scale: 4 serve + 2 trainer (16 rank).
+#
+# Topology (see common/eagle3/train_eagle_streaming.sh dispatch):
+#   6 Slurm nodes, 8 GPU each. SERVE_NODES=4 -> nodes 0..3 = 4 independent serve
+#   replicas (each SERVE_TP=1, 1 of 8 GPUs; sidecar 18999, no cross-node collision).
+#   nodes 4,5 = 2 trainer nodes, 8 DDP ranks each = 16 ranks (accelerate multi-node
+#   rendezvous; head trainer = node 4). Trainer round-robins fetches across the 4
+#   serve URLs, pulling hidden states over NIXL RDMA (no disk).
+#
+# Scales 2s1t proportionally (2 serve:8 rank -> 4 serve:16 rank); per-serve in-flight
+# stays 16 (16 ranks x4 workers /4 serves). ALSO validates >1 trainer node (DDP across
+# nodes), which rdma_2s1t.yaml did not exercise. HS_POOL_SLOTS=64 >> 16 in-flight/serve.
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/perf_study/rdma_4s2t.yaml --yes
+
+job_name: Qwen3-8B_EAGLE3_streaming_multi_node
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3-8B
+
+  task_0:
+    script: common/eagle3/make_dataset.sh
+    args:
+      - -f modules/Model-Optimizer/examples/dataset/example_data_config.yaml
+      - --full-conversations
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+
+  task_1:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.mode=streaming
+      - data.data_path=/scratchspace/data/train.jsonl
+      - training.output_dir=/scratchspace/eagle3
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+      - training.num_train_epochs=1
+      - eagle.eagle_use_torch_compile=false
+      - training.max_steps=200
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - EAGLE_CAPTURE_IDS: "[2,18,33,36]"
+      - SERVE_TP: "1"
+      - SERVE_NODES: "4"
+      - STREAMING_NUM_WORKERS: "4"
+      - HS_TRANSPORT: "rdma"
+      - HS_SIDECAR_PORT: "18999"
+      - HS_POOL_SLOTS: "64"
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 6
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      container: vllm/vllm-openai:latest
+
+  task_2:
+    script: common/specdec_bench/quick_check.sh
+    args:
+      - --draft_model_dir /scratchspace/export
+      - --draft_length 3
+      - --output_length 4096
+      - --engine VLLM
+      - --tp_size 1
+      - --ep_size 1
+      - --speculative_algorithm EAGLE3
+      - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
+      - --concurrency 1
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: vllm/vllm-openai:latest

--- a/tools/launcher/examples/Qwen/Qwen3-8B/perf_study/rdma_8s4t.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/perf_study/rdma_8s4t.yaml
@@ -1,0 +1,86 @@
+# EAGLE3 streaming (RDMA, no-disk) — MULTI-NODE scale: 8 serve + 4 trainer (32 rank).
+#
+# Topology (see common/eagle3/train_eagle_streaming.sh dispatch):
+#   12 Slurm nodes, 8 GPU each. SERVE_NODES=8 -> nodes 0..7 = 8 independent serve
+#   replicas (each SERVE_TP=1, 1 of 8 GPUs; sidecar 18999, no cross-node collision).
+#   nodes 8..11 = 4 trainer nodes, 8 DDP ranks each = 32 ranks (accelerate multi-node
+#   rendezvous; head trainer = node 8). Trainer round-robins fetches across the 8
+#   serve URLs, pulling hidden states over NIXL RDMA (no disk).
+#
+# Scales the curve proportionally (per-serve in-flight = 32 ranks x4 workers /8 serves
+# = 16, same as 2s1t/4s2t). HS_POOL_SLOTS=64 >> 16 in-flight/serve.
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/perf_study/rdma_8s4t.yaml --yes
+
+job_name: Qwen3-8B_EAGLE3_streaming_multi_node
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3-8B
+
+  task_0:
+    script: common/eagle3/make_dataset.sh
+    args:
+      - -f modules/Model-Optimizer/examples/dataset/example_data_config.yaml
+      - --full-conversations
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+
+  task_1:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/eagle3.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.mode=streaming
+      - data.data_path=/scratchspace/data/train.jsonl
+      - training.output_dir=/scratchspace/eagle3
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+      - training.num_train_epochs=1
+      - eagle.eagle_use_torch_compile=false
+      - training.max_steps=200
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - EAGLE_CAPTURE_IDS: "[2,18,33,36]"
+      - SERVE_TP: "1"
+      - SERVE_NODES: "8"
+      - STREAMING_NUM_WORKERS: "4"
+      - HS_TRANSPORT: "rdma"
+      - HS_SIDECAR_PORT: "18999"
+      - HS_POOL_SLOTS: "64"
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 12
+      ntasks_per_node: 1
+      gpus_per_node: 8
+      container: vllm/vllm-openai:latest
+
+  task_2:
+    script: common/specdec_bench/quick_check.sh
+    args:
+      - --draft_model_dir /scratchspace/export
+      - --draft_length 3
+      - --output_length 4096
+      - --engine VLLM
+      - --tp_size 1
+      - --ep_size 1
+      - --speculative_algorithm EAGLE3
+      - --mtbench /hf-local/HuggingFaceH4/mt_bench_prompts/raw/question.jsonl
+      - --concurrency 1
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: vllm/vllm-openai:latest


### PR DESCRIPTION
## What

Stacked on #1611. Adds **`RdmaHiddenStatesConnector`** — a drop-in alternative to `ExampleHiddenStatesConnector` that moves captured hidden states from the vLLM serve to the trainer over **NIXL RDMA** instead of writing per-request safetensors to shared storage. Opt-in via `HS_TRANSPORT=rdma`; the disk path stays the default and is untouched.

## Why

Today the hand-off is serve GPU → pinned host → **safetensors on lustre** → trainer reads lustre → GPU. That disk round-trip (~270 ms for a 128 MB sample, measured on H100/IB) is longer than a training step and, under multi-trainer load, backs the serve up until it 500s and the streaming dataset's circuit breaker aborts the run. RDMA replaces the two disk crossings with one kernel-bypass transfer: **~0.33 ms / 2 MB, ~47 GB/s at 128 MB** — transfer becomes a negligible fraction of per-step time.

## How

- **`modelopt/torch/speculative/plugins/rdma_hidden_states_connector.py`** (new): out-of-tree vLLM connector via `kv_connector_module_path` (no vLLM source edits). One-time NIXL pinned-pool registration (the only `ibv_reg_mr`; static agent metadata), ring slot per request, tiny HTTP sidecar serving agent metadata + per-request transfer descriptors. `request_finished` returns `{"hs_req_id": ...}`.
- **`hf_streaming_dataset.py`**: `EagleVllmStreamingDataset` RDMA fetch path (`HS_TRANSPORT=rdma`) — per-worker NIXL agent, one-time recv buffer, `add_remote_agent` once/serve; same token-drift + loss-mask contract and return shape as disk. (The recv buffer is a plain pageable tensor: forked dataloader workers have no CUDA context, so `pin_memory()` would fail — NIXL/`ibv_reg_mr` pins the pages itself.)
- **`train_eagle_streaming.sh`**: `launch_vllm` selects connector by `HS_TRANSPORT` (disk default; rdma ⇒ our connector + pool/sidecar config).
- **`examples/Qwen/Qwen3-8B/perf_study/rdma_{1n2g,1s1t,2s1t,4s2t,8s4t}.yaml`**: reproducible no-disk configs (the runs in the table below).

## Config (env / extra_config)

`HS_TRANSPORT=rdma`, `HS_SIDECAR_PORT` (18999), `HS_POOL_SLOTS` (16), `HS_MAX_TOKENS` (4096).

## Validation (Qwen3-8B, H100, oci-nrt)

Micro-benchmarks: NIXL cross-node RDMA PoC ~47 GB/s host-pinned READ; pooled connector over 190 continuous requests — 0 per-request registrations, 0 bad reads, ~0.33 ms/req @ 2 MB.

End-to-end real training (`HS_TRANSPORT=rdma`, 200 steps, batch 1/rank, hidden states never touch disk). Serve replicas scaled with trainer ranks; `HS_POOL_SLOTS=64` for the multi-node runs. Step time and throughput are from HF Trainer (`train_steps_per_second` / `train_samples_per_second`):

| serve / trainer | nodes | step time | samples / step | samples / sec (global) | acc @ step 200 |
|---|---|---|---|---|---|
| 1 serve / 1 rank (co-located, 1 node 2 GPU) | 1 | 0.23 s | 1  | 4.4 | [0.141, 0.094, 0.072] |
| 1 serve / 1 rank (cross-node)               | 2 | 0.23 s | 1  | 4.3 | [0.137, 0.105, 0.074] |
| 2 serve / 8 ranks                           | 3 | 0.26 s | 8  | 31.1 | [0.215, 0.126, 0.097] |
| 4 serve / 16 ranks (2 trainer nodes, cross-node DDP) | 6 | 0.28 s | 16 | 56.5 | [0.217, 0.148, 0.110] |
| 8 serve / 32 ranks (4 trainer nodes, cross-node DDP) | 12 | 0.31 s | 32 | 101.9 | [0.235, 0.165, 0.137] |

**Takeaways:** the RDMA path works co-located (loopback/shm) and cross-node (IB) with the same code. Global throughput scales 4.4 → 101.9 samples/s from 1 → 32 ranks (~23×, ~73% efficiency); the per-step growth (0.23 → 0.31 s) is cross-node DDP gradient all-reduce, **not** the streaming path. Throughout, the serve sits idle (GPU KV-cache usage ~0%, 0 running / 0 waiting reqs) and RDMA is ~0.33 ms/req — i.e. the hidden-state transport is far from saturated and is **not** the bottleneck at these scales; trainer compute + DDP sync is. Serve DP fan-out stays balanced (<2% request skew across up to 8 replicas); with `pool_slots` above peak per-serve in-flight there were no ring-slot races, fetch timeouts, or 500s. All runs converge.


## Server TP correctness test
<img width="910" height="546" alt="image" src="https://github.com/user-attachments/assets/73df9214-7ff0-4ab4-bf2f-95842b12cd5f" />


## Limits

- Host(pinned)-memory RDMA (container UCX lacks CUDA support); GPU-direct needs a CUDA-enabled UCX build.
- Validated topology is N TP=1 serve replicas (data-parallel) + DDP trainers. Ring-slot reuse has no credit protocol yet (ok when in-flight < `pool_slots`); TP>1 hidden-state sharding and >1 serve instance per node (sidecar port reuse) are not handled yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
