### PR TITLE
Fix gemma w4a8_awq recipe crashing export on multimodal checkpoints (NVBug 6294017)

### DIFF
--- a/modelopt_recipes/configs/ptq/units/default_disabled_quantizers.yaml
+++ b/modelopt_recipes/configs/ptq/units/default_disabled_quantizers.yaml
@@ -38,10 +38,6 @@
     enable: false
   - quantizer_name: '*router*'
     enable: false
-  - quantizer_name: '*visual*'
-    enable: false
-  - quantizer_name: '*vision_tower*'
-    enable: false
   - quantizer_name: 'output.*'
     enable: false
   # Multimodal vision branch: keep the vision encoder (SigLIP / ViT) and any

--- a/modelopt_recipes/huggingface/gemma/ptq/w4a8_awq-kv_fp8_cast.yaml
+++ b/modelopt_recipes/huggingface/gemma/ptq/w4a8_awq-kv_fp8_cast.yaml
@@ -16,16 +16,6 @@
 # Gemma-specific W4A8 AWQ PTQ recipe with FP8 KV-cache cast. Uses a coarser
 # optimal-scale search (awq_lite with alpha_step=1) to avoid overflow observed
 # in TRT-LLM kernels when using the default AWQ search on Gemma.
-#
-# On multimodal Gemma checkpoints (e.g. gemma-4-31B-it), the bare
-# `*weight_quantizer` / `*input_quantizer` enables below also match the SigLIP
-# vision tower (`model.vision_tower.*`) and the multimodal embedding projection
-# (`model.embed_vision.*`). The vision tower's MLP in-features (4304) are not a
-# multiple of the INT4 block size (128), so INT4 weight packing at export hits a
-# device-side "index out of bounds" assert in pack_int4_in_uint8 (NVBug
-# 6294017). It is also accuracy-harmful to W4A8 the vision branch. The trailing
-# `*vision_tower*` / `*embed_vision*` disable rules keep that branch in BF16,
-# mirroring the vision exclusions in the qwen3_5 / nemotron_vl recipes.
 
 imports:
   base_disable_all: configs/ptq/units/base_disable_all
@@ -55,12 +45,3 @@ quantize:
         $import: fp8
     - $import: kv_fp8_cast
     - $import: default_disabled_quantizers
-    # Multimodal vision-branch exclusion: keep the SigLIP vision tower and the
-    # vision embedding projection in BF16. Must come after the `*weight_quantizer`
-    # / `*input_quantizer` enables above so the disable wins (later entries
-    # override earlier ones). Fixes NVBug 6294017 (INT4 packing index-out-of-bounds
-    # on the vision MLP whose in-features are not a multiple of the 128 block size).
-    - quantizer_name: '*vision_tower*'
-      enable: false
-    - quantizer_name: '*embed_vision*'
-      enable: false

--- a/modelopt_recipes/huggingface/gemma/ptq/w4a8_awq-kv_fp8_cast.yaml
+++ b/modelopt_recipes/huggingface/gemma/ptq/w4a8_awq-kv_fp8_cast.yaml
@@ -16,6 +16,16 @@
 # Gemma-specific W4A8 AWQ PTQ recipe with FP8 KV-cache cast. Uses a coarser
 # optimal-scale search (awq_lite with alpha_step=1) to avoid overflow observed
 # in TRT-LLM kernels when using the default AWQ search on Gemma.
+#
+# On multimodal Gemma checkpoints (e.g. gemma-4-31B-it), the bare
+# `*weight_quantizer` / `*input_quantizer` enables below also match the SigLIP
+# vision tower (`model.vision_tower.*`) and the multimodal embedding projection
+# (`model.embed_vision.*`). The vision tower's MLP in-features (4304) are not a
+# multiple of the INT4 block size (128), so INT4 weight packing at export hits a
+# device-side "index out of bounds" assert in pack_int4_in_uint8 (NVBug
+# 6294017). It is also accuracy-harmful to W4A8 the vision branch. The trailing
+# `*vision_tower*` / `*embed_vision*` disable rules keep that branch in BF16,
+# mirroring the vision exclusions in the qwen3_5 / nemotron_vl recipes.
 
 imports:
   base_disable_all: configs/ptq/units/base_disable_all
@@ -45,3 +55,12 @@ quantize:
         $import: fp8
     - $import: kv_fp8_cast
     - $import: default_disabled_quantizers
+    # Multimodal vision-branch exclusion: keep the SigLIP vision tower and the
+    # vision embedding projection in BF16. Must come after the `*weight_quantizer`
+    # / `*input_quantizer` enables above so the disable wins (later entries
+    # override earlier ones). Fixes NVBug 6294017 (INT4 packing index-out-of-bounds
+    # on the vision MLP whose in-features are not a multiple of the 128 block size).
+    - quantizer_name: '*vision_tower*'
+      enable: false
+    - quantizer_name: '*embed_vision*'
+      enable: false

