### PR TITLE
docs(deployment skill): drop wrong "release predates arch" cu130 fallback

### DIFF
--- a/.agents/skills/deployment/SKILL.md
+++ b/.agents/skills/deployment/SKILL.md
@@ -130,9 +130,8 @@ For NVFP4 checkpoints, use `--quantization modelopt_fp4`.
 > default cu12 build has **no sm_103 FP4 kernel**, so vLLM loads the checkpoint
 > then dies at engine init with `CUDA error: no kernel image is available for
 > execution on the device` (affects the `flashinfer` and `cutlass` NVFP4
-> backends; `marlin` separately fails on non-64-divisible layer dims). If a
-> pinned release predates the model's arch, use `cu130-nightly-<arch>` instead
-> (Qwen3.5-9B's `qwen3_5` needed it). Cross-check via
+> backends; `marlin` separately fails on non-64-divisible layer dims).
+> Cross-check via
 > `recipes.vllm.ai/<org>/<model>?hardware=b300` (JS-rendered — fetch the raw
 > markdown at `github.com/vllm-project/recipes/blob/main/<org>/<model>.md`). For
 > multimodal models on sm_103, also pass `--mm-encoder-attn-backend TRITON_ATTN`


### PR DESCRIPTION
### What does this PR do?

**Type of change:** Documentation (agent skill)

Removes an incorrect fallback note from the **deployment** skill's NVFP4-on-Blackwell (sm_103) guidance. The note claimed:

> *If a pinned release predates the model's arch, use `cu130-nightly-<arch>` instead (Qwen3.5-9B's `qwen3_5` needed it).*

This is a wrong inference. I verified on a **B300** that the pinned release **`vllm/vllm-openai:v0.19.1-cu130`** loads and serves the Qwen3.5-9B NVFP4 checkpoint (`qwen3_5` / `Qwen3_5ForConditionalGeneration`) cleanly — `/health` 200, lists the model, generates. So the release does **not** predate `qwen3_5`; the only real requirement is the `-cu130` build (sm_103 FP4 kernels), which the note already states and this PR keeps.

This mirrors the same removal in the **evaluation** skill (#1649) — that PR didn't touch the deployment skill, so this is the companion one-liner.

### Testing

Empirical: served the checkpoint with `v0.19.1-cu130` on aws-pdx (B300) → engine init succeeds, `/v1/models` lists it, chat completion returns text. Docs-only change otherwise.

### Before your PR is "Ready for review"

- Is this change backward compatible?: ✅ (docs only)
- Did you write any new necessary tests?: N/A (docs)
- Did you add or update any necessary documentation?: ✅ (this is the doc fix)
- Did you update Changelog?: N/A (skill docs, not shipped library)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vLLM deployment instructions for NVFP4 on Blackwell, simplifying documentation by removing nightly release usage guidance and reorganizing the instruction flow for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->