### PR TITLE
[OMNIML-4965] cell_t1_d7

### DIFF
--- a/tools/launcher/common/specdec_bench/_cells/Qwen3.5-4B_dflash_vllm_t1_d7.yaml
+++ b/tools/launcher/common/specdec_bench/_cells/Qwen3.5-4B_dflash_vllm_t1_d7.yaml
@@ -1,0 +1,4 @@
+sampling_kwargs:
+  temperature: 1
+engine_args:
+  max_model_len: 40960

--- a/tools/launcher/examples/Qwen3.5/Qwen3.5-4B/specdec_bench_dflash_vllm_t1_d7.yaml
+++ b/tools/launcher/examples/Qwen3.5/Qwen3.5-4B/specdec_bench_dflash_vllm_t1_d7.yaml
@@ -1,0 +1,60 @@
+job_name: Qwen3.5-4B_specdec_bench_dflash_vllm_t1_d7
+
+pipeline:
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3.5-4B
+
+  task_0:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/qualitative
+      - --engine VLLM
+      - --speculative_algorithm DFlash
+      - --draft_model_dir /hf-local/z-lab/Qwen3.5-4B-DFlash
+      - --draft_length 7
+      - --runtime_params common/specdec_bench/_cells/Qwen3.5-4B_dflash_vllm_t1_d7.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 32
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/Qwen3.5-4B_dflash_vllm_t1_d7/qualitative
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130
+
+  task_1:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/throughput_32k
+      - --engine VLLM
+      - --speculative_algorithm DFlash
+      - --draft_model_dir /hf-local/z-lab/Qwen3.5-4B-DFlash
+      - --draft_length 7
+      - --runtime_params common/specdec_bench/_cells/Qwen3.5-4B_dflash_vllm_t1_d7.yaml
+      - --tp_size 2
+      - --ep_size 1
+      - --concurrency 8
+      - --num_requests 80
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/Qwen3.5-4B_dflash_vllm_t1_d7/throughput_32k
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 2
+      container: vllm/vllm-openai:qwen3_5-cu130


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-4965](https://jirasw.nvidia.com/browse/OMNIML-4965).

Stage `cell_t1_d7` of Epic `OMNIML-4961`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._

---

**Agent's self-narration** (stripped from PR diff; surfaced here for context):

`INTERN_ARTIFACTS.json`:
```
{
  "sweep_name": "Qwen3.5-4B_dflash_vllm_t1_d7",
  "experiment_id": "cicd_1781183797+cicd_1781186434",
  "experiment_dir": "/lustre/fsw/portfolios/coreai/users/chenhany/experiments/cicd/cicd_1781183797/ ; throughput retry: /lustre/fsw/portfolios/coreai/users/chenhany/experiments/cicd/cicd_1781186434/",
  "AL_qualitative_overall": 3.1058,
  "AL_qualitative_categories": {
    "coding": 3.8935,
    "humanities": 2.7412,
    "math": 3.4271,
    "qa": 2.9313,
    "rag": 3.7216,
    "reasoning": 3.0767,
    "stem": 2.8343,
    "writing": 2.4952,
    "multilingual": 3.3626,
    "summarization": 3.2538,
    "roleplay": 2.426
  },
  "AL_throughput_32k_overall": 1.1392,
  "AL_throughput_32k_categories": {
    "high_entropy": 1.1283,
    "mixed": 1.1869,
    "low_entropy": 1.1009
  }
}
```



_Pollution-strip removed `INTERN_ARTIFACTS.json` from this commit (sidecar narration and/or incidental lockfile regeneration are never part of the agent's intended deliverable)._