### PR TITLE
[OMNIML-4944] peft: add lora_dtype field to PEFTAttributeConfig

### DIFF
--- a/modelopt/torch/peft/config.py
+++ b/modelopt/torch/peft/config.py
@@ -88,6 +88,18 @@ class PEFTAttributeConfig(ModeloptBaseConfig):
         description="Initializer from ``torch.nn.init`` (in-place; name ends with ``\\_``).",
     )
 
+    lora_dtype: str | None = ModeloptField(
+        default=None,
+        title="LoRA factor dtype",
+        description=(
+            "Dtype string for the LoRA factor tensors, independent of the base layer "
+            "(e.g. ``'bf16'`` to pin a BF16 sidecar on top of a fake-quantized base). "
+            "One of ``'bf16'``, ``'fp16'``, ``'fp32'``, or the equivalent long forms "
+            "``'bfloat16'``, ``'float16'``, ``'float32'``. "
+            "``None`` (default) inherits from the wrapped layer's parameter dtype."
+        ),
+    )
+
     @field_validator("lora_a_init", "lora_b_init", mode="before")
     @classmethod
     def _parse_init_callable(cls, v):
@@ -142,6 +154,26 @@ class PEFTAttributeConfig(ModeloptBaseConfig):
         if v <= 0:
             raise ValueError("scale must be a positive number")
         return v
+
+    @field_validator("lora_dtype")
+    @classmethod
+    def validate_lora_dtype(cls, v):
+        """Validate and normalize lora_dtype to one of the canonical short forms."""
+        if v is None:
+            return v
+        aliases = {
+            "bf16": "bf16",
+            "bfloat16": "bf16",
+            "fp16": "fp16",
+            "float16": "fp16",
+            "fp32": "fp32",
+            "float32": "fp32",
+        }
+        if v not in aliases:
+            raise ValueError(
+                f"lora_dtype must be one of {sorted(set(aliases))} or None, got {v!r}"
+            )
+        return aliases[v]
 
 
 # Type alias for adapter configuration

--- a/modelopt/torch/peft/config.py
+++ b/modelopt/torch/peft/config.py
@@ -18,7 +18,7 @@
 import importlib
 import inspect
 from collections.abc import Callable
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 import torch.nn.init as init
 from pydantic import PlainSerializer, WithJsonSchema, field_validator
@@ -97,6 +97,22 @@ class PEFTAttributeConfig(ModeloptBaseConfig):
             "One of ``'bf16'``, ``'fp16'``, ``'fp32'``, or the equivalent long forms "
             "``'bfloat16'``, ``'float16'``, ``'float32'``. "
             "``None`` (default) inherits from the wrapped layer's parameter dtype."
+        ),
+    )
+
+    lora_init_method: Literal["kaiming_zeros", "svdquant"] = ModeloptField(
+        default="kaiming_zeros",
+        title="LoRA initialization method",
+        description=(
+            "How to seed the LoRA factor tensors. "
+            "``'kaiming_zeros'`` (default) honors ``lora_a_init`` / ``lora_b_init`` and "
+            "matches the legacy behavior. "
+            "``'svdquant'`` seeds the factors from a rank-r SVD of the quantization residual "
+            "``W_fp - quant(W_fp)``, requiring the wrapped layer to have an attached "
+            "``weight_quantizer`` (i.e. ``mtq.quantize`` must run first). If no quantizer is "
+            "present, ``'svdquant'`` falls back to zero-init on both factors and emits a "
+            "warning. Currently honored by the TE-grouped MoE plugin "
+            "(``modelopt/torch/peft/lora/plugins/megatron_moe.py``)."
         ),
     )
 

--- a/modelopt/torch/peft/lora/plugins/__init__.py
+++ b/modelopt/torch/peft/lora/plugins/__init__.py
@@ -18,5 +18,14 @@
 from modelopt.torch.utils import import_plugin
 
 with import_plugin("megatron"):
-    from .megatron import *
+    # Import TE-grouped MoE plugin BEFORE the non-grouped Megatron plugin so its
+    # registrations land first in LoRAModuleRegistry. The registry's resolution rule
+    # (modelopt/torch/opt/dynamic.py:_get_registered_nn_class) picks the first
+    # registered class whose `forward` identity-matches the target's forward; both
+    # the TE-grouped and non-grouped Megatron quant classes inherit their forward
+    # from _QuantFunctionalMixin (modelopt/torch/quantization/plugins/custom.py),
+    # so they would otherwise tie and the earlier-registered one would win. The
+    # non-grouped lookup is unaffected because its `issubclass` check still excludes
+    # TE-grouped targets.
     from .megatron_moe import *
+    from .megatron import *

--- a/modelopt/torch/peft/lora/plugins/__init__.py
+++ b/modelopt/torch/peft/lora/plugins/__init__.py
@@ -19,3 +19,4 @@ from modelopt.torch.utils import import_plugin
 
 with import_plugin("megatron"):
     from .megatron import *
+    from .megatron_moe import *

--- a/modelopt/torch/peft/lora/plugins/megatron_moe.py
+++ b/modelopt/torch/peft/lora/plugins/megatron_moe.py
@@ -38,6 +38,12 @@ try:
         TEColumnParallelGroupedLinear,
         TERowParallelGroupedLinear,
     )
