### PR TITLE
launcher: move gemma-4-E4B-it yaml to google/ subdir

### DIFF
--- a/tools/launcher/examples/google/gemma-4-E4B-it/specdec_bench_mtp_vllm.yaml
+++ b/tools/launcher/examples/google/gemma-4-E4B-it/specdec_bench_mtp_vllm.yaml
@@ -15,7 +15,7 @@
 # pipeline.task_N.args+=[...]:
 #
 #   uv run slurm.py \
-#     --yaml modules/Model-Optimizer/tools/launcher/examples/gemma-4/gemma-4-E4B-it/specdec_bench_mtp_vllm.yaml \
+#     --yaml modules/Model-Optimizer/tools/launcher/examples/google/gemma-4-E4B-it/specdec_bench_mtp_vllm.yaml \
 #     --yes detach=true \
 #     pipeline.task_0.args+=["--temperature 0","--max_seq_len 65536","--save_dir /scratchspace/<sweep>/qualitative","--draft_length 3"] \
 #     pipeline.task_1.args+=["--temperature 0","--max_seq_len 65536","--save_dir /scratchspace/<sweep>/throughput_32k","--num_requests 80","--draft_length 3"]


### PR DESCRIPTION
## Summary

- Moves `tools/launcher/examples/gemma-4/gemma-4-E4B-it/specdec_bench_mtp_vllm.yaml` to `tools/launcher/examples/google/gemma-4-E4B-it/specdec_bench_mtp_vllm.yaml` to align with the `google/` vendor-prefix convention used by other models in the launcher examples directory.
- Updates the embedded `--yaml` path in the YAML comment to match the new location.

## Test plan
- [ ] Confirm the file appears at the new path
- [ ] Confirm the old path is gone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an example benchmark invocation reference to reflect the project’s reorganized directory layout. This edits only the example comment in the benchmark YAML; no benchmark settings, model paths, task arguments, or runtime configuration were modified. Low-risk documentation alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->