### PR TITLE
[nvbug 6294744] Exclude Qwen visual modules from NVFP4 quantization

### DIFF
--- a/modelopt_recipes/configs/ptq/units/default_disabled_quantizers.yaml
+++ b/modelopt_recipes/configs/ptq/units/default_disabled_quantizers.yaml
@@ -20,6 +20,10 @@
     enable: false
   - quantizer_name: '*linear_attn.conv1d*'
     enable: false
+  - quantizer_name: '*linear_attn.in_proj_a*'
+    enable: false
+  - quantizer_name: '*linear_attn.in_proj_b*'
+    enable: false
   - quantizer_name: '*lm_head*'
     enable: false
   - quantizer_name: '*mixer.conv1d*'
@@ -33,6 +37,10 @@
   - quantizer_name: '*proj_out.*'
     enable: false
   - quantizer_name: '*router*'
+    enable: false
+  - quantizer_name: '*visual*'
+    enable: false
+  - quantizer_name: '*vision_tower*'
     enable: false
   - quantizer_name: 'output.*'
     enable: false

--- a/tests/unit/recipe/test_loader.py
+++ b/tests/unit/recipe/test_loader.py
@@ -167,6 +167,7 @@ _BUILTIN_PTQ_RECIPES = [
     "general/ptq/nvfp4_mlp_only-kv_fp8_cast",
     "general/ptq/nvfp4_omlp_only-kv_fp8",
     "general/ptq/nvfp4_omlp_only-kv_fp8_cast",
+    "general/ptq/nvfp4_weight_only-kv_fp16",
     "general/ptq/nvfp4_weight_only-kv_fp8_cast",
 ]
 
@@ -178,6 +179,22 @@ def test_load_recipe_all_builtins(recipe_path):
     assert recipe.recipe_type == RecipeType.PTQ
     assert isinstance(recipe, ModelOptPTQRecipe)
     assert recipe.quantize
+
+
+def test_nvfp4_weight_only_recipe_disables_vllm_marlin_incompatible_projections():
+    recipe = load_recipe("general/ptq/nvfp4_weight_only-kv_fp16")
+    disabled_quantizers = {
+        entry["quantizer_name"]
+        for entry in recipe.quantize.model_dump()["quant_cfg"]
+        if entry.get("enable") is False
+    }
+
+    assert {
+        "*linear_attn.in_proj_a*",
+        "*linear_attn.in_proj_b*",
+        "*visual*",
+        "*vision_tower*",
+    } <= disabled_quantizers
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/recipe/test_presets.py
+++ b/tests/unit/recipe/test_presets.py
@@ -68,6 +68,21 @@ def test_kv_none_sentinel_is_not_a_discovered_preset():
     assert presets.KV_CACHE_NONE not in presets.KV_QUANT_CFG_CHOICES
 
 
+def test_w4a16_nvfp4_preset_disables_vllm_marlin_incompatible_projections():
+    disabled_quantizers = {
+        entry["quantizer_name"]
+        for entry in presets.QUANT_CFG_CHOICES["w4a16_nvfp4"]["quant_cfg"]
+        if entry.get("enable") is False
+    }
+
+    assert {
+        "*linear_attn.in_proj_a*",
+        "*linear_attn.in_proj_b*",
+        "*visual*",
+        "*vision_tower*",
+    } <= disabled_quantizers
+
+
 def test_load_quant_cfg_choices_rejects_stale_alias():
     with pytest.raises(ValueError, match="does-not-exist"):
         presets.load_quant_cfg_choices(


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Exclude Qwen visual and vision_tower modules from NVFP4 quantization and keep the Qwen linear attention projection exclusions. These modules can produce matrix dimensions that are incompatible with vLLM 0.22.1's ModelOpt FP4 Marlin fallback path, causing checkpoint load or profiling failures such as `size_n = 4304 is not divisible by tile_n_size = 64`.

### Usage

N/A. This is a recipe configuration fix.

### Testing

- `python -m pytest tests/unit/recipe/test_presets.py tests/unit/recipe/test_loader.py -q`
- `python -m pre_commit run --files modelopt_recipes/configs/ptq/units/default_disabled_quantizers.yaml tests/unit/recipe/test_loader.py tests/unit/recipe/test_presets.py`
- E2E validation with `vllm/vllm-openai:v0.22.1`: PTQ export validation passed with zero Marlin-incompatible quantized layers, and vLLM `/health`, `/v1/models`, and `/v1/completions` passed. The final PR broadens the validated visual MLP exclusions to the full `*visual*` subtree and adds the common `*vision_tower*` naming pattern.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: Yes
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: Yes
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests that verify the built-in PTQ recipe and preset correctly disable incompatible projection and visual components for certain quantization modes.
  * Ensures quantization settings are validated across recipes and presets.

* **Chores**
  * Updated quantization configuration to disable quantizers for select projection and vision-related model layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->