### PR TITLE
Fix conversation loading logic in UltraChat dataset

### DIFF
--- a/examples/dataset/README.md
+++ b/examples/dataset/README.md
@@ -23,7 +23,7 @@ speculative decoding draft-model training, etc.
 | --- | --- |
 | `make_nemotron_ptv3_dataset.py` | Build a dataset from the [Nemotron PT v3 collection](https://huggingface.co/collections/nvidia/nemotron-post-training-v3) using a configurable YAML mix |
 | `make_nemotron_ptv2_dataset.py` | Build a dataset from [Nemotron-Post-Training-Dataset-v2](https://huggingface.co/datasets/nvidia/Nemotron-Post-Training-Dataset-v2) |
-| `make_dataset.py` | General-purpose mixer for arbitrary HuggingFace datasets (mtbench, sharegpt, ultrachat, magpie, etc.) |
+| `make_dataset.py` | General-purpose mixer for arbitrary HuggingFace datasets (mtbench, sharegpt, magpie, etc.) |
 | `conversation_utils.py` | Shared utilities: augmentation, role normalization, assistant-turn stripping |
 | `add_nemotron_chat.py` | Add Nemotron v2 chat conversations to an existing dataset |
 | `augmentations.yaml` | Augmentation variants (language redirects, style hints) for `make_nemotron_pt*.py` |

--- a/examples/dataset/example_data_config.yaml
+++ b/examples/dataset/example_data_config.yaml
@@ -5,12 +5,6 @@ outputs:
       - name: "sharegpt"
         splits:
           all: 0
-      - name: "ultrachat"
-        # UltraChat's loader yields prompt-only turns (no assistant completions),
-        # which makes answer_only_loss=true mask nothing. Use daring-anteater below.
-        splits:
-          train_gen: 0
-          train_sft: 0
       - name: "mtbench"
         splits:
           all: 0

--- a/examples/dataset/make_dataset.py
+++ b/examples/dataset/make_dataset.py
@@ -276,14 +276,14 @@ async def _load_ultrachat_conversations(
     ds = ds.shuffle(seed=42)
     yield len(ds)
     for i in range(len(ds)):
-        prompt = ds[i]["prompt"].strip()
         prompt_id = ds[i]["prompt_id"].strip()
-        if prompt:
-            msgs = [{"role": "user", "content": prompt}]
-            if not prompt_id:
-                prompt_id = id_for_conversation(msgs)
-            prompt_id = f"ultrachat-{split_name}-{prompt_id}"
-            yield {"conversation_id": prompt_id, "conversations": msgs}
+        msgs = ds[i]["messages"]
+        if not msgs:
+            continue
+        if not prompt_id:
+            prompt_id = id_for_conversation(msgs)
+        prompt_id = f"ultrachat-{split_name}-{prompt_id}"
+        yield {"conversation_id": prompt_id, "conversations": msgs}
     logger.info(f"Finished loading UltraChat {split_name} conversations.")
 
 

--- a/examples/dataset/make_dataset.py
+++ b/examples/dataset/make_dataset.py
@@ -26,7 +26,6 @@ A global limit can also be placed on the total number of conversations in each o
 The dataset choices available are:
 - "mtbench"
 - "sharegpt"
-- "ultrachat"
 - "daring-anteater"
 - "magpie"
 - "nemotron-post-training-v2"
@@ -40,11 +39,10 @@ outputs:
     sources:
       - name: "mtbench"
         splits: ["all"]
-      - name: "ultrachat"
+      - name: "magpie"
         splits:
-          train_gen: 0.5 # 50% of examples from train_gen split
-          train_sft: 100 # 100 examples from train_sft split
-          test_gen: "all" # all examples from test_gen split
+          300k: 0.5 # 50% of examples from the 300k split
+          500k: 100 # 100 examples from the 500k split
 ```
 """
 
@@ -269,24 +267,6 @@ async def _load_sharegpt_conversations(
     logger.info("Finished loading ShareGPT conversations.")
 
 
-async def _load_ultrachat_conversations(
-    split_name: str,
-) -> AsyncGenerator[int | dict[str, Any], None]:
-    ds = load_dataset("HuggingFaceH4/ultrachat_200k", split=split_name)
-    ds = ds.shuffle(seed=42)
-    yield len(ds)
-    for i in range(len(ds)):
-        prompt_id = ds[i]["prompt_id"].strip()
-        msgs = ds[i]["messages"]
-        if not msgs:
-            continue
-        if not prompt_id:
-            prompt_id = id_for_conversation(msgs)
-        prompt_id = f"ultrachat-{split_name}-{prompt_id}"
-        yield {"conversation_id": prompt_id, "conversations": msgs}
-    logger.info(f"Finished loading UltraChat {split_name} conversations.")
-
-
 def _parse_daring_anteater_conversation(daring_anteater_conv: list) -> list[dict] | None:
     """Parse a DaringAnteater conversation into a list of messages."""
     msgs = []
@@ -410,8 +390,6 @@ async def load_conversations_for_split(
         samples_it = _load_mtbench_conversations(split_name)
     elif dataset_name == "sharegpt":
         samples_it = _load_sharegpt_conversations(split_name)
-    elif dataset_name == "ultrachat":
-        samples_it = _load_ultrachat_conversations(split_name)
     elif dataset_name == "daring-anteater":
         samples_it = _load_daring_anteater_conversations(split_name)
     elif dataset_name == "magpie":

--- a/examples/speculative_decoding/README.md
+++ b/examples/speculative_decoding/README.md
@@ -4,7 +4,7 @@
 
 Speculative decoding accelerates auto-regressive generation in large language models (LLMs) by leveraging a lightweight draft model to predict the next γ tokens. The main LLM then verifies these candidate tokens in a single forward pass. If the draft model correctly predicts α tokens, the LLM can accept and generate α+1 tokens per verification step, significantly improving generation speed.
 
-This folder contains an end-to-end runnable speculative decoding fine‑tuning pipeline in which Llama‑3.2‑1B (Hugging Face) is trained on the [UltraChat-200k](https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k) dataset.
+This folder contains an end-to-end runnable speculative decoding fine‑tuning pipeline in which Llama‑3.2‑1B (Hugging Face) is trained on the [Daring-Anteater](https://huggingface.co/datasets/nvidia/Daring-Anteater) dataset.
 
 This example focuses on training with Hugging Face. To train with Megatron‑LM, see the [Megatron‑LM example](https://github.com/NVIDIA/Megatron-LM/tree/main/examples/post_training/modelopt).
 
@@ -46,7 +46,7 @@ pip install -r requirements.txt
 
 ### Data Preparation
 
-We support a range of input datasets. In this example, we will use the [UltraChat-200k](https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k) dataset.
+We support a range of input datasets. In this example, we will use the [Daring-Anteater](https://huggingface.co/datasets/nvidia/Daring-Anteater) dataset.
 
 ```bash
 python ../dataset/make_dataset.py -f ../dataset/example_data_config.yaml --full-conversations
@@ -213,8 +213,6 @@ In addition to the default dataset, we support adding several other commonly use
 
 - MTBench (for debugging)
 - ShareGPT
-- UltraChat
-- Daring-Anteater
 - Magpie (Full 1M, and 500k and 300k filtered)
 - Nemotron Post-Training Dataset V2
 


### PR DESCRIPTION
### What does this PR do?
Type of change: Bug fix.

<!-- Details about the change. -->
Previously, only the first user prompt was extracted from each example, discarding all subsequent turns. UltraChat stores full multi-turn conversations in the "messages" field, so switching to that field preserves the complete dialogue rather than truncating to a single user message.
### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
 python make_dataset.py -f test_cfg.yaml --full
 python make_dataset.py -f test_cfg.yaml
```yaml
      - name: "ultrachat"
        splits:
          train_gen: 100
          train_sft: 100
```
### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed UltraChat support from the example dataset mixer, so UltraChat splits can no longer be loaded.

* **Documentation**
  * Updated the dataset examples README and example dataset configuration to remove UltraChat and adjust split/sample settings for other datasets.
  * Updated speculative decoding fine-tuning documentation to reference Daring-Anteater instead of UltraChat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->