### PR TITLE
[nvbug 6289151, nvbug 6301817] Fix exported Step layer type and RoPE metadata

### DIFF
--- a/modelopt/torch/export/plugins/__init__.py
+++ b/modelopt/torch/export/plugins/__init__.py
@@ -15,16 +15,26 @@
 
 """Export package plugin."""
 
+from typing import Any
+
 from modelopt.torch.utils import import_plugin
 
 with import_plugin("megatron_importer"):
     from .megatron_importer import *
 
 from .hf_spec_export import *
+
+with import_plugin("hf_checkpoint_utils"):
+    from .hf_checkpoint_utils import *
+
+if "sanitize_hf_config_for_deployment" not in globals():
+
+    def sanitize_hf_config_for_deployment(config_data: dict[str, Any], model: Any) -> None:
+        """No-op fallback when Hugging Face checkpoint utilities are unavailable."""
+        return None
+
+
 from .vllm_fakequant_hf import *
 
 with import_plugin("vllm_fakequant_megatron"):
     from .vllm_fakequant_megatron import *
-
-with import_plugin("hf_checkpoint_utils"):
-    from .hf_checkpoint_utils import *

--- a/modelopt/torch/export/plugins/hf_checkpoint_utils.py
+++ b/modelopt/torch/export/plugins/hf_checkpoint_utils.py
@@ -18,7 +18,9 @@
 import json
 import os
 import shutil
+import warnings
 from pathlib import Path
+from typing import Any
 
 import torch
 from huggingface_hub import snapshot_download
@@ -27,6 +29,111 @@ from safetensors.torch import safe_open
 from tqdm import tqdm
 
 _HF_HUB_OFFLINE_TRUE_VALUES = {"1", "ON", "YES", "TRUE"}
+
+
+def _as_nonnegative_int(value: Any) -> int | None:
+    """Return ``value`` as an int when it is a non-negative integer."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value >= 0:
+        return value
+    return None
+
+
+def _count_mtp_layer_prefixes(prefixes: list[Any] | tuple[Any, ...]) -> int | None:
+    """Count actual MTP layer prefixes, excluding broad prefixes like ``mtp``."""
+    layer_prefixes = {
+        prefix
+        for prefix in prefixes
+        if isinstance(prefix, str)
+        and (parts := prefix.split("."))
+        and len(parts) >= 2
+        and parts[-2] == "layers"
+        and parts[-1].isdigit()
+    }
+    return len(layer_prefixes) or None
+
+
+def _get_num_nextn_predict_layers(config_data: dict[str, Any], model: Any) -> int | None:
+    """Get the number of next-token-prediction layers from config metadata."""
+    num_nextn_predict_layers = _as_nonnegative_int(config_data.get("num_nextn_predict_layers"))
+    if num_nextn_predict_layers is not None:
+        return num_nextn_predict_layers
+
+    model_config = getattr(model, "config", None)
+    if model_config is not None:
+        num_nextn_predict_layers = _as_nonnegative_int(
+            getattr(model_config, "num_nextn_predict_layers", None)
+        )
+        if num_nextn_predict_layers is not None:
+            return num_nextn_predict_layers
+
+    mtp_layer_prefixes = getattr(model, "_mtp_layer_prefixes", None)
+    if isinstance(mtp_layer_prefixes, (list, tuple)):
+        return _count_mtp_layer_prefixes(mtp_layer_prefixes)
+
+    return None
+
+
+def _get_rope_theta(config_data: dict[str, Any], model: Any) -> Any:
+    rope_theta = config_data.get("rope_theta")
+    if rope_theta is not None:
+        return rope_theta
+
+    model_config = getattr(model, "config", None)
+    if model_config is None:
+        return None
+
+    return getattr(model_config, "rope_theta", None)
+
+
+def _sanitize_llama3_rope_config(config_data: dict[str, Any], model: Any) -> None:
+    rope_theta = _get_rope_theta(config_data, model)
+    if rope_theta is None:
+        return
+
+    for key in ("rope_parameters", "rope_scaling"):
+        rope_config = config_data.get(key)
+        if not isinstance(rope_config, dict):
+            continue
+
+        rope_type = rope_config.get("rope_type", rope_config.get("type"))
+        if rope_type == "llama3" and "rope_theta" not in rope_config:
+            rope_config["rope_theta"] = rope_theta
+
+
+def sanitize_hf_config_for_deployment(config_data: dict[str, Any], model: Any) -> None:
+    """Sanitize exported Hugging Face config metadata for deployment runtimes.
+
+    Transformers 5.x validates that ``len(layer_types) == num_hidden_layers``.
+    Some checkpoints include MTP/next-token-prediction layer entries after the
+    main decoder layer entries. Those extra entries are not part of
+    ``num_hidden_layers`` and make deployment stacks fail while loading config.
+    """
+    _sanitize_llama3_rope_config(config_data, model)
+
+    num_hidden_layers = _as_nonnegative_int(config_data.get("num_hidden_layers"))
+    layer_types = config_data.get("layer_types")
+    if num_hidden_layers is None or not isinstance(layer_types, list):
+        return
+
+    num_layer_types = len(layer_types)
+    if num_layer_types == num_hidden_layers:
+        return
+
+    num_nextn_predict_layers = _get_num_nextn_predict_layers(config_data, model)
+    if (
+        num_layer_types > num_hidden_layers
+        and num_nextn_predict_layers == num_layer_types - num_hidden_layers
+    ):
+        warnings.warn(
+            "Trimming config.layer_types from "
+            f"{num_layer_types} to {num_hidden_layers} entries so it matches "
+            "num_hidden_layers; the removed entries correspond to "
+            "num_nextn_predict_layers.",
+            stacklevel=2,
+        )
+        config_data["layer_types"] = layer_types[:num_hidden_layers]
 
 
 def _is_hf_hub_offline() -> bool:

--- a/modelopt/torch/export/plugins/hf_checkpoint_utils.py
+++ b/modelopt/torch/export/plugins/hf_checkpoint_utils.py
@@ -76,6 +76,7 @@ def _get_num_nextn_predict_layers(config_data: dict[str, Any], model: Any) -> in
 
 
 def _get_rope_theta(config_data: dict[str, Any], model: Any) -> Any:
+    """Return rope_theta from exported config data or the in-memory model config."""
     rope_theta = config_data.get("rope_theta")
     if rope_theta is not None:
         return rope_theta
@@ -88,6 +89,7 @@ def _get_rope_theta(config_data: dict[str, Any], model: Any) -> Any:
 
 
 def _sanitize_llama3_rope_config(config_data: dict[str, Any], model: Any) -> None:
+    """Fill missing llama3 rope_theta in rope config metadata when available."""
     rope_theta = _get_rope_theta(config_data, model)
     if rope_theta is None:
         return
@@ -105,10 +107,11 @@ def _sanitize_llama3_rope_config(config_data: dict[str, Any], model: Any) -> Non
 def sanitize_hf_config_for_deployment(config_data: dict[str, Any], model: Any) -> None:
     """Sanitize exported Hugging Face config metadata for deployment runtimes.
 
