### PR TITLE
launcher: add draft_model to GlobalVariables for spec-decode parents

### DIFF
--- a/tools/launcher/core.py
+++ b/tools/launcher/core.py
@@ -154,6 +154,16 @@ class GlobalVariables:
     hf_data: str = None
     hf_local: str = None
     output_dir: str = None
+    # Speculative-decoding draft / assistant model path. SPEED-bench
+    # MTP/EAGLE3/DRAFT_TARGET/DFLASH parent YAMLs reference this via
+    # ``--draft_model_dir <<global_vars.draft_model>>`` on both the
+    # qualitative + throughput_32k tasks so the path lives in one
+    # place. Surfaced on OMNIML-5024: the gemma-4-E4B-it / MTP / vLLM
+    # parent used the indirection but the launcher rejected it with
+    # ``No parameter named 'draft_model' exists`` because the
+    # dataclass schema didn't include the key; the agent worked
+    # around it inline but the canonical YAML stayed broken.
+    draft_model: str = None
 
 
 @dataclass


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Adds `draft_model: str = None` to the launcher's `GlobalVariables` dataclass so SPEED-bench MTP / EAGLE3 / DRAFT_TARGET / DFLASH parent YAMLs can reference the draft/assistant model path via `<<global_vars.draft_model>>` indirection on both task_0 (qualitative) and task_1 (throughput_32k).

### Bug

The gemma-4-E4B-it / MTP / vLLM parent YAML (merged in PR #1663) wires the draft model as:

```yaml
pipeline:
  global_vars:
    hf_model: /hf-local/google/gemma-4-E4B-it
    draft_model: /hf-local/google/gemma-4-E4B-it-assistant
  task_0:
    args:
      - --draft_model_dir <<global_vars.draft_model>>
```

The launcher rejects this with:

```
ValueError: No parameter named 'draft_model' exists
```

because `GlobalVariables` is a strict dataclass with only 4 fields (`hf_model`, `hf_data`, `hf_local`, `output_dir`). Surfaced on OMNIML-5024 pipeline #54356795 — the agent worked around it by inlining the literal path, but the canonical YAML in #1663 remains broken until this lands.

### Usage

```yaml
pipeline:
  global_vars:
    hf_model: /hf-local/google/gemma-4-E4B-it
    draft_model: /hf-local/google/gemma-4-E4B-it-assistant
  task_0:
    args:
      - --speculative_algorithm MTP
      - --draft_model_dir <<global_vars.draft_model>>
  task_1:
    args:
      - --draft_model_dir <<global_vars.draft_model>>
```

### Testing

- 4 existing `global_vars` / `GlobalVariables` tests in `tests/test_core.py` + `tests/test_core_extended.py` pass.
- The existing `<<global_vars.X>>` resolution in `SandboxPipeline.__post_init__` (uses `dataclasses.asdict`) picks the new field up automatically — no other changes needed.

### Before your PR is "*Ready for review*"

- Backward compatible: ✅ (existing parents that don't use `draft_model` keep working).
- New PIP dependency: N/A.
- New tests: ❌ — the existing `global_vars` parameterized tests cover the resolution path; no schema-level test was needed for the prior 4 fields, so adding one just for this would be inconsistent.
- Changelog: ❌ — small dataclass extension; not worth a Changelog entry.
- Claude review: ❌ — will trigger if reviewers request.

### Additional Information

- JIRA: [OMNIML-5024](https://jirasw.nvidia.com/browse/OMNIML-5024) (the cell that surfaced this)
- Related: PR #1663 (Gemma-4 parent YAML that referenced the unresolved global var)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added draft model configuration option for pipeline templates, enabling enhanced flexibility in model selection for advanced pipeline scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->