### PR TITLE
[OMNIML-4969] cell_t0_d3

### DIFF
--- a/tools/launcher/common/specdec_bench/_cells/NVIDIA-Nemotron-3-Super-120B-A12B-BF16_dflash_vllm_t0_d3.yaml
+++ b/tools/launcher/common/specdec_bench/_cells/NVIDIA-Nemotron-3-Super-120B-A12B-BF16_dflash_vllm_t0_d3.yaml
@@ -1,0 +1,5 @@
+sampling_kwargs:
+  temperature: 0
+engine_args:
+  max_model_len: 40960
+  num_speculative_tokens: 3

--- a/tools/launcher/examples/nemotron-3/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/specdec_bench_dflash_vllm_t0_d3.yaml
+++ b/tools/launcher/examples/nemotron-3/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/specdec_bench_dflash_vllm_t0_d3.yaml
@@ -1,0 +1,69 @@
+# SPEED-bench DFlash speculative-decoding run for NVIDIA-Nemotron-3-Super-120B-A12B-BF16 via vLLM.
+#
+# Slurm run on cw_dfw:
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/nemotron-3/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/specdec_bench_dflash_vllm_t0_d3.yaml --yes
+
+job_name: NVIDIA-Nemotron-3-Super-120B-A12B-BF16_specdec_bench_dflash_vllm_t0_d3
+
+pipeline:
+  global_vars:
+    hf_model: /hf-local/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+
+  # task_0: SPEED qualitative split
+  task_0:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/qualitative
+      - --engine VLLM
+      - --speculative_algorithm DFLASH
+      - --draft_length 3
+      - --runtime_params common/specdec_bench/_cells/NVIDIA-Nemotron-3-Super-120B-A12B-BF16_dflash_vllm_t0_d3.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 32
+      - --output_length 4096
+      - --block_size 3
+      - --trust_remote_code
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/NVIDIA-Nemotron-3-Super-120B-A12B-BF16_dflash_vllm_t0_d3/qualitative
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130
+
+  # task_1: SPEED throughput_32k split
+  task_1:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/throughput_32k
+      - --engine VLLM
+      - --speculative_algorithm DFLASH
+      - --draft_length 3
+      - --runtime_params common/specdec_bench/_cells/NVIDIA-Nemotron-3-Super-120B-A12B-BF16_dflash_vllm_t0_d3.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 8
+      - --num_requests 80
+      - --output_length 4096
+      - --block_size 3
+      - --trust_remote_code
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/NVIDIA-Nemotron-3-Super-120B-A12B-BF16_dflash_vllm_t0_d3/throughput_32k
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-4969](https://jirasw.nvidia.com/browse/OMNIML-4969).

Stage `cell_t0_d3` of Epic `OMNIML-4967`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._

---

**Agent's self-narration** (stripped from PR diff; surfaced here for context):

`VERIFICATION_COMMENT.txt`:
```
SPEED-bench cell run failed repeatedly on cw_dfw. Latest experiment cicd_1780969016 (jobs 12660637/12660638) failed with vLLM SpeculativeConfig validation: method 'dflash' is not supported by vllm/vllm-openai:qwen3_5-cu130 (expected methods list excludes dflash). Earlier failures: lowercase dflash CLI validation, missing speculative_num_draft_tokens (block_size), and trust_remote_code requirement. No specbench_results.json produced, so INTERN_ARTIFACTS.json not written.
```



_Pollution-strip removed `VERIFICATION_COMMENT.txt` from this commit (sidecar narration and/or incidental lockfile regeneration are never part of the agent's intended deliverable)._