-    Transformers 5.x validates that ``len(layer_types) == num_hidden_layers``.
-    Some checkpoints include MTP/next-token-prediction layer entries after the
-    main decoder layer entries. Those extra entries are not part of
-    ``num_hidden_layers`` and make deployment stacks fail while loading config.
+    Fix conservative deployment-only config incompatibilities:
+
+    * add missing llama3 ``rope_theta`` metadata when available;
+    * trim trailing MTP/next-token-prediction ``layer_types`` entries only when
+      the mismatch is exactly explained by next-token-prediction metadata.
     """
     _sanitize_llama3_rope_config(config_data, model)
 

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -740,6 +740,10 @@ def _process_quantized_modules(
         if is_modelopt_qlora and (hasattr(sub_module, "base_layer")):
             continue
 
+        if type(sub_module).__name__ == "QuantMoELinear" and hasattr(sub_module, "experts"):
+            set_expert_quantizer_amax(list(sub_module.experts), quantizer_attrs="input_quantizer")
+            continue
+
         # Preprocessing: restore unpacked weight so the export path can read
         # the live quantizer state. Falls through to the export branches below.
         if hasattr(sub_module, "weight_packed") or (

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -90,7 +90,7 @@ from .model_config import (
 )
 from .model_utils import get_language_model_from_vl, is_multimodal_model
 from .moe_utils import _export_fused_experts
-from .plugins import SpeculativeDecodingExporter, has_spec_opt
+from .plugins import SpeculativeDecodingExporter, has_spec_opt, sanitize_hf_config_for_deployment
 from .quant_utils import (
     fuse_prequant_layernorm,
     fuse_prequant_to_linear,
@@ -1380,6 +1380,8 @@ def export_hf_checkpoint(
 
         with open(original_config) as file:
             config_data = json.load(file)
+
+        sanitize_hf_config_for_deployment(config_data, model)
 
         if hf_quant_config is not None:
             config_data["quantization_config"] = hf_quant_config

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -740,6 +740,9 @@ def _process_quantized_modules(
         if is_modelopt_qlora and (hasattr(sub_module, "base_layer")):
             continue
 
+        # Step-3.5 QuantMoELinear reconstructs packed MoE tensors from child
+        # expert QuantLinears after export. Fill missing input amax here, before
+        # named_modules() reaches those children, so every expert emits input_scale.
         if type(sub_module).__name__ == "QuantMoELinear" and hasattr(sub_module, "experts"):
             set_expert_quantizer_amax(list(sub_module.experts), quantizer_attrs="input_quantizer")
             continue

--- a/tests/unit/torch/export/test_export_weight.py
+++ b/tests/unit/torch/export/test_export_weight.py
@@ -16,10 +16,14 @@
 
 import pytest
 import torch
+import torch.nn as nn
 from _test_utils.torch.export.utils import ToyModel, partial_fp8_config, partial_w4a8_config
 
 import modelopt.torch.quantization as mtq
-from modelopt.torch.export.unified_export_hf import _export_quantized_weight
+from modelopt.torch.export.unified_export_hf import (
+    _export_quantized_weight,
+    _process_quantized_modules,
+)
 from modelopt.torch.quantization.utils import quantizer_attr_names
 
 
@@ -96,3 +100,43 @@ def test_export_per_block_quantized_weight():
     assert hasattr(model.linears[2], quantizer_attrs.output_quantizer)
     assert not getattr(model.linears[2], quantizer_attrs.output_quantizer).is_enabled
     assert not hasattr(model.linears[2], quantizer_attrs.output_scale)
+
+
+class QuantMoELinear(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.experts = nn.ModuleList([nn.Linear(8, 8, bias=False) for _ in range(2)])
+
+    def forward(self, x):
+        return self.experts[0](x)
+
+
+class _SingleRoutedExpertModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.moe = QuantMoELinear()
+
+    def forward(self, x):
+        return self.moe(x)
+
+
+def test_process_quantized_modules_fills_step3p5_moe_input_scale_for_unrouted_experts():
+    model = _SingleRoutedExpertModel()
+    quant_cfg = {
+        "quant_cfg": [
+            {"quantizer_name": "*", "enable": False},
+            {"quantizer_name": "*weight_quantizer", "cfg": {"num_bits": 8, "axis": None}},
+            {"quantizer_name": "*input_quantizer", "cfg": {"num_bits": 8, "axis": None}},
+        ],
+        "algorithm": "max",
+    }
+
+    mtq.quantize(model, quant_cfg, lambda m: m(torch.randn(2, 4, 8)))
+
+    assert model.moe.experts[0].input_quantizer.amax is not None
+    assert model.moe.experts[1].input_quantizer.amax is None
+
+    _process_quantized_modules(model, torch.float32)
+
+    assert hasattr(model.moe.experts[0], "input_scale")
+    assert hasattr(model.moe.experts[1], "input_scale")

--- a/tests/unit/torch/export/test_hf_checkpoint_utils.py
+++ b/tests/unit/torch/export/test_hf_checkpoint_utils.py
@@ -15,6 +15,7 @@
 
 """Tests for modelopt/torch/export/plugins/hf_checkpoint_utils.py"""
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -23,7 +24,7 @@ pytest.importorskip("huggingface_hub")
 hf_hub_errors = pytest.importorskip("huggingface_hub.errors")
 LocalEntryNotFoundError = hf_hub_errors.LocalEntryNotFoundError
 
-from modelopt.torch.export import copy_hf_ckpt_remote_code
+from modelopt.torch.export import copy_hf_ckpt_remote_code, sanitize_hf_config_for_deployment
 
 
 def test_copy_hf_ckpt_remote_code_local_dir(tmp_path):
@@ -118,3 +119,161 @@ def test_copy_hf_ckpt_remote_code_hub_id_offline_missing_cache_raises(tmp_path, 
         pytest.raises(RuntimeError, match="HF_HUB_OFFLINE"),
     ):
         copy_hf_ckpt_remote_code("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", tmp_path / "dst")
+
+
+def test_sanitize_hf_config_for_deployment_trims_nextn_layer_types():
+    """Drop MTP/next-token-prediction layer types from exported config.json."""
+    hidden_layer_types = ["full_attention"] * 45
+    nextn_layer_types = ["nextn_predict"] * 3
+    config_data = {
+        "num_hidden_layers": 45,
+        "num_nextn_predict_layers": 3,
+        "layer_types": hidden_layer_types + nextn_layer_types,
+    }
+
+    with pytest.warns(UserWarning, match="Trimming config.layer_types"):
+        sanitize_hf_config_for_deployment(config_data, model=SimpleNamespace())
+
+    assert config_data["layer_types"] == hidden_layer_types
+
+
+def test_sanitize_hf_config_for_deployment_adds_rope_theta_to_llama3_rope_parameters():
+    """Transformers 5.x requires rope_theta inside llama3 rope_parameters."""
+    config_data = {
+        "rope_theta": 500000,
+        "rope_parameters": {
+            "rope_type": "llama3",
+            "factor": 8.0,
+            "original_max_position_embeddings": 4096,
+            "low_freq_factor": 1.0,
+            "high_freq_factor": 4.0,
+        },
+    }
+
+    sanitize_hf_config_for_deployment(config_data, SimpleNamespace(config=SimpleNamespace()))
+
+    assert config_data["rope_parameters"]["rope_theta"] == 500000
+
+
+def test_sanitize_hf_config_for_deployment_uses_model_rope_theta_for_rope_parameters():
+    """Use model.config.rope_theta when save_pretrained omits the top-level field."""
+    config_data = {
+        "rope_parameters": {
+            "rope_type": "llama3",
+            "factor": 8.0,
+            "original_max_position_embeddings": 4096,
+            "low_freq_factor": 1.0,
+            "high_freq_factor": 4.0,
+        },
+    }
+    model = SimpleNamespace(config=SimpleNamespace(rope_theta=500000))
+
+    sanitize_hf_config_for_deployment(config_data, model)
+
+    assert config_data["rope_parameters"]["rope_theta"] == 500000
+
+
+def test_sanitize_hf_config_for_deployment_adds_rope_theta_to_llama3_rope_scaling():
+    """Legacy rope_scaling metadata is normalized for llama3 configs as well."""
+    config_data = {
+        "rope_scaling": {
+            "type": "llama3",
+            "factor": 8.0,
+            "original_max_position_embeddings": 4096,
+            "low_freq_factor": 1.0,
+            "high_freq_factor": 4.0,
+        },
+    }
+    model = SimpleNamespace(config=SimpleNamespace(rope_theta=500000))
+
+    sanitize_hf_config_for_deployment(config_data, model)
+
+    assert config_data["rope_scaling"]["rope_theta"] == 500000
+
+
+def test_sanitize_hf_config_for_deployment_keeps_existing_rope_theta():
+    """Existing rope_theta in rope metadata is not overwritten."""
+    config_data = {
+        "rope_theta": 500000,
+        "rope_parameters": {
+            "rope_type": "llama3",
+            "rope_theta": 1000000,
+        },
+    }
+
+    sanitize_hf_config_for_deployment(config_data, SimpleNamespace(config=SimpleNamespace()))
+
+    assert config_data["rope_parameters"]["rope_theta"] == 1000000
+
+
+def test_sanitize_hf_config_for_deployment_ignores_non_llama3_rope_parameters():
+    """Only llama3 RoPE parameters need the Transformers 5.x compatibility fix."""
+    config_data = {
+        "rope_theta": 500000,
+        "rope_parameters": {
+            "rope_type": "default",
+        },
+    }
+
+    sanitize_hf_config_for_deployment(config_data, SimpleNamespace(config=SimpleNamespace()))
+
+    assert "rope_theta" not in config_data["rope_parameters"]
+
+
+def test_sanitize_hf_config_for_deployment_uses_model_config_nextn_count():
+    """Handle exports where save_pretrained omits num_nextn_predict_layers."""
+    config_data = {
+        "num_hidden_layers": 2,
+        "layer_types": ["full_attention", "linear_attention", "nextn_predict"],
+    }
+    model = SimpleNamespace(config=SimpleNamespace(num_nextn_predict_layers=1))
+
+    with pytest.warns(UserWarning, match="Trimming config.layer_types"):
+        sanitize_hf_config_for_deployment(config_data, model=model)
+
+    assert config_data["layer_types"] == ["full_attention", "linear_attention"]
+
+
+def test_sanitize_hf_config_for_deployment_counts_mtp_layer_prefixes():
+    """Do not count broad MTP exclude prefixes as prediction layers."""
+    config_data = {
+        "num_hidden_layers": 2,
+        "layer_types": ["full_attention", "linear_attention", "nextn_predict"],
+    }
+    model = SimpleNamespace(_mtp_layer_prefixes=["mtp", "mtp.layers.0"])
+
+    with pytest.warns(UserWarning, match="Trimming config.layer_types"):
+        sanitize_hf_config_for_deployment(config_data, model=model)
+
+    assert config_data["layer_types"] == ["full_attention", "linear_attention"]
+
+
+def test_sanitize_hf_config_for_deployment_ignores_broad_mtp_prefix_only():
+    """Do not infer prediction-layer count from a broad exclude prefix alone."""
+    config_data = {
+        "num_hidden_layers": 2,
+        "layer_types": ["full_attention", "linear_attention", "nextn_predict"],
+    }
+    model = SimpleNamespace(_mtp_layer_prefixes=["mtp"])
+
+    sanitize_hf_config_for_deployment(config_data, model=model)
+
+    assert config_data["layer_types"] == ["full_attention", "linear_attention", "nextn_predict"]
+
+
+def test_sanitize_hf_config_for_deployment_keeps_unexplained_layer_type_mismatch():
+    """Do not rewrite config when extra layer types are not explained by nextn metadata."""
+    config_data = {
+        "num_hidden_layers": 2,
+        "num_nextn_predict_layers": 1,
+        "layer_types": ["full_attention", "linear_attention", "extra_a", "extra_b"],
+    }
+
+    sanitize_hf_config_for_deployment(config_data, model=SimpleNamespace())
+
+    assert config_data["layer_types"] == [
+        "full_attention",
+        "linear_attention",
+        "extra_a",
+        "extra_b",
+    ]


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fixes three Step-3.5-Flash HF checkpoint export issues that can break Transformers / vLLM deployment:

1. `nvbug 6289151`: exported `layer_types` can include the main decoder layers plus MTP / next-token-prediction entries. Transformers 5.x validates `len(layer_types) == num_hidden_layers`, so the sanitizer trims only trailing next-token-prediction entries when the mismatch is exactly explained by `num_nextn_predict_layers` or supported MTP layer-prefix metadata.
2. `nvbug 6301817`: Transformers 5.10.2 / vLLM validates `llama3` RoPE metadata and requires `rope_theta` inside `rope_parameters`. The sanitizer fills missing `rope_theta` into `llama3` `rope_parameters` / `rope_scaling` from `config.json["rope_theta"]` or `model.config.rope_theta`.
3. Step-3.5 MoE NVFP4 checkpoints can miss packed MoE `input_scale` tensors when some experts are not routed during calibration. The export path now fills missing Step-3.5 `QuantMoELinear` expert input quantizer amax values before child expert export, so the existing HF plugin reconstruction emits complete MoE `input_scale` metadata.

Unexplained `layer_types` mismatches and non-`llama3` RoPE metadata are left unchanged.

For vLLM deployment, the old vLLM Step-3.5 ModelOpt NVFP4 patch from https://github.com/vllm-project/vllm/pull/37462 is still required on the vLLM side. The StepFun vLLM image used for validation already contains that patch; this PR fixes the remaining ModelOpt checkpoint export issue.

### Usage

N/A. Export Step-3.5 HF checkpoints as usual with `hf_ptq.py`; the exported checkpoint config and MoE quantization metadata are fixed during export.

### Testing

- `/Users/weimingc/miniconda3/envs/modelopt/bin/pre-commit run ruff-format --files modelopt/torch/export/plugins/hf_checkpoint_utils.py tests/unit/torch/export/test_hf_checkpoint_utils.py`
- `/Users/weimingc/miniconda3/envs/modelopt/bin/pre-commit run ruff-check --files modelopt/torch/export/plugins/hf_checkpoint_utils.py tests/unit/torch/export/test_hf_checkpoint_utils.py`
- `/Users/weimingc/miniconda3/envs/modelopt/bin/pre-commit run mypy --files modelopt/torch/export/plugins/hf_checkpoint_utils.py tests/unit/torch/export/test_hf_checkpoint_utils.py`
- `/Users/weimingc/miniconda3/envs/modelopt/bin/pre-commit run mypy --all-files`
- `PYTHONPATH=/Users/weimingc/workspace/nvbug/Model-Optimizer /Users/weimingc/miniconda3/envs/modelopt/bin/python -m pytest tests/unit/torch/export/test_hf_checkpoint_utils.py -vv`
- `/Users/weimingc/miniconda3/envs/modelopt/bin/python -m pytest tests/unit/torch/export/test_export_weight.py -q`
- `/Users/weimingc/miniconda3/envs/modelopt/bin/python -m pytest tests/unit/torch/quantization/plugins/test_fused_experts.py -q`
- `/Users/weimingc/miniconda3/envs/modelopt/bin/python -m ruff check modelopt/torch/export/unified_export_hf.py tests/unit/torch/export/test_export_weight.py`
- `/Users/weimingc/miniconda3/envs/modelopt/bin/python -m ruff format --check modelopt/torch/export/unified_export_hf.py tests/unit/torch/export/test_export_weight.py`
- `git diff --check`
- Transformers 5.10.2 config-load reproduction:
  - unsanitized Step3p5 config reproduced `Missing required keys in rope_parameters ... {'rope_theta'}`
  - sanitized config loaded successfully with `rope_parameters["rope_theta"] == 500000`
- HF-source PTQ/export E2E on the configured cluster:
  - SLURM `564757` completed with exit `0:0`
  - source model: `stepfun-ai/Step-3.5-Flash`
  - recipe: `modelopt_recipes/huggingface/step3p5/Step3.5-Flash/ptq/nvfp4-mlp-only.yaml`
  - exported checkpoint: `/lustre/fsw/portfolios/coreai/users/weimingc/e2e/pr1693-step35-hf-20260616-092135/output/step35-flash-nvfp4-mlp-only-ptq4`
  - post-export validation with Transformers 5.10.2 passed: the checkpoint config can be loaded, `num_hidden_layers == len(layer_types) == 45`, `rope_type == llama3`, and `rope_theta` is present
- Step-3.5 full PTQ/export E2E with the MoE `input_scale` fix on the configured cluster:
  - SLURM `572589` completed with exit `0:0`
  - source model: Step-3.5-Flash
  - recipe: `modelopt_recipes/huggingface/step3p5/Step3.5-Flash/ptq/nvfp4-mlp-only.yaml`
  - exported checkpoint: `/lustre/fsw/portfolios/coreai/users/weimingc/e2e/pr1693-step35-hf-20260616-092135/output/step35-flash-nvfp4-mlp-only-full32-inputscale-cuda3`
  - metadata validation passed: `weight_scale 135`, `weight_scale_2 135`, `input_scale 135`, `missing_moe_input_scale_layers []`
- vLLM deployment smoke with the PR-exported config-fix checkpoint on the configured cluster:
  - environment: 4x GB300 node, TP=4, `vllm 0.23.0`, `transformers 5.12.1`, `torch 2.11.0+cu130`, `modelopt 0.43.0`
  - SLURM `568265` completed with exit `0:0`; vLLM loaded the 111.60 GiB ModelOpt NVFP4 checkpoint, confirming the exported checkpoint can be loaded by the deployment stack, passed `/health`, listed the model via `/v1/models`, and accepted `/v1/completions` sample requests
  - SLURM `568366` completed with exit `0:0` using the warmed FlashInfer cache; `/v1/completions` and `/v1/chat/completions` sample requests returned HTTP 200 with completion token usage and generated token ids
  - the first serve run spent most startup time compiling/autotuning FlashInfer kernels for `sm_103a`; this is an environment warmup cost, not a config-load failure
- vLLM deployment smoke with the Step-3.5 MoE `input_scale` fixed checkpoint on the configured cluster:
  - SLURM `572753` completed with exit `0:0`
  - environment: 4x GB300 node, TP=4, StepFun vLLM image, `vllm 0.1.dev16944+ge9c8946e7`, `transformers 5.9.0`, `torch 2.11.0+cu130`
  - confirmed the old vLLM Step-3.5 ModelOpt NVFP4 changes are present in the image: `.experts` quant lookup fallback, Step3p5 `input_scale` mapping, and scalar-scale guard
  - `/health` passed, `/v1/models` listed the checkpoint, `/v1/completions` and `/v1/chat/completions` returned HTTP 200
  - sample completion for `The capital of France is`: ` Paris. The capital of Germany is Berlin. The capital of Italy is Rome. The capital of Spain is Madrid. The capital of the United Kingdom is London.`

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information

nvbug 6289151
nvbug 6301817

PR #1745 was closed because its RoPE metadata fix is folded into this PR.

Related MTP handling: #1532.

vLLM-side Step-3.5 ModelOpt NVFP4 support: https://github.com/vllm-project/vllm/pull/37462.
