### PR TITLE
Fix Qwen AutoQuant disabled layer test

### DIFF
--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -55,11 +55,7 @@ logger = logging.getLogger(__name__)
 SPECULATIVE_MODEL_LIST = ["Eagle", "Medusa"]
 
 # TODO: Refactor into the config system.
-_QWEN36_AUTOQ_DISABLED_LAYERS = (
-    "*shared_expert_gate*",
-    "*linear_attn.in_proj_a*",
-    "*linear_attn.in_proj_b*",
-)
+_QWEN36_AUTOQ_DISABLED_LAYERS = ("*shared_expert_gate*",)
 _VLM_AUTOQ_DISABLED_LAYERS = ("*visual*", "*mtp*", "*vision_tower*")
 
 

--- a/tests/examples/llm_ptq/test_hf_ptq_args.py
+++ b/tests/examples/llm_ptq/test_hf_ptq_args.py
@@ -97,8 +97,6 @@ def test_qwen_autoquant_disabled_layers_are_scoped_to_qwen_models(monkeypatch):
     llama_model = SimpleNamespace(config=SimpleNamespace(model_type="llama"))
     qwen_only_patterns = {
         "*shared_expert_gate*",
-        "*linear_attn.in_proj_a*",
-        "*linear_attn.in_proj_b*",
     }
 
     monkeypatch.setattr(example_utils, "is_multimodal_model", lambda model: False)


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fixes the `llm_ptq` example-test failure on current `main`:

```text
tests/examples/llm_ptq/test_hf_ptq_args.py::test_qwen_autoquant_disabled_layers_are_scoped_to_qwen_models
```

`*linear_attn.in_proj_a*` and `*linear_attn.in_proj_b*` were promoted into the global default disabled quantizer list, so they are no longer Qwen-only AutoQuant exclusions. This PR removes the redundant entries from the example-specific Qwen AutoQuant exclusion tuple and narrows the test to the remaining Qwen-only pattern, `*shared_expert_gate*`.

### Usage

N/A

### Testing

- Reproduced the failure on `origin/main` (`cc17f2c45`) with:
  - `python -m pytest tests/examples/llm_ptq/test_hf_ptq_args.py::test_qwen_autoquant_disabled_layers_are_scoped_to_qwen_models -vv`
- Verified the fix with:
  - `python -m pytest tests/examples/llm_ptq/test_hf_ptq_args.py::test_qwen_autoquant_disabled_layers_are_scoped_to_qwen_models tests/unit/recipe/test_presets.py::test_w4a16_nvfp4_preset_disables_vllm_marlin_incompatible_projections tests/unit/recipe/test_loader.py::test_nvfp4_weight_only_recipe_disables_vllm_marlin_incompatible_projections -vv`
  - `python -m py_compile examples/llm_ptq/example_utils.py tests/examples/llm_ptq/test_hf_ptq_args.py`
  - `git diff --check`

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information

Observed while checking the failing `trtllm-pr (llm_ptq) / run-test` job on PR #1697. The failure reproduces on `main`, so this PR is independent of #1697.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted quantization exclusion configuration for the Qwen model family to narrow which layers are excluded.

* **Tests**
  * Updated test expectations to align with the revised quantization exclusion behavior for Qwen models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->