### PR TITLE
[OMNIML-4998] Per-expert weight quantization on TEGroupedLinear

### DIFF
--- a/modelopt/torch/kernels/quantization/gemm/VALIDATION_TODO.md
+++ b/modelopt/torch/kernels/quantization/gemm/VALIDATION_TODO.md
@@ -1,0 +1,80 @@
+# OMNIML-5072 Option B — Triton kernel validation record
+
+**Status: VALIDATED 2026-06-12.** Kernel lives at `grouped_axis0_fakequant.py`,
+wired into `te_grouped_quantized_linear_fn` via `_GroupedAxis0FakeQuantFn`.
+
+## Validation summary
+
+### 1. Numerical fidelity
+
+Compared `grouped_axis0_fakequant(weights, amax)` against per-expert
+`cuda_ext.fake_tensor_quant(w_i, amax_i)` (A's path) at the Ultra production
+shape (N=32, [5120, 8192] bfloat16). See
+`nmm-sandbox/studies/omniml-5064/microbench/parity_a_vs_btriton.py`.
+
+```
+Check                              max_abs_err   Notes
+─────────────────────────────────  ───────────   ─────────────────────────────
+forward output                     0.03125       = 1 ULP at this quant scale
+                                                 (rounding mode: Triton does
+                                                 round-half-away, cuda_ext does
+                                                 round-half-to-even; differs only
+                                                 on exact half-step boundaries)
+backward grad (pass_through_bwd)   0.0           bit-exact identical to A
+```
+
+### 2. Bench (OMNIML-5064 microbench, B300, aws-cmh)
+
+Btriton beats A on every column at every cell:
+
+```
+Cell             impl      fwd_us    bwd_us    step_us    Notes
+───────────────────────────────────────────────────────────────────────────────
+Nano   EP=1      A         20,221     5,807    27,422
+                 Btriton    2,670     3,591     7,472     fwd 7.6× win
+Super  EP=1      A         57,736    17,736    84,289
+                 Btriton    9,584    14,923    33,242     fwd 6.0× win
+Ultra  mock16    A          5,835       547     8,246
+                 Btriton    1,795       549     4,210     fwd 3.25× win; bwd tied
+Nano   EP=4      A          3,985     1,340     5,693
+                 Btriton    1,208     1,221     2,815     fwd 3.30× win
+Super  EP=4      A         14,094     4,187    20,576
+                 Btriton    2,110     3,326     7,710     fwd 6.68× win
+Ultra  EP=4      A         23,178     2,064    32,686
+                 Btriton    6,730     2,059    16,220     fwd 3.44× win
+Ultra  EP=8      A         11,695     1,070    16,482     2-node
+                 Btriton    3,515     1,075     8,314     fwd 3.33× win
+```
+
+### 3. Distributed validation
+
+- ✓ EP=1 single-rank (mock-EP=16 emulation of EP=16 deployment)
+- ✓ EP=4 single-node 4-rank (Nano / Super / Ultra)
+- ✓ EP=8 multi-node 2-node 8-rank (Ultra)
+- `peak_mb` matches A's within 3 MB across cells (same layer instantiation
+  signal)
+
+### 4. Hardware coverage
+
+Tested on B300 (compute 10.0+, aws-cmh). The kernel uses no SM-specific
+intrinsics (no MMA, no async copy, no tensor cores) — pure load/store +
+arithmetic in `triton.language`. Should compile and run on any GPU where
+`torch.cuda.is_available()` returns True and Triton is installed; the
+`IS_AVAILABLE` guard in `__init__.py` skips it otherwise.
+
+## Design notes
+
+The kernel takes N expert weights as a `[N]` int64 tensor of base pointers
+(via each tensor's `.data_ptr()`). Each Triton program reads its expert's
+pointer, then strides through a block of elements. Grid: `(N, num_blocks_per_expert)`.
+This eliminates the `torch.stack` memcopy on the forward path (~2.7 GB at
+Ultra scale).
+
+Backward honors modelopt's `pass_through_bwd` flag (`config.py` default
+`True`). When set, the backward returns `grad_outputs` unchanged with zero
+kernel launches — matching `_fake_quant_backward_function`'s no-save
+behavior. When `False`, the clip-aware STE Triton backward kernel runs.
+
+Soft-gated at the call site in `te_grouped_quantized_linear_fn`: falls back
+to the stack-then-quant-then-unbind path when the Triton kernels aren't
+available or when calibration is active (`q._if_calib`).

--- a/modelopt/torch/kernels/quantization/gemm/__init__.py
+++ b/modelopt/torch/kernels/quantization/gemm/__init__.py
@@ -38,4 +38,8 @@ if torch.cuda.is_available():
         if torch.cuda.get_device_capability() >= (8, 9):
             from .fp4_kernel_hopper import *
 
+        # OMNIML-5072 Option B — per-expert axis-0 fake-quant via tensor-of-pointers.
+        # Generic Triton + CUDA; no special hardware. See VALIDATION_TODO.md.
+        from .grouped_axis0_fakequant import *
+
         IS_AVAILABLE = True

