### PR TITLE
Fix chat_template handling in get_dataset_dataloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Model Optimizer is also integrated with [NVIDIA Megatron-Bridge](https://github.
 
 ## Latest News
 
-- [2026/05/27] [**End-to-end Minitron workflow for Nemotron-3-Nano-30B-A3B**](./examples/megatron_bridge/tutorials/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16): Pruning + two-phase distillation + FP8 quantization achieving 2.6× vLLM throughput and 2.6× memory reduction.
+- [2026/05/27] [**End-to-end optimization tutorial for Nemotron-3-Nano-30B-A3B**](./examples/megatron_bridge/tutorials/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16): Pruning + distillation (with long context extension) + FP8 quantization achieving 2.6× vLLM throughput and 2.6× memory reduction.
 - [2026/05/13] [**Puzzletron**](./examples/puzzletron): A new algorithm for heterogeneous pruning & NAS of LLM and VLM models.
 - [2026/04/15] Customer story: [Domyn compresses Colosseum-355B → 260B using ModelOpt's Minitron pruning + distillation](https://www.domyn.com/blog/domyn-large-the-journey-of-a-european-sovereign-ai-model-for-regulated-industries)
 - [2026/03/17] Customer story: [Bielik.AI builds Bielik Minitron 7B (33% smaller, 50% faster, 90% quality retained) using ModelOpt's Minitron pruning + distillation](https://bielik.ai/en/nvidia-gtc-bielik-minitron-premiere/)

--- a/modelopt/torch/utils/dataset_utils.py
+++ b/modelopt/torch/utils/dataset_utils.py
@@ -22,7 +22,7 @@ import random
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager, suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import requests
 import torch
@@ -34,9 +34,102 @@ from .logging import print_rank_0, warn_rank_0
 if TYPE_CHECKING:
     from transformers import PreTrainedTokenizerBase
 
+ReasoningContentMode = Literal["strip", "inline", "native"]
+REASONING_CONTENT_MODES: frozenset[ReasoningContentMode] = frozenset(("strip", "inline", "native"))
+
 
 def _join_messages_content(sample: dict) -> str:
     return "\n".join(turn["content"] for turn in sample["messages"])
+
+
+def _fix_tool_call_arguments(args: Any) -> dict:
+    """Ensure tool_call.arguments is a dict for Jinja2 ``|items`` compatibility."""
+    if isinstance(args, dict):
+        return args
+    if isinstance(args, str):
+        try:
+            parsed = json.loads(args)
+            return parsed if isinstance(parsed, dict) else {}
+        except (json.JSONDecodeError, TypeError):
+            return {}
+    return {}
+
+
+def prepare_messages_for_chat_template(
+    messages: list[dict],
+    *,
+    reasoning_content: ReasoningContentMode = "strip",
+    normalize_tool_calls: bool = True,
+) -> list[dict]:
+    """Prepare OpenAI-style messages before ``apply_chat_template``.
+
+    Args:
+        messages: Conversation turns.
+        reasoning_content: How to handle ``reasoning_content`` on assistant turns:
+            ``"strip"`` (default) removes the field, ``"inline"`` prepends a
+            ``<think>…</think>`` block to ``content``, and
+            ``"native"`` leaves the field intact for the tokenizer chat template.
+        normalize_tool_calls: Parse JSON-string ``tool_calls`` arguments to dicts
+            so Nemotron v3 chat templates can iterate them with Jinja2 ``|items``.
+    """
+    if reasoning_content not in REASONING_CONTENT_MODES:
+        raise ValueError(
+            f"reasoning_content must be one of {sorted(REASONING_CONTENT_MODES)!r}, "
+            f"got {reasoning_content!r}."
+        )
+    if reasoning_content == "native" and not normalize_tool_calls:
+        return messages
+
+    processed: list[dict] = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            processed.append(msg)
+            continue
+        has_tool_calls = "tool_calls" in msg and isinstance(msg.get("tool_calls"), list)
+        needs_copy = (reasoning_content != "native" and "reasoning_content" in msg) or (
+            normalize_tool_calls and has_tool_calls
+        )
+        if not needs_copy:
+            processed.append(msg)
+            continue
+        msg = dict(msg)
+        if reasoning_content != "native":
+            rc = msg.pop("reasoning_content", None)
+            if reasoning_content == "inline" and rc:
+                msg["content"] = f"<think>\n{rc}\n</think>\n{msg.get('content', '')}"
+        if normalize_tool_calls and has_tool_calls:
+            fixed_tool_calls = []
+            for tc in msg["tool_calls"]:
+                if not isinstance(tc, dict):
+                    fixed_tool_calls.append(tc)
+                    continue
+                tc = dict(tc)
+                if "arguments" in tc and not isinstance(tc["arguments"], dict):
+                    tc["arguments"] = _fix_tool_call_arguments(tc["arguments"])
+                if isinstance(tc.get("function"), dict):
+                    fn = dict(tc["function"])
+                    if "arguments" in fn and not isinstance(fn["arguments"], dict):
+                        fn["arguments"] = _fix_tool_call_arguments(fn["arguments"])
+                    tc["function"] = fn
+                fixed_tool_calls.append(tc)
+            msg["tool_calls"] = fixed_tool_calls
+        processed.append(msg)
+    return processed
+
+
+def _apply_chat_template_to_messages(
+    tokenizer: "PreTrainedTokenizerBase",
+    messages: list[dict],
+    *,
+    tools: Any | None = None,
+) -> str:
+    kwargs: dict[str, Any] = {}
+    if tools is not None:
+        kwargs["tools"] = tools
+    prepared = prepare_messages_for_chat_template(
+        messages, reasoning_content="native", normalize_tool_calls=True
+    )
+    return tokenizer.apply_chat_template(prepared, tokenize=False, **kwargs)
 
 
 # Use dict to store the config for each dataset.
@@ -236,6 +329,8 @@ def _validate_dataset_combos() -> None:
 _validate_dataset_combos()
 
 __all__ = [
+    "REASONING_CONTENT_MODES",
+    "ReasoningContentMode",
     "create_forward_loop",
     "download_hf_dataset_as_jsonl",
     "get_dataset_dataloader",
@@ -243,6 +338,7 @@ __all__ = [
     "get_jsonl_text_samples",
     "get_max_batch_size",
     "get_supported_datasets",
+    "prepare_messages_for_chat_template",
 ]
 
 
@@ -318,11 +414,9 @@ def _auto_preprocess_sample(
                 f"Dataset '{dataset_name}' has a '{chat_key}' column but no tokenizer with "
                 "apply_chat_template was provided."
             )
-        kwargs: dict[str, Any] = {}
-        tools = sample.get("tools")
-        if tools is not None:
-            kwargs["tools"] = tools
-        return tokenizer.apply_chat_template(sample[chat_key], tokenize=False, **kwargs)
+        return _apply_chat_template_to_messages(
+            tokenizer, sample[chat_key], tools=sample.get("tools")
+        )
 
     if _has_non_null_value("prompt"):
         parts = [sample["prompt"]]
@@ -457,12 +551,8 @@ def get_dataset_samples(
 
         def _preprocess(sample: dict) -> str:
             if apply_chat_template and "chat_key" in dataset_config:
-                kwargs: dict[str, Any] = {}
-                tools = sample.get("tools")
-                if tools is not None:
-                    kwargs["tools"] = tools
-                return tokenizer.apply_chat_template(  # type: ignore[union-attr]
-                    sample[dataset_config["chat_key"]], tokenize=False, **kwargs
+                return _apply_chat_template_to_messages(
+                    tokenizer, sample[dataset_config["chat_key"]], tools=sample.get("tools")
                 )
             return dataset_config["preprocess"](sample)
 

--- a/modelopt/torch/utils/dataset_utils.py
+++ b/modelopt/torch/utils/dataset_utils.py
@@ -211,6 +211,12 @@ SUPPORTED_DATASET_CONFIG: dict[str, Any] = {
             "path": "nvidia/Nemotron-SFT-Agentic-v2",
             "split": ["search"],
         },
+        # ``datasets>=4`` strictly casts each JSONL chunk to the repo's declared
+        # ``dataset_info`` features, which don't match the raw rows (extra ``uuid`` /
+        # ``used_in`` columns, different ``metadata`` / ``tools`` structs) -> ``CastError``.
+        # Reading the raw files through the generic ``json`` builder infers the schema
+        # from the actual data and sidesteps the cast.  ``{split}`` is substituted per split.
+        "data_files": "data/{split}*.jsonl",
         "preprocess": _join_messages_content,
         "chat_key": "messages",
     },
@@ -531,11 +537,19 @@ def get_dataset_samples(
 
     is_registered = not is_jsonl and dataset_name in SUPPORTED_DATASET_CONFIG
 
+    # Optional per-dataset ``data_files`` template (e.g. ``"data/{split}*.jsonl"``).  When
+    # set, the split is loaded from the repo's raw files via the generic ``json`` builder
+    # instead of the declared ``dataset_info`` schema, sidestepping ``datasets>=4`` casts.
+    # Only applies to remote registered datasets (not local-path overrides).
+    data_files_tmpl: str | None = None
+
     if is_registered:
         dataset_config = SUPPORTED_DATASET_CONFIG[dataset_name]
         config = dataset_config["config"].copy()
         if local_dataset_path:
             config["path"] = local_dataset_path
+        else:
+            data_files_tmpl = dataset_config.get("data_files")
         splits = requested_splits if requested_splits is not None else config.pop("split", [None])
         if split is not None:
             config.pop("split", None)
@@ -597,9 +611,22 @@ def get_dataset_samples(
         pass
 
     # load_dataset does not support a list of splits while streaming, so load each separately.
-    print_rank_0(f"Loading dataset with {config=} and {splits=}")
+    print_rank_0(f"Loading dataset with {config=} and {splits=} {data_files_tmpl=}")
+
+    def _load_split(s: str):
+        if data_files_tmpl:
+            # Raw files via the ``json`` builder: schema is inferred from data, and the
+            # file-based builder labels everything as the ``train`` split.
+            return load_dataset(
+                config["path"],
+                data_files=data_files_tmpl.format(split=s),
+                split="train",
+                streaming=True,
+            )
+        return load_dataset(streaming=True, **config, split=s)
+
     try:
-        dataset_splits = [load_dataset(streaming=True, **config, split=s) for s in splits]
+        dataset_splits = [_load_split(s) for s in splits]
 
         num_per_split = [num_samples // len(dataset_splits)] * len(dataset_splits)
         num_per_split[-1] += num_samples - sum(num_per_split)

--- a/modelopt/torch/utils/plugins/megatron_preprocess_data.py
+++ b/modelopt/torch/utils/plugins/megatron_preprocess_data.py
@@ -95,7 +95,12 @@ from datasets import get_dataset_config_names, get_dataset_split_names, load_dat
 from megatron.core.datasets import indexed_dataset
 from transformers import AutoTokenizer
 
-from modelopt.torch.utils import num2hrb
+from modelopt.torch.utils import (
+    REASONING_CONTENT_MODES,
+    ReasoningContentMode,
+    num2hrb,
+    prepare_messages_for_chat_template,
+)
 
 __all__ = ["megatron_preprocess_data"]
 
@@ -121,7 +126,7 @@ class _Encoder:
         json_keys: list[str],
         append_eod: bool,
         max_sequence_length: int | None,
-        reasoning_content: str = "strip",
+        reasoning_content: ReasoningContentMode = "strip",
         strip_newlines: bool = False,
     ):
         self.tokenizer_name_or_path = tokenizer_name_or_path
@@ -159,53 +164,11 @@ class _Encoder:
         - ``"native"``: pass messages unchanged; the tokenizer's chat template must
           handle ``reasoning_content`` itself (e.g. Qwen3).
         """
-        if self.reasoning_content == "native":
-            return messages
-
-        def _fix_arguments(args):
-            """Ensure tool_call.arguments is a dict for Jinja2 |items compatibility."""
-            if isinstance(args, dict):
-                return args
-            if isinstance(args, str):
-                try:
-                    parsed = json.loads(args)
-                    return parsed if isinstance(parsed, dict) else {}
-                except (json.JSONDecodeError, TypeError):
-                    return {}
-            return {}
-
-        processed = []
-        for msg in messages:
-            has_tool_calls = "tool_calls" in msg and isinstance(msg.get("tool_calls"), list)
-            needs_copy = "reasoning_content" in msg or has_tool_calls
-            if not needs_copy:
-                processed.append(msg)
-                continue
-            msg = dict(msg)  # shallow copy — don't mutate the original
-            rc = msg.pop("reasoning_content", None)
-            if self.reasoning_content == "inline" and rc:
-                msg["content"] = f"<think>\n{rc}\n</think>\n{msg.get('content', '')}"
-            # Always normalize tool_call.arguments to dict so Jinja2 |items doesn't crash.
-            # The Nemotron v3 chat template reassigns tool_call = tool_call.function when
-            # the nested OpenAI format is used, so we fix both the direct and nested levels.
-            if has_tool_calls:
-                fixed_tool_calls = []
-                for tc in msg["tool_calls"]:
-                    if not isinstance(tc, dict):
-                        fixed_tool_calls.append(tc)
-                        continue
-                    tc = dict(tc)
-                    if "arguments" in tc and not isinstance(tc["arguments"], dict):
-                        tc["arguments"] = _fix_arguments(tc["arguments"])
-                    if isinstance(tc.get("function"), dict):
-                        fn = dict(tc["function"])
-                        if "arguments" in fn and not isinstance(fn["arguments"], dict):
-                            fn["arguments"] = _fix_arguments(fn["arguments"])
-                        tc["function"] = fn
-                    fixed_tool_calls.append(tc)
-                msg["tool_calls"] = fixed_tool_calls
-            processed.append(msg)
-        return processed
+        return prepare_messages_for_chat_template(
+            messages,
+            reasoning_content=self.reasoning_content,
+            normalize_tool_calls=self.reasoning_content != "native",
+        )
 
     def encode(self, json_line: str):
         try:
@@ -489,7 +452,7 @@ def megatron_preprocess_data(
     max_sequence_length: int | None = None,
     workers: int = 1,
     log_interval: int = 100000,
-    reasoning_content: str = "strip",
+    reasoning_content: ReasoningContentMode = "strip",
     strip_newlines: bool = False,
 ):
     """Process large data for pretraining.
@@ -658,7 +621,7 @@ def main():
         "--reasoning_content",
         type=str,
         default="strip",
-        choices=["strip", "inline", "native"],
+        choices=sorted(REASONING_CONTENT_MODES),
         help=(
             "How to handle the reasoning_content field in Nemotron v3 datasets. "
             "'strip': discard (default, safe for any tokenizer). "

--- a/tests/gpu/torch/utils/test_dataset_utils.py
+++ b/tests/gpu/torch/utils/test_dataset_utils.py
@@ -24,12 +24,52 @@ import json
 import pytest
 from datasets import load_dataset
 from huggingface_hub import get_token
+from transformers import AutoTokenizer
 
 from modelopt.torch.utils.dataset_utils import (
-    SUPPORTED_DATASET_CONFIG,
+    DATASET_COMBOS,
     get_dataset_dataloader,
     get_dataset_samples,
 )
+
+
+@pytest.fixture(scope="module")
+def qwen3_tokenizer():
+    tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B")
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    tokenizer.padding_side = "left"
+    return tokenizer
+
+
+def test_get_dataset_dataloader_nemotron_v3_chat_template(qwen3_tokenizer):
+    if not get_token():
+        pytest.skip(
+            "No HF token (env HF_TOKEN or `hf auth login`); skipping gated Nemotron smoke test"
+        )
+
+    num_samples = len(DATASET_COMBOS["nemotron-post-training-v3"]) * 2
+    seq_length = 32
+    loader = get_dataset_dataloader(
+        dataset_name="nemotron-post-training-v3",
+        tokenizer=qwen3_tokenizer,
+        batch_size=2,
+        num_samples=num_samples,
+        max_sample_length=seq_length,
+        apply_chat_template=True,
+    )
+    batches = list(loader)
+    assert batches
+    total_rows = sum(batch["input_ids"].shape[0] for batch in batches)
+    assert total_rows == num_samples
+    assert all(batch["input_ids"].shape[1] == seq_length for batch in batches)
+    assert all(batch["attention_mask"].shape == batch["input_ids"].shape for batch in batches)
+
+
+# Live HF dataset round-trips. ``hf-internal-testing/dataset_with_data_files`` is a
+# 10-row x {train,test} fixture maintained by HF for their own CI — tiny enough to
+# download in a test and stable across releases, and ungated (no HF token needed).
+_HF_TINY = "hf-internal-testing/dataset_with_data_files"  # train, test splits, ``text`` col
 
 
 def _write_jsonl(path, rows):
@@ -37,72 +77,6 @@ def _write_jsonl(path, rows):
     with open(path, "w", encoding="utf-8") as f:
         f.writelines(json.dumps(row) + "\n" for row in rows)
     return str(path)
-
-
-_NEW_NEMOTRON_KEYS = [
-    "nemotron-sft-instruction-following-chat-v2",
-    "nemotron-science-v1",
-    "nemotron-competitive-programming-v1",
-    "nemotron-sft-agentic-v2",
-    "nemotron-math-v2",
-    "nemotron-sft-swe-v2",
-    "nemotron-sft-multilingual-v1",
-]
-
-
-@pytest.mark.parametrize("dataset_key", _NEW_NEMOTRON_KEYS)
-def test_new_nemotron_registry_shape(dataset_key):
-    """Shape check on the 7 newly registered nvidia/Nemotron-* entries.
-
-    Complements the gated smoke test below — catches typos in dataset paths or
-    split names even when the runner has no HF credentials.
-    """
-    assert dataset_key in SUPPORTED_DATASET_CONFIG
-    entry = SUPPORTED_DATASET_CONFIG[dataset_key]
-    config = entry["config"]
-    assert config["path"].startswith("nvidia/Nemotron-")
-    splits = config["split"]
-    assert isinstance(splits, list) and splits
-    assert all(isinstance(s, str) and s for s in splits)
-    assert len(set(splits)) == len(splits)
-    assert callable(entry["preprocess"])
-    assert entry["chat_key"] == "messages"
-
-
-@pytest.mark.parametrize(
-    "dataset_key",
-    [
-        # nvidia/Nemotron-SFT-Agentic-v2's ``search`` split currently fails the HF datasets
-        # JSON schema cast (upstream column drift), so skip its live download smoke; the
-        # registry shape check above still validates its configuration.
-        pytest.param(k, marks=pytest.mark.skip(reason="upstream search-split schema cast failure"))
-        if k == "nemotron-sft-agentic-v2"
-        else k
-        for k in _NEW_NEMOTRON_KEYS
-    ],
-)
-def test_get_dataset_samples_new_nemotron(dataset_key):
-    """Smoke-test the 7 newly registered nvidia/Nemotron-* calibration datasets.
-
-    Skipped when no HF token is available because these datasets live behind the HF Hub.
-    ``huggingface_hub.get_token()`` covers both the ``HF_TOKEN`` env var and tokens
-    cached by ``hf auth login``.
-    """
-    if not get_token():
-        pytest.skip(
-            "No HF token (env HF_TOKEN or `hf auth login`); skipping gated Nemotron smoke test"
-        )
-
-    samples = get_dataset_samples(dataset_key, num_samples=2)
-    assert isinstance(samples, list)
-    assert len(samples) == 2
-    assert all(isinstance(s, str) and len(s) > 0 for s in samples)
-
-
-# Live HF dataset round-trips. ``hf-internal-testing/dataset_with_data_files`` is a
-# 10-row x {train,test} fixture maintained by HF for their own CI — tiny enough to
-# download in a test and stable across releases, and ungated (no HF token needed).
-_HF_TINY = "hf-internal-testing/dataset_with_data_files"  # train, test splits, ``text`` col
 
 
 def _hf_dump_to_jsonl(name: str, split: str, path) -> str:

--- a/tests/unit/torch/utils/test_dataset_utils.py
+++ b/tests/unit/torch/utils/test_dataset_utils.py
@@ -30,7 +30,32 @@ from modelopt.torch.utils.dataset_utils import (
     get_dataset_dataloader,
     get_dataset_samples,
     get_max_batch_size,
+    prepare_messages_for_chat_template,
 )
+
+
+def test_prepare_messages_for_chat_template():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_content": "think",
+            "tool_calls": [
+                {"function": {"name": "search", "arguments": '{"q": "x"}'}},
+            ],
+        },
+    ]
+    prepared = prepare_messages_for_chat_template(
+        messages, reasoning_content="native", normalize_tool_calls=True
+    )
+    assert prepared[0]["reasoning_content"] == "think"
+    assert prepared[0]["tool_calls"][0]["function"]["arguments"] == {"q": "x"}
+    assert (
+        prepare_messages_for_chat_template(
+            messages, reasoning_content="native", normalize_tool_calls=False
+        )
+        is messages
+    )
 
 
 def setup_test_data():


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fixes `apply_chat_template` failures when loading `nemotron-sft-agentic-v2` with Nemotron3 Nano tokenizer.

HF agentic datasets store OpenAI-style `tool_calls` with `function.arguments` as JSON **strings**, but Nemotron v3 chat templates iterate `tool_call.arguments|items` in Jinja2, which requires a **mapping**. That mismatch raised:

```
TypeError: Can only get item pairs from a mapping.
```

This PR:

- Adds shared `prepare_messages_for_chat_template()` in `modelopt.torch.utils.dataset_utils` to normalize string tool-call arguments to dicts (including both nested `function.arguments` and top-level `arguments`).
- Routes `get_dataset_samples` / `get_dataset_dataloader` chat-template paths through the helper with `reasoning_content="native"` and `normalize_tool_calls=True`, preserving `reasoning_content` for tokenizers that handle it natively while fixing tool calls.
- Refactors `megatron_preprocess_data._process_messages` to delegate to the same helper (no behavior change: `strip`/`inline` still handle reasoning; `native` still returns messages unchanged without tool-call normalization).
- Consolidates tests: hermetic logic stays in unit tests; one live GPU integration test covers the v3 calibration path.

### Testing

- New e2e tests added to replace previous simpler tests
- Manual verification (Nemotron 3 Nano tokenizer + `nemotron-sft-agentic-v2`):

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: Not yet <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information

Root cause: Nemotron v3 Jinja chat templates use `tool_call.arguments|items`; OpenAI-format dataset rows store arguments as JSON strings.

Related prior art in-repo: `megatron_preprocess_data` already normalized tool-call arguments inline; this PR deduplicates that logic into `prepare_messages_for_chat_template`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added utilities to prepare OpenAI-style chat messages with configurable reasoning-content handling (strip/inline/native).
  * Normalized tool-call arguments so tool inputs (including JSON strings) are handled consistently.

* **Refactor**
  * Unified chat-template preprocessing across auto-detected and registered chat datasets; remote dataset loading now supports a configurable data-files template for streaming.

* **Tests**
  * Added unit and integration tests covering reasoning-content prep and chat-template dataloader behavior.

* **Documentation**
  * Updated README news entry to reflect a Nemotron-3 optimization tutorial.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->