+    from megatron.core.utils import (
+        get_pg_rank,
+        get_pg_size,
+        make_sharded_tensor_for_checkpoint,
+        make_tp_sharded_tensor_for_checkpoint,
+    )
 
     HAVE_TE_GROUPED = (
         TEColumnParallelGroupedLinear is not None and TERowParallelGroupedLinear is not None
@@ -45,6 +51,9 @@ try:
 except ImportError:
     TEColumnParallelGroupedLinear = None  # type: ignore[assignment]
     TERowParallelGroupedLinear = None  # type: ignore[assignment]
+    get_pg_rank = get_pg_size = None  # type: ignore[assignment]
+    make_sharded_tensor_for_checkpoint = None  # type: ignore[assignment]
+    make_tp_sharded_tensor_for_checkpoint = None  # type: ignore[assignment]
     HAVE_TE_GROUPED = False
 
 # Quantized TE-grouped classes registered by modelopt.torch.quantization.plugins.megatron.
@@ -275,6 +284,118 @@ if HAVE_TE_GROUPED:
 
             return result, base_bias
 
+        def _factor_tp_axis(self, factor_name: str) -> int | None:
+            """Return the TP-sharded axis of a per-expert factor slice, or None if replicated.
+
+            Subclasses override. The axis is relative to the 2-D per-expert SLICE
+            (``[rank, in]`` for ``lora_a``, ``[out, rank]`` for ``lora_b``), not the 3-D
+            stacked tensor; ``make_tp_sharded_tensor_for_checkpoint`` adds the prepended
+            EP axis on top.
+            """
+            raise NotImplementedError("Subclasses must implement _factor_tp_axis")
+
+        def _ep_rank_size_tp_group(self):
+            """Resolve (ep_rank, ep_size, tp_group), preferring ``self._pg_collection`` and
+            falling back to Megatron's global ``parallel_state`` when the attribute isn't
+            populated on the wrapped instance. Both paths return the same groups; the
+            fallback is necessary because some construction paths (notably the small test
+            factory) don't reliably set ``_pg_collection`` on the per-rank linear instance.
+            """
+            from megatron.core import parallel_state
+
+            try:
+                ep_group = self._pg_collection.ep
+                tp_group = self._tp_group
+                return get_pg_rank(ep_group), get_pg_size(ep_group), tp_group
+            except AttributeError:
+                # EP info — use the expert-parallel group from global state.
+                ep_rank = parallel_state.get_expert_model_parallel_rank()
+                ep_size = parallel_state.get_expert_model_parallel_world_size()
+                # Pass None to the sharded helpers; they fall back to parallel_state.
+                return ep_rank, ep_size, None
+
+        def sharded_state_dict(self, prefix: str = "", sharded_offsets: tuple = (), metadata=None):
+            """Megatron dist-checkpoint sharding for the per-expert stacked LoRA factors.
+
+            Splits each stacked factor (``[E_local, ...]``) into per-global-expert entries
+            keyed ``{prefix}{factor}_{adapter}.weight{global_idx}`` -- mirroring TE's
+            ``_sharded_state_dict_grouped`` convention (``transformer_engine.py:1981``).
+            EP is encoded as a prepended sharded axis; the TP axis (if any) is the
+            per-expert slice's own axis returned by ``_factor_tp_axis``.
+
+            Load path is handled in ``_load_from_state_dict`` below, which stacks the
+            per-expert entries back into a single ``weight`` tensor that matches the
+            carrier's regular ``state_dict`` shape.
+            """
+            sharded_state_dict = super().sharded_state_dict(prefix, sharded_offsets, metadata)
+
+            if not getattr(self, "_lora_adapters", None):
+                return sharded_state_dict
+
+            ep_rank, ep_size, tp_group = self._ep_rank_size_tp_group()
+            num_global_experts = ep_size * self.num_gemms
+            local_expert_indices_offset = ep_rank * self.num_gemms
+            ep_axis = len(sharded_offsets)
+
+            for adapter_name, adapter in self._lora_adapters.items():
+                for factor_name in ("lora_a", "lora_b"):
+                    stacked = adapter[factor_name].weight  # [E_local, ...]
+                    tp_axis = self._factor_tp_axis(factor_name)
+                    for gemm_idx in range(self.num_gemms):
+                        global_expert_idx = local_expert_indices_offset + gemm_idx
+                        slice_ = stacked[gemm_idx]
+                        key = (
+                            f"{prefix}{factor_name}_{adapter_name}.weight{global_expert_idx}"
+                        )
+                        prepend = (
+                            *sharded_offsets,
+                            (ep_axis, global_expert_idx, num_global_experts),
+                        )
+                        if tp_axis is None:
+                            sharded_state_dict[key] = make_sharded_tensor_for_checkpoint(
+                                slice_, key, prepend_offsets=prepend, tp_group=tp_group
+                            )
+                        else:
+                            sharded_state_dict[key] = make_tp_sharded_tensor_for_checkpoint(
+                                slice_,
+                                key,
+                                tp_axis,
+                                prepend_offsets=prepend,
+                                tp_group=tp_group,
+                            )
+            return sharded_state_dict
+
+        def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
+            """Stack per-global-expert ``weight{i}`` entries back into a single ``weight``.
+
+            Inverse of ``sharded_state_dict``'s per-expert split. When Megatron's dist
+            checkpoint loader feeds us per-expert keys, collect them, stack on dim 0
+            to reconstruct the carrier's stacked ``[E_local, ...]`` layout, then let
+            ``super()._load_from_state_dict`` proceed as normal. No-op when the stacked
+            ``weight`` key is already present (plain ``torch.save/load`` path) -- the
+            EP-rank lookup only runs when stacking is actually needed.
+            """
+            for adapter_name in getattr(self, "_lora_adapters", None) or {}:
+                for factor_name in ("lora_a", "lora_b"):
+                    stacked_key = f"{prefix}{factor_name}_{adapter_name}.weight"
+                    if stacked_key in state_dict:
+                        continue  # plain torch.save/load: already stacked
+                    ep_rank, _, _ = self._ep_rank_size_tp_group()
+                    local_expert_indices_offset = ep_rank * self.num_gemms
+                    per_expert = []
+                    for gemm_idx in range(self.num_gemms):
+                        global_expert_idx = local_expert_indices_offset + gemm_idx
+                        expert_key = (
+                            f"{prefix}{factor_name}_{adapter_name}.weight{global_expert_idx}"
+                        )
+                        if expert_key not in state_dict:
+                            per_expert = None
+                            break
+                        per_expert.append(state_dict.pop(expert_key))
+                    if per_expert is not None and len(per_expert) == self.num_gemms:
+                        state_dict[stacked_key] = torch.stack(per_expert, dim=0)
+            return super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
+
     @LoRAModuleRegistry.register(
         {TEColumnParallelGroupedLinear: "megatron_TEColumnParallelGroupedLinear"}
     )
@@ -285,6 +406,12 @@ if HAVE_TE_GROUPED:
         ``in_features`` is the full hidden size.
         """
 
+        def _factor_tp_axis(self, factor_name: str) -> int | None:
+            # Per-expert slice shapes:
+            #   lora_a: [rank, in_features]   -- in is full (TP-replicated)  -> None
+            #   lora_b: [out_features, rank]  -- out is TP-sharded along axis 0
+            return {"lora_a": None, "lora_b": 0}[factor_name]
+
     @LoRAModuleRegistry.register(
         {TERowParallelGroupedLinear: "megatron_TERowParallelGroupedLinear"}
     )
@@ -294,6 +421,12 @@ if HAVE_TE_GROUPED:
         ``in_features`` is the per-rank TP-sharded value;
         ``out_features`` is the full hidden size.
         """
+
+        def _factor_tp_axis(self, factor_name: str) -> int | None:
+            # Per-expert slice shapes:
+            #   lora_a: [rank, in_features]   -- in is TP-sharded along axis 1
+            #   lora_b: [out_features, rank]  -- out is full (TP-replicated) -> None
+            return {"lora_a": 1, "lora_b": None}[factor_name]
 
     # Register the LoRA classes against the *quantized* TE-grouped classes too, so the
     # ``mtq.quantize`` then ``mtpeft.update_model`` flow finds them on the grouped path.

--- a/modelopt/torch/peft/lora/plugins/megatron_moe.py
+++ b/modelopt/torch/peft/lora/plugins/megatron_moe.py
@@ -27,6 +27,7 @@ sidecar can be pinned to BF16 independently of the base layer's storage
 dtype (e.g. on top of a fake-quantized low-bit base for QAD).
 """
 
+import warnings
 from typing import Any
 
 import torch
@@ -45,6 +46,26 @@ except ImportError:
     TEColumnParallelGroupedLinear = None  # type: ignore[assignment]
     TERowParallelGroupedLinear = None  # type: ignore[assignment]
     HAVE_TE_GROUPED = False
+
+# Quantized TE-grouped classes registered by modelopt.torch.quantization.plugins.megatron.
+# Used at module bottom to register the LoRA class against the quantized base too, so the
+# quantize -> LoRA flow ("mtq.quantize then mtpeft.update_model") works on the grouped path.
+try:
+    from modelopt.torch.quantization.plugins.megatron import (
+        _MegatronTEGroupedColumnParallelLinear as _QuantTEColumnParallelGroupedLinear,
+    )
+    from modelopt.torch.quantization.plugins.megatron import (
+        _MegatronTEGroupedRowParallelLinear as _QuantTERowParallelGroupedLinear,
+    )
+
+    HAVE_QUANT_TE_GROUPED = (
+        _QuantTEColumnParallelGroupedLinear is not None
+        and _QuantTERowParallelGroupedLinear is not None
+    )
+except ImportError:
+    _QuantTEColumnParallelGroupedLinear = None  # type: ignore[assignment]
+    _QuantTERowParallelGroupedLinear = None  # type: ignore[assignment]
+    HAVE_QUANT_TE_GROUPED = False
 
 from ...config import PEFTAttributeConfig
 from ..layer import LoRAModule, LoRAModuleRegistry
@@ -147,12 +168,65 @@ if HAVE_TE_GROUPED:
             lora_b = _StackedLoRAFactor(num_experts, self.out_features, rank, dtype=dtype)
 
             with torch.no_grad():
-                attr_config.lora_a_init(lora_a.weight)
-                attr_config.lora_b_init(lora_b.weight)
+                if attr_config.lora_init_method == "svdquant":
+                    self._init_factors_svdquant(lora_a.weight, lora_b.weight, rank)
+                else:
+                    # "kaiming_zeros" (default): honor the user's lora_a_init / lora_b_init
+                    # initializers (defaults: Kaiming on A, zeros on B).
+                    attr_config.lora_a_init(lora_a.weight)
+                    attr_config.lora_b_init(lora_b.weight)
 
             self._register_stacked_adapter(
                 adapter_name, lora_a, lora_b, rank, attr_config.scale, attr_config.enable
             )
+
+        def _init_factors_svdquant(
+            self,
+            lora_a_weight: torch.Tensor,
+            lora_b_weight: torch.Tensor,
+            rank: int,
+        ) -> None:
+            """Per-expert SVD of the quantization residual ``W - quant(W)``.
+
+            For each expert ``e`` in range(num_gemms): compute the residual between the
+            full-precision per-expert weight and its fake-quantized image, run rank-``r``
+            SVD via ``modelopt.torch.quantization.model_calib.svd``, then write the
+            factors into the stacked carrier tensors:
+
+            - ``lora_a_weight[e]`` <- ``vt`` (shape ``[r, in_features]``)
+            - ``lora_b_weight[e]`` <- ``us`` (shape ``[out_features, r]``)
+
+            so that ``B_e @ A_e == us @ vt`` approximates the quantization residual at
+            init time. Falls back to zero-init on both factors (with a warning) if the
+            wrapped layer has no attached/enabled ``weight_quantizer`` -- in that case the
+            residual is undefined and ``mtq.quantize`` must run before ``mtpeft.update_model``.
+            """
+            quantizer = getattr(self, "weight_quantizer", None)
+            quant_enabled = quantizer is not None and getattr(quantizer, "is_enabled", True)
+            if not quant_enabled:
+                warnings.warn(
+                    "lora_init_method='svdquant' requested but no enabled weight_quantizer "
+                    "is attached to this TE-grouped linear. The quantization residual is "
+                    "undefined; falling back to zero-init on both LoRA factors. To get a "
+                    "meaningful SVDQuant init, run mtq.quantize() before mtpeft.update_model().",
+                    stacklevel=2,
+                )
+                lora_a_weight.zero_()
+                lora_b_weight.zero_()
+                return
+
+            # Local import keeps the dependency on quantization optional at module-load
+            # time -- only callers using lora_init_method='svdquant' pay the import cost.
+            from modelopt.torch.quantization.model_calib import svd as _svd_helper
+
+            for e in range(self.num_gemms):
+                w_e = getattr(self, f"weight{e}")  # [out_features, in_features]
+                w_q = quantizer(w_e)
+                residual = (w_e - w_q).detach()
+                us, vt = _svd_helper(residual, rank)
+                # vt: [rank, in_features], us: [out_features, rank]
+                lora_a_weight[e].copy_(vt.to(lora_a_weight.dtype))
+                lora_b_weight[e].copy_(us.to(lora_b_weight.dtype))
 
         def forward(
             self, x: torch.Tensor, tokens_per_expert, *args, **kwargs
@@ -220,3 +294,23 @@ if HAVE_TE_GROUPED:
         ``in_features`` is the per-rank TP-sharded value;
         ``out_features`` is the full hidden size.
         """
+
+    # Register the LoRA classes against the *quantized* TE-grouped classes too, so the
+    # ``mtq.quantize`` then ``mtpeft.update_model`` flow finds them on the grouped path.
+    # Mirrors the pattern in peft/lora/plugins/megatron.py:244-250 for non-grouped linears.
+    # Required for lora_init_method='svdquant' to find a weight_quantizer on self.
+    if HAVE_QUANT_TE_GROUPED:
+        LoRAModuleRegistry.register(
+            {
+                _QuantTEColumnParallelGroupedLinear: (
+                    "quant_megatron_TEColumnParallelGroupedLinear"
+                )
+            }
+        )(_LoRATEGroupedColumnParallelLinear)
+        LoRAModuleRegistry.register(
+            {
+                _QuantTERowParallelGroupedLinear: (
+                    "quant_megatron_TERowParallelGroupedLinear"
+                )
+            }
+        )(_LoRATEGroupedRowParallelLinear)

--- a/modelopt/torch/peft/lora/plugins/megatron_moe.py
+++ b/modelopt/torch/peft/lora/plugins/megatron_moe.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Megatron-Core TE GroupedLinear LoRA plugin for MoE expert layers.
+
+Registers LoRA adapters against ``TEColumnParallelGroupedLinear`` and
+``TERowParallelGroupedLinear`` -- the grouped-GEMM modules used by
+Megatron-Core when ``moe_grouped_gemm=True`` (the default for Nemotron-3
+Hybrid MoE). Per-expert ``(A_e, B_e)`` factors are stored as stacked
+tensors of shape ``[num_experts, ...]`` and dispatched in ``forward`` by
+splitting the input along ``tokens_per_expert``.
+
+The plugin also honors ``PEFTAttributeConfig.lora_dtype`` so the LoRA
+sidecar can be pinned to BF16 independently of the base layer's storage
+dtype (e.g. on top of a fake-quantized low-bit base for QAD).
+"""
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+try:
+    from megatron.core.extensions.transformer_engine import (
+        TEColumnParallelGroupedLinear,
+        TERowParallelGroupedLinear,
+    )
+
+    HAVE_TE_GROUPED = (
+        TEColumnParallelGroupedLinear is not None and TERowParallelGroupedLinear is not None
+    )
+except ImportError:
+    TEColumnParallelGroupedLinear = None  # type: ignore[assignment]
+    TERowParallelGroupedLinear = None  # type: ignore[assignment]
+    HAVE_TE_GROUPED = False
+
+from ...config import PEFTAttributeConfig
+from ..layer import LoRAModule, LoRAModuleRegistry
+
+__all__ = []
+
+_DTYPE_MAP = {
+    "bf16": torch.bfloat16,
+    "fp16": torch.float16,
+    "fp32": torch.float32,
+}
+
+
+def _resolve_lora_dtype(
+    attr_config: PEFTAttributeConfig, fallback: torch.dtype
+) -> torch.dtype:
+    """Map ``attr_config.lora_dtype`` to a ``torch.dtype``; ``None`` inherits ``fallback``."""
+    if attr_config.lora_dtype is None:
+        return fallback
+    return _DTYPE_MAP[attr_config.lora_dtype]
+
+
+class _StackedLoRAFactor(nn.Module):
+    """Carrier ``nn.Module`` that holds a single stacked per-expert LoRA factor.
+
+    The wrapped ``nn.Parameter`` has shape ``[num_experts, *suffix]``. ``forward``
+    is intentionally unused -- the parent ``LoRAModule`` subclass dispatches
+    per-expert against ``self.weight`` directly. Inheriting from ``nn.Module``
+    keeps the factor visible in ``state_dict`` and reachable by ``add_module``,
+    which is what ``LoRAModule._register_adapter`` expects.
+    """
+
+    def __init__(self, num_experts: int, *suffix: int, dtype: torch.dtype):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(num_experts, *suffix, dtype=dtype))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover
+        raise RuntimeError(
+            "_StackedLoRAFactor.forward should not be called directly; "
+            "the parent LoRAModule subclass dispatches per-expert against self.weight."
+        )
+
+
+if HAVE_TE_GROUPED:
+
+    class _LoRATEGroupedBase(LoRAModule):
+        """Shared base for column- and row-parallel TE-grouped LoRA wrappers.
+
+        Subclasses exist only to bind the registration to a specific TE grouped
+        linear class -- column or row parallel. All allocation and dispatch
+        logic lives here.
+
+        Tensor layout (matches the TE grouped weight convention ``[out, in]`` per expert):
+
+        * ``lora_a.weight``: ``[num_gemms, rank, in_features]``
+        * ``lora_b.weight``: ``[num_gemms, out_features, rank]``
+
+        For column-parallel grouped, ``out_features`` is already the per-rank
+        TP-sharded value (TE's ``explicit_expert_comm`` divides ``output_size``
+        by ``tp_size`` at construction). For row-parallel grouped, ``in_features``
+        is the per-rank value. Sharded-state-dict integration is deferred to a
+        later commit; this PR carries the forward path only.
+        """
+
+        def _register_stacked_adapter(
+            self,
+            adapter_name: str,
+            lora_a: _StackedLoRAFactor,
+            lora_b: _StackedLoRAFactor,
+            rank: int,
+            scale: float,
+            enable: bool,
+        ) -> None:
+            """Register stacked factors on the parent's device, preserving their dtype.
+
+            Differs from ``_MegatronParallelLoRABase._register_adapter_with_device``
+            (the non-grouped variant) in that we do not copy the parent layer's
+            dtype onto the factors -- their dtype was set at construction per
+            ``attr_config.lora_dtype``. That decoupling is what makes a BF16 LoRA
+            sidecar over a fake-quant low-bit base possible.
+            """
+            base_param = next(iter(self.parameters()), None)
+            if base_param is not None:
+                lora_a = lora_a.to(base_param.device)
+                lora_b = lora_b.to(base_param.device)
+            super()._register_adapter(adapter_name, lora_a, lora_b, rank, scale, enable)
+
+        def update_layer_lora(
+            self, adapter_name: str, attr_config: PEFTAttributeConfig
+        ) -> None:
+            """Allocate and initialize per-expert stacked LoRA factors."""
+            num_experts = self.num_gemms
+            rank = attr_config.rank
+
+            base_param = next(iter(self.parameters()), None)
+            fallback_dtype = base_param.dtype if base_param is not None else torch.bfloat16
+            dtype = _resolve_lora_dtype(attr_config, fallback_dtype)
+
+            lora_a = _StackedLoRAFactor(num_experts, rank, self.in_features, dtype=dtype)
+            lora_b = _StackedLoRAFactor(num_experts, self.out_features, rank, dtype=dtype)
+
+            with torch.no_grad():
+                attr_config.lora_a_init(lora_a.weight)
+                attr_config.lora_b_init(lora_b.weight)
+
+            self._register_stacked_adapter(
+                adapter_name, lora_a, lora_b, rank, attr_config.scale, attr_config.enable
+            )
+
+        def forward(
+            self, x: torch.Tensor, tokens_per_expert, *args, **kwargs
+        ) -> Any:
+            """Add per-expert LoRA outputs to the grouped GEMM's base output.
+
+            Bypasses ``LoRAModule.forward`` via ``super(LoRAModule, self)`` because
+            its adapter loop calls ``lora_a(x)``, which would invoke
+            ``_StackedLoRAFactor.forward`` and raise. The stacked layout requires
+            per-expert dispatch keyed by ``tokens_per_expert``.
+            """
+            base_out, base_bias = super(LoRAModule, self).forward(
+                x, tokens_per_expert, *args, **kwargs
+            )
+
+            if not self._lora_adapters:
+                return base_out, base_bias
+
+            # tokens_per_expert is normally list[int] by the time it reaches the
+            # grouped linear (TEGroupedMLP.forward converts via .tolist() before
+            # calling fc1/fc2). Accept a tensor too for direct-call use cases.
+            if isinstance(tokens_per_expert, torch.Tensor):
+                tpe_list = tokens_per_expert.tolist()
+            else:
+                tpe_list = list(tokens_per_expert)
+
+            x_splits = torch.split(x, tpe_list, dim=0)
+
+            result = base_out
+            for adapter in self._lora_adapters.values():
+                if not adapter["enable"]:
+                    continue
+                a_weight = adapter["lora_a"].weight  # [E, r, in]
+                b_weight = adapter["lora_b"].weight  # [E, out, r]
+                scale = adapter["scale"]
+
+                per_expert_outputs = []
+                for e, x_e in enumerate(x_splits):
+                    # matmul handles n_e == 0; output stays [0, out_features].
+                    intermediate = x_e.to(a_weight.dtype) @ a_weight[e].T
+                    out_e = (intermediate @ b_weight[e].T).to(base_out.dtype) * scale
+                    per_expert_outputs.append(out_e)
+
+                lora_out = torch.cat(per_expert_outputs, dim=0)
+                result = result + lora_out
+
+            return result, base_bias
+
+    @LoRAModuleRegistry.register(
+        {TEColumnParallelGroupedLinear: "megatron_TEColumnParallelGroupedLinear"}
+    )
+    class _LoRATEGroupedColumnParallelLinear(_LoRATEGroupedBase):
+        """LoRA wrapper for ``TEColumnParallelGroupedLinear``.
+
+        ``out_features`` is the per-rank TP-sharded value;
+        ``in_features`` is the full hidden size.
+        """
+
+    @LoRAModuleRegistry.register(
+        {TERowParallelGroupedLinear: "megatron_TERowParallelGroupedLinear"}
+    )
+    class _LoRATEGroupedRowParallelLinear(_LoRATEGroupedBase):
+        """LoRA wrapper for ``TERowParallelGroupedLinear``.
+
+        ``in_features`` is the per-rank TP-sharded value;
+        ``out_features`` is the full hidden size.
+        """

--- a/tests/gpu_megatron/torch/peft/plugins/test_megatron_moe_lora.py
+++ b/tests/gpu_megatron/torch/peft/plugins/test_megatron_moe_lora.py
@@ -28,10 +28,18 @@ import pytest
 import torch
 import torch.nn.init as init
 from _test_utils.torch.megatron.models import get_mcore_gpt_model
-from _test_utils.torch.megatron.utils import initialize_for_megatron
+from _test_utils.torch.megatron.utils import (
+    initialize_for_megatron,
+    load_distributed_checkpoint,
+    save_distributed_checkpoint,
+)
 
 import modelopt.torch.peft as mtpeft
 import modelopt.torch.quantization as mtq
+from modelopt.torch.opt.plugins.mcore_dist_checkpointing import (
+    restore_sharded_modelopt_state,
+    save_sharded_modelopt_state,
+)
 from modelopt.torch.peft.lora.layer import LoRAModule
 from modelopt.torch.peft.lora.plugins.megatron_moe import HAVE_TE_GROUPED
 from modelopt.torch.utils.plugins import megatron_prefill
@@ -434,3 +442,59 @@ def _test_quantize_then_lora_svdquant_state_dict_roundtrip(rank, size):
 
 def test_quantize_then_lora_svdquant_state_dict_roundtrip(dist_workers):
     dist_workers.run(_test_quantize_then_lora_svdquant_state_dict_roundtrip)
+
+
+def _test_quantize_then_lora_svdquant_dist_checkpoint_roundtrip(tmp_path, rank, size):
+    """Megatron dist-checkpoint round-trip for the per-expert stacked LoRA factors.
+
+    Mirrors test_megatron_peft.py::test_mcore_quantize_then_lora_save_restore but for
+    the TE-grouped MoE LoRA path: build a quantized+LoRA model, save with
+    ``save_distributed_checkpoint`` + ``save_sharded_modelopt_state``, restore into a
+    fresh model with ``restore_sharded_modelopt_state`` + ``load_distributed_checkpoint``,
+    and assert the post-LoRA forward output matches the source within tolerance.
+
+    Exercises the new ``_LoRATEGroupedBase.sharded_state_dict`` and
+    ``_load_from_state_dict`` hooks end-to-end on Megatron's sharded format (the format
+    that real Nemotron-3 checkpoints use).
+    """
+    initialize_for_megatron(tensor_model_parallel_size=size, pipeline_model_parallel_size=1)
+    model_ref = _moe_model_provider(tp_size=size)
+    model_test = _moe_model_provider(tp_size=size)
+    prompt_tokens = torch.randint(
+        0, model_ref.vocab_size, (2, model_ref.max_sequence_length)
+    ).cuda()
+
+    # Capture the pre-LoRA output of model_test for the "LoRA actually changed something"
+    # sanity assertion at the bottom.
+    pre_lora_output_test = megatron_prefill(model_test, prompt_tokens)
+
+    def forward_func(mod):
+        _ = megatron_prefill(model_ref, prompt_tokens)
+
+    mtq.quantize(model_ref, INT8_PER_TENSOR_QUANT_CFG, forward_func)
+    mtpeft.update_model(model_ref, SVDQUANT_LORA_CFG)
+    ref_output = megatron_prefill(model_ref, prompt_tokens)
+
+    # Save: ref's distributed checkpoint + sharded modelopt state (quantizers).
+    save_distributed_checkpoint(tmp_path, model_ref)
+    save_sharded_modelopt_state([model_ref], tmp_path)
+
+    # Restore: sharded modelopt state first (attaches quantizers + LoRA module shape via
+    # the saved modelopt_state), then the model parameters.
+    restore_sharded_modelopt_state([model_test], tmp_path)
+    model_test = load_distributed_checkpoint(tmp_path, model_test)
+    test_output = megatron_prefill(model_test, prompt_tokens)
+
+    assert torch.allclose(ref_output, test_output, rtol=1e-5), (
+        "dist-checkpoint round-trip changed the model output -- LoRA factors did not "
+        "fully restore"
+    )
+    assert not torch.allclose(ref_output, pre_lora_output_test, rtol=1e-5), (
+        "ref output equals the pre-LoRA baseline; LoRA may not be perturbing the model"
+    )
+
+
+def test_quantize_then_lora_svdquant_dist_checkpoint_roundtrip(dist_workers, tmp_path):
+    dist_workers.run(
+        partial(_test_quantize_then_lora_svdquant_dist_checkpoint_roundtrip, str(tmp_path))
+    )

--- a/tests/gpu_megatron/torch/peft/plugins/test_megatron_moe_lora.py
+++ b/tests/gpu_megatron/torch/peft/plugins/test_megatron_moe_lora.py
@@ -365,3 +365,72 @@ def _test_svdquant_init_no_quantizer_falls_back(rank, size):
 
 def test_svdquant_init_no_quantizer_falls_back(dist_workers):
     dist_workers.run(_test_svdquant_init_no_quantizer_falls_back)
+
+
+def _test_quantize_then_lora_svdquant_state_dict_roundtrip(rank, size):
+    """Disk save + load round-trips the per-expert stacked LoRA factors bitwise.
+
+    Sanity scaffold for Phase 2 plumbing (OMNIML-4944): validates that a model
+    in the quantize -> LoRA(svdquant) state can serialize its LoRA factors via
+    torch.save and restore them via torch.load + load_state_dict. Doesn't use
+    Megatron's distributed-checkpoint format (sharded_state_dict integration is
+    deferred); each rank saves to its own temp path so dist_workers ranks don't
+    collide. Confirms the LoRA-on-quant-checkpoint claim end-to-end at small
+    scale before we wire into the production trainer.
+    """
+    import os
+    import shutil
+    import tempfile
+
+    initialize_for_megatron(tensor_model_parallel_size=size, pipeline_model_parallel_size=1)
+    model = _moe_model_provider(tp_size=size)
+    prompt_tokens = torch.randint(0, model.vocab_size, (2, model.max_sequence_length)).cuda()
+
+    def forward_func(mod):
+        _ = megatron_prefill(model, prompt_tokens)
+
+    mtq.quantize(model, INT8_PER_TENSOR_QUANT_CFG, forward_func)
+    mtpeft.update_model(model, SVDQUANT_LORA_CFG)
+
+    # Snapshot the original LoRA factors per grouped module.
+    original_factors = {}
+    for name, module in _grouped_lora_modules(model):
+        adapter = module._lora_adapters["svdquant"]
+        original_factors[name] = (
+            adapter["lora_a"].weight.detach().clone(),
+            adapter["lora_b"].weight.detach().clone(),
+        )
+    assert original_factors, "expected at least one TE-grouped LoRA module with svdquant adapter"
+
+    # Save to a per-rank temp path so dist_workers ranks don't collide.
+    tmpdir = tempfile.mkdtemp(prefix=f"omniml4944_lora_roundtrip_rank{rank}_")
+    path = os.path.join(tmpdir, "state.pt")
+    try:
+        torch.save(model.state_dict(), path)
+
+        # Mutate the LoRA factors in place so a successful load is observable.
+        with torch.no_grad():
+            for _, module in _grouped_lora_modules(model):
+                adapter = module._lora_adapters["svdquant"]
+                adapter["lora_a"].weight.zero_()
+                adapter["lora_b"].weight.zero_()
+
+        # Restore from disk and assert bitwise equality with the snapshot.
+        loaded = torch.load(path, map_location="cuda", weights_only=True)
+        model.load_state_dict(loaded, strict=True)
+
+        for name, module in _grouped_lora_modules(model):
+            adapter = module._lora_adapters["svdquant"]
+            a_orig, b_orig = original_factors[name]
+            assert torch.equal(adapter["lora_a"].weight, a_orig), (
+                f"{name}: lora_a did not bitwise round-trip through torch.save/load"
+            )
+            assert torch.equal(adapter["lora_b"].weight, b_orig), (
+                f"{name}: lora_b did not bitwise round-trip through torch.save/load"
+            )
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def test_quantize_then_lora_svdquant_state_dict_roundtrip(dist_workers):
+    dist_workers.run(_test_quantize_then_lora_svdquant_state_dict_roundtrip)

--- a/tests/gpu_megatron/torch/peft/plugins/test_megatron_moe_lora.py
+++ b/tests/gpu_megatron/torch/peft/plugins/test_megatron_moe_lora.py
@@ -31,6 +31,7 @@ from _test_utils.torch.megatron.models import get_mcore_gpt_model
 from _test_utils.torch.megatron.utils import initialize_for_megatron
 
 import modelopt.torch.peft as mtpeft
+import modelopt.torch.quantization as mtq
 from modelopt.torch.peft.lora.layer import LoRAModule
 from modelopt.torch.peft.lora.plugins.megatron_moe import HAVE_TE_GROUPED
 from modelopt.torch.utils.plugins import megatron_prefill
@@ -84,6 +85,44 @@ BF16_SIDECAR_LORA_CFG = {
         },
         "*output_layer*": {"enable": False},
     },
+}
+
+SVDQUANT_LORA_CFG = {
+    "adapter_type": "lora",
+    "adapter_name": "svdquant",
+    "adapter_cfg": {
+        # SVDQuant init only on MoE expert grouped linears (matches the OMNIML-4944
+        # spec: "LoRA adapters placed one per up_proj/down_proj across all MoE expert
+        # layers"). Patterns are applied in order, last match wins. This also avoids
+        # a pre-existing modelopt bug in the quantize -> LoRA path for TE plain linears
+        # (LoRAQuantTERowParallelLinear lacks `input_size`).
+        "*": {"enable": False},
+        "*experts*linear_fc*": {
+            "rank": 8,
+            "scale": 1.0,
+            "lora_init_method": "svdquant",
+            "enable": True,
+        },
+        "*output_layer*": {"enable": False},
+    },
+}
+
+# Per-tensor INT8 weight quantization. Compatible with TEGroupedLinear which restricts
+# weight quantization to per-tensor (assertion at quantization/plugins/megatron.py:696
+# in _process_quantizer_amax). A meaningful but small residual lets us check that
+# the SVDQuant init produces non-trivial, residual-correlated LoRA factors. Matches
+# the list-of-dicts shape used by NVFP4_DEFAULT_CONFIG in tests/.../test_megatron_peft.py.
+INT8_PER_TENSOR_QUANT_CFG = {
+    "quant_cfg": [
+        {"quantizer_name": "*", "enable": False},
+        {
+            "quantizer_name": "*weight_quantizer",
+            "cfg": {"num_bits": 8, "axis": None},
+            "enable": True,
+        },
+        {"quantizer_name": "*output_layer*", "enable": False},
+    ],
+    "algorithm": "max",
 }
 
 
@@ -234,3 +273,95 @@ def _test_gradient_flow(rank, size):
 
 def test_gradient_flow(dist_workers):
     dist_workers.run(_test_gradient_flow)
+
+
+def _test_svdquant_init_recovers_residual(rank, size):
+    """After mtq.quantize -> mtpeft.update_model(svdquant), per-expert B @ A is a
+    rank-r approximation of the quantization residual W_e - quant(W_e).
+
+    Verifies (a) the LoRA factors are populated non-trivially when there's a real
+    residual, and (b) the reconstruction error is bounded by the residual norm
+    (i.e. SVD recovered some structure, not random/zero factors).
+    """
+    initialize_for_megatron(tensor_model_parallel_size=size, pipeline_model_parallel_size=1)
+    model = _moe_model_provider(tp_size=size)
+    prompt_tokens = torch.randint(0, model.vocab_size, (2, model.max_sequence_length)).cuda()
+
+    def forward_func(mod):
+        _ = megatron_prefill(model, prompt_tokens)
+
+    # Quantize first so weight_quantizer exists on each TE-grouped linear.
+    mtq.quantize(model, INT8_PER_TENSOR_QUANT_CFG, forward_func)
+    # Then add LoRA: update_layer_lora reads weight_quantizer per module to compute residuals.
+    mtpeft.update_model(model, SVDQUANT_LORA_CFG)
+
+    found = False
+    for name, module in _grouped_lora_modules(model):
+        quantizer = getattr(module, "weight_quantizer", None)
+        if quantizer is None or not getattr(quantizer, "is_enabled", True):
+            continue
+        adapter = module._lora_adapters["svdquant"]
+        a = adapter["lora_a"].weight  # [E, r, in]
+        b = adapter["lora_b"].weight  # [E, out, r]
+
+        with torch.no_grad():
+            for e in range(module.num_gemms):
+                w_e = getattr(module, f"weight{e}")
+                w_q = quantizer(w_e)
+                expected_residual = (w_e - w_q).detach().float()
+                reconstructed = b[e].float() @ a[e].float()  # [out, in]
+
+                ref = expected_residual.norm()
+                err = (reconstructed - expected_residual).norm()
+
+                # When the residual is non-trivial, rank-r SVD should:
+                # (1) produce non-zero factors
+                # (2) reduce reconstruction error below the residual norm.
+                if ref > 0:
+                    assert a[e].abs().sum() > 0, (
+                        f"{name} expert {e}: lora_a is all zeros despite non-zero residual"
+                    )
+                    assert b[e].abs().sum() > 0, (
+                        f"{name} expert {e}: lora_b is all zeros despite non-zero residual"
+                    )
+                    assert err < ref, (
+                        f"{name} expert {e}: reconstruction err {err.item():.4g} "
+                        f">= residual norm {ref.item():.4g} -- SVDQuant init didn't recover "
+                        f"any structure"
+                    )
+                found = True
+
+    assert found, "no TE-grouped LoRA modules with svdquant adapter found"
+
+
+def test_svdquant_init_recovers_residual(dist_workers):
+    dist_workers.run(_test_svdquant_init_recovers_residual)
+
+
+def _test_svdquant_init_no_quantizer_falls_back(rank, size):
+    """Without a prior mtq.quantize call, lora_init_method='svdquant' has no residual
+    to SVD; it must fall back to zero-init on both factors (with a warning).
+    """
+    initialize_for_megatron(tensor_model_parallel_size=size, pipeline_model_parallel_size=1)
+    model = _moe_model_provider(tp_size=size)
+
+    # Deliberately skip mtq.quantize -- no weight_quantizer attached to grouped linears.
+    mtpeft.update_model(model, SVDQUANT_LORA_CFG)
+
+    found = False
+    for _, module in _grouped_lora_modules(model):
+        adapter = module._lora_adapters["svdquant"]
+        a = adapter["lora_a"].weight
+        b = adapter["lora_b"].weight
+        assert torch.all(a == 0), (
+            "lora_a should be zero-init when svdquant runs without a weight_quantizer"
+        )
+        assert torch.all(b == 0), (
+            "lora_b should be zero-init when svdquant runs without a weight_quantizer"
+        )
+        found = True
+    assert found, "no TE-grouped LoRA modules with svdquant adapter found"
+
+
+def test_svdquant_init_no_quantizer_falls_back(dist_workers):
+    dist_workers.run(_test_svdquant_init_no_quantizer_falls_back)

--- a/tests/gpu_megatron/torch/peft/plugins/test_megatron_moe_lora.py
+++ b/tests/gpu_megatron/torch/peft/plugins/test_megatron_moe_lora.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Smoke tests for the TE-grouped MoE LoRA plugin (OMNIML-4944).
+
+Exercises modelopt/torch/peft/lora/plugins/megatron_moe.py end-to-end on a
+small MoE GPT model built with ``moe_grouped_gemm=True`` and the TE
+spec -- i.e. the production path used by Nemotron-3 Hybrid. The tests
+verify registration, the zero-init forward identity, random-init
+divergence from base, ``lora_dtype`` pinning, and gradient flow.
+"""
+
+from functools import partial
+
+import pytest
+import torch
+import torch.nn.init as init
+from _test_utils.torch.megatron.models import get_mcore_gpt_model
+from _test_utils.torch.megatron.utils import initialize_for_megatron
+
+import modelopt.torch.peft as mtpeft
+from modelopt.torch.peft.lora.layer import LoRAModule
+from modelopt.torch.peft.lora.plugins.megatron_moe import HAVE_TE_GROUPED
+from modelopt.torch.utils.plugins import megatron_prefill
+
+pytestmark = pytest.mark.skipif(
+    not HAVE_TE_GROUPED,
+    reason="Requires Transformer Engine >= 1.9.0.dev0 with TEGroupedLinear support",
+)
+
+if HAVE_TE_GROUPED:
+    from modelopt.torch.peft.lora.plugins.megatron_moe import (
+        _LoRATEGroupedColumnParallelLinear,
+        _LoRATEGroupedRowParallelLinear,
+    )
+
+NUM_EXPERTS = 4
+
+DEFAULT_LORA_CFG = {
+    "adapter_type": "lora",
+    "adapter_name": "default",
+    "adapter_cfg": {
+        "*": {"rank": 8, "scale": 1.0, "enable": True},
+        "*output_layer*": {"enable": False},
+    },
+}
+
+RANDOM_INIT_LORA_CFG = {
+    "adapter_type": "lora",
+    "adapter_name": "random",
+    "adapter_cfg": {
+        "*": {
+            "rank": 8,
+            "scale": 1.0,
+            "lora_a_init": init.kaiming_uniform_,
+            "lora_b_init": init.kaiming_uniform_,
+            "enable": True,
+        },
+        "*output_layer*": {"enable": False},
+    },
+}
+
+BF16_SIDECAR_LORA_CFG = {
+    "adapter_type": "lora",
+    "adapter_name": "bf16_sidecar",
+    "adapter_cfg": {
+        "*": {
+            "rank": 8,
+            "scale": 1.0,
+            "lora_dtype": "bf16",
+            "enable": True,
+        },
+        "*output_layer*": {"enable": False},
+    },
+}
+
+
+def _moe_model_provider(tp_size: int, hidden_size: int = 256):
+    """Build a tiny TE-MoE GPT with grouped GEMM (production path)."""
+    model = get_mcore_gpt_model(
+        tensor_model_parallel_size=tp_size,
+        num_layers=2,
+        ffn_hidden_size=None,
+        num_attention_heads=4,
+        activation_func="swiglu",
+        transformer_impl="transformer_engine",
+        hidden_size=hidden_size,
+        vocab_size=64,
+        moe_grouped_gemm=True,
+        num_moe_experts=NUM_EXPERTS,
+        moe_ffn_hidden_size=hidden_size * 2,
+    ).cuda()
+    return model.eval()
+
+
+def _grouped_lora_modules(model):
+    """Yield (name, module) for every TE-grouped LoRA wrapper in the model."""
+    for name, module in model.named_modules():
+        if isinstance(
+            module, (_LoRATEGroupedColumnParallelLinear, _LoRATEGroupedRowParallelLinear)
+        ):
+            yield name, module
+
+
+def _test_registration_and_zero_init_identity(rank, size):
+    """Default (Kaiming on A / zeros on B) init must not perturb the base output."""
+    initialize_for_megatron(tensor_model_parallel_size=size, pipeline_model_parallel_size=1)
+    model = _moe_model_provider(tp_size=size)
+    prompt_tokens = torch.randint(0, model.vocab_size, (2, model.max_sequence_length)).cuda()
+
+    base_output = megatron_prefill(model, prompt_tokens)
+    mtpeft.update_model(model, DEFAULT_LORA_CFG)
+    lora_output = megatron_prefill(model, prompt_tokens)
+
+    # The plugin must have replaced at least one expert linear per expert layer.
+    grouped_lora_modules = list(_grouped_lora_modules(model))
+    assert len(grouped_lora_modules) > 0, "no TE-grouped LoRA modules were registered"
+
+    for _, module in grouped_lora_modules:
+        # Per-expert stacked factor shapes
+        assert "default" in module._lora_adapters
+        adapter = module._lora_adapters["default"]
+        a_w = adapter["lora_a"].weight
+        b_w = adapter["lora_b"].weight
+        assert a_w.shape == (module.num_gemms, 8, module.in_features)
+        assert b_w.shape == (module.num_gemms, module.out_features, 8)
+
+    # Zero-init on B → LoRA contribution is exactly zero → outputs match base.
+    assert lora_output.shape == base_output.shape
+    assert torch.allclose(lora_output, base_output, rtol=1e-5, atol=1e-5)
+
+    # Disabling + re-enabling adapters round-trips correctly.
+    mtpeft.disable_adapters(model)
+    assert torch.allclose(megatron_prefill(model, prompt_tokens), base_output, rtol=1e-5, atol=1e-5)
+    mtpeft.enable_adapters(model)
+    assert torch.allclose(megatron_prefill(model, prompt_tokens), lora_output, rtol=1e-5, atol=1e-5)
+
+
+def test_registration_and_zero_init_identity(dist_workers):
+    dist_workers.run(_test_registration_and_zero_init_identity)
+
+
+def _test_random_init_perturbs_output(rank, size):
+    """Random init on both A and B must change the model output."""
+    initialize_for_megatron(tensor_model_parallel_size=size, pipeline_model_parallel_size=1)
+    model = _moe_model_provider(tp_size=size)
+    prompt_tokens = torch.randint(0, model.vocab_size, (2, model.max_sequence_length)).cuda()
+
+    base_output = megatron_prefill(model, prompt_tokens)
+    mtpeft.update_model(model, RANDOM_INIT_LORA_CFG)
+    lora_output = megatron_prefill(model, prompt_tokens)
+
+    assert lora_output.shape == base_output.shape
+    assert not torch.allclose(lora_output, base_output, rtol=1e-5)
+
+
+def test_random_init_perturbs_output(dist_workers):
+    dist_workers.run(_test_random_init_perturbs_output)
+
+
+def _test_lora_dtype_pin(rank, size):
+    """lora_dtype='bf16' must pin LoRA factor tensors to bfloat16."""
+    initialize_for_megatron(tensor_model_parallel_size=size, pipeline_model_parallel_size=1)
+    model = _moe_model_provider(tp_size=size)
+    mtpeft.update_model(model, BF16_SIDECAR_LORA_CFG)
+
+    found = False
+    for _, module in _grouped_lora_modules(model):
+        adapter = module._lora_adapters["bf16_sidecar"]
+        assert adapter["lora_a"].weight.dtype == torch.bfloat16
+        assert adapter["lora_b"].weight.dtype == torch.bfloat16
+        found = True
+    assert found, "no TE-grouped LoRA modules with bf16_sidecar adapter"
+
+
+def test_lora_dtype_pin(dist_workers):
+    dist_workers.run(_test_lora_dtype_pin)
+
+
+def _test_gradient_flow(rank, size):
+    """Random-init LoRA factors must receive gradients; base weights must not (default freeze)."""
+    initialize_for_megatron(tensor_model_parallel_size=size, pipeline_model_parallel_size=1)
+    model = _moe_model_provider(tp_size=size)
+    prompt_tokens = torch.randint(0, model.vocab_size, (2, model.max_sequence_length)).cuda()
+
+    mtpeft.update_model(model, RANDOM_INIT_LORA_CFG)
+    model.train()
+
+    batch_size, seq_len = prompt_tokens.shape
+    attention_mask = (
+        torch.triu(torch.ones((batch_size, seq_len, seq_len), device=prompt_tokens.device), diagonal=1)
+        .bool()
+        .view(batch_size, 1, seq_len, seq_len)
+    )
+    output = model(prompt_tokens, position_ids=None, attention_mask=attention_mask)
+    output.sum().backward()
+
+    grouped_lora_param_names = []
+    for mod_name, _ in _grouped_lora_modules(model):
+        grouped_lora_param_names.append(mod_name)
+    assert grouped_lora_param_names, "no TE-grouped LoRA modules present"
+
+    saw_grouped_lora_grad = False
+    for name, param in model.named_parameters():
+        if "lora" in name and any(g in name for g in grouped_lora_param_names):
+            assert param.grad is not None, f"lora param {name} has no grad"
+            assert torch.any(param.grad != 0), f"lora param {name} grad is all zero"
+            saw_grouped_lora_grad = True
+        elif "lora" not in name:
+            # default freeze_base_model=True → base params should not have grads
+            assert param.grad is None, f"base param {name} unexpectedly got a grad"
+
+    assert saw_grouped_lora_grad, "no per-expert stacked LoRA param received a gradient"
+
+
+def test_gradient_flow(dist_workers):
+    dist_workers.run(_test_gradient_flow)