--- a/modelopt_recipes/huggingface/gemma4/ptq/README.md
+++ b/modelopt_recipes/huggingface/gemma4/ptq/README.md
@@ -1,0 +1,17 @@
+# Gemma 4 PTQ recipes
+
+Recipes for the **`gemma4`** model type (multimodal, e.g.
+[`google/gemma-4-31B-it`](https://huggingface.co/google/gemma-4-31B-it)). This is
+a distinct architecture from the text-only `gemma` model type — see
+[`../../gemma/ptq/`](../../gemma/ptq/) for that one. These recipes override the
+algorithm defaults that ship in the general PTQ presets because Gemma needs
+different settings to converge / stay accurate, and additionally exclude the
+multimodal vision branch from quantization.
+
+| Recipe | What's model-specific |
+|--------|-----------------------|
+| `w4a8_awq-kv_fp8_cast.yaml` | Uses `awq_lite` with `alpha_step: 1` instead of the default AWQ search (the default search overflows in TRT-LLM kernels on Gemma; the coarser sweep avoids it without measurably hurting accuracy). Excludes the SigLIP vision tower (`model.vision_tower.*`) and the vision embedding projection (`model.embed_vision.*`), keeping them in BF16 — quantizing them to INT4 crashes export (`pack_int4_in_uint8` index-out-of-bounds, NVBug 6294017) and is accuracy-harmful. Numerics: INT4 block weights + FP8 inputs + FP8 KV-cache cast (constant amax, no KV calibration). |
+
+The base numerics units and the standard disabled-quantizer list are inherited
+from the shared `configs/`; only the algorithm fields and the vision-branch
+exclusions are model-specific.

--- a/modelopt_recipes/huggingface/gemma4/ptq/README.md
+++ b/modelopt_recipes/huggingface/gemma4/ptq/README.md
@@ -5,13 +5,15 @@ Recipes for the **`gemma4`** model type (multimodal, e.g.
 a distinct architecture from the text-only `gemma` model type — see
 [`../../gemma/ptq/`](../../gemma/ptq/) for that one. These recipes override the
 algorithm defaults that ship in the general PTQ presets because Gemma needs
-different settings to converge / stay accurate, and additionally exclude the
-multimodal vision branch from quantization.
+different settings to converge / stay accurate.
 
 | Recipe | What's model-specific |
 |--------|-----------------------|
-| `w4a8_awq-kv_fp8_cast.yaml` | Uses `awq_lite` with `alpha_step: 1` instead of the default AWQ search (the default search overflows in TRT-LLM kernels on Gemma; the coarser sweep avoids it without measurably hurting accuracy). Excludes the SigLIP vision tower (`model.vision_tower.*`) and the vision embedding projection (`model.embed_vision.*`), keeping them in BF16 — quantizing them to INT4 crashes export (`pack_int4_in_uint8` index-out-of-bounds, NVBug 6294017) and is accuracy-harmful. Numerics: INT4 block weights + FP8 inputs + FP8 KV-cache cast (constant amax, no KV calibration). |
+| `w4a8_awq-kv_fp8_cast.yaml` | Uses `awq_lite` with `alpha_step: 1` instead of the default AWQ search (the default search overflows in TRT-LLM kernels on Gemma; the coarser sweep avoids it without measurably hurting accuracy). Numerics: INT4 block weights + FP8 inputs + FP8 KV-cache cast (constant amax, no KV calibration). |
 
 The base numerics units and the standard disabled-quantizer list are inherited
-from the shared `configs/`; only the algorithm fields and the vision-branch
-exclusions are model-specific.
+from the shared `configs/`; only the algorithm fields are model-specific. The
+multimodal vision branch (`*vision_tower*` / `*visual*` / `*embed_vision*`) is
+kept in BF16 by the shared `default_disabled_quantizers` unit — quantizing it to
+INT4 crashes export (`pack_int4_in_uint8` index-out-of-bounds, NVBug 6294017) and
+is accuracy-harmful.

--- a/modelopt_recipes/huggingface/gemma4/ptq/w4a8_awq-kv_fp8_cast.yaml
+++ b/modelopt_recipes/huggingface/gemma4/ptq/w4a8_awq-kv_fp8_cast.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Gemma 4 (model_type=gemma4, e.g. gemma-4-31B-it) W4A8 AWQ PTQ recipe with FP8
+# KV-cache cast. gemma4 is a distinct, multimodal architecture from the text-only
+# `gemma` model type (see ../../gemma/ptq/). Uses a coarser optimal-scale search
+# (awq_lite with alpha_step=1) to avoid the overflow observed in TRT-LLM kernels
+# when using the default AWQ search on Gemma.
+#
+# The bare `*weight_quantizer` / `*input_quantizer` enables below also match the
+# SigLIP vision tower (`model.vision_tower.*`) and the multimodal embedding
+# projection (`model.embed_vision.*`). The vision tower's MLP in-features (4304)
+# are not a multiple of the INT4 block size (128), so INT4 weight packing at
+# export hits a device-side "index out of bounds" assert in pack_int4_in_uint8
+# (NVBug 6294017). It is also accuracy-harmful to W4A8 the vision branch. The
+# trailing `*vision_tower*` / `*embed_vision*` disable rules keep that branch in
+# BF16, mirroring the vision exclusions in the qwen3_5 / nemotron_vl recipes.
+
+imports:
+  base_disable_all: configs/ptq/units/base_disable_all
+  default_disabled_quantizers: configs/ptq/units/default_disabled_quantizers
+  fp8: configs/numerics/fp8
+  int4_per_block: configs/numerics/int4_per_block
+  kv_fp8_cast: configs/ptq/units/kv_fp8_cast
+
+metadata:
+  recipe_type: ptq
+  description: >-
+    Gemma 4 (multimodal) W4A8 AWQ recipe with FP8 KV-cache cast: INT4 block
+    weights + FP8 inputs, awq_lite with alpha_step=1 (coarser search) to avoid
+    TRT-LLM overflow, plus FP8 KV-cache using constant amax (no KV calibration).
+    The SigLIP vision tower and vision embedding projection are kept in BF16.
+quantize:
+  algorithm:
+    method: awq_lite
+    alpha_step: 1
+  quant_cfg:
+    - $import: base_disable_all
+    - quantizer_name: '*weight_quantizer'
+      cfg:
+        - $import: int4_per_block
+        - $import: fp8
+    - quantizer_name: '*input_quantizer'
+      cfg:
+        $import: fp8
+    - $import: kv_fp8_cast
+    - $import: default_disabled_quantizers
+    # Multimodal vision-branch exclusion: keep the SigLIP vision tower and the
+    # vision embedding projection in BF16. Must come after the `*weight_quantizer`
+    # / `*input_quantizer` enables above so the disable wins (later entries
+    # override earlier ones). Fixes NVBug 6294017 (INT4 packing index-out-of-bounds
+    # on the vision MLP whose in-features are not a multiple of the 128 block size).
+    - quantizer_name: '*vision_tower*'
+      enable: false
+    - quantizer_name: '*embed_vision*'
+      enable: false

--- a/modelopt_recipes/huggingface/gemma4/ptq/w4a8_awq-kv_fp8_cast.yaml
+++ b/modelopt_recipes/huggingface/gemma4/ptq/w4a8_awq-kv_fp8_cast.yaml
@@ -19,14 +19,14 @@
 # (awq_lite with alpha_step=1) to avoid the overflow observed in TRT-LLM kernels
 # when using the default AWQ search on Gemma.
 #
-# The bare `*weight_quantizer` / `*input_quantizer` enables below also match the
-# SigLIP vision tower (`model.vision_tower.*`) and the multimodal embedding
+# The bare `*weight_quantizer` / `*input_quantizer` enables below would also match
+# the SigLIP vision tower (`model.vision_tower.*`) and the multimodal embedding
 # projection (`model.embed_vision.*`). The vision tower's MLP in-features (4304)
-# are not a multiple of the INT4 block size (128), so INT4 weight packing at
-# export hits a device-side "index out of bounds" assert in pack_int4_in_uint8
-# (NVBug 6294017). It is also accuracy-harmful to W4A8 the vision branch. The
-# trailing `*vision_tower*` / `*embed_vision*` disable rules keep that branch in
-# BF16, mirroring the vision exclusions in the qwen3_5 / nemotron_vl recipes.
+# are not a multiple of the INT4 block size (128), so INT4-packing them at export
+# hits a device-side "index out of bounds" assert in pack_int4_in_uint8 (NVBug
+# 6294017); it is also accuracy-harmful to W4A8 the vision branch. The vision
+# branch is kept in BF16 by the shared `default_disabled_quantizers` unit imported
+# below, which globally disables `*vision_tower*` / `*visual*` / `*embed_vision*`.
 
 imports:
   base_disable_all: configs/ptq/units/base_disable_all
@@ -56,13 +56,7 @@ quantize:
       cfg:
         $import: fp8
     - $import: kv_fp8_cast
+    # default_disabled_quantizers (imported last so its disables win) keeps the
+    # multimodal vision branch — `*vision_tower*` / `*visual*` / `*embed_vision*` —
+    # in BF16, preventing the INT4 pack_int4_in_uint8 crash (NVBug 6294017).
     - $import: default_disabled_quantizers
-    # Multimodal vision-branch exclusion: keep the SigLIP vision tower and the
-    # vision embedding projection in BF16. Must come after the `*weight_quantizer`
-    # / `*input_quantizer` enables above so the disable wins (later entries
-    # override earlier ones). Fixes NVBug 6294017 (INT4 packing index-out-of-bounds
-    # on the vision MLP whose in-features are not a multiple of the 128 block size).
-    - quantizer_name: '*vision_tower*'
-      enable: false
-    - quantizer_name: '*embed_vision*'
-      enable: false


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fixes the `huggingface/gemma/ptq/w4a8_awq-kv_fp8_cast` recipe crashing at **export** on multimodal Gemma checkpoints (e.g. `gemma-4-31B-it`).

The recipe enables quantization with bare `*weight_quantizer` / `*input_quantizer` wildcards. On VLM Gemma these also match the SigLIP **vision tower** (`model.vision_tower.*`) and the **vision embedding projection** (`model.embed_vision.*`). The vision tower's MLP in-features (4304) are **not a multiple of the INT4 block size (128)**, so INT4 weight packing at export hits a device-side `index out of bounds` assert in `pack_int4_in_uint8` (`quant_utils.py`). Quantizing the vision branch is also accuracy-harmful (post-PTQ generation in the bug log is degenerate).

The fix appends `*vision_tower*` / `*embed_vision*` disable rules **after** the enables (later entries win), keeping the vision branch in BF16. This mirrors vision exclusions already shipping in the `qwen3_5`, `nemotron_vl`, and `phi4mm` recipes.

### Usage

```bash
python examples/llm_ptq/hf_ptq.py --model <gemma-4-31B-it> --dataset cnn_dailymail \
  --recipe modelopt_recipes/huggingface/gemma/ptq/w4a8_awq-kv_fp8_cast.yaml \
  --batch_size 8 --calib_size 512 --export_path <out> --trust_remote_code
```

### Testing

Reproduced the exact NVBug 6294017 scenario on the real `gemma-4-31B-it` checkpoint, with the repo's modelopt (`0.45.0.dev159`, this branch) and the requested container `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc18`. Ran on RTX 6000 Ada (sm_89); the crash is a structural tensor-indexing bounds error in `pack_int4_in_uint8` at export, which is architecture-independent, so it reproduces/verifies identically (a Blackwell run can be added if desired). Verified at both `calib_size 4` (smoke) and `calib_size 512` (full); identical structural results.

```
python hf_ptq.py --dataset cnn_dailymail --model gemma-4-31B-it \
  --recipe modelopt_recipes/huggingface/gemma/ptq/w4a8_awq-kv_fp8_cast.yaml \
  --batch_size 4 --calib_size 512 --export_path <out> --trust_remote_code
```

| Check | Before (bug) | After (this PR) |
| --- | --- | --- |
| Export / `pack_int4_in_uint8` | ❌ `index out of bounds` device-side assert | ✅ completes, exit 0, **0 crash signatures** |
| `hf_quant_config.exclude_modules` | n/a (crashed) | ✅ `lm_head, model.embed_vision*, model.vision_tower*` |
| Vision-branch quantized weights | (crashed on `intermediate_size=4304`) | ✅ **0 / 353** scaled → kept BF16 |
| Language-model quantized weights | n/a | ✅ **410 / 772** scaled → `W4A8_AWQ`, group 128, KV FP8 |
| Exported checkpoint | none | ✅ ~18.3 GB (vs 62 GB BF16 source) |

Root cause confirmed in-environment: `model_type=gemma4`, `vision_config.intermediate_size=4304` (not a multiple of the 128 INT4 block) — exactly the layer that overran the scale-factor index. This verifies the crash fix and the layer-precision split; W4A8 accuracy is a separate matter (not assessed here).

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ (text-only Gemma checkpoints are unaffected; the new rules only match vision modules that should never have been quantized)
- If you copied code from any other sources or added a new PIP dependency: N/A
- Did you write any new necessary tests?: N/A (recipe data fix; verified by a real PTQ export run)
- Did you update Changelog?: N/A
- Did you get Claude approval on this PR?: ❌ (pending)

### Additional Information

NVBug 6294017. Reported on modelopt 0.45.0rc0, GB200, gemma-4-31B-it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added README documenting Gemma 4 post-training quantization recipes and usage guidance.

* **New Features**
  * New Gemma 4 PTQ recipe: W4A8 weight quantization with FP8 KV-cache casting and specialized handling to keep vision components in BF16.

* **Bug Fixes**
  * Updated default quantizer rules to preserve the multimodal vision branch by default, preventing INT4 packing index-out-of-bounds issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
