### PR TITLE
docs(eval skill): drop arch-specific cu130 nightly tag (release images are multi-arch)

### DIFF
--- a/.agents/skills/evaluation/SKILL.md
+++ b/.agents/skills/evaluation/SKILL.md
@@ -144,7 +144,7 @@ For how to choose `--tensor-parallel-size` / `--data-parallel-size` / `--pipelin
 
 **Image / vLLM version.** Default `image: vllm/vllm-openai:v0.19.1` (pinned for reproducibility). If `recipes.vllm.ai` states a higher minimum version for the chosen variant (e.g. "vLLM >= 0.20.0"), bump the image tag accordingly (e.g. `v0.20.0`) — do **not** stay on `0.19.1` when the recipe explicitly requires newer. Do **not** use `:latest` (drifts across re-runs, breaks reproducibility). The version is part of the cross-check: surface to the user when bumping.
 
-> **NVFP4 on Blackwell B300/GB300 (sm_103): append `-cu130` to the image tag** (e.g. `vllm/vllm-openai:v0.19.1-cu130` — release tags are multi-arch). The default cu12 build has no sm_103 FP4 kernel, so engine init dies with `CUDA error: no kernel image is available`. If a pinned release predates the model's arch, use `cu130-nightly-<arch>` (Qwen3.5-9B's `qwen3_5` needed it, vLLM 0.19.2rc1.dev134). Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`. Full note in `recipes/examples/example_eval.yaml`.
+> **NVFP4 on Blackwell B300/GB300 (sm_103): append `-cu130` to the image tag** (e.g. `vllm/vllm-openai:v0.19.1-cu130` — release tags are multi-arch). The default cu12 build has no sm_103 FP4 kernel, so engine init dies with `CUDA error: no kernel image is available`. Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`. Full note in `recipes/examples/example_eval.yaml`.
 
 #### vLLM-backend defaults — always include unless the recipe *contradicts*
 
@@ -297,7 +297,7 @@ Default images:
 | Framework | Image | Registry |
 | --- | --- | --- |
 | vLLM | `vllm/vllm-openai:v0.19.1` (bump per recipe; never `:latest`) | DockerHub |
-| vLLM (NVFP4 on B300/GB300) | `vllm/vllm-openai:v0.19.1-cu130` (bump to `cu130-nightly-<arch>` for new archs) | DockerHub |
+| vLLM (NVFP4 on B300/GB300) | `vllm/vllm-openai:v0.19.1-cu130` | DockerHub |
 | SGLang | `lmsysorg/sglang:latest` | DockerHub |
 | TRT-LLM | `nvcr.io/nvidia/tensorrt-llm/release:...` | NGC |
 | Eval tasks | `nvcr.io/nvidia/eval-factory/*:26.03` | NGC |

--- a/.agents/skills/evaluation/recipes/examples/example_eval.yaml
+++ b/.agents/skills/evaluation/recipes/examples/example_eval.yaml
@@ -82,8 +82,6 @@ deployment:
   # image tag — the default cu12 build has no sm_103 FP4 kernel, so the deploy
   # dies at engine init with CUDA "no kernel image is available". e.g.:
   #   image: vllm/vllm-openai:v0.19.1-cu130
-  # If a pinned release predates your model's arch, use the nightly instead
-  # (Qwen3.5-9B's qwen3_5 needed vllm/vllm-openai:cu130-nightly-x86_64, 0.19.2rc1.dev134).
   # Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`
   # (ViT flash-attn workaround; drop if the encoder loads without it).
   #


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Documentation (agent skill)

**Overview:** vLLM release image tags (e.g. `vllm/vllm-openai:v0.19.1-cu130`) are multi-arch, so users should not pin an architecture themselves. This removes the `cu130-nightly-<arch>` / `cu130-nightly-x86_64` fallback guidance from the evaluation skill:

- Step 3 "Image / vLLM version" NVFP4-on-Blackwell note
- Step 7.5 default-images table row
- `recipes/examples/example_eval.yaml` deployment comment

The `-cu130` tag itself (required for sm_103 FP4 kernels on B300/GB300) is kept — only the redundant per-arch suffix guidance is dropped.

## Usage

N/A — docs only.

## Testing

`pre-commit run` (markdownlint, yaml) passes on both changed files. No code paths affected.

## Before your PR is "Ready for review"

- [x] Make sure you read and follow Contributor guidelines and your commits are signed.
- [x] Is this change backward compatible?: Yes
- [ ] Did you write any new necessary tests?: N/A (docs)
- [x] Did you add or update any necessary documentation?: Yes
- [x] Did you update Changelog?: N/A (skill docs, not shipped library)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated container image configuration guidance for NVFP4-on-Blackwell hardware setups.
  * Simplified image tag recommendations and removed outdated fallback build instructions.
  * Clarified container registry authentication table with updated image variant information for improved setup clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->