--- a/tests/gpu_megatron/torch/peft/plugins/test_megatron_moe_lora.py
+++ b/tests/gpu_megatron/torch/peft/plugins/test_megatron_moe_lora.py
@@ -196,7 +196,14 @@ def _test_gradient_flow(rank, size):
     prompt_tokens = torch.randint(0, model.vocab_size, (2, model.max_sequence_length)).cuda()
 
     mtpeft.update_model(model, RANDOM_INIT_LORA_CFG)
-    model.train()
+    # Intentionally keep the model in the eval mode set by _moe_model_provider.
+    # Megatron's MoELayer.forward asserts at moe_layer.py:616 when
+    # self.training AND attn_tp_group.size() > 1 AND not sequence_parallel --
+    # the test factory hardcodes sequence_parallel=False, and dist_workers
+    # runs at tp_size=4 here, so model.train() would raise before our LoRA
+    # forward dispatch is even reached. PyTorch autograd is mode-independent,
+    # so loss.backward() in eval mode still produces gradients on the LoRA
+    # factors and base weights as required by this test.
 
     batch_size, seq_len = prompt_tokens.shape
     attention_mask = (


### PR DESCRIPTION
Adds an optional dtype string ('bf16' | 'fp16' | 'fp32', with long-form aliases) that lets a LoRA adapter pin its factor dtype independent of the wrapped layer.

Motivation: for low-bit MoE QAD, the base layer's storage dtype can be fake-quantized (e.g. uint4/int4 stand-ins) while the LoRA sidecar must stay BF16. Today _register_adapter_with_device copies the parent's dtype onto LoRA factors, which is wrong in that regime. lora_dtype gives plugins an explicit override knob; None (default) preserves today's inherit-from-parent behavior.

Validator normalizes long forms to canonical short forms and rejects unsupported strings.

### What does this PR do?

Type of change: ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

<!-- Details about the change. -->

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->