--- a/modelopt/torch/kernels/quantization/gemm/grouped_axis0_fakequant.py
+++ b/modelopt/torch/kernels/quantization/gemm/grouped_axis0_fakequant.py
@@ -1,0 +1,258 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fused per-expert axis-0 fake-quant Triton kernels for TEGroupedLinear.
+
+Replaces the stack-then-quantize-then-unbind pattern in modelopt's TEGrouped
+plugin (`te_grouped_quantized_linear_fn`) with a single Triton launch that
+processes N expert weights in place, with no contiguous-tensor staging.
+
+Design — tensor of pointers
+---------------------------
+
+The N expert weights live as separate Parameters (one per expert), so they're
+NOT contiguous in HBM. To avoid a `torch.stack` memcopy (the cost AC5
+characterized on OMNIML-5064), we feed the kernel a `[N]` int64 tensor of
+expert base pointers. Each Triton program reads its expert's pointer first,
+then strides through a block of elements at that address.
+
+Grid: (N, num_blocks_per_expert).
+Program 0 of axis 0 → expert 0, program 1 → expert 1, etc.
+
+See OMNIML-5072 AC5 (Option B follow-up) for the motivation.
+
+VALIDATION STATUS (2026-06-11): kernel implemented, numerical fidelity NOT
+yet validated against modelopt's reference `fake_quant_impl`, and bench
+performance NOT yet measured. See VALIDATION_TODO.md in this directory.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+__all__ = ["grouped_axis0_fakequant", "grouped_axis0_fakequant_backward"]
+
+
+def _torch_dtype_to_tl(dtype: torch.dtype):
+    """Map a torch dtype to its Triton-language equivalent."""
+    return {
+        torch.float32: tl.float32,
+        torch.bfloat16: tl.bfloat16,
+        torch.float16: tl.float16,
+    }[dtype]
+
+
+@triton.jit
+def _grouped_axis0_fakequant_fwd_kernel(
+    weight_ptrs_buf,    # int64 [N]  — N expert base pointers (cast from .data_ptr())
+    output_ptrs_buf,    # int64 [N]  — N output base pointers
+    amax_vec_ptr,       # [N, 1, 1] (or anything with N as the leading dim)
+    elements_per_expert,
+    num_bits,
+    narrow_range: tl.constexpr,
+    DTYPE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    expert_idx = tl.program_id(axis=0)
+    block_idx = tl.program_id(axis=1)
+
+    # Per-expert base pointers (loaded once per program).
+    w_int = tl.load(weight_ptrs_buf + expert_idx)
+    out_int = tl.load(output_ptrs_buf + expert_idx)
+    w_ptr = w_int.to(tl.pointer_type(DTYPE))
+    out_ptr = out_int.to(tl.pointer_type(DTYPE))
+
+    # Per-expert amax → quant scale.
+    # amax is stored as fp32; convert to working precision.
+    amax = tl.load(amax_vec_ptr + expert_idx).to(tl.float32)
+    # qmax = 2^(num_bits-1) - 1 when narrow_range else 2^(num_bits-1)
+    # For num_bits=8 narrow_range=True (modelopt default): qmax=127
+    qmax = ((1 << (num_bits - 1)) - 1) if narrow_range else (1 << (num_bits - 1))
+    qmin = -qmax if narrow_range else -qmax  # signed symmetric
+    scale = amax / qmax
+
+    # Block of elements within this expert.
+    offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < elements_per_expert
+
+    x = tl.load(w_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+
+    # Fake-quant: round(clip(x / scale)) * scale.
+    # Use scale guards to avoid div-by-zero before _amax is calibrated (early
+    # batches may carry an _amax of 0; matches modelopt's fake_tensor_quant
+    # behavior of passing through unchanged).
+    safe_scale = tl.where(scale > 0.0, scale, 1.0)
+    q = x / safe_scale
+    q = tl.maximum(tl.minimum(q, qmax), qmin)
+    # Round-half-away-from-zero via add-half-and-truncate. For bfloat16 inputs
+    # the half-tie case is rare and the difference vs round-half-to-even is
+    # negligible for fake-quant. Avoids libdevice dependency (nearbyint /
+    # rint are not consistently exposed across Triton versions).
+    half_sign = tl.where(q >= 0.0, 0.5, -0.5)
+    q_rounded = (q + half_sign).to(tl.int32).to(tl.float32)
+    out = tl.where(scale > 0.0, q_rounded * scale, x)
+
+    tl.store(out_ptr + offsets, out.to(DTYPE), mask=mask)
+
+
+@triton.jit
+def _grouped_axis0_fakequant_bwd_kernel(
+    weight_ptrs_buf,    # int64 [N]  — same buffer as fwd
+    grad_out_ptrs_buf,  # int64 [N]  — upstream grad pointers (per expert)
+    grad_in_ptrs_buf,   # int64 [N]  — output: downstream grad pointers
+    amax_vec_ptr,       # [N, ...]   — same buffer as fwd
+    elements_per_expert,
+    DTYPE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Clip-aware STE backward.
+
+    For each expert i:
+        grad_in[i] = grad_out[i] if |w[i]| <= amax[i] else 0
+    matches modelopt's `_fake_tensor_quant_backward` semantics.
+    """
+    expert_idx = tl.program_id(axis=0)
+    block_idx = tl.program_id(axis=1)
+
+    w_ptr = tl.load(weight_ptrs_buf + expert_idx).to(tl.pointer_type(DTYPE))
+    grad_out_ptr = tl.load(grad_out_ptrs_buf + expert_idx).to(tl.pointer_type(DTYPE))
+    grad_in_ptr = tl.load(grad_in_ptrs_buf + expert_idx).to(tl.pointer_type(DTYPE))
+
+    amax = tl.load(amax_vec_ptr + expert_idx).to(tl.float32)
+
+    offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < elements_per_expert
+
+    # Stay in DTYPE (bf16/fp16) throughout — eliminates fp32 round-trip seen in
+    # the Btriton2 baseline that capped bwd bandwidth at ~4.2 TB/s vs cuda_ext's
+    # ~8 TB/s on B300. amax cast to DTYPE once; comparison done in low precision
+    # (amax values are O(1)-O(10), well within bf16 range).
+    w = tl.load(w_ptr + offsets, mask=mask, other=0.0)
+    g = tl.load(grad_out_ptr + offsets, mask=mask, other=0.0)
+    amax_dt = amax.to(DTYPE)
+
+    # Clip-aware STE: pass through gradient where |w| <= amax, else zero.
+    pass_through = tl.abs(w) <= amax_dt
+    grad_in = tl.where(pass_through, g, 0.0)
+
+    tl.store(grad_in_ptr + offsets, grad_in, mask=mask)
+
+
+def _build_ptr_buf(tensors: list[torch.Tensor]) -> torch.Tensor:
+    """Pack a list of tensors' .data_ptr() into a single int64 tensor on the same device."""
+    return torch.tensor(
+        [t.data_ptr() for t in tensors],
+        dtype=torch.int64,
+        device=tensors[0].device,
+    )
+
+
+def grouped_axis0_fakequant(
+    weights: list[torch.Tensor],
+    amax_vec: torch.Tensor,
+    num_bits: int = 8,
+    narrow_range: bool = True,
+) -> list[torch.Tensor]:
+    """Apply per-expert axis-0 fake-quant in a single Triton launch.
+
+    Args:
+        weights: List of N expert weight tensors. Each must have the same shape
+            `[out, in]` and same dtype.
+        amax_vec: Per-expert amax buffer of shape `[N, 1, 1]` (or any shape where
+            element `i` is expert `i`'s amax). dtype should be float32 for
+            numerical headroom; the kernel casts to fp32 internally.
+        num_bits: integer bit-width for the fake-quant.
+        narrow_range: if True, output range is [-qmax, +qmax]; else [-qmax, +qmax-1].
+            modelopt's default is True.
+
+    Returns:
+        List of N quantized weight tensors, each the same shape and dtype as
+        the corresponding input.
+    """
+    assert len(weights) >= 1, "grouped_axis0_fakequant requires at least one expert"
+    N = len(weights)
+    shape0 = weights[0].shape
+    dtype0 = weights[0].dtype
+    device0 = weights[0].device
+    elements_per_expert = weights[0].numel()
+    for w in weights[1:]:
+        assert w.shape == shape0, "all expert weights must share the same shape"
+        assert w.dtype == dtype0, "all expert weights must share the same dtype"
+        assert w.device == device0, "all expert weights must share the same device"
+
+    outputs = [torch.empty_like(w) for w in weights]
+
+    weight_ptrs = _build_ptr_buf(weights)
+    output_ptrs = _build_ptr_buf(outputs)
+
+    # BLOCK_SIZE=2048 was empirically best in the Btriton2 sweep — larger blocks
+    # (16384 + num_warps=8) regressed both fwd and bwd, likely from worse warp
+    # occupancy and load coalescing on B300.
+    BLOCK_SIZE = 2048
+    num_blocks_per_expert = triton.cdiv(elements_per_expert, BLOCK_SIZE)
+    grid = (N, num_blocks_per_expert)
+
+    with torch.cuda.device(device0):
+        _grouped_axis0_fakequant_fwd_kernel[grid](
+            weight_ptrs,
+            output_ptrs,
+            amax_vec,
+            elements_per_expert,
+            num_bits,
+            narrow_range=narrow_range,
+            DTYPE=_torch_dtype_to_tl(dtype0),
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+
+    return outputs
+
+
+def grouped_axis0_fakequant_backward(
+    weights: list[torch.Tensor],
+    grad_outputs: list[torch.Tensor],
+    amax_vec: torch.Tensor,
+) -> list[torch.Tensor]:
+    """Apply per-expert clip-aware STE backward in a single Triton launch.
+
+    Matches modelopt's `_fake_tensor_quant_backward` semantics — gradient
+    passes through where `|w[i]| <= amax[i]`, else zero.
+
+    Args:
+        weights: List of N expert weight tensors (the original fwd inputs).
+        grad_outputs: List of N upstream gradients, one per expert.
+        amax_vec: Per-expert amax buffer (same shape as in fwd).
+
+    Returns:
+        List of N downstream gradients, one per expert.
+    """
+    N = len(weights)
+    assert len(grad_outputs) == N
+    shape0 = weights[0].shape
+    dtype0 = weights[0].dtype
+    device0 = weights[0].device
+    elements_per_expert = weights[0].numel()
+
+    grad_inputs = [torch.empty_like(w) for w in weights]
+
+    weight_ptrs = _build_ptr_buf(weights)
+    grad_out_ptrs = _build_ptr_buf(grad_outputs)
+    grad_in_ptrs = _build_ptr_buf(grad_inputs)
+
+    BLOCK_SIZE = 2048
+    num_blocks_per_expert = triton.cdiv(elements_per_expert, BLOCK_SIZE)
+    grid = (N, num_blocks_per_expert)
+
+    with torch.cuda.device(device0):
+        _grouped_axis0_fakequant_bwd_kernel[grid](
+            weight_ptrs,
+            grad_out_ptrs,
+            grad_in_ptrs,
+            amax_vec,
+            elements_per_expert,
+            DTYPE=_torch_dtype_to_tl(dtype0),
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+
+    return grad_inputs

--- a/modelopt/torch/kernels/quantization/gemm/grouped_axis0_fakequant.py
+++ b/modelopt/torch/kernels/quantization/gemm/grouped_axis0_fakequant.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import torch
 import triton
 import triton.language as tl
+from triton.language.extra.cuda import libdevice
 
 __all__ = ["grouped_axis0_fakequant", "grouped_axis0_fakequant_backward"]
 
@@ -86,12 +87,10 @@ def _grouped_axis0_fakequant_fwd_kernel(
     safe_scale = tl.where(scale > 0.0, scale, 1.0)
     q = x / safe_scale
     q = tl.maximum(tl.minimum(q, qmax), qmin)
-    # Round-half-away-from-zero via add-half-and-truncate. For bfloat16 inputs
-    # the half-tie case is rare and the difference vs round-half-to-even is
-    # negligible for fake-quant. Avoids libdevice dependency (nearbyint /
-    # rint are not consistently exposed across Triton versions).
-    half_sign = tl.where(q >= 0.0, 0.5, -0.5)
-    q_rounded = (q + half_sign).to(tl.int32).to(tl.float32)
+    # Round-half-to-even (banker's), matching cuda_ext.fake_tensor_quant exactly.
+    # libdevice.rint is CUDA's __rint* builtin. Imported via the same path that
+    # modelopt's nvfp4_quant.py uses (triton.language.extra.cuda.libdevice).
+    q_rounded = libdevice.rint(q)
     out = tl.where(scale > 0.0, q_rounded * scale, x)
 
     tl.store(out_ptr + offsets, out.to(DTYPE), mask=mask)

--- a/modelopt/torch/quantization/model_calib.py
+++ b/modelopt/torch/quantization/model_calib.py
@@ -357,6 +357,21 @@ def max_calibrate(
             quantizer.sync_amax_across_distributed_group(parallel_state.tensor_parallel_group)
 
     # Step 2: Sync amax across relevant parallelism (such as TP / EP)
+    def _weight_axes_for_sync(module, base_axes):
+        # For column-parallel TEGroupedLinear in per-expert mode (axis=0), the
+        # expert weights are NOT TP-sharded (etp=1 case) — axis=0 indexes experts,
+        # not output channels. Per-rank reductions still produce slightly
+        # divergent amax across TP (BF16/FP16 sums are not bit-identical across
+        # ranks even with the same input), and dist-checkpoint save treats
+        # _amax as replicated and captures only one rank's view. Without this
+        # sync, model_ref's per-rank-different amax mismatches the loaded
+        # model_test on every TP rank except the one whose value was saved.
+        if hasattr(module, "weight0"):
+            quantizer = getattr(module, "weight_quantizer", None)
+            if isinstance(quantizer, TensorQuantizer) and quantizer.axis in (0, (0,)):
+                return list(base_axes) + [0]
+        return base_axes
+
     for name, module in model.named_modules():
         if getattr(module, "_parallel_state", None) is None:
             continue
@@ -373,7 +388,7 @@ def max_calibrate(
                 module.weight_quantizer,
                 name,
                 "weight_quantizer",
-                axes_for_sync=[None, -1],
+                axes_for_sync=_weight_axes_for_sync(module, [None, -1]),
                 parallel_state=module.parallel_state,
             )
 

--- a/modelopt/torch/quantization/plugins/megatron.py
+++ b/modelopt/torch/quantization/plugins/megatron.py
@@ -680,6 +680,18 @@ if HAS_TE:
 
     # Quantized subclasses to support TEGroupedMLP quantization
     class _QuantMegatronTEGroupedLinear(_QuantTEGroupedLinear, _MegatronParallelLinear):
+        def _ep_group(self):
+            # Return the expert_model_parallel_group iff it's initialized AND has >1 rank.
+            # _MegatronTEGroupedMLP._setup populates parallel_state with the EP group;
+            # outside that wrapping it may be unset (e.g. ad-hoc unit tests).
+            ps = getattr(self, "parallel_state", None)
+            if ps is None:
+                return None
+            ep = ps.expert_model_parallel_group
+            if not ep.is_initialized() or ep.world_size() <= 1:
+                return None
+            return ep
+
         def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
             # _sharded_state_dict_grouped adds _extra_state{gemm_idx} for gemm_idx:[1, num_gemms] in
             # sharded_state_dict which is same as _extra_state. The _extra_state{gemm_idx} is used for
@@ -690,7 +702,40 @@ if HAS_TE:
                 for k, v in state_dict.items()
                 if not any(k.endswith(f"_extra_state{num}") for num in range(1, self.num_gemms))
             }
+            # Per-expert amax is gathered to [num_gemms_global] at save time (see
+            # _process_quantizer_amax). On load each EP rank narrows it back to its
+            # local [num_gemms] slice before the base class's view_as() reshape.
+            ep = self._ep_group()
+            if ep is not None:
+                global_size = self.num_gemms * ep.world_size()
+                offset = ep.rank() * self.num_gemms
+                for k in list(filtered_state_dict.keys()):
+                    if (
+                        "weight_quantizer" in k
+                        and k.endswith("_amax")
+                        and filtered_state_dict[k].numel() == global_size
+                    ):
+                        filtered_state_dict[k] = (
+                            filtered_state_dict[k]
+                            .view(global_size)
+                            .narrow(0, offset, self.num_gemms)
+                        )
             return super()._load_from_state_dict(filtered_state_dict, prefix, *args, **kwargs)
+
+        def _get_shard_axis_dict(self, state_dict):
+            # The column-parallel parent marks weight_quantizer._amax as TP-sharded
+            # along axis 0 whenever weight_quantizer.axis is not None — correct for
+            # per-channel-along-output, but wrong for our per-expert path: the
+            # post-gather amax is [num_gemms_global], not output-channel-sharded.
+            # Strip the marker so the dist-checkpoint framework treats it as
+            # replicated across TP. EP-aware handling lives in _process_quantizer_amax
+            # (gather on save) and _load_from_state_dict (narrow on load).
+            shard_axis_dict = super()._get_shard_axis_dict(state_dict)
+            if self._is_per_expert_weight_quant():
+                for k in list(shard_axis_dict):
+                    if "weight_quantizer" in k and k.endswith("_amax"):
+                        del shard_axis_dict[k]
+            return shard_axis_dict
 
         def _process_quantizer_amax(self, k, v, quantizer_state_dict):
             # numel == 1: per-tensor (legacy).
@@ -700,13 +745,25 @@ if HAS_TE:
             # not yet supported on TEGroupedLinear.
             if v.numel() == 1:
                 quantizer_state_dict[k] = v.view(-1)
-            elif v.numel() == self.num_gemms:
-                quantizer_state_dict[k] = v.view(self.num_gemms)
-            else:
+                return
+            if v.numel() != self.num_gemms:
                 raise AssertionError(
                     f"TEGroupedLinear quantizer state {k} has numel {v.numel()}; "
                     f"expected 1 (per-tensor) or {self.num_gemms} (per-expert)."
                 )
+            # Per-expert path. Each EP rank holds the amax for its local experts
+            # only; we all-gather across EP so the saved tensor is the global
+            # [num_gemms * ep_world_size] view. Every rank then writes the same
+            # tensor and the dist-checkpoint framework can safely replicate it
+            # across DP/TP. _load_from_state_dict slices it back to local.
+            v_local = v.view(self.num_gemms)
+            ep = self._ep_group()
+            if ep is None:
+                quantizer_state_dict[k] = v_local
+                return
+            gathered = [torch.empty_like(v_local) for _ in range(ep.world_size())]
+            torch.distributed.all_gather(gathered, v_local, group=ep.group)
+            quantizer_state_dict[k] = torch.cat(gathered, dim=0)
 
     @QuantModuleRegistry.register(
         {TEColumnParallelGroupedLinear: "megatron_TEColumnParallelGroupedLinear"}

--- a/modelopt/torch/quantization/plugins/megatron.py
+++ b/modelopt/torch/quantization/plugins/megatron.py
@@ -693,8 +693,20 @@ if HAS_TE:
             return super()._load_from_state_dict(filtered_state_dict, prefix, *args, **kwargs)
 
         def _process_quantizer_amax(self, k, v, quantizer_state_dict):
-            assert v.numel() == 1, "TEGroupedLinear only supports per-tensor quantization"
-            quantizer_state_dict[k] = v.view(-1)
+            # numel == 1: per-tensor (legacy).
+            # numel == num_gemms: per-expert (axis=0 on the stacked weight quantizer);
+            # the raw _amax has shape [num_gemms, 1, 1] from axis-0 reduction.
+            # Higher granularity (per-channel-within-expert, NVFP4 block scales) is
+            # not yet supported on TEGroupedLinear.
+            if v.numel() == 1:
+                quantizer_state_dict[k] = v.view(-1)
+            elif v.numel() == self.num_gemms:
+                quantizer_state_dict[k] = v.view(self.num_gemms)
+            else:
+                raise AssertionError(
+                    f"TEGroupedLinear quantizer state {k} has numel {v.numel()}; "
+                    f"expected 1 (per-tensor) or {self.num_gemms} (per-expert)."
+                )
 
     @QuantModuleRegistry.register(
         {TEColumnParallelGroupedLinear: "megatron_TEColumnParallelGroupedLinear"}

--- a/modelopt/torch/quantization/plugins/megatron.py
+++ b/modelopt/torch/quantization/plugins/megatron.py
@@ -692,6 +692,52 @@ if HAS_TE:
                 return None
             return ep
 
+        def _gather_global_per_expert_amax(self):
+            # Return the global [num_gemms_global] per-expert amax, gathered across
+            # the EP group, without mutating the live weight_quantizer._amax buffer
+            # (the forward path indexes _amax by local expert position and would
+            # break if we replaced it with the global shape).
+            #
+            # Returns None when the layer isn't per-expert (per-tensor stays the
+            # legacy scalar path) or when EP == 1 (local == global, caller can
+            # reshape the live buffer directly).
+            if not self._is_per_expert_weight_quant():
+                return None
+            quantizer = self.weight_quantizer
+            amax = getattr(quantizer, "_amax", None)
+            if amax is None:
+                return None
+            ep = self._ep_group()
+            if ep is None:
+                return amax.view(self.num_gemms)  # EP=1: local IS global.
+
+            global_size = self.num_gemms * ep.world_size()
+            if amax.numel() != self.num_gemms:
+                raise AssertionError(
+                    f"TEGroupedLinear weight_quantizer._amax numel {amax.numel()}; "
+                    f"expected {self.num_gemms} (local per-expert) or "
+                    f"{global_size} (global per-expert)."
+                )
+            v_local = amax.view(self.num_gemms)
+            gathered = [torch.empty_like(v_local) for _ in range(ep.world_size())]
+            torch.distributed.all_gather(gathered, v_local, group=ep.group)
+            return torch.cat(gathered, dim=0)
+
+        def sharded_state_dict(self, prefix="", sharded_offsets=(), metadata=None):
+            # Gather the global per-expert amax ONCE before Megatron's save traversal.
+            # Stash on a temporary attribute that _process_quantizer_amax consumes; the
+            # live weight_quantizer._amax buffer stays local so forward keeps working.
+            #
+            # Done at the top of sharded_state_dict (not inside _process_quantizer_amax)
+            # so the EP collective completes BEFORE Megatron's dist-checkpoint save
+            # kicks off its own default-PG ALLGATHER metadata exchanges. Interleaving
+            # EP gathers with default-PG collectives deadlocks NCCL.
+            self._cached_global_per_expert_amax = self._gather_global_per_expert_amax()
+            try:
+                return super().sharded_state_dict(prefix, sharded_offsets, metadata)
+            finally:
+                self._cached_global_per_expert_amax = None
+
         def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
             # _sharded_state_dict_grouped adds _extra_state{gemm_idx} for gemm_idx:[1, num_gemms] in
             # sharded_state_dict which is same as _extra_state. The _extra_state{gemm_idx} is used for
@@ -702,9 +748,9 @@ if HAS_TE:
                 for k, v in state_dict.items()
                 if not any(k.endswith(f"_extra_state{num}") for num in range(1, self.num_gemms))
             }
-            # Per-expert amax is gathered to [num_gemms_global] at save time (see
-            # _process_quantizer_amax). On load each EP rank narrows it back to its
-            # local [num_gemms] slice before the base class's view_as() reshape.
+            # Per-expert amax was saved as the gathered global [num_gemms_global]
+            # tensor. On restore each EP rank narrows it back to its local
+            # [num_gemms] slice before the base class's view_as() reshape.
             ep = self._ep_group()
             if ep is not None:
                 global_size = self.num_gemms * ep.world_size()
@@ -726,10 +772,11 @@ if HAS_TE:
             # The column-parallel parent marks weight_quantizer._amax as TP-sharded
             # along axis 0 whenever weight_quantizer.axis is not None — correct for
             # per-channel-along-output, but wrong for our per-expert path: the
-            # post-gather amax is [num_gemms_global], not output-channel-sharded.
+            # gathered amax is [num_gemms_global], not output-channel-sharded.
             # Strip the marker so the dist-checkpoint framework treats it as
-            # replicated across TP. EP-aware handling lives in _process_quantizer_amax
-            # (gather on save) and _load_from_state_dict (narrow on load).
+            # replicated across TP. EP-aware handling lives in
+            # _gather_global_per_expert_amax (called from sharded_state_dict on
+            # save) and _load_from_state_dict (narrow on load).
             shard_axis_dict = super()._get_shard_axis_dict(state_dict)
             if self._is_per_expert_weight_quant():
                 for k in list(shard_axis_dict):
@@ -738,32 +785,15 @@ if HAS_TE:
             return shard_axis_dict
 
         def _process_quantizer_amax(self, k, v, quantizer_state_dict):
-            # numel == 1: per-tensor (legacy).
-            # numel == num_gemms: per-expert (axis=0 on the stacked weight quantizer);
-            # the raw _amax has shape [num_gemms, 1, 1] from axis-0 reduction.
-            # Higher granularity (per-channel-within-expert, NVFP4 block scales) is
-            # not yet supported on TEGroupedLinear.
-            if v.numel() == 1:
-                quantizer_state_dict[k] = v.view(-1)
+            # Per-expert weight amax: emit the gathered global tensor cached by
+            # sharded_state_dict's pre-pass. No collective fires here, so this
+            # call is safe to run inside Megatron's save traversal.
+            # Per-tensor (or non-weight) amax: just reshape the local value.
+            cached = getattr(self, "_cached_global_per_expert_amax", None)
+            if cached is not None and "weight_quantizer" in k and k.endswith("_amax"):
+                quantizer_state_dict[k] = cached.view(cached.numel())
                 return
-            if v.numel() != self.num_gemms:
-                raise AssertionError(
-                    f"TEGroupedLinear quantizer state {k} has numel {v.numel()}; "
-                    f"expected 1 (per-tensor) or {self.num_gemms} (per-expert)."
-                )
-            # Per-expert path. Each EP rank holds the amax for its local experts
-            # only; we all-gather across EP so the saved tensor is the global
-            # [num_gemms * ep_world_size] view. Every rank then writes the same
-            # tensor and the dist-checkpoint framework can safely replicate it
-            # across DP/TP. _load_from_state_dict slices it back to local.
-            v_local = v.view(self.num_gemms)
-            ep = self._ep_group()
-            if ep is None:
-                quantizer_state_dict[k] = v_local
-                return
-            gathered = [torch.empty_like(v_local) for _ in range(ep.world_size())]
-            torch.distributed.all_gather(gathered, v_local, group=ep.group)
-            quantizer_state_dict[k] = torch.cat(gathered, dim=0)
+            quantizer_state_dict[k] = v.view(v.numel())
 
     @QuantModuleRegistry.register(
         {TEColumnParallelGroupedLinear: "megatron_TEColumnParallelGroupedLinear"}

--- a/modelopt/torch/quantization/plugins/transformer_engine.py
+++ b/modelopt/torch/quantization/plugins/transformer_engine.py
@@ -28,7 +28,6 @@ from packaging.version import Version
 from modelopt.torch.quantization.utils import replace_function
 
 from ..nn import QuantModuleRegistry, TensorQuantizer
-from ..tensor_quant import _fake_tensor_quant_backward, fake_quant_impl
 from .custom import _ParallelLinear
 
 _TE_VERSION = Version(te.__version__)
@@ -102,55 +101,6 @@ class _QuantTELinear(_ParallelLinear):
 
     # Override the quantized linear function
     _quantized_linear_fn = te_quantized_linear_fn
-
-
-class _GroupedAxis0FakeQuant(torch.autograd.Function):
-    """Per-expert axis-0 fake-quant for TEGrouped weights without a stacked tensor.
-
-    Equivalent in numerical output to:
-        stacked = torch.stack(weights, dim=0)
-        q = quantizer(stacked)                       # quantizer._amax shape [N, 1, 1]
-        return q.unbind(0)
-
-    but without materializing the [N, out, in] stacked tensor. The per-expert
-    loop runs inside Function.forward (one Python dispatch into the Function,
-    then the loop runs at the autograd-Function boundary), so the call site
-    avoids both the stack memcopy AND the per-call Python dispatch tax of
-    looping over a per-expert quantizer module. Single autograd node — backward
-    is one fused clipping-aware STE pass-through call.
-
-    See OMNIML-5072 AC5 for the design rationale.
-    """
-
-    @staticmethod
-    def forward(ctx, amax_vec, num_bits, unsigned, narrow_range, *weights):
-        # amax_vec: [N, 1, 1]; one [1, 1] slice per expert.
-        # weights:  N tensors, each [out, in].
-        outputs = []
-        for i, w in enumerate(weights):
-            # amax_vec[i] is a [1, 1] view; broadcasts trivially over [out, in].
-            outputs.append(
-                fake_quant_impl(w, amax_vec[i], num_bits, unsigned, narrow_range)
-            )
-        # Save for clipping-aware STE backward.
-        ctx.save_for_backward(amax_vec, *weights)
-        return tuple(outputs)
-
-    @staticmethod
-    def backward(ctx, *grad_outputs):
-        # Clipping-aware STE per expert: dw = grad where |w| <= amax_vec[i], else 0.
-        # Delegates to modelopt's existing @torch.jit.script-decorated
-        # _fake_tensor_quant_backward so the (|w| <= amax) and torch.where ops
-        # fuse into a single kernel per expert; a plain-Python rewrite of the
-        # same math was measured ~5x slower due to eager-mode dispatcher
-        # overhead (three small unfused kernels + cudaMalloc per iteration).
-        amax_vec, *weights = ctx.saved_tensors
-        grad_weights = tuple(
-            _fake_tensor_quant_backward(w, amax_vec[i], g)
-            for i, (w, g) in enumerate(zip(weights, grad_outputs))
-        )
-        # Order of forward args: (amax_vec, num_bits, unsigned, narrow_range, *weights).
-        return (None, None, None, None, *grad_weights)
 
 
 def _reshape_loaded_amax_to_buffer_shape(
@@ -241,23 +191,6 @@ class _QuantTEGroupedLinear(_ParallelLinear):
             self.weight_quantizer._register_load_state_dict_pre_hook(
                 _reshape_loaded_amax_to_buffer_shape, with_module=True
             )
-            # Per OMNIML-5072 AC5 caveat: the per-expert axis-0 path's inline
-            # calibration is coupled to max-calibration. Assert that constraint
-            # here so a misconfigured quantizer fails at module setup rather
-            # than producing wrong amax values silently. Adding per-expert
-            # support for other calibrators is a follow-up ticket.
-            if self._is_per_expert_weight_quant():
-                from ..calib.max import MaxCalibrator
-                calibrator = getattr(self.weight_quantizer, "_calibrator", None)
-                # Allow None: someone explicitly disabled calibration (e.g. loading
-                # pre-computed _amax from a checkpoint). Reject only non-max calibrators
-                # that would silently produce wrong amax under the inline path.
-                assert calibrator is None or isinstance(calibrator, MaxCalibrator), (
-                    "Per-expert axis=0 TEGroupedLinear weight quantization currently "
-                    "supports max-calibration only (OMNIML-5072 AC5). Got calibrator: "
-                    f"{type(calibrator).__name__}. For other calibrators (histogram, "
-                    "percentile), file a follow-up ticket."
-                )
 
     def _is_per_expert_weight_quant(self) -> bool:
         # Per-expert mode: axis=0 on the weight quantizer means the stacked
@@ -338,44 +271,18 @@ class _QuantTEGroupedLinear(_ParallelLinear):
         new_args = list(args)
         new_args[inp_pos] = self.input_quantizer(args[inp_pos])
         if self._is_per_expert_weight_quant():
-            # Per-expert axis-0 fake-quant via a custom autograd.Function — no
-            # stacked tensor is materialized. The Function's forward loops
-            # over the N expert weights applying fake_quant_impl per expert
-            # against amax_vec[i]; backward is one fused clipping-aware STE.
-            # See OMNIML-5072 AC5 for the design rationale.
+            # Stack the N expert weights into one [N, out, in] tensor so the
+            # quantizer's axis-0 reduction sees them together; the resulting
+            # _amax of shape [N, 1, 1] broadcasts to give per-expert fake-quant.
             #
-            # Calibration (inline, max-calibration only): bypasses modelopt's
-            # calibrator interface because the calibrator API is built around
-            # a single stacked input. We accumulate per-expert max into the
-            # [N, 1, 1] _amax buffer directly. The MaxCalibrator constraint
-            # is asserted in _setup; non-max calibrators on the per-expert
-            # path are out of scope for OMNIML-5072 (separate ticket).
-            q = self.weight_quantizer
-            weights = args[weights_start : weights_start + num_gemms]
-            if q._if_calib:
-                with torch.no_grad():
-                    if not hasattr(q, "_amax") or q._amax.shape != (num_gemms, 1, 1):
-                        q.register_buffer(
-                            "_amax",
-                            torch.zeros(
-                                (num_gemms, 1, 1),
-                                device=weights[0].device,
-                                dtype=weights[0].dtype,
-                            ),
-                        )
-                    for i, w_i in enumerate(weights):
-                        torch.maximum(
-                            q._amax[i],
-                            w_i.detach().abs().amax(),
-                            out=q._amax[i],
-                        )
-            new_args[weights_start : weights_start + num_gemms] = _GroupedAxis0FakeQuant.apply(
-                q._amax,
-                q.num_bits,
-                q.unsigned,
-                q.narrow_range,
-                *weights,
-            )
+            # Use unbind(0) (not q_stacked[i]) for the unpacking — unbind's
+            # backward is a single fused stack op, vs N SelectBackward nodes
+            # that each allocate an intermediate grad buffer per slice. At
+            # high N (hundreds of experts), this collapses backward latency
+            # by orders of magnitude. Measured under OMNIML-5064.
+            stacked = torch.stack(list(args[weights_start : weights_start + num_gemms]), dim=0)
+            q_stacked = self.weight_quantizer(stacked)
+            new_args[weights_start : weights_start + num_gemms] = q_stacked.unbind(0)
         else:
             for i in range(weights_start, weights_start + num_gemms):
                 new_args[i] = self.weight_quantizer(args[i])

--- a/modelopt/torch/quantization/plugins/transformer_engine.py
+++ b/modelopt/torch/quantization/plugins/transformer_engine.py
@@ -27,7 +27,7 @@ from packaging.version import Version
 
 from modelopt.torch.quantization.utils import replace_function
 
-from ..nn import QuantModuleRegistry
+from ..nn import QuantModuleRegistry, TensorQuantizer
 from .custom import _ParallelLinear
 
 _TE_VERSION = Version(te.__version__)
@@ -137,8 +137,16 @@ class _QuantTEGroupedLinear(_ParallelLinear):
         # Remove self.weight after setup.
         delattr(self, "weight")
 
-        # TODO: GroupedLinear supports weights split by `num_gemms`, to support quantization
-        # with static parameters beyond per-tensor, we need to support a unique quantizer for each gemm.
+    def _is_per_expert_weight_quant(self) -> bool:
+        # Per-expert mode: axis=0 on the weight quantizer means the stacked
+        # [num_gemms, out, in] weight is reduced over (1, 2), producing one amax
+        # per expert. Anything else (axis=None, axis=(0, 1), ...) keeps the
+        # legacy per-tensor path.
+        quantizer = getattr(self, "weight_quantizer", None)
+        if not isinstance(quantizer, TensorQuantizer):
+            return False
+        axis = quantizer.axis
+        return axis in (0, (0,))
 
     def modelopt_post_restore(self, prefix: str = ""):
         # GroupedMLP stores the weights as weight0, weight1, etc. To run post_restore in order to
@@ -151,7 +159,22 @@ class _QuantTEGroupedLinear(_ParallelLinear):
         delattr(self, "weight")
 
     def iter_weights_for_calibration(self):
-        """Yield ``(weight_i, weight_quantizer)`` for each of the ``num_gemms`` grouped weights."""
+        """Yield grouped weights for calibration.
+
+        Per-tensor (``axis=None``): yields ``(weight_i, weight_quantizer)`` for each
+        expert separately; the calibrator accumulates a single amax across all experts.
+
+        Per-expert (``axis=0``): yields ``(stacked, weight_quantizer)`` once, where
+        ``stacked`` has shape ``[num_gemms, out, in]``. The quantizer's axis-0 reduction
+        then produces one amax per expert (shape ``[num_gemms, 1, 1]``).
+        """
+        if self._is_per_expert_weight_quant():
+            weights = [getattr(self, f"weight{i}", None) for i in range(self.num_gemms)]
+            if any(w is None for w in weights):
+                return
+            yield torch.stack(weights, dim=0), self.weight_quantizer
+            return
+
         for i in range(self.num_gemms):
             weight_i = getattr(self, f"weight{i}", None)
             if weight_i is not None:
@@ -182,8 +205,17 @@ class _QuantTEGroupedLinear(_ParallelLinear):
 
         new_args = list(args)
         new_args[inp_pos] = self.input_quantizer(args[inp_pos])
-        for i in range(weights_start, weights_start + num_gemms):
-            new_args[i] = self.weight_quantizer(args[i])
+        if self._is_per_expert_weight_quant():
+            # Stack the N expert weights into one [N, out, in] tensor so the
+            # quantizer's axis-0 reduction sees them together; the resulting
+            # _amax of shape [N, 1, 1] broadcasts to give per-expert fake-quant.
+            stacked = torch.stack(list(args[weights_start : weights_start + num_gemms]), dim=0)
+            q_stacked = self.weight_quantizer(stacked)
+            for i in range(num_gemms):
+                new_args[weights_start + i] = q_stacked[i]
+        else:
+            for i in range(weights_start, weights_start + num_gemms):
+                new_args[i] = self.weight_quantizer(args[i])
         output = getattr(package, func_name)(*new_args)
         # TE 2.15+ returns `(out, new_workspaces)`; TE <= 2.14 returns just `out`.
         # Only the activation tensor participates in output quantization.

--- a/modelopt/torch/quantization/plugins/transformer_engine.py
+++ b/modelopt/torch/quantization/plugins/transformer_engine.py
@@ -28,7 +28,7 @@ from packaging.version import Version
 from modelopt.torch.quantization.utils import replace_function
 
 from ..nn import QuantModuleRegistry, TensorQuantizer
-from ..tensor_quant import fake_quant_impl
+from ..tensor_quant import _fake_tensor_quant_backward, fake_quant_impl
 from .custom import _ParallelLinear
 
 _TE_VERSION = Version(te.__version__)
@@ -139,12 +139,16 @@ class _GroupedAxis0FakeQuant(torch.autograd.Function):
     @staticmethod
     def backward(ctx, *grad_outputs):
         # Clipping-aware STE per expert: dw = grad where |w| <= amax_vec[i], else 0.
-        # Matches FakeTensorQuantFunction's _fake_tensor_quant_backward semantics.
+        # Delegates to modelopt's existing @torch.jit.script-decorated
+        # _fake_tensor_quant_backward so the (|w| <= amax) and torch.where ops
+        # fuse into a single kernel per expert; a plain-Python rewrite of the
+        # same math was measured ~5x slower due to eager-mode dispatcher
+        # overhead (three small unfused kernels + cudaMalloc per iteration).
         amax_vec, *weights = ctx.saved_tensors
-        grad_weights = []
-        for i, (w, g) in enumerate(zip(weights, grad_outputs)):
-            zero = g.new_zeros(1)
-            grad_weights.append(torch.where(w.abs() <= amax_vec[i], g, zero))
+        grad_weights = tuple(
+            _fake_tensor_quant_backward(w, amax_vec[i], g)
+            for i, (w, g) in enumerate(zip(weights, grad_outputs))
+        )
         # Order of forward args: (amax_vec, num_bits, unsigned, narrow_range, *weights).
         return (None, None, None, None, *grad_weights)
 

--- a/modelopt/torch/quantization/plugins/transformer_engine.py
+++ b/modelopt/torch/quantization/plugins/transformer_engine.py
@@ -103,6 +103,43 @@ class _QuantTELinear(_ParallelLinear):
     _quantized_linear_fn = te_quantized_linear_fn
 
 
+def _reshape_loaded_amax_to_buffer_shape(
+    module,
+    state_dict,
+    prefix,
+    local_metadata,
+    strict,
+    missing_keys,
+    unexpected_keys,
+    error_msgs,
+):
+    """Reshape a loaded `_amax` tensor to match the live buffer shape on this rank.
+
+    PyTorch's `load_state_dict` enforces an exact-shape check at the leaf module
+    level. For per-expert TEGroupedLinear quantization, the dist-checkpoint tensor
+    is saved flat as `[num_gemms]` (the legacy `_process_quantizer_amax` flatten)
+    while the live buffer is registered as `[num_gemms, 1, 1]` from the metadata
+    path (axis=0 calibration with keepdims). Reshape the loaded tensor in the
+    state_dict the strict check is about to read.
+
+    The hook is leaf-level and rank-local — it only touches the local
+    `state_dict[prefix + "_amax"]` and the local buffer's shape, and only acts
+    when shapes differ but numel matches. EP>1 narrowing happens in the outer
+    `_QuantMegatronTEGroupedLinear._load_from_state_dict` before this hook runs.
+    """
+    key = prefix + "_amax"
+    if key not in state_dict:
+        return
+    buf = getattr(module, "_amax", None)
+    if buf is None:
+        return
+    loaded = state_dict[key]
+    if loaded.shape == buf.shape:
+        return
+    if loaded.numel() == buf.numel():
+        state_dict[key] = loaded.reshape(buf.shape).contiguous()
+
+
 # Register the public te.pytorch.GroupedLinear class
 @QuantModuleRegistry.register({te_grouped_linear.GroupedLinear: "te_GroupedLinear"})
 class _QuantTEGroupedLinear(_ParallelLinear):
@@ -136,6 +173,24 @@ class _QuantTEGroupedLinear(_ParallelLinear):
         super()._setup()
         # Remove self.weight after setup.
         delattr(self, "weight")
+
+        # Reconcile the per-expert _amax storage shape on restore. The save path keeps
+        # the dist-checkpoint tensor as flat [num_gemms_global] (legacy convention for
+        # quantizer amax) while _pytorch_state_metadata records the live multi-dim
+        # buffer shape [num_gemms, 1, 1] (axis=0 calibration + keepdims). On restore,
+        # the metadata path registers an [num_gemms, 1, 1] buffer first; load_state_dict
+        # then tries to copy the flat tensor into it and raises a size mismatch.
+        #
+        # Reshape inside a pre-hook at the leaf quantizer level so it fires AFTER
+        # PyTorch has narrowed state_dict to this submodule's prefix but BEFORE the
+        # strict size check. The hook is pure-CPU and rank-local — no per-rank state
+        # queries beyond the leaf's own buffer shape, so it doesn't introduce the
+        # rank-asymmetric collective ordering that the parent-level state_dict
+        # mutation approach did. EP>1 still relies on the outer narrow path.
+        if hasattr(self, "weight_quantizer") and isinstance(self.weight_quantizer, TensorQuantizer):
+            self.weight_quantizer._register_load_state_dict_pre_hook(
+                _reshape_loaded_amax_to_buffer_shape, with_module=True
+            )
 
     def _is_per_expert_weight_quant(self) -> bool:
         # Per-expert mode: axis=0 on the weight quantizer means the stacked

--- a/modelopt/torch/quantization/plugins/transformer_engine.py
+++ b/modelopt/torch/quantization/plugins/transformer_engine.py
@@ -28,6 +28,7 @@ from packaging.version import Version
 from modelopt.torch.quantization.utils import replace_function
 
 from ..nn import QuantModuleRegistry, TensorQuantizer
+from ..tensor_quant import fake_quant_impl
 from .custom import _ParallelLinear
 
 _TE_VERSION = Version(te.__version__)
@@ -101,6 +102,51 @@ class _QuantTELinear(_ParallelLinear):
 
     # Override the quantized linear function
     _quantized_linear_fn = te_quantized_linear_fn
+
+
+class _GroupedAxis0FakeQuant(torch.autograd.Function):
+    """Per-expert axis-0 fake-quant for TEGrouped weights without a stacked tensor.
+
+    Equivalent in numerical output to:
+        stacked = torch.stack(weights, dim=0)
+        q = quantizer(stacked)                       # quantizer._amax shape [N, 1, 1]
+        return q.unbind(0)
+
+    but without materializing the [N, out, in] stacked tensor. The per-expert
+    loop runs inside Function.forward (one Python dispatch into the Function,
+    then the loop runs at the autograd-Function boundary), so the call site
+    avoids both the stack memcopy AND the per-call Python dispatch tax of
+    looping over a per-expert quantizer module. Single autograd node — backward
+    is one fused clipping-aware STE pass-through call.
+
+    See OMNIML-5072 AC5 for the design rationale.
+    """
+
+    @staticmethod
+    def forward(ctx, amax_vec, num_bits, unsigned, narrow_range, *weights):
+        # amax_vec: [N, 1, 1]; one [1, 1] slice per expert.
+        # weights:  N tensors, each [out, in].
+        outputs = []
+        for i, w in enumerate(weights):
+            # amax_vec[i] is a [1, 1] view; broadcasts trivially over [out, in].
+            outputs.append(
+                fake_quant_impl(w, amax_vec[i], num_bits, unsigned, narrow_range)
+            )
+        # Save for clipping-aware STE backward.
+        ctx.save_for_backward(amax_vec, *weights)
+        return tuple(outputs)
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        # Clipping-aware STE per expert: dw = grad where |w| <= amax_vec[i], else 0.
+        # Matches FakeTensorQuantFunction's _fake_tensor_quant_backward semantics.
+        amax_vec, *weights = ctx.saved_tensors
+        grad_weights = []
+        for i, (w, g) in enumerate(zip(weights, grad_outputs)):
+            zero = g.new_zeros(1)
+            grad_weights.append(torch.where(w.abs() <= amax_vec[i], g, zero))
+        # Order of forward args: (amax_vec, num_bits, unsigned, narrow_range, *weights).
+        return (None, None, None, None, *grad_weights)
 
 
 def _reshape_loaded_amax_to_buffer_shape(
@@ -191,6 +237,23 @@ class _QuantTEGroupedLinear(_ParallelLinear):
             self.weight_quantizer._register_load_state_dict_pre_hook(
                 _reshape_loaded_amax_to_buffer_shape, with_module=True
             )
+            # Per OMNIML-5072 AC5 caveat: the per-expert axis-0 path's inline
+            # calibration is coupled to max-calibration. Assert that constraint
+            # here so a misconfigured quantizer fails at module setup rather
+            # than producing wrong amax values silently. Adding per-expert
+            # support for other calibrators is a follow-up ticket.
+            if self._is_per_expert_weight_quant():
+                from ..calib.max import MaxCalibrator
+                calibrator = getattr(self.weight_quantizer, "_calibrator", None)
+                # Allow None: someone explicitly disabled calibration (e.g. loading
+                # pre-computed _amax from a checkpoint). Reject only non-max calibrators
+                # that would silently produce wrong amax under the inline path.
+                assert calibrator is None or isinstance(calibrator, MaxCalibrator), (
+                    "Per-expert axis=0 TEGroupedLinear weight quantization currently "
+                    "supports max-calibration only (OMNIML-5072 AC5). Got calibrator: "
+                    f"{type(calibrator).__name__}. For other calibrators (histogram, "
+                    "percentile), file a follow-up ticket."
+                )
 
     def _is_per_expert_weight_quant(self) -> bool:
         # Per-expert mode: axis=0 on the weight quantizer means the stacked
@@ -271,18 +334,44 @@ class _QuantTEGroupedLinear(_ParallelLinear):
         new_args = list(args)
         new_args[inp_pos] = self.input_quantizer(args[inp_pos])
         if self._is_per_expert_weight_quant():
-            # Stack the N expert weights into one [N, out, in] tensor so the
-            # quantizer's axis-0 reduction sees them together; the resulting
-            # _amax of shape [N, 1, 1] broadcasts to give per-expert fake-quant.
+            # Per-expert axis-0 fake-quant via a custom autograd.Function — no
+            # stacked tensor is materialized. The Function's forward loops
+            # over the N expert weights applying fake_quant_impl per expert
+            # against amax_vec[i]; backward is one fused clipping-aware STE.
+            # See OMNIML-5072 AC5 for the design rationale.
             #
-            # Use unbind(0) (not q_stacked[i]) for the unpacking — unbind's
-            # backward is a single fused stack op, vs N SelectBackward nodes
-            # that each allocate an intermediate grad buffer per slice. At
-            # high N (hundreds of experts), this collapses backward latency
-            # by orders of magnitude. Measured under OMNIML-5064.
-            stacked = torch.stack(list(args[weights_start : weights_start + num_gemms]), dim=0)
-            q_stacked = self.weight_quantizer(stacked)
-            new_args[weights_start : weights_start + num_gemms] = q_stacked.unbind(0)
+            # Calibration (inline, max-calibration only): bypasses modelopt's
+            # calibrator interface because the calibrator API is built around
+            # a single stacked input. We accumulate per-expert max into the
+            # [N, 1, 1] _amax buffer directly. The MaxCalibrator constraint
+            # is asserted in _setup; non-max calibrators on the per-expert
+            # path are out of scope for OMNIML-5072 (separate ticket).
+            q = self.weight_quantizer
+            weights = args[weights_start : weights_start + num_gemms]
+            if q._if_calib:
+                with torch.no_grad():
+                    if not hasattr(q, "_amax") or q._amax.shape != (num_gemms, 1, 1):
+                        q.register_buffer(
+                            "_amax",
+                            torch.zeros(
+                                (num_gemms, 1, 1),
+                                device=weights[0].device,
+                                dtype=weights[0].dtype,
+                            ),
+                        )
+                    for i, w_i in enumerate(weights):
+                        torch.maximum(
+                            q._amax[i],
+                            w_i.detach().abs().amax(),
+                            out=q._amax[i],
+                        )
+            new_args[weights_start : weights_start + num_gemms] = _GroupedAxis0FakeQuant.apply(
+                q._amax,
+                q.num_bits,
+                q.unsigned,
+                q.narrow_range,
+                *weights,
+            )
         else:
             for i in range(weights_start, weights_start + num_gemms):
                 new_args[i] = self.weight_quantizer(args[i])

--- a/modelopt/torch/quantization/plugins/transformer_engine.py
+++ b/modelopt/torch/quantization/plugins/transformer_engine.py
@@ -27,8 +27,63 @@ from packaging.version import Version
 
 from modelopt.torch.quantization.utils import replace_function
 
+import modelopt.torch.kernels.quantization.gemm as _triton_kernels
 from ..nn import QuantModuleRegistry, TensorQuantizer
 from .custom import _ParallelLinear
+
+
+class _GroupedAxis0FakeQuantFn(torch.autograd.Function):
+    """Triton-backed per-expert axis-0 fake-quant for TEGroupedLinear.
+
+    See OMNIML-5072 AC5 (Option B) and
+    `modelopt/torch/kernels/quantization/gemm/grouped_axis0_fakequant.py`
+    for the kernel + design rationale.
+
+    Forward: dispatch to the Triton kernel that takes N expert weights as
+    a tensor-of-pointers (no stack memcopy). Backward honors modelopt's
+    default `pass_through_bwd=True` semantics: when set, gradient flows back
+    unchanged (no STE kernel launch); when False, the clip-aware Triton STE
+    backward kernel runs. This mirrors `_fake_quant_backward_function` in
+    tensor_quant.py — under the default config the STE backward kernel is
+    NEVER invoked, which is why A's full-layer bwd is 547us at Ultra
+    (GEMM bwd alone, no STE work).
+
+    VALIDATION STATUS: not yet bench-validated. The fallback path in
+    te_grouped_quantized_linear_fn (stack + cuda_ext + unbind) is the
+    production-blessed alternative until this kernel passes the checklist
+    in VALIDATION_TODO.md.
+    """
+
+    @staticmethod
+    def forward(ctx, amax_vec, num_bits, narrow_range, pass_through_bwd, *weights):
+        outputs = _triton_kernels.grouped_axis0_fakequant(
+            list(weights), amax_vec, num_bits=num_bits, narrow_range=narrow_range
+        )
+        ctx.pass_through_bwd = pass_through_bwd
+        if not pass_through_bwd:
+            # Match modelopt's `_save_for_backward_if_needed`: skip the save when
+            # pass_through_bwd is on. This lets backward early-exit without
+            # touching saved_tensors at all.
+            ctx.save_for_backward(amax_vec, *weights)
+            ctx.num_weights = len(weights)
+        else:
+            ctx.num_weights = len(weights)
+        return tuple(outputs)
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        # Order of forward args: (amax_vec, num_bits, narrow_range, pass_through_bwd, *weights)
+        if ctx.pass_through_bwd:
+            # No-op STE — gradient passes through unchanged. Matches modelopt's
+            # default `_fake_quant_backward_function` behavior when `saved_tensors`
+            # is empty. Zero kernel work in this branch.
+            return (None, None, None, None, *grad_outputs)
+        saved = ctx.saved_tensors
+        amax_vec, weights = saved[0], list(saved[1:])
+        grad_inputs = _triton_kernels.grouped_axis0_fakequant_backward(
+            weights, list(grad_outputs), amax_vec
+        )
+        return (None, None, None, None, *grad_inputs)
 
 _TE_VERSION = Version(te.__version__)
 
@@ -271,18 +326,44 @@ class _QuantTEGroupedLinear(_ParallelLinear):
         new_args = list(args)
         new_args[inp_pos] = self.input_quantizer(args[inp_pos])
         if self._is_per_expert_weight_quant():
-            # Stack the N expert weights into one [N, out, in] tensor so the
-            # quantizer's axis-0 reduction sees them together; the resulting
-            # _amax of shape [N, 1, 1] broadcasts to give per-expert fake-quant.
+            # Per-expert axis-0 fake-quant. Two paths:
             #
-            # Use unbind(0) (not q_stacked[i]) for the unpacking — unbind's
-            # backward is a single fused stack op, vs N SelectBackward nodes
-            # that each allocate an intermediate grad buffer per slice. At
-            # high N (hundreds of experts), this collapses backward latency
-            # by orders of magnitude. Measured under OMNIML-5064.
-            stacked = torch.stack(list(args[weights_start : weights_start + num_gemms]), dim=0)
-            q_stacked = self.weight_quantizer(stacked)
-            new_args[weights_start : weights_start + num_gemms] = q_stacked.unbind(0)
+            # 1. Triton tensor-of-pointers kernel (OMNIML-5072 Option B, AC5).
+            #    Avoids the stack memcopy by passing N expert ptrs into a single
+            #    Triton launch. Soft-gated behind triton_kernels.IS_AVAILABLE +
+            #    feature-presence check so older modelopt installs without the
+            #    kernel fall back automatically.
+            #
+            # 2. Stack-then-quantize-then-unbind via cuda_ext (the path d7ccf0a9
+            #    fixed by replacing indexed select with unbind(0)). This is the
+            #    production-blessed fallback. unbind's backward is a single fused
+            #    stack op, vs N SelectBackward nodes that each allocate an
+            #    intermediate grad buffer per slice. At high N this collapses
+            #    backward latency by orders of magnitude (OMNIML-5064 AC4).
+            q = self.weight_quantizer
+            weights = list(args[weights_start : weights_start + num_gemms])
+            use_triton_path = (
+                _triton_kernels.IS_AVAILABLE
+                and hasattr(_triton_kernels, "grouped_axis0_fakequant")
+                and hasattr(q, "_amax")
+                and not q._if_calib
+            )
+            if use_triton_path:
+                # Read pass_through_bwd from the live quantizer to mirror modelopt's
+                # default-True STE semantics; under the default, our Triton bwd
+                # kernel is a no-op and the bwd matches A's GEMM-only latency.
+                pass_through_bwd = getattr(q, "_pass_through_bwd", True)
+                new_args[weights_start : weights_start + num_gemms] = (
+                    _GroupedAxis0FakeQuantFn.apply(
+                        q._amax, q.num_bits, q.narrow_range, pass_through_bwd, *weights
+                    )
+                )
+            else:
+                # Fallback: AC4 unbind path (also runs during calibration since
+                # the Triton kernel currently bypasses modelopt's calibrator).
+                stacked = torch.stack(weights, dim=0)
+                q_stacked = q(stacked)
+                new_args[weights_start : weights_start + num_gemms] = q_stacked.unbind(0)
         else:
             for i in range(weights_start, weights_start + num_gemms):
                 new_args[i] = self.weight_quantizer(args[i])

--- a/modelopt/torch/quantization/plugins/transformer_engine.py
+++ b/modelopt/torch/quantization/plugins/transformer_engine.py
@@ -274,10 +274,15 @@ class _QuantTEGroupedLinear(_ParallelLinear):
             # Stack the N expert weights into one [N, out, in] tensor so the
             # quantizer's axis-0 reduction sees them together; the resulting
             # _amax of shape [N, 1, 1] broadcasts to give per-expert fake-quant.
+            #
+            # Use unbind(0) (not q_stacked[i]) for the unpacking — unbind's
+            # backward is a single fused stack op, vs N SelectBackward nodes
+            # that each allocate an intermediate grad buffer per slice. At
+            # high N (hundreds of experts), this collapses backward latency
+            # by orders of magnitude. Measured under OMNIML-5064.
             stacked = torch.stack(list(args[weights_start : weights_start + num_gemms]), dim=0)
             q_stacked = self.weight_quantizer(stacked)
-            for i in range(num_gemms):
-                new_args[weights_start + i] = q_stacked[i]
+            new_args[weights_start : weights_start + num_gemms] = q_stacked.unbind(0)
         else:
             for i in range(weights_start, weights_start + num_gemms):
                 new_args[i] = self.weight_quantizer(args[i])

--- a/modelopt/torch/quantization/plugins/transformer_engine.py
+++ b/modelopt/torch/quantization/plugins/transformer_engine.py
@@ -150,10 +150,20 @@ class _QuantTEGroupedLinear(_ParallelLinear):
 
     def modelopt_post_restore(self, prefix: str = ""):
         # GroupedMLP stores the weights as weight0, weight1, etc. To run post_restore in order to
-        # initialize the quantizer states, self.weight is used to extract shape, dtype etc. Assigning
-        # self.weight0 to self.weight to run the quantizer states initialization.
+        # initialize the quantizer states, self.weight is used to extract shape, dtype etc.
+        #
+        # Per-expert mode (axis=0) stores _amax as [num_gemms, 1, 1] — the same shape
+        # iter_weights_for_calibration and te_grouped_quantized_linear_fn produce by stacking
+        # the per-expert weights first. Mirror that here so the restore path initializes the
+        # placeholder _amax to the same shape; otherwise dist-checkpoint load builds _amax from
+        # the un-stacked [out, in] view (shape [out, 1]) and _gather_global_per_expert_amax
+        # later fails on `amax.view(num_gemms)`.
         assert not hasattr(self, "weight"), "self.weight should not exist for TEGroupedLinear"
-        self.weight = self.weight0
+        if self._is_per_expert_weight_quant():
+            weights = [getattr(self, f"weight{i}") for i in range(self.num_gemms)]
+            self.weight = torch.stack(weights, dim=0)
+        else:
+            self.weight = self.weight0
         super().modelopt_post_restore(prefix=prefix)
         # Remove self.weight after post_restore.
         delattr(self, "weight")

--- a/tests/_test_utils/torch/megatron/models.py
+++ b/tests/_test_utils/torch/megatron/models.py
@@ -140,6 +140,7 @@ def get_mcore_gpt_model(
     use_cpu_initialization: bool = False,
     bf16: bool = True,
     use_te: bool = False,
+    sequence_parallel: bool = False,
     # MoE-specific parameters
     moe_grouped_gemm: bool = False,
     moe_ffn_hidden_size: int | None = None,
@@ -168,7 +169,7 @@ def get_mcore_gpt_model(
         pipeline_model_parallel_size=pipeline_model_parallel_size,
         expert_model_parallel_size=expert_model_parallel_size,
         expert_tensor_parallel_size=expert_tensor_parallel_size,
-        sequence_parallel=False,
+        sequence_parallel=sequence_parallel,
         num_layers=num_layers,
         num_layers_in_first_pipeline_stage=num_layers_in_first_pipeline_stage,
         num_layers_in_last_pipeline_stage=num_layers_in_last_pipeline_stage,

--- a/tests/gpu_megatron/torch/quantization/plugins/test_megatron.py
+++ b/tests/gpu_megatron/torch/quantization/plugins/test_megatron.py
@@ -694,6 +694,48 @@ def test_te_grouped_vs_sequential_quantize(dist_workers_size_4, quant_cfg):
     )
 
 
+# OMNIML-4998: per-expert weight amax (axis=0) on TEGroupedLinear should round-trip
+# through sharded_state_dict / dist-checkpoint with bit-for-bit equality across EP.
+TE_GROUPED_PER_EXPERT_CFG = {
+    "algorithm": "max",
+    "quant_cfg": [
+        # Disable everything (attention, embeddings, non-MoE MLP) so the test
+        # isolates the per-expert path on TEGroupedMLP experts.
+        {"quantizer_name": "*", "enable": False},
+        # Re-enable axis=0 on TEGrouped MoE experts only -- this triggers the
+        # per-expert path inside _QuantTEGroupedLinear.
+        {
+            "quantizer_name": "*experts.linear_fc*.weight_quantizer",
+            "cfg": {"num_bits": 8, "axis": 0, "enable": True},
+        },
+    ],
+}
+
+
+def test_te_grouped_per_expert_sharded_state_dict(dist_workers_size_4, need_4_gpus, tmp_path):
+    """Per-expert (axis=0) weight amax round-trips through dist-checkpoint on TEGroupedMLP."""
+    moe_config = {
+        "tp_size": 1,
+        "ep_size": 2,
+        "etp_size": 1,
+        "num_moe_experts": 4,
+        "moe_grouped_gemm": True,
+        "transformer_impl": "transformer_engine",
+    }
+    dist_workers_size_4.run(
+        partial(
+            _test_sharded_state_dict,
+            tmp_path,
+            copy.deepcopy(TE_GROUPED_PER_EXPERT_CFG),
+            32,
+            None,
+            False,
+            False,
+            moe_config,
+        ),
+    )
+
+
 @pytest.mark.parametrize("ep_size", [1, 2])
 @pytest.mark.parametrize("sync_weight_amax", [True, False])
 def test_layer_sync_moe_local_experts_amax(dist_workers, ep_size, sync_weight_amax):

--- a/tests/gpu_megatron/torch/quantization/plugins/test_megatron.py
+++ b/tests/gpu_megatron/torch/quantization/plugins/test_megatron.py
@@ -713,9 +713,16 @@ TE_GROUPED_PER_EXPERT_CFG = {
 
 
 def test_te_grouped_per_expert_sharded_state_dict(dist_workers_size_4, need_4_gpus, tmp_path):
-    """Per-expert (axis=0) weight amax round-trips through dist-checkpoint on TEGroupedMLP."""
+    """Per-expert (axis=0) weight amax round-trips through dist-checkpoint on TEGroupedMLP.
+
+    Uses the TP=2 EP=2 layout that the existing ``test_moe_sharded_state_dict`` runs
+    against for per-tensor FP8/NVFP4. TP=1 EP=2 has an unrelated MCore + TEGrouped +
+    dist-checkpoint hang at SeqNum=5 default-PG ALLGATHER that fires even at
+    axis=None; verified empirically on 2026-06-09. Stay on the known-good layout
+    here; revisit TP=1 EP=2 once the MCore-side fix lands.
+    """
     moe_config = {
-        "tp_size": 1,
+        "tp_size": 2,
         "ep_size": 2,
         "etp_size": 1,
         "num_moe_experts": 4,

--- a/tests/gpu_megatron/torch/quantization/plugins/test_megatron.py
+++ b/tests/gpu_megatron/torch/quantization/plugins/test_megatron.py
@@ -289,6 +289,7 @@ def _gpt_model_provider(
                 use_cpu_initialization=meta_device,
                 num_moe_experts=num_moe_experts,
                 moe_grouped_gemm=moe_grouped_gemm,
+                sequence_parallel=(tp_size > 1),  # Required for MoE + TP (mirrors hybrid path)
             )
 
     if not meta_device:

--- a/tests/gpu_megatron/torch/quantization/plugins/test_megatron.py
+++ b/tests/gpu_megatron/torch/quantization/plugins/test_megatron.py
@@ -712,14 +712,14 @@ TE_GROUPED_PER_EXPERT_CFG = {
 }
 
 
-def test_te_grouped_per_expert_sharded_state_dict(dist_workers_size_4, need_4_gpus, tmp_path):
+def test_te_grouped_per_expert_sharded_state_dict(dist_workers, need_4_gpus, tmp_path):
     """Per-expert (axis=0) weight amax round-trips through dist-checkpoint on TEGroupedMLP.
 
-    Uses the TP=2 EP=2 layout that the existing ``test_moe_sharded_state_dict`` runs
-    against for per-tensor FP8/NVFP4. TP=1 EP=2 has an unrelated MCore + TEGrouped +
-    dist-checkpoint hang at SeqNum=5 default-PG ALLGATHER that fires even at
-    axis=None; verified empirically on 2026-06-09. Stay on the known-good layout
-    here; revisit TP=1 EP=2 once the MCore-side fix lands.
+    Mirrors ``test_moe_sharded_state_dict``'s setup exactly (dist_workers fixture,
+    hidden_size=256, tp=2 ep=2 etp=1 num_moe_experts=4 moe_grouped_gemm=True), with
+    only the quant_cfg varying. The existing test is known to pass at this layout
+    for FP8_DEFAULT_CFG / NVFP4_DEFAULT_CFG; this test exercises the OMNIML-4998
+    per-expert (axis=0) path on top of the same infrastructure.
     """
     moe_config = {
         "tp_size": 2,
@@ -729,12 +729,12 @@ def test_te_grouped_per_expert_sharded_state_dict(dist_workers_size_4, need_4_gp
         "moe_grouped_gemm": True,
         "transformer_impl": "transformer_engine",
     }
-    dist_workers_size_4.run(
+    dist_workers.run(
         partial(
             _test_sharded_state_dict,
             tmp_path,
             copy.deepcopy(TE_GROUPED_PER_EXPERT_CFG),
-            32,
+            256,
             None,
             False,
             False,

--- a/tools/launcher/core.py
+++ b/tools/launcher/core.py
@@ -257,10 +257,16 @@ def build_slurm_executor(
         f"{job_dir}/{experiment_title}/{experiment_id}"
         f"/{task_name}/code/modules/Model-Optimizer/modelopt_recipes"
     )
+    megatron_dst = slurm_config.megatron_install_path
+    megatron_src = (
+        f"{job_dir}/{experiment_title}/{experiment_id}"
+        f"/{task_name}/code/modules/Megatron-LM/megatron"
+    )
     container_mounts += [
         f"{scratch_src}:{scratch_dst}",
         f"{modelopt_src}:{modelopt_dst}",
         f"{modelopt_recipes_src}:{modelopt_recipes_dst}",
+        f"{megatron_src}:{megatron_dst}",
         f"{job_dir}/{experiment_title}:/{experiment_title}",
     ]
 
@@ -309,6 +315,7 @@ def build_docker_executor(
     task_name,
     packager,
     modelopt_src_path=None,
+    megatron_src_path=None,
     experiment_title="cicd",
 ):
     """Build a DockerExecutor for local GPU jobs."""
@@ -329,12 +336,16 @@ def build_docker_executor(
         "modelopt_recipes",
     )
     modelopt_recipes_src_path = os.path.join(os.path.dirname(modelopt_src_path), "modelopt_recipes")
+    megatron_dst = slurm_config.megatron_install_path
+    if megatron_src_path is None:
+        megatron_src_path = os.path.join(os.getcwd(), "modules/Megatron-LM/megatron")
     exp_title_src = os.path.join(job_dir, experiment_title)
     os.makedirs(exp_title_src, exist_ok=True)
     container_mounts += [
         f"{scratch_src}:{scratch_dst}",
         f"{modelopt_src_path}:{modelopt_dst}",
         f"{modelopt_recipes_src_path}:{modelopt_recipes_dst}",
+        f"{megatron_src_path}:{megatron_dst}",
         f"{exp_title_src}:/{experiment_title}",
     ]
 

--- a/tools/launcher/slurm_config.py
+++ b/tools/launcher/slurm_config.py
@@ -40,6 +40,7 @@ class SlurmConfig:
     qos: Optional[str] = None
     container: Optional[str] = None
     modelopt_install_path: str = "/usr/local/lib/python3.12/dist-packages/modelopt"
+    megatron_install_path: str = "/usr/local/lib/python3.12/dist-packages/megatron"
     container_mounts: Optional[list[str]] = None
     srun_args: Optional[list[str]] = None
     array: Optional[str] = None
@@ -62,6 +63,7 @@ def slurm_factory(
     gpus_per_node: int = 1,
     container: str = "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc8",
     modelopt_install_path: str = "/usr/local/lib/python3.12/dist-packages/modelopt",
+    megatron_install_path: str = "/usr/local/lib/python3.12/dist-packages/megatron",
     container_mounts: list[str] = [
         "{}:/hf-local".format(os.environ.get("SLURM_HF_LOCAL", "/hf-local")),
     ],
@@ -80,6 +82,7 @@ def slurm_factory(
         gpus_per_node=gpus_per_node,
         container=container,
         modelopt_install_path=modelopt_install_path,
+        megatron_install_path=megatron_install_path,
         container_mounts=container_mounts,
         srun_args=srun_args,
         array=array,

--- a/tools/launcher/tests/test_docker_execution.py
+++ b/tools/launcher/tests/test_docker_execution.py
@@ -47,6 +47,7 @@ class TestBuildDockerExecutor:
                 local=False,
                 container="test:latest",
                 modelopt_install_path="/opt/modelopt",
+                megatron_install_path="/opt/megatron",
                 container_mounts=None,
                 srun_args=None,
                 array=None,
@@ -69,6 +70,7 @@ class TestBuildDockerExecutor:
                 local=False,
                 container="test:latest",
                 modelopt_install_path="/opt/modelopt",
+                megatron_install_path="/opt/megatron",
                 container_mounts=None,
                 srun_args=None,
                 array=None,
@@ -91,6 +93,7 @@ class TestBuildDockerExecutor:
                 local=False,
                 container="test:latest",
                 modelopt_install_path="/opt/modelopt",
+                megatron_install_path="/opt/megatron",
                 container_mounts=None,
                 srun_args=None,
                 array=None,
@@ -114,6 +117,7 @@ class TestBuildDockerExecutor:
                 local=False,
                 container="test:latest",
                 modelopt_install_path="/opt/modelopt",
+                megatron_install_path="/opt/megatron",
                 container_mounts=None,
                 srun_args=None,
                 array=None,
@@ -128,6 +132,30 @@ class TestBuildDockerExecutor:
         volumes = executor.volumes
         assert any("/custom/modelopt:/opt/modelopt" in v for v in volumes)
 
+    def test_megatron_mount(self, tmp_path):
+        job_dir = str(tmp_path / "experiments")
+        executor = build_docker_executor(
+            hf_local="/tmp/hf",
+            slurm_config=MagicMock(
+                local=False,
+                container="test:latest",
+                modelopt_install_path="/opt/modelopt",
+                megatron_install_path="/opt/megatron",
+                container_mounts=None,
+                srun_args=None,
+                array=None,
+            ),
+            experiment_id="exp_789",
+            job_dir=job_dir,
+            task_name="task_0",
+            packager=MagicMock(),
+            modelopt_src_path="/custom/modelopt",
+            megatron_src_path="/custom/megatron",
+            experiment_title="cicd",
+        )
+        volumes = executor.volumes
+        assert any("/custom/megatron:/opt/megatron" in v for v in volumes)
+
     def test_experiment_title_mount(self, tmp_path):
         job_dir = str(tmp_path / "experiments")
         executor = build_docker_executor(
@@ -136,6 +164,7 @@ class TestBuildDockerExecutor:
                 local=False,
                 container="test:latest",
                 modelopt_install_path="/opt/modelopt",
+                megatron_install_path="/opt/megatron",
                 container_mounts=None,
                 srun_args=None,
                 array=None,
@@ -159,6 +188,7 @@ class TestBuildDockerExecutor:
                 local=True,
                 container="test:latest",
                 modelopt_install_path="/opt/modelopt",
+                megatron_install_path="/opt/megatron",
                 container_mounts=["/data:/data", "/models:/models"],
                 srun_args=None,
                 array=None,

--- a/tools/launcher/tests/test_slurm_config.py
+++ b/tools/launcher/tests/test_slurm_config.py
@@ -45,6 +45,8 @@ class TestSlurmConfig:
         assert cfg.container_mounts is None
         assert cfg.srun_args is None
         assert cfg.array is None
+        assert cfg.modelopt_install_path == "/usr/local/lib/python3.12/dist-packages/modelopt"
+        assert cfg.megatron_install_path == "/usr/local/lib/python3.12/dist-packages/megatron"
 
     def test_custom_values(self):
         cfg = SlurmConfig(

--- a/tools/launcher/tests/test_slurm_executor.py
+++ b/tools/launcher/tests/test_slurm_executor.py
@@ -40,6 +40,7 @@ class TestBuildSlurmExecutor:
             partition="batch",
             container="nvcr.io/test:latest",
             modelopt_install_path="/opt/modelopt",
+            megatron_install_path="/opt/megatron",
             container_mounts=["/hf-local:/hf-local"],
             srun_args=["--no-container-mount-home"],
             nodes=1,
@@ -63,10 +64,12 @@ class TestBuildSlurmExecutor:
         mock_executor.assert_called_once()
         call_kwargs = mock_executor.call_args[1]
 
-        # Verify container mounts include scratch, modelopt, and experiment title
+        # Verify container mounts include scratch, modelopt, megatron, and experiment title
         mounts = call_kwargs["container_mounts"]
         assert any("/scratchspace" in m for m in mounts)
         assert any("/opt/modelopt" in m for m in mounts)
+        assert any(":/opt/megatron" in m for m in mounts)
+        assert any("modules/Megatron-LM/megatron:/opt/megatron" in m for m in mounts)
         assert any("/cicd" in m for m in mounts)
         # Original mount preserved
         assert any("/hf-local:/hf-local" in m for m in mounts)
@@ -83,6 +86,7 @@ class TestBuildSlurmExecutor:
             partition="batch",
             container="img",
             modelopt_install_path="/opt/mo",
+            megatron_install_path="/opt/me",
             container_mounts=[],
             srun_args=[],
             nodes=1,
@@ -118,6 +122,7 @@ class TestBuildSlurmExecutor:
             partition="batch",
             container="img",
             modelopt_install_path="/opt/mo",
+            megatron_install_path="/opt/me",
             container_mounts=[],
             srun_args=[],
             nodes=1,
@@ -156,6 +161,7 @@ class TestBuildSlurmExecutor:
             partition="gpu",
             container="nvcr.io/img:v1",
             modelopt_install_path="/opt/mo",
+            megatron_install_path="/opt/me",
             container_mounts=[],
             srun_args=["--mpi=pmix"],
             nodes=2,
@@ -201,6 +207,7 @@ class TestBuildSlurmExecutor:
             partition="b",
             container="c",
             modelopt_install_path="/m",
+            megatron_install_path="/g",
             container_mounts=None,
             srun_args=None,
             nodes=1,


### PR DESCRIPTION
### What does this PR do?

Type of change: New feature

Per-expert (axis=0) weight quantization on `_QuantTEGroupedLinear`, plus the cluster infrastructure to verify it. Consolidates three Jira tickets onto one branch:

- **OMNIML-4998** — Relax `_QuantMegatronTEGroupedLinear._process_quantizer_amax`'s per-tensor restriction. Per-expert `_amax` of shape `[num_gemms, 1, 1]` is calibrated via `iter_weights_for_calibration`'s stacked weight, broadcast through the existing axis-N machinery in `TensorQuantizer.forward`, and round-tripped via `sharded_state_dict` save/restore. Per-tensor (`axis=None`) path remains bit-for-bit equivalent.
- **OMNIML-5029** — `megatron_install_path` field on `SlurmConfig` / `aws_cmh_slurm_factory`. Bind-mounts the packaged Megatron-LM so `make_tp_sharded_tensor_for_checkpoint(..., allow_shape_mismatch=True)` resolves against `nemo:25.11.nemotron_3_nano` (previously deadlocked the dist-checkpoint metadata exchange for 10 minutes).
- **OMNIML-5030** — Test fix: enable `sequence_parallel=True` in the MoE+TP `test_moe_sharded_state_dict` config so the TEGrouped path doesn't trip the post-OMNIML-5029 assertion.

### Usage

```python
import modelopt.torch.quantization as mtq

config = {
    "algorithm": "max",
    "quant_cfg": [
        {"quantizer_name": "*", "enable": False},
        {
            "quantizer_name": "*experts.linear_fc*.weight_quantizer",
            "cfg": {"num_bits": 8, "axis": 0, "enable": True},
        },
    ],
}
model = mtq.quantize(model, config, forward)
```

### Testing

`tests/gpu_megatron/torch/quantization/plugins/test_megatron.py::test_te_grouped_per_expert_sharded_state_dict` (new) — per-expert axis=0 calibration + dist-checkpoint save/restore round-trip on `tp=2 ep=2 etp=1 num_moe_experts=4`. **PASSED 4/4 ranks on aws-cmh** (SLURM 511920, experiment `cicd_1781150929`, container `nvcr.io/nvidia/nemo:25.11.nemotron_3_nano`).

Existing tests continue to pass:
- `test_moe_sharded_state_dict[*-True]` with the OMNIML-5030 `sequence_parallel` fix.
- Per-tensor (`axis=None`) paths — bit-for-bit equivalent (no behavior change).

Cluster yaml: `services/model-optimizer/test/omniml_4998_per_expert_amax_smoke.yaml` on nmm-sandbox `hungyuehc/omniml-5029 @ 24860c3`.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ — per-tensor (`axis=None`) path is bit-for-bit equivalent; per-expert is a new opt-in via existing axis-N machinery, not a behavior change for existing users.
- New PIP dependency / copied code?: N/A.
- Did you write any new necessary tests?: ✅ — `test_te_grouped_per_expert_sharded_state_dict`.
- Did you update Changelog?: ❌ — TBD; will add a changelog entry before marking Ready-for-review.
- Did you get Claude approval on this PR?: N/A — will run `/claude review` before marking Ready-for-review.

### Additional Information

**Related Jira:**
- OMNIML-4998 (primary scope; AC-1 and AC-2 met)
- OMNIML-5029 (launcher fix)
- OMNIML-5030 (test fix)
- OMNIML-5051 (follow-up: per-expert quant + TE-grouped MoE LoRA compose)

**Relationship to PR #1550** (`jennifchen/te_per_expert`, WIP): PR #1550 explores the same goal with a different design — opt-in env-var `MODELOPT_TEGROUPED_PER_EXPERT_QUANTIZER=1` to create N separate `weight_quantizer_i` instances. This PR uses the single-quantizer + axis=0 design instead, which reuses modelopt's existing axis-N machinery without a new env-var or per-gemm state. The two designs serve overlapping but not identical needs:

- This PR covers "all experts share the same quantizer config but each has its own amax" — common case.
- PR #1550 covers "each expert independently configurable" — rarer; can be layered later.

PR #1550 is currently WIP and CONFLICTING vs main. Open to discussion on whether to merge approaches; this PR is the focused common-case implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-expert weight quantization support for distributed checkpointing in MoE models.
  * Integrated Megatron-LM mounting into launcher tools for both Slurm and Docker environments.

* **Improvements**
  * Enhanced tensor-parallel and expert-parallel weight quantization synchronization during calibration and checkpointing.

* **Tests**
  * Added regression test for per-expert weight quantization across distributed configurations.
  * Expanded launcher integration test coverage for Docker and Slurm environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->