### PR TITLE
[OMNIML-5025] specdec_bench cell t0_d7 — google/gemma-4-E4B-it / MTP / vllm

### DIFF
--- a/tools/launcher/common/specdec_bench/_cells/gemma-4-E4B-it_mtp_vllm_t0_d7.yaml
+++ b/tools/launcher/common/specdec_bench/_cells/gemma-4-E4B-it_mtp_vllm_t0_d7.yaml
@@ -1,0 +1,4 @@
+sampling_kwargs:
+  temperature: 0
+engine_args:
+  max_model_len: 65536


### PR DESCRIPTION
Adds the per-cell runtime params for SPEED-bench gemma-4-E4B-it / MTP / vLLM cell t0_d7.

Sweep: gemma-4-E4B-it_mtp_vllm_t0_d7