### PR TITLE
[OMNIML-4963] cell_t0_d7

### DIFF
--- a/tools/launcher/common/specdec_bench/_cells/Qwen3.5-4B_dflash_vllm_t0_d7.yaml
+++ b/tools/launcher/common/specdec_bench/_cells/Qwen3.5-4B_dflash_vllm_t0_d7.yaml
@@ -1,0 +1,4 @@
+sampling_kwargs:
+  temperature: 0
+engine_args:
+  max_model_len: 40960

--- a/tools/launcher/examples/Qwen3.5/Qwen3.5-4B/specdec_bench_dflash_vllm_t0_d7.yaml
+++ b/tools/launcher/examples/Qwen3.5/Qwen3.5-4B/specdec_bench_dflash_vllm_t0_d7.yaml
@@ -1,0 +1,69 @@
+# SPEED-bench DFlash speculative-decoding run for Qwen3.5-4B via vLLM.
+#
+# The qwen3_5 model_type and DFlash speculative method both require a
+# recent vLLM image; qwen3_5-cu130 predates the public dflash method.
+
+job_name: Qwen3.5-4B_specdec_bench_dflash_vllm_t0_d7
+
+pipeline:
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3.5-4B
+
+  # task_0: SPEED qualitative split
+  task_0:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/qualitative
+      - --engine VLLM
+      - --speculative_algorithm DFLASH
+      - --draft_length 7
+      - --block_size 8
+      - --draft_model_dir /hf-local/z-lab/Qwen3.5-4B-DFlash
+      - --runtime_params common/specdec_bench/_cells/Qwen3.5-4B_dflash_vllm_t0_d7.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 32
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/Qwen3.5-4B_dflash_vllm_t0_d7/qualitative
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:v0.22.1
+
+  # task_1: SPEED throughput_32k split
+  task_1:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/throughput_32k
+      - --engine VLLM
+      - --speculative_algorithm DFLASH
+      - --draft_length 7
+      - --block_size 8
+      - --draft_model_dir /hf-local/z-lab/Qwen3.5-4B-DFlash
+      - --runtime_params common/specdec_bench/_cells/Qwen3.5-4B_dflash_vllm_t0_d7.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 8
+      - --num_requests 80
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/Qwen3.5-4B_dflash_vllm_t0_d7/throughput_32k
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:v0.22.1


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-4963](https://jirasw.nvidia.com/browse/OMNIML-4963).

Stage `cell_t0_d7` of Epic `OMNIML-4961`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._

_Pollution-strip removed `uv.lock` from this commit (sidecar narration and/or incidental lockfile regeneration are never part of the agent's intended deliverable)._