### PR TITLE
feat(tools/mcp): MCP server for ModelOpt launcher (OMNIML-5123)

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -12,6 +12,7 @@ on:
       - "pyproject.toml"
       - "tests/unit/**"
       - "tools/launcher/**"
+      - "tools/mcp/**"
       - ".agents/skills/**"
   schedule:
     - cron: "0 0 * * *" # Nightly
@@ -55,6 +56,7 @@ jobs:
             pyproject.toml
             tests/unit/**
             tools/launcher/**
+            tools/mcp/**
             .agents/skills/**
   linux:
     needs: [check-dco]
@@ -147,6 +149,29 @@ jobs:
           uv venv .venv
           uv pip install -e . pytest
           uv run python3 -m pytest -v
+  mcp:
+    if: needs.check-file-changes.outputs.any_changed == 'true'
+    needs: [linux, check-file-changes]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Run modelopt-mcp tests
+        working-directory: tools/mcp
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          export PATH="$HOME/.local/bin:$PATH"
+          uv venv .venv
+          # Install the sibling launcher package first; it's a runtime
+          # dep declared in tools/mcp/pyproject.toml as `modelopt-launcher`
+          # but uv resolves the source via [tool.uv.sources] to a local
+          # editable path. -e on both packages keeps the install cheap
+          # and matches the dev-mode install in tools/mcp/README.md.
+          uv pip install -e ../launcher
+          uv pip install -e . pytest
+          uv run python3 -m pytest -v
   skills:
     if: needs.check-file-changes.outputs.any_changed == 'true'
     needs: [linux, check-file-changes]
@@ -167,7 +192,7 @@ jobs:
   unit-pr-required-check:
     # Run even if some jobs are skipped
     if: ${{ github.event_name == 'pull_request' && always() }}
-    needs: [check-file-changes, linux, windows, multi-version, partial-install, launcher, skills]
+    needs: [check-file-changes, linux, windows, multi-version, partial-install, launcher, mcp, skills]
     runs-on: ubuntu-latest
     steps:
       - name: Required unit tests did not succeed
@@ -177,6 +202,7 @@ jobs:
             needs.multi-version.result != 'success' ||
             needs.partial-install.result != 'success' ||
             needs.launcher.result != 'success' ||
+            needs.mcp.result != 'success' ||
             needs.skills.result != 'success'
           )) }}
         run: exit 1

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -20,7 +20,7 @@ Mode is determined by which args you pass, not by which tool you call. One tool,
 | Tool | Description |
 |---|---|
 | `list_examples` | Enumerate bundled launcher YAMLs under `tools/launcher/examples/` with model + description metadata extracted from each YAML. Discovery primitive — call this first when you don't know which YAML to launch. |
-| `verify_setup(executor, ...)` | Fail-fast probe for the named executor. Docker: `docker info` (daemon up) + GPU passthrough check. Slurm: `ssh -o BatchMode=yes -o ConnectTimeout=5` to the cluster login node. Returns structured failure on auth / network / daemon issues — no exception. |
+| `verify_setup(executor, ...)` | Fail-fast probe for the named executor. Docker: `docker info` (daemon up) + `docker info --format` runtime-registry check (looks for `"nvidia"` runtime registered by the NVIDIA Container Toolkit — no image pull, daemon-fast). Slurm: `ssh -o BatchMode=yes -o ConnectTimeout=5` to the cluster login node. Returns structured failure on auth / network / daemon issues — no exception. |
 | `submit_job(yaml_path, hf_local? \| cluster_host?, ...)` | Submit a launcher YAML. Mode resolved from mutually-exclusive args. Returns `experiment_id` (Slurm) or PID (Docker) immediately; the actual job runs detached. Auto-runs `verify_setup` first by default (skippable). |
 | `job_status(experiment_id)` | Filesystem-based status from nemo_run's experiment dir (`_DONE`, `status_*.out`). Returns `done` / `failed` / `running` plus per-task statuses. No in-memory registry; survives MCP server restarts. |
 | `job_logs(experiment_id, task?, tail?)` | Read `log_<task>.out` from the experiment dir. Per-task filtering + optional tail to truncate. |
@@ -117,7 +117,7 @@ For local Docker execution, drop `cluster_host`/`cluster_user`/`identity` and pa
 |---|---|---|
 | `NEMORUN_HOME` | submit + status + logs | Where the launcher writes experiment artifacts. Defaults to cwd if unset. `job_status` / `job_logs` search `$NEMORUN_HOME/experiments/<id>/`. |
 | `MODELOPT_MCP_LOG` | (optional) server | Log level. Defaults to `INFO`. Logs go to stderr — stdout is the MCP wire. |
-| `MODELOPT_MCP_SKIP_GPU_CHECK` | (optional) `verify_setup(executor='docker')` | Set to skip the `docker run --gpus all nvidia-smi` step. Useful for CI hosts without GPUs. |
+| `MODELOPT_MCP_SKIP_GPU_CHECK` | (optional) `verify_setup(executor='docker')` | Set to skip the `docker info --format` runtime-registry check. Useful for CI hosts where the daemon is up but the NVIDIA Container Toolkit isn't installed. |
 | `MODELOPT_LAUNCHER_EXAMPLES_DIR` | (optional) `list_examples` | Override the examples directory location. Defaults to `../launcher/examples/` relative to this package. |
 
 ## Design principles
@@ -153,10 +153,15 @@ tools/mcp/
                                 # (mocked subprocess + tmp_path fixtures)
 ```
 
-## Phase 2
+## Phase 2 & beyond
 
-Out of scope for this PR; tracked separately:
+Tracked under [OMNIML-5123](https://jirasw.nvidia.com/browse/OMNIML-5123) (Epic). Highlights:
 
-* Capture `experiment_id` from Docker subprocess output (Phase 1 returns PID; nemo_run's id only appears in stdout after a few seconds).
-* `wait_for_experiment(experiment_id, timeout_sec)` for blocking polls — pairs with `job_status` to avoid pause-loops in the agent.
-* Extract the verify + submit helpers into a shared lib that `nmm-sandbox-mcp` can consume if it ever needs deeper Python integration.
+**Phase 2 — close the `cell.md` simplification loop:**
+* [OMNIML-5128](https://jirasw.nvidia.com/browse/OMNIML-5128) — `wait_for_experiment`, `read_cluster_artifact`, `open_draft_pr`
+* [OMNIML-5132](https://jirasw.nvidia.com/browse/OMNIML-5132) — `provision_passwordless_ssh_dry_run` (operator UX helper)
+* Capture `experiment_id` from Docker subprocess output (Phase 1 returns PID; nemo_run's id only appears in stdout after a few seconds — Phase 2 tails launcher output via a side-channel log file).
+
+**Phase 3 — NEL integration + checkpoint introspection:**
+* [OMNIML-5133](https://jirasw.nvidia.com/browse/OMNIML-5133) — `nel_submit`, `nel_status`, `nel_run_eval`, `nel_export`, `nel_compare`, `nel_gate` (wraps `nemo-evaluator-launcher`)
+* [OMNIML-5134](https://jirasw.nvidia.com/browse/OMNIML-5134) — `inspect_checkpoint`, `inspect_model`

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -24,6 +24,10 @@ Mode is determined by which args you pass, not by which tool you call. One tool,
 | `submit_job(yaml_path, hf_local? \| cluster_host?, ...)` | Submit a launcher YAML. Mode resolved from mutually-exclusive args. Returns `experiment_id` (Slurm) or PID (Docker) immediately; the actual job runs detached. Auto-runs `verify_setup` first by default (skippable). |
 | `job_status(experiment_id)` | Filesystem-based status from nemo_run's experiment dir (`_DONE`, `status_*.out`). Returns `done` / `failed` / `running` plus per-task statuses. No in-memory registry; survives MCP server restarts. |
 | `job_logs(experiment_id, task?, tail?)` | Read `log_<task>.out` from the experiment dir. Per-task filtering + optional tail to truncate. |
+| `wait_for_experiment(experiment_id, timeout_sec?, poll_interval_sec?)` | Block until `job_status` returns `done` / `failed`, or until `timeout_sec` elapses. Single tool call replaces the agent's `while True: status; sleep` loop — saves tool-call turns and avoids overshooting the poll interval. Returns the final status plus `waited_seconds`. |
+| `provision_passwordless_ssh_dry_run(cluster_host, cluster_user, identity?)` | Operator UX helper. Inspects `~/.ssh/` and emits the exact `ssh-keygen` / `ssh-copy-id` commands the user should run to make `verify_setup(executor='slurm')` pass. No side effects — pure inspection + shell-command formatting. |
+| `read_cluster_artifact(experiment_id, path?, job_idx?)` | Pull artifact content from the remote cluster via nemo_run's tunnel primitives. With `path=None`, wraps `nemo experiment logs <id> <job_idx>` (built-in log fetch). With a `path`, uses the experiment's `Tunnel` to `cat` the file. No reinvented SSH. |
+| `open_draft_pr(target_repo, title, body, base_branch?, cwd?)` | Push the current branch and open a draft PR via `gh pr create --draft`. Validates `cwd` is a git repo before doing anything. On `gh` failure after a successful push, returns `branch_pushed=True` so the operator can retry just the PR-open step. |
 
 ## Install
 
@@ -145,11 +149,12 @@ tools/mcp/
 ├── README.md                   # ← this file
 ├── modelopt_mcp/
 │   ├── __init__.py
-│   ├── server.py               # FastMCP entry; 5 tool definitions
+│   ├── server.py               # FastMCP entry; 9 tool definitions
 │   └── bridge.py               # thin wrapper over launcher's core.py
 │                               # + filesystem status/log helpers
+│                               # + tunnel/PR helpers (Phase 1.5)
 └── tests/
-    └── test_bridge.py          # 19 unit tests, fully hermetic
+    └── test_bridge.py          # 32 unit tests, fully hermetic
                                 # (mocked subprocess + tmp_path fixtures)
 ```
 
@@ -157,9 +162,9 @@ tools/mcp/
 
 Tracked under [OMNIML-5123](https://jirasw.nvidia.com/browse/OMNIML-5123) (Epic). Highlights:
 
-**Phase 2 — close the `cell.md` simplification loop:**
-* [OMNIML-5128](https://jirasw.nvidia.com/browse/OMNIML-5128) — `wait_for_experiment`, `read_cluster_artifact`, `open_draft_pr`
-* [OMNIML-5132](https://jirasw.nvidia.com/browse/OMNIML-5132) — `provision_passwordless_ssh_dry_run` (operator UX helper)
+**Phase 1.5 — shipped in this PR:** `wait_for_experiment`, `provision_passwordless_ssh_dry_run`, `read_cluster_artifact`, `open_draft_pr`. Anchors: [OMNIML-5128](https://jirasw.nvidia.com/browse/OMNIML-5128) (partial: the three high-leverage tools), [OMNIML-5132](https://jirasw.nvidia.com/browse/OMNIML-5132) (full).
+
+**Phase 2 — close the remaining `cell.md` simplification loop:**
 * Capture `experiment_id` from Docker subprocess output (Phase 1 returns PID; nemo_run's id only appears in stdout after a few seconds — Phase 2 tails launcher output via a side-channel log file).
 
 **Phase 3 — NEL integration + checkpoint introspection:**

--- a/tools/mcp/README.md
+++ b/tools/mcp/README.md
@@ -1,0 +1,162 @@
+# modelopt-mcp
+
+MCP server exposing the ModelOpt launcher (`tools/launcher/`) as typed tools for codex / Claude Code agents.
+
+Anchor design: [OMNIML-5123](https://jirasw.nvidia.com/browse/OMNIML-5123).
+
+## What this is
+
+A thin MCP wrapper around `tools/launcher/core.py`. Agents that want to submit ModelOpt jobs — PTQ, QAT, training, evaluation — call typed tools here instead of shelling out to `uv run launch.py --yaml ...` and parsing prose output.
+
+Two executors, one tool surface:
+
+* **Docker** (local GPU) — `submit_job(yaml_path, hf_local=...)`. The launcher runs the job in a container on the local machine.
+* **Slurm** (remote cluster via SSH) — `submit_job(yaml_path, cluster_host=..., cluster_user=..., identity=...)`. The launcher tunnels in and submits via sbatch.
+
+Mode is determined by which args you pass, not by which tool you call. One tool, two backends.
+
+## Tool surface
+
+| Tool | Description |
+|---|---|
+| `list_examples` | Enumerate bundled launcher YAMLs under `tools/launcher/examples/` with model + description metadata extracted from each YAML. Discovery primitive — call this first when you don't know which YAML to launch. |
+| `verify_setup(executor, ...)` | Fail-fast probe for the named executor. Docker: `docker info` (daemon up) + GPU passthrough check. Slurm: `ssh -o BatchMode=yes -o ConnectTimeout=5` to the cluster login node. Returns structured failure on auth / network / daemon issues — no exception. |
+| `submit_job(yaml_path, hf_local? \| cluster_host?, ...)` | Submit a launcher YAML. Mode resolved from mutually-exclusive args. Returns `experiment_id` (Slurm) or PID (Docker) immediately; the actual job runs detached. Auto-runs `verify_setup` first by default (skippable). |
+| `job_status(experiment_id)` | Filesystem-based status from nemo_run's experiment dir (`_DONE`, `status_*.out`). Returns `done` / `failed` / `running` plus per-task statuses. No in-memory registry; survives MCP server restarts. |
+| `job_logs(experiment_id, task?, tail?)` | Read `log_<task>.out` from the experiment dir. Per-task filtering + optional tail to truncate. |
+
+## Install
+
+Two paths, both **from source via uv**. No PyPI wheel — OMNIML-5123 deliberately picks `uvx`-from-git over publication overhead.
+
+### End-user install (recommended)
+
+```bash
+# Claude Code
+claude mcp add modelopt -- uvx --from \
+  "git+https://github.com/NVIDIA/Model-Optimizer.git#subdirectory=tools/mcp" \
+  modelopt-mcp
+
+# Codex
+codex mcp add modelopt -- uvx --from \
+  "git+https://github.com/NVIDIA/Model-Optimizer.git#subdirectory=tools/mcp" \
+  modelopt-mcp
+```
+
+`uvx` clones the whole repo to its cache, installs `tools/mcp/` as the entry point, and resolves the sibling `modelopt-launcher` dep via `[tool.uv.sources]` (path → `../launcher`) inside the cloned tree.
+
+### Dev install (local checkout)
+
+```bash
+uv pip install -e tools/launcher    # sibling dep first
+uv pip install -e tools/mcp         # then this package
+modelopt-mcp                         # stdio server entry on PATH
+```
+
+Both packages share the launcher's `core.py` orchestrator. The dev path relies on `[tool.uv.sources]` to point `modelopt-launcher` at `../launcher`.
+
+### Why no plain `pip install` today
+
+`modelopt-mcp` and `modelopt-launcher` are not on PyPI. Plain `pip` doesn't read `[tool.uv.sources]`, so even from a local checkout, `pip install -e tools/mcp` fails to resolve the bare `modelopt-launcher` name. Stick with `uv` / `uvx` while we're git-only.
+
+To enable `pip install` later, two options:
+
+| Path | Tradeoff |
+|---|---|
+| **Publish to PyPI** — versioned wheels for both packages | Clean `pip install`, but requires release machinery + version cadence |
+| **PEP-440 direct URL** — `"modelopt-launcher @ git+...#subdirectory=tools/launcher"` | Works with pip + uv, but double-clones the repo on install |
+
+Out of scope for Phase 1.
+
+## Example workflow
+
+Agent picking a bundled example and running it on a remote cluster:
+
+```python
+# 1. Discover available YAMLs
+examples = mcp__modelopt__list_examples()
+# {"ok": True, "count": 47, "examples": [{"path": "launcher/examples/Qwen/Qwen3-8B/megatron_lm_ptq.yaml", "model": "Qwen/Qwen3-8B", ...}, ...]}
+
+# 2. Pre-flight check before submission
+mcp__modelopt__verify_setup(
+    executor="slurm",
+    cluster_host="cw-dfw-cs-001-login-01.nvidia.com",
+    cluster_user="alice",
+)
+# {"ok": True, "ssh_ok": True, "whoami": "alice", "remote_hostname": "cw-dfw-cs-001-login-01"}
+
+# 3. Submit
+result = mcp__modelopt__submit_job(
+    yaml_path="launcher/examples/Qwen/Qwen3-8B/megatron_lm_ptq.yaml",
+    cluster_host="cw-dfw-cs-001-login-01.nvidia.com",
+    cluster_user="alice",
+    identity="/home/alice/.ssh/id_ed25519",
+    skip_verify=True,  # we just probed
+)
+# {"ok": True, "experiment_id": "cicd_1781240000", "slurm_job_id": "12345", ...}
+
+# 4. Poll until done
+while True:
+    status = mcp__modelopt__job_status(experiment_id="cicd_1781240000")
+    if status["status"] in ("done", "failed"):
+        break
+
+# 5. Fetch logs
+logs = mcp__modelopt__job_logs(
+    experiment_id="cicd_1781240000",
+    task="task_0",
+    tail=200,
+)
+```
+
+For local Docker execution, drop `cluster_host`/`cluster_user`/`identity` and pass `hf_local=<path>` to `submit_job` instead.
+
+## Required env vars
+
+| Var | When | Notes |
+|---|---|---|
+| `NEMORUN_HOME` | submit + status + logs | Where the launcher writes experiment artifacts. Defaults to cwd if unset. `job_status` / `job_logs` search `$NEMORUN_HOME/experiments/<id>/`. |
+| `MODELOPT_MCP_LOG` | (optional) server | Log level. Defaults to `INFO`. Logs go to stderr — stdout is the MCP wire. |
+| `MODELOPT_MCP_SKIP_GPU_CHECK` | (optional) `verify_setup(executor='docker')` | Set to skip the `docker run --gpus all nvidia-smi` step. Useful for CI hosts without GPUs. |
+| `MODELOPT_LAUNCHER_EXAMPLES_DIR` | (optional) `list_examples` | Override the examples directory location. Defaults to `../launcher/examples/` relative to this package. |
+
+## Design principles
+
+Three constants drive the surface here:
+
+1. **Single `submit_job` with mode by args.** Not separate `submit_docker` / `submit_slurm` tools. The LLM tool catalog stays compact; the mutual-exclusion is a runtime check that returns structured failure when both or neither mode is specified.
+2. **Filesystem is the source of truth.** Status + logs both read from nemo_run's experiment dir. No in-memory registry — survives MCP server restarts. The bridge module never holds per-job state across calls.
+3. **`verify_setup` is auto-called by `submit_job` by default.** The probe takes ~1 second; the cost of a misconfigured submission is 30+ seconds of cluster timeout or container-pull. Always-on verification pays back immediately. Callers can pass `skip_verify=True` when they just probed.
+
+## Internal companion (NVIDIA only)
+
+For NVIDIA-internal users running on the in-house clusters, there's a companion server [`nmm-sandbox-mcp`](https://gitlab-master.nvidia.com/omniml/integration/nmm-sandbox/-/tree/main/tools/mcp) that adds:
+
+* `resolve_cluster_factory(name)` — turn `"cw_dfw"` into the `{cluster_host, cluster_user, identity, account, ...}` dict that `submit_job` consumes, so internal users supply 1 arg instead of 6.
+* `submit_via_gitlab_ci(...)` — alternative submission path that triggers the nmm-sandbox CI's `intern-step` pipeline. Useful when the operator doesn't have direct cluster access.
+
+Both servers are registered in the operator's `.mcp.json` side by side. The agent threads results from one into calls to the other. No Python coupling between them.
+
+## Layout
+
+```text
+tools/mcp/
+├── pyproject.toml              # name: modelopt-mcp, console_script
+├── README.md                   # ← this file
+├── modelopt_mcp/
+│   ├── __init__.py
+│   ├── server.py               # FastMCP entry; 5 tool definitions
+│   └── bridge.py               # thin wrapper over launcher's core.py
+│                               # + filesystem status/log helpers
+└── tests/
+    └── test_bridge.py          # 19 unit tests, fully hermetic
+                                # (mocked subprocess + tmp_path fixtures)
+```
+
+## Phase 2
+
+Out of scope for this PR; tracked separately:
+
+* Capture `experiment_id` from Docker subprocess output (Phase 1 returns PID; nemo_run's id only appears in stdout after a few seconds).
+* `wait_for_experiment(experiment_id, timeout_sec)` for blocking polls — pairs with `job_status` to avoid pause-loops in the agent.
+* Extract the verify + submit helpers into a shared lib that `nmm-sandbox-mcp` can consume if it ever needs deeper Python integration.

--- a/tools/mcp/modelopt_mcp/__init__.py
+++ b/tools/mcp/modelopt_mcp/__init__.py
@@ -26,9 +26,11 @@ Tool surface (Phase 1):
 * ``verify_setup`` — fail-fast probe for the named executor (docker or
   slurm) BEFORE the user burns minutes on a misconfigured submission.
 * ``submit_job`` — submit a launcher YAML; mode determined by args
-  (``hf_local`` → Docker; ``cluster_host`` → Slurm). Returns the
-  experiment id immediately; Docker runs in a background thread,
-  Slurm submits with ``detach=True``.
+  (``hf_local`` → Docker; ``cluster_host`` → Slurm). Returns
+  immediately: Slurm returns ``experiment_id`` (parsed from launch.py's
+  detach-mode stdout), Docker returns the background subprocess
+  ``pid`` (Phase 2 will tail launcher output to capture the nemo_run
+  experiment_id for the Docker path too).
 * ``job_status`` — filesystem-based status from nemo_run's experiment
   dir (``_DONE``, ``status_*.out``). No in-memory registry; survives
   MCP server restarts.

--- a/tools/mcp/modelopt_mcp/__init__.py
+++ b/tools/mcp/modelopt_mcp/__init__.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ModelOpt launcher MCP server.
+
+Anchor design: OMNIML-5123. Exposes the launcher's submit / status / logs
+operations as typed MCP tools that codex / Claude Code agents can call
+directly, instead of shelling out to ``uv run launch.py --yaml ...``.
+
+Tool surface (Phase 1):
+
+* ``list_examples`` — discover bundled example YAMLs under
+  ``tools/launcher/examples/`` with their model + description metadata.
+* ``verify_setup`` — fail-fast probe for the named executor (docker or
+  slurm) BEFORE the user burns minutes on a misconfigured submission.
+* ``submit_job`` — submit a launcher YAML; mode determined by args
+  (``hf_local`` → Docker; ``cluster_host`` → Slurm). Returns the
+  experiment id immediately; Docker runs in a background thread,
+  Slurm submits with ``detach=True``.
+* ``job_status`` — filesystem-based status from nemo_run's experiment
+  dir (``_DONE``, ``status_*.out``). No in-memory registry; survives
+  MCP server restarts.
+* ``job_logs`` — read ``log_*.out`` per task, with optional tail.
+
+Two design constants:
+
+1. **Mode determined by args, not by tool choice.** Single
+   ``submit_job`` rather than separate ``submit_docker`` / ``submit_slurm``.
+   The mutually-exclusive arg shape is a runtime check; the LLM catalog
+   stays compact.
+2. **Filesystem is the source of truth.** Status + logs both read from
+   nemo_run's experiment dir. The MCP server carries no per-job state
+   across calls — survives restarts cleanly.
+"""
+
+from modelopt_mcp.server import main
+
+__all__ = ["main"]

--- a/tools/mcp/modelopt_mcp/bridge.py
+++ b/tools/mcp/modelopt_mcp/bridge.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess  # nosec B404
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -822,4 +823,477 @@ def job_logs_impl(
         "experiment_id": experiment_id,
         "experiment_dir": str(exp_dir),
         "logs": logs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# wait_for_experiment — closes the polling loop the agent would write by hand
+# ---------------------------------------------------------------------------
+
+
+def wait_for_experiment_impl(
+    experiment_id: str,
+    timeout_sec: int,
+    poll_interval_sec: int,
+) -> dict:
+    """Block until ``experiment_id`` reaches a terminal status or the timeout elapses.
+
+    Returns the same dict shape as ``job_status_impl`` plus a
+    ``waited_seconds`` field. On timeout, returns
+    ``{ok: False, reason: "wait_timeout", last_status: <last poll>}``
+    instead of raising — same structured-failure convention as the
+    other tools.
+
+    The poll uses ``job_status_impl`` directly (no subprocess shell-out),
+    so the resolution rules for finding the experiment dir match
+    exactly. If the dir never shows up,
+    ``job_status_impl`` returns ``experiment_dir_not_found`` and we
+    pass that through immediately rather than spinning to the timeout.
+    """
+    started = time.monotonic()
+    while True:
+        status = job_status_impl(experiment_id)
+        if not status.get("ok"):
+            # Pass through job_status's structured failure (e.g.
+            # experiment_dir_not_found) — no point spinning when the
+            # dir doesn't exist.
+            return {**status, "waited_seconds": time.monotonic() - started}
+        if status["status"] in ("done", "failed"):
+            return {**status, "waited_seconds": time.monotonic() - started}
+        if time.monotonic() - started > timeout_sec:
+            return {
+                "ok": False,
+                "experiment_id": experiment_id,
+                "reason": "wait_timeout",
+                "diagnostic": (
+                    f"Experiment {experiment_id!r} still "
+                    f"{status['status']!r} after {timeout_sec}s. "
+                    f"Last status: {status}."
+                ),
+                "last_status": status,
+                "waited_seconds": time.monotonic() - started,
+            }
+        time.sleep(poll_interval_sec)
+
+
+# ---------------------------------------------------------------------------
+# provision_passwordless_ssh_dry_run — operator UX helper
+# ---------------------------------------------------------------------------
+
+
+def provision_passwordless_ssh_dry_run_impl(
+    cluster_host: str,
+    cluster_user: str | None,
+    identity: str | None,
+) -> dict:
+    """Emit the exact commands to set up passwordless SSH — does NOT execute them.
+
+    Strategy:
+
+    1. Resolve which identity file to inspect (explicit arg → env →
+       ``~/.ssh/id_ed25519`` default).
+    2. If the private key file is missing, emit a ``ssh-keygen`` command
+       and stop. Operator runs it, then re-invokes this tool.
+    3. If the private key exists but the public key (``<identity>.pub``)
+       is missing, that's an unusual state — surface it as a failure
+       with a recovery hint.
+    4. If both exist, read the public key + emit the exact
+       ``ssh-copy-id`` command pointing at the named cluster. Note
+       that this is the only step that needs a password — the operator
+       runs it, types the cluster password once, and from then on
+       passwordless SSH works.
+
+    Returns ``{ok, step, commands, next_check, ...}``. ``commands`` is
+    a list of shell strings the operator should run in order.
+    ``next_check`` always recommends calling
+    ``verify_setup(executor="slurm", ...)`` after the operator
+    runs the commands.
+    """
+    # Resolve identity
+    resolved_identity = (
+        identity or os.environ.get("IDENTITY") or str(Path.home() / ".ssh" / "id_ed25519")
+    )
+    identity_path = Path(resolved_identity).expanduser()
+    pubkey_path = Path(f"{identity_path}.pub")
+    target = f"{cluster_user}@{cluster_host}" if cluster_user else cluster_host
+
+    next_check_hint = (
+        f"After running the commands above, call "
+        f"verify_setup(executor='slurm', cluster_host={cluster_host!r}"
+        + (f", cluster_user={cluster_user!r}" if cluster_user else "")
+        + (f", identity={resolved_identity!r}" if identity else "")
+        + ") to confirm key-auth now works."
+    )
+
+    if not identity_path.exists():
+        # Step 1: keygen needed
+        keygen_cmd = (
+            f"ssh-keygen -t ed25519 -N '' -f {identity_path} "
+            f'-C "{os.environ.get("USER", "user")}@$(hostname)"'
+        )
+        return {
+            "ok": True,
+            "step": "keygen_required",
+            "identity_path": str(identity_path),
+            "commands": [
+                keygen_cmd,
+                # After keygen, the operator should re-invoke this tool
+                # — they'll hit the next branch and get the ssh-copy-id
+                # command.
+            ],
+            "diagnostic": (
+                f"No SSH private key at {identity_path}. Run the "
+                f"command above, then call this tool again — it will "
+                f"emit the ssh-copy-id step to authorize the new key "
+                f"on the cluster."
+            ),
+            "next_step": (
+                f"Re-invoke provision_passwordless_ssh_dry_run("
+                f"cluster_host={cluster_host!r}"
+                + (f", cluster_user={cluster_user!r}" if cluster_user else "")
+                + ")"
+            ),
+        }
+
+    if not pubkey_path.exists():
+        return {
+            "ok": False,
+            "step": "pubkey_missing",
+            "identity_path": str(identity_path),
+            "pubkey_path": str(pubkey_path),
+            "reason": "pubkey_missing",
+            "diagnostic": (
+                f"Private key exists at {identity_path} but the matching "
+                f"public key at {pubkey_path} is missing. This is "
+                f"unusual — typically both are produced together by "
+                f"ssh-keygen. Recover by regenerating the keypair "
+                f"(move {identity_path} aside first if you don't want "
+                f"to lose it):\n"
+                f"  mv {identity_path} {identity_path}.bak\n"
+                f"  ssh-keygen -t ed25519 -N '' -f {identity_path}"
+            ),
+        }
+
+    # Step 2: ssh-copy-id needed
+    pubkey_content = pubkey_path.read_text(encoding="utf-8").strip()
+    copy_cmd = f"ssh-copy-id -i {pubkey_path} {target}"
+    return {
+        "ok": True,
+        "step": "ssh_copy_id_required",
+        "identity_path": str(identity_path),
+        "pubkey_path": str(pubkey_path),
+        "pubkey": pubkey_content,
+        "commands": [copy_cmd],
+        "diagnostic": (
+            f"Public key exists at {pubkey_path}. Run the command above "
+            f"to authorize it on {target}. ssh-copy-id will prompt for "
+            f"the cluster password ONCE — that's the only place a "
+            f"password is required. After it succeeds, passwordless "
+            f"key-auth is set up."
+        ),
+        "next_check": next_check_hint,
+    }
+
+
+# ---------------------------------------------------------------------------
+# read_cluster_artifact — wraps nemo_run's tunnel
+# ---------------------------------------------------------------------------
+
+
+def read_cluster_artifact_impl(
+    experiment_id: str,
+    path: str | None,
+    job_idx: int,
+) -> dict:
+    """Read an artifact from a remote experiment via nemo_run's tunnel.
+
+    nemo_run already knows how to talk to the cluster — the executor
+    metadata is stored alongside the experiment locally. This tool
+    delegates so we don't reinvent the SSH path.
+
+    Two modes:
+
+    * ``path=None`` + ``job_idx=N`` → fetch the job's log via
+      ``nemo experiment logs <id> <N>``.
+    * ``path="<rel>"`` → relative path inside the experiment dir; we
+      use the experiment's executor tunnel to ``cat`` it.
+
+    The tool returns ``{ok, content, ...}`` with the file content as a
+    text string (8 KB max — same as the launcher's log_excerpt cap).
+    """
+    if not path:
+        # Mode 1: fetch log via `nemo experiment logs`. Subprocess
+        # because the CLI handles tunnel auth and remote-path
+        # resolution.
+        argv = [
+            "uv",
+            "run",
+            "nemo",
+            "experiment",
+            "logs",
+            experiment_id,
+            str(job_idx),
+        ]
+        launcher_dir = _THIS_DIR.parent.parent / "launcher"
+        cwd = str(launcher_dir) if launcher_dir.exists() else None
+        try:
+            proc = subprocess.run(  # nosec B603 B607
+                argv,
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                "ok": False,
+                "experiment_id": experiment_id,
+                "job_idx": job_idx,
+                "reason": "logs_fetch_timeout",
+                "diagnostic": (
+                    f"`nemo experiment logs {experiment_id} {job_idx}` "
+                    f"did not return within 60s — tunnel may be slow "
+                    f"or unreachable."
+                ),
+            }
+        if proc.returncode != 0:
+            return {
+                "ok": False,
+                "experiment_id": experiment_id,
+                "job_idx": job_idx,
+                "reason": "logs_fetch_failed",
+                "exit_code": proc.returncode,
+                "diagnostic": (
+                    f"`nemo experiment logs` exited with code "
+                    f"{proc.returncode}. stderr: {proc.stderr.strip()[-400:]}"
+                ),
+            }
+        content = (proc.stdout or "")[-8192:]
+        return {
+            "ok": True,
+            "experiment_id": experiment_id,
+            "job_idx": job_idx,
+            "mode": "logs",
+            "content": content,
+            "bytes": len(content),
+        }
+
+    # Mode 2: arbitrary path via the experiment's tunnel. nemo_run's
+    # Experiment loads the executor + tunnel from disk; we rsync the
+    # named relative path into a local tmp dir, then read it back.
+    try:
+        from nemo_run.run.experiment import Experiment
+    except ImportError:
+        return {
+            "ok": False,
+            "experiment_id": experiment_id,
+            "reason": "nemo_run_not_installed",
+            "diagnostic": (
+                "nemo_run is not importable from the MCP server's "
+                "environment. The arbitrary-path mode requires "
+                "nemo_run's tunnel + executor metadata. Install "
+                "nemo_run (>=0.8) or use path=None + job_idx=N to "
+                "fall back to the `nemo experiment logs` CLI path."
+            ),
+        }
+    try:
+        exp = Experiment.from_id(experiment_id)
+    except (FileNotFoundError, ValueError) as e:
+        return {
+            "ok": False,
+            "experiment_id": experiment_id,
+            "reason": "experiment_not_loadable",
+            "diagnostic": (
+                f"nemo_run could not load experiment {experiment_id!r}: "
+                f"{e}. Check that NEMORUN_HOME points at the same dir "
+                f"the submission used."
+            ),
+        }
+
+    # The executor exposes a tunnel; tunnel.run() runs a remote shell
+    # command. Use `cat` for small files; rsync for large ones is a
+    # Phase-2.1 follow-up.
+    try:
+        task = exp.tasks[job_idx]
+        executor = task.executor
+        tunnel = getattr(executor, "tunnel", None)
+    except (IndexError, AttributeError) as e:
+        return {
+            "ok": False,
+            "experiment_id": experiment_id,
+            "reason": "no_tunnel",
+            "diagnostic": (
+                f"Cannot reach the experiment's tunnel: {e}. Local-mode "
+                f"experiments don't have a remote tunnel; use "
+                f"`read_local_artifact` (Phase 2 follow-up) or read "
+                f"the file directly via job_logs / job_status."
+            ),
+        }
+    if tunnel is None:
+        return {
+            "ok": False,
+            "experiment_id": experiment_id,
+            "reason": "no_tunnel",
+            "diagnostic": "Experiment executor has no tunnel attribute.",
+        }
+
+    # Resolve the remote path. The experiment dir on the cluster is
+    # exposed via tunnel.job_dir or executor.job_dir; for the launcher's
+    # SlurmExecutor, this is set at submit time.
+    remote_dir = getattr(executor, "job_dir", None) or getattr(tunnel, "job_dir", None)
+    if not remote_dir:
+        return {
+            "ok": False,
+            "experiment_id": experiment_id,
+            "reason": "no_remote_job_dir",
+            "diagnostic": (
+                "Executor / tunnel metadata didn't carry a remote "
+                "job_dir. Pass the full remote path as `path` instead "
+                "of a relative one."
+            ),
+        }
+    remote_path = path if path.startswith("/") else f"{remote_dir}/{experiment_id}/{path}"
+
+    try:
+        result = tunnel.run(f"cat {remote_path}", warn=True)
+    except Exception as e:
+        return {
+            "ok": False,
+            "experiment_id": experiment_id,
+            "remote_path": remote_path,
+            "reason": "tunnel_run_failed",
+            "diagnostic": f"tunnel.run failed: {type(e).__name__}: {e}",
+        }
+    stdout = getattr(result, "stdout", "") or ""
+    return {
+        "ok": True,
+        "experiment_id": experiment_id,
+        "remote_path": remote_path,
+        "mode": "arbitrary_path",
+        "content": stdout[-8192:],
+        "bytes": len(stdout),
+    }
+
+
+# ---------------------------------------------------------------------------
+# open_draft_pr — wraps `gh pr create --draft`
+# ---------------------------------------------------------------------------
+
+
+def open_draft_pr_impl(
+    target_repo: str,
+    title: str,
+    body: str,
+    base_branch: str,
+    cwd: str | None,
+) -> dict:
+    """Open a draft PR on the named target repo from the caller's current branch.
+
+    Preconditions enforced by the agent (NOT this tool):
+    * The agent's working tree at ``cwd`` is at the branch it wants to
+      PR (created + committed).
+    * The branch carries a DCO ``Signed-off-by:`` trailer where the
+      target repo requires one (e.g. NVIDIA repos).
+
+    Steps:
+    1. ``git push -u origin HEAD`` to publish the branch.
+    2. ``gh pr create --draft --title ... --body ... --base ...`` to
+       open the draft PR against the target_repo.
+    3. Parse the PR URL out of gh's stdout and return it.
+    """
+    cwd_path = Path(cwd or os.getcwd())
+    if not (cwd_path / ".git").exists():
+        return {
+            "ok": False,
+            "reason": "not_a_git_repo",
+            "cwd": str(cwd_path),
+            "diagnostic": (
+                f"{cwd_path} does not look like a git repo (no .git "
+                f"directory). Pass an explicit cwd= pointing at the "
+                f"checkout where the branch + commit live."
+            ),
+        }
+
+    # Step 1: push
+    try:
+        push = subprocess.run(  # nosec B603 B607
+            ["git", "push", "-u", "origin", "HEAD"],
+            cwd=str(cwd_path),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except FileNotFoundError:
+        return {
+            "ok": False,
+            "reason": "git_not_installed",
+            "diagnostic": "`git` not on PATH.",
+        }
+    if push.returncode != 0:
+        return {
+            "ok": False,
+            "reason": "git_push_failed",
+            "exit_code": push.returncode,
+            "diagnostic": (
+                f"git push failed (exit={push.returncode}). stderr: {push.stderr.strip()[-400:]}"
+            ),
+        }
+
+    # Step 2: gh pr create
+    try:
+        gh = subprocess.run(  # nosec B603 B607
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                target_repo,
+                "--draft",
+                "--title",
+                title,
+                "--body",
+                body,
+                "--base",
+                base_branch,
+            ],
+            cwd=str(cwd_path),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except FileNotFoundError:
+        return {
+            "ok": False,
+            "reason": "gh_not_installed",
+            "diagnostic": "`gh` (GitHub CLI) not on PATH.",
+            "branch_pushed": True,  # branch is published; only PR-open failed
+        }
+    if gh.returncode != 0:
+        return {
+            "ok": False,
+            "reason": "gh_pr_create_failed",
+            "exit_code": gh.returncode,
+            "diagnostic": (
+                f"gh pr create failed (exit={gh.returncode}). stderr: {gh.stderr.strip()[-400:]}"
+            ),
+            "branch_pushed": True,
+        }
+
+    # Parse the PR URL out of gh's stdout (last URL on stdout is the
+    # newly-created PR).
+    url_match = re.search(
+        r"https://github\.com/[^\s]+/pull/\d+",
+        gh.stdout or "",
+    )
+    pr_url = url_match.group(0) if url_match else None
+    return {
+        "ok": True,
+        "target_repo": target_repo,
+        "title": title,
+        "base_branch": base_branch,
+        "pr_url": pr_url,
+        "stdout_tail": (gh.stdout or "")[-400:],
     }

--- a/tools/mcp/modelopt_mcp/bridge.py
+++ b/tools/mcp/modelopt_mcp/bridge.py
@@ -1,0 +1,747 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Thin Python bridge between the MCP tool layer and the launcher's ``core.py`` orchestrator.
+
+Responsibilities, in order of how the MCP tools call in:
+
+1. **List**: enumerate launcher example YAMLs at
+   ``tools/launcher/examples/`` with metadata extracted from each YAML's
+   top-level fields.
+2. **Verify**: probe a target executor (docker or slurm) is reachable.
+3. **Submit**: invoke the launcher's ``core.run_jobs`` for a single
+   launcher-format YAML. Returns immediately with the experiment id
+   (Docker mode spawns a background thread; Slurm mode uses
+   ``detach=True``).
+4. **Status / Logs**: read nemo_run's experiment dir directly.
+
+This module deliberately doesn't expose anything the MCP tools don't
+need — keeps the surface area auditable.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess  # nosec B404
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+# Locate the bundled launcher examples relative to THIS package's install
+# path. Works for both editable installs (../launcher/examples/) and
+# uvx-from-git installs (the launcher is a sibling site-packages install).
+_THIS_DIR = Path(__file__).resolve().parent
+
+
+def _find_launcher_examples_dir() -> Path | None:
+    """Resolve the launcher examples directory.
+
+    Strategy (in order):
+    1. ``MODELOPT_LAUNCHER_EXAMPLES_DIR`` env override — for tests + ad-hoc
+       relocations.
+    2. ``../../launcher/examples/`` from this file — the in-repo layout
+       when running from a Model-Optimizer clone (this is the dev mode
+       AND the uvx-from-git mode, since uvx checks out the whole repo).
+    3. Site-packages install: walk back through the modelopt_launcher
+       package to find its examples/ — fallback for the case where the
+       launcher was pip-installed standalone.
+
+    Returns None if no candidate exists; callers surface that as a
+    structured failure rather than blowing up.
+    """
+    env = os.environ.get("MODELOPT_LAUNCHER_EXAMPLES_DIR")
+    if env:
+        p = Path(env)
+        return p if p.exists() else None
+
+    # In-repo: this file is at tools/mcp/modelopt_mcp/bridge.py;
+    # examples are at tools/launcher/examples/.
+    candidate = _THIS_DIR.parent.parent / "launcher" / "examples"
+    if candidate.exists():
+        return candidate
+
+    # Site-packages fallback: the modelopt-launcher package may carry
+    # its examples next to its core.py.
+    try:
+        import modelopt_launcher
+
+        pkg_dir = Path(modelopt_launcher.__file__).resolve().parent
+        candidate = pkg_dir / "examples"
+        if candidate.exists():
+            return candidate
+    except ImportError:
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# list_examples
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ExampleEntry:
+    """One bundled launcher example YAML."""
+
+    path: str  # repo-relative path (from launcher/examples/)
+    abs_path: str  # absolute path on disk
+    model: str | None  # extracted from job_name / task fields
+    description: str | None  # first comment block or top-level field
+
+
+def list_examples_impl() -> dict:
+    """Enumerate all .yaml files under tools/launcher/examples/.
+
+    Returns ``{"ok": True, "examples": [...]}`` with one entry per YAML.
+    Each entry carries a best-effort ``model`` + ``description`` parsed
+    from the YAML — useful for the LLM to pick a relevant example
+    without reading every file.
+    """
+    examples_dir = _find_launcher_examples_dir()
+    if examples_dir is None:
+        return {
+            "ok": False,
+            "reason": "examples_dir_not_found",
+            "diagnostic": (
+                "Could not locate tools/launcher/examples/. Set "
+                "MODELOPT_LAUNCHER_EXAMPLES_DIR or run from inside a "
+                "Model-Optimizer checkout."
+            ),
+        }
+
+    entries: list[dict] = []
+    for path in sorted(examples_dir.rglob("*.yaml")):
+        rel = path.relative_to(examples_dir.parent)  # launcher/examples/...
+        entry = ExampleEntry(
+            path=str(rel),
+            abs_path=str(path),
+            model=None,
+            description=None,
+        )
+        # Best-effort parse — examples occasionally have non-standard
+        # shapes, don't crash list_examples on a single bad YAML.
+        try:
+            with open(path) as f:
+                doc = yaml.safe_load(f) or {}
+            if isinstance(doc, dict):
+                # job_name is the most common identifier; "model" may
+                # also be a top-level field in some examples.
+                entry.model = doc.get("model") or doc.get("base_model") or doc.get("job_name")
+                entry.description = doc.get("description")
+        except (yaml.YAMLError, OSError):
+            pass
+        entries.append(
+            {
+                "path": entry.path,
+                "abs_path": entry.abs_path,
+                "model": entry.model,
+                "description": entry.description,
+            }
+        )
+
+    return {
+        "ok": True,
+        "examples_dir": str(examples_dir),
+        "count": len(entries),
+        "examples": entries,
+    }
+
+
+# ---------------------------------------------------------------------------
+# verify_setup
+# ---------------------------------------------------------------------------
+
+
+def verify_docker_setup_impl() -> dict:
+    """Probe local Docker daemon + GPU access.
+
+    Two checks:
+    1. ``docker info`` exits 0 → daemon is up
+    2. ``docker run --rm --gpus all <small-image> nvidia-smi`` exits 0 →
+       GPU passthrough works (skipped if NO_GPU_CHECK env is set, for
+       CPU-only test environments)
+    """
+    # Daemon check. Bandit B603/B607 are false positives here: we're
+    # invoking the docker CLI by name with a fixed argv list, no
+    # shell-interpretation, no untrusted input.
+    try:
+        proc = subprocess.run(  # nosec B603 B607
+            ["docker", "info"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except FileNotFoundError:
+        return {
+            "ok": False,
+            "executor": "docker",
+            "reason": "docker_not_installed",
+            "diagnostic": "`docker` binary not on PATH.",
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "executor": "docker",
+            "reason": "docker_daemon_timeout",
+            "diagnostic": "`docker info` did not respond within 10s.",
+        }
+    if proc.returncode != 0:
+        return {
+            "ok": False,
+            "executor": "docker",
+            "reason": "docker_daemon_unavailable",
+            "diagnostic": (
+                f"`docker info` exit={proc.returncode}. stderr: {proc.stderr.strip()[-400:]}"
+            ),
+        }
+
+    # GPU check (opt-out for CI runners without GPU)
+    if os.environ.get("MODELOPT_MCP_SKIP_GPU_CHECK"):
+        return {
+            "ok": True,
+            "executor": "docker",
+            "daemon_ok": True,
+            "gpu_check_skipped": True,
+        }
+
+    # Same B603/B607 false-positive shape as the daemon check above —
+    # fixed argv, no shell interpolation, no untrusted input.
+    try:
+        gpu = subprocess.run(  # nosec B603 B607
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--gpus",
+                "all",
+                "nvidia/cuda:12.0-base-ubuntu22.04",
+                "nvidia-smi",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "executor": "docker",
+            "daemon_ok": True,
+            "reason": "gpu_check_timeout",
+            "diagnostic": "GPU smoketest container did not return in 60s.",
+        }
+    if gpu.returncode != 0:
+        return {
+            "ok": False,
+            "executor": "docker",
+            "daemon_ok": True,
+            "reason": "gpu_unavailable",
+            "diagnostic": (
+                "Docker daemon is up but `--gpus all` + nvidia-smi "
+                f"failed. exit={gpu.returncode}. Likely missing the "
+                "NVIDIA Container Toolkit; install per "
+                "https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html. "
+                f"stderr: {gpu.stderr.strip()[-400:]}"
+            ),
+        }
+    return {
+        "ok": True,
+        "executor": "docker",
+        "daemon_ok": True,
+        "gpu_ok": True,
+    }
+
+
+def verify_slurm_setup_impl(
+    cluster_host: str,
+    cluster_user: str | None = None,
+    identity: str | None = None,
+) -> dict:
+    """Probe passwordless SSH to a Slurm cluster login node.
+
+    Uses ``ssh -o BatchMode=yes`` (refuses to prompt for password) +
+    a 5s connect timeout. Failure means either the cluster is
+    unreachable from this host OR key-auth is broken — both are
+    actionable diagnostics for the user.
+    """
+    argv = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        "ConnectTimeout=5",
+    ]
+    if identity:
+        argv += ["-i", identity]
+    target = f"{cluster_user}@{cluster_host}" if cluster_user else cluster_host
+    argv += [target, "whoami && hostname"]
+
+    # B603/B607 false positive — `ssh` invoked by name with a controlled
+    # argv (BatchMode, ConnectTimeout, identity path, target). No shell.
+    try:
+        proc = subprocess.run(  # nosec B603 B607
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "executor": "slurm",
+            "cluster_host": cluster_host,
+            "reason": "ssh_timeout",
+            "diagnostic": (
+                f"ssh to {cluster_host} did not respond within 15s. "
+                f"Cluster login node unreachable from this host."
+            ),
+        }
+    except FileNotFoundError:
+        return {
+            "ok": False,
+            "executor": "slurm",
+            "reason": "ssh_not_installed",
+            "diagnostic": "`ssh` binary not on PATH.",
+        }
+    if proc.returncode != 0:
+        return {
+            "ok": False,
+            "executor": "slurm",
+            "cluster_host": cluster_host,
+            "cluster_user": cluster_user,
+            "identity": identity,
+            "reason": "ssh_auth_failed",
+            "diagnostic": (
+                "ssh -o BatchMode=yes failed — key-auth isn't working "
+                "(no password prompts in this mode). Check that the "
+                "right identity is loaded into ssh-agent and the "
+                "cluster has the public key in ~/.ssh/authorized_keys. "
+                f"exit={proc.returncode}. stderr: "
+                f"{proc.stderr.strip()[-400:]}"
+            ),
+        }
+    lines = (proc.stdout or "").strip().splitlines()
+    return {
+        "ok": True,
+        "executor": "slurm",
+        "cluster_host": cluster_host,
+        "cluster_user": cluster_user,
+        "whoami": lines[0] if lines else "",
+        "remote_hostname": lines[1] if len(lines) > 1 else "",
+    }
+
+
+# ---------------------------------------------------------------------------
+# submit_job
+# ---------------------------------------------------------------------------
+
+
+def _normalize_yaml_path(yaml_path: str) -> Path:
+    """Resolve a launcher YAML path to an absolute Path.
+
+    Lookup order:
+    1. Absolute path — use as-is
+    2. Relative to ``MODELOPT_LAUNCHER_EXAMPLES_DIR`` (or its parent)
+    3. Relative to cwd
+
+    The double-fallback lets the agent pass either ``examples/Qwen/.../X.yaml``
+    or just the absolute path.
+    """
+    p = Path(yaml_path)
+    if p.is_absolute():
+        return p
+    # Look under examples dir
+    examples_dir = _find_launcher_examples_dir()
+    if examples_dir is not None:
+        candidate = examples_dir / yaml_path
+        if candidate.exists():
+            return candidate
+        candidate = examples_dir.parent / yaml_path
+        if candidate.exists():
+            return candidate
+    # cwd fallback
+    return (Path.cwd() / yaml_path).resolve()
+
+
+def submit_job_impl(
+    *,
+    yaml_path: str,
+    hf_local: str | None,
+    cluster_host: str | None,
+    cluster_user: str | None,
+    identity: str | None,
+    job_dir: str | None,
+    job_name: str | None,
+    extra_overrides: dict[str, str] | None,
+    skip_verify: bool,
+) -> dict:
+    """Submit a launcher YAML.
+
+    Mode is determined by mutually-exclusive args:
+      * ``hf_local`` set → Docker (local GPU)
+      * ``cluster_host`` set → Slurm (remote SSH)
+      * Neither set → error
+      * Both set → error
+
+    The actual orchestration is delegated to the launcher's
+    ``core.run_jobs``. We don't re-implement nemo_run integration here —
+    that lives upstream.
+    """
+    # ---- Mode resolution -------------------------------------------
+    if hf_local and cluster_host:
+        return {
+            "ok": False,
+            "reason": "ambiguous_executor",
+            "diagnostic": (
+                "Both hf_local (Docker mode) and cluster_host (Slurm "
+                "mode) were provided — these are mutually exclusive. "
+                "Pass exactly one."
+            ),
+        }
+    if not hf_local and not cluster_host:
+        return {
+            "ok": False,
+            "reason": "no_executor_specified",
+            "diagnostic": (
+                "Must pass either hf_local=<path> for local Docker mode "
+                "or cluster_host=<hostname> for remote Slurm mode."
+            ),
+        }
+    executor = "docker" if hf_local else "slurm"
+
+    # ---- Pre-flight verification -----------------------------------
+    if not skip_verify:
+        if executor == "docker":
+            check = verify_docker_setup_impl()
+        else:
+            check = verify_slurm_setup_impl(
+                cluster_host=cluster_host or "",
+                cluster_user=cluster_user,
+                identity=identity,
+            )
+        if not check.get("ok"):
+            return {
+                "ok": False,
+                "reason": "verify_setup_failed",
+                "executor": executor,
+                "diagnostic": (
+                    f"Skipping submission — verify_setup returned "
+                    f"ok=false with reason={check.get('reason')!r}. Fix "
+                    f"the underlying issue, then retry."
+                ),
+                "verify_result": check,
+            }
+
+    # ---- Resolve the YAML path ------------------------------------
+    abs_yaml = _normalize_yaml_path(yaml_path)
+    if not abs_yaml.exists():
+        return {
+            "ok": False,
+            "reason": "yaml_not_found",
+            "yaml_path": yaml_path,
+            "resolved_path": str(abs_yaml),
+            "diagnostic": (
+                f"YAML not found at {abs_yaml}. Pass a path under "
+                f"tools/launcher/examples/ (relative), an absolute path, "
+                f"or one of the examples returned by list_examples."
+            ),
+        }
+
+    # ---- Dispatch to the launcher ---------------------------------
+    # Subprocess `uv run launch.py --yaml <abs_yaml> --yes ...` rather
+    # than calling core.run_jobs directly in-process. Why subprocess:
+    # launch.py's run.cli.entrypoint integration handles arg parsing,
+    # NEMORUN_HOME defaulting, and signal handling in ways that are
+    # painful to replicate. Phase 2 may move to direct in-process
+    # invocation once we've audited those edge cases.
+    argv = ["uv", "run", "launch.py", "--yaml", str(abs_yaml), "--yes"]
+    if hf_local:
+        argv.append(f"hf_local={shlex.quote(hf_local)}")
+    else:
+        # Slurm mode — pass cluster config knobs as nemo-run overrides.
+        argv.append(f"cluster_host={shlex.quote(cluster_host or '')}")
+        if cluster_user:
+            argv.append(f"user={shlex.quote(cluster_user)}")
+        if identity:
+            argv.append(f"identity={shlex.quote(identity)}")
+        argv.append("detach=true")
+    if job_dir:
+        argv.append(f"job_dir={shlex.quote(job_dir)}")
+    if job_name:
+        argv.append(f"job_name={shlex.quote(job_name)}")
+    for k, v in (extra_overrides or {}).items():
+        argv.append(f"{k}={shlex.quote(str(v))}")
+
+    # Run from the launcher dir so it picks up its own ./core.py etc.
+    launcher_dir = _THIS_DIR.parent.parent / "launcher"
+    if not launcher_dir.exists():
+        return {
+            "ok": False,
+            "reason": "launcher_dir_not_found",
+            "diagnostic": (
+                f"Expected tools/launcher/ at {launcher_dir} but it "
+                f"doesn't exist. modelopt-mcp must be installed from a "
+                f"Model-Optimizer clone or via uvx-from-git."
+            ),
+        }
+
+    if executor == "docker":
+        # Docker mode: spawn in background so we don't block the MCP
+        # call. The subprocess writes its experiment dir + status into
+        # NEMORUN_HOME; we'll read it back via job_status.
+        # B603 false positive — `argv` is a list built by this module
+        # from typed parameters, no shell interpretation.
+        proc = subprocess.Popen(  # nosec B603
+            argv,
+            cwd=str(launcher_dir),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        # Detached: don't wait. The caller polls job_status by
+        # experiment_id (derived from job_name or auto-named).
+        # Generate a best-effort experiment_id from job_name + timestamp.
+        # nemo_run names experiments deterministically as
+        # `<title>_<job_name>_<timestamp>`; if the caller didn't provide
+        # job_name we can't predict the id ahead of time.
+        return {
+            "ok": True,
+            "executor": "docker",
+            "pid": proc.pid,
+            "argv": argv,
+            "experiment_id": None,  # Phase 2: tail the subprocess output
+            # until nemo_run logs the id, then return it
+            "spike_note": (
+                "Docker mode launched in background. Phase 1: the "
+                "experiment_id is None — Phase 2 tails the subprocess "
+                "output to capture the id. For now, list experiments "
+                "via nemo_run's CLI or check NEMORUN_HOME."
+            ),
+        }
+
+    # Slurm mode: synchronous call (slurm.py exits quickly after sbatch
+    # with detach=true). Capture stdout to parse experiment_id.
+    # B603 false positive — same as above; controlled argv list.
+    try:
+        proc = subprocess.run(  # nosec B603
+            argv,
+            cwd=str(launcher_dir),
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        return {
+            "ok": False,
+            "executor": "slurm",
+            "reason": "submission_timeout",
+            "diagnostic": (
+                "launch.py submission did not return within 5 minutes. "
+                f"Partial stdout: "
+                f"{(e.stdout or b'').decode(errors='replace')[-400:]}"
+            ),
+            "argv": argv,
+        }
+
+    # `proc` here is the CompletedProcess from subprocess.run with
+    # text=True, but mypy's narrowing widens across the Docker-branch
+    # Popen assignment above. Coerce explicitly.
+    stdout_tail = str(proc.stdout or "")[-2000:]
+    stderr_tail = str(proc.stderr or "")[-2000:]
+
+    if proc.returncode != 0:
+        return {
+            "ok": False,
+            "executor": "slurm",
+            "reason": "launch_py_failed",
+            "exit_code": proc.returncode,
+            "stdout_tail": stdout_tail,
+            "stderr_tail": stderr_tail,
+            "diagnostic": (
+                f"launch.py exited with code {proc.returncode}. Common "
+                f"causes: SSH publickey rejection, malformed YAML, "
+                f"NEMORUN_HOME unset. Inspect stderr_tail."
+            ),
+            "argv": argv,
+        }
+
+    # Best-effort experiment_id parse
+    import re as _re
+
+    experiment_id = None
+    experiment_dir = None
+    slurm_job_id = None
+    for m in _re.finditer(
+        r"experiment[_\s-]+([a-zA-Z0-9_]+_\d{10,})",
+        stdout_tail,
+        _re.IGNORECASE,
+    ):
+        experiment_id = m.group(1)
+        break
+    for m in _re.finditer(
+        r"(/lustre/[^\s]+|/home/[^\s]+)/experiments/[^\s]+",
+        stdout_tail,
+    ):
+        experiment_dir = m.group(0)
+        break
+    for m in _re.finditer(r"Submitted batch job (\d+)", stdout_tail):
+        slurm_job_id = m.group(1)
+        break
+
+    return {
+        "ok": True,
+        "executor": "slurm",
+        "experiment_id": experiment_id,
+        "experiment_dir": experiment_dir,
+        "slurm_job_id": slurm_job_id,
+        "exit_code": 0,
+        "stdout_tail": stdout_tail,
+        "argv": argv,
+    }
+
+
+# ---------------------------------------------------------------------------
+# job_status / job_logs — filesystem-based
+# ---------------------------------------------------------------------------
+
+
+def _resolve_experiment_dir(experiment_id: str) -> Path | None:
+    """Map an experiment_id to its on-disk directory.
+
+    nemo_run lays experiments out under ``$NEMORUN_HOME/experiments/<id>/``
+    by default; ``NEMORUN_HOME`` falls back to cwd. We also check
+    ``./experiments/<id>`` directly and ``./local_experiments/<id>``
+    (the Docker-mode fallback path).
+    """
+    candidates = []
+    nemorun_home = os.environ.get("NEMORUN_HOME")
+    if nemorun_home:
+        candidates.append(Path(nemorun_home) / "experiments" / experiment_id)
+    candidates.append(Path.cwd() / "experiments" / experiment_id)
+    candidates.append(Path.cwd() / "local_experiments" / experiment_id)
+    for c in candidates:
+        if c.exists():
+            return c
+    return None
+
+
+def job_status_impl(experiment_id: str) -> dict:
+    """Read filesystem-based status from a nemo_run experiment dir.
+
+    Status resolution:
+      * ``_DONE`` file present + no ``status_*.out`` with ``failed`` →
+        ``done``
+      * ``_DONE`` present + any ``status_*.out`` contains ``failed`` →
+        ``failed``
+      * No ``_DONE`` + experiment dir exists → ``running``
+      * Experiment dir missing → ``unknown`` (with reason)
+
+    Per-task statuses (``status_<task_name>.out``) are also surfaced so
+    multi-task pipelines can be inspected.
+    """
+    exp_dir = _resolve_experiment_dir(experiment_id)
+    if exp_dir is None:
+        return {
+            "ok": False,
+            "experiment_id": experiment_id,
+            "reason": "experiment_dir_not_found",
+            "diagnostic": (
+                "Searched NEMORUN_HOME/experiments/, ./experiments/, "
+                "./local_experiments/ — no match. Either the id is "
+                "wrong or NEMORUN_HOME isn't set the same as it was "
+                "at submit time."
+            ),
+        }
+
+    done_marker = exp_dir / "_DONE"
+    task_statuses: dict[str, str] = {}
+    any_failed = False
+    for status_file in sorted(exp_dir.glob("status_*.out")):
+        # Convention: filename is `status_<task_name>.out`, contents
+        # are a single word ("succeeded" or "failed").
+        task_name = status_file.stem.removeprefix("status_")
+        body = status_file.read_text(encoding="utf-8", errors="replace").strip()
+        task_statuses[task_name] = body
+        if "fail" in body.lower():
+            any_failed = True
+
+    if done_marker.exists():
+        overall = "failed" if any_failed else "done"
+    else:
+        overall = "running"
+
+    return {
+        "ok": True,
+        "experiment_id": experiment_id,
+        "experiment_dir": str(exp_dir),
+        "status": overall,
+        "task_statuses": task_statuses,
+        "has_done_marker": done_marker.exists(),
+    }
+
+
+def job_logs_impl(
+    experiment_id: str,
+    task: str | None,
+    tail: int | None,
+) -> dict:
+    """Read ``log_<task>.out`` files from the experiment dir.
+
+    If ``task`` is None, returns logs for ALL tasks.
+    If ``tail`` is set, returns only the last N lines per task.
+    """
+    exp_dir = _resolve_experiment_dir(experiment_id)
+    if exp_dir is None:
+        return {
+            "ok": False,
+            "experiment_id": experiment_id,
+            "reason": "experiment_dir_not_found",
+        }
+
+    if task is not None:
+        log_files = list(exp_dir.glob(f"log_{task}.out"))
+        if not log_files:
+            return {
+                "ok": False,
+                "experiment_id": experiment_id,
+                "reason": "task_log_not_found",
+                "diagnostic": (
+                    f"No log_{task}.out under {exp_dir}. Available logs: "
+                    f"{[p.name for p in exp_dir.glob('log_*.out')]}"
+                ),
+            }
+    else:
+        log_files = sorted(exp_dir.glob("log_*.out"))
+
+    logs: dict[str, str] = {}
+    for log_file in log_files:
+        task_name = log_file.stem.removeprefix("log_")
+        body = log_file.read_text(encoding="utf-8", errors="replace")
+        if tail is not None:
+            body = "\n".join(body.splitlines()[-tail:])
+        logs[task_name] = body
+
+    return {
+        "ok": True,
+        "experiment_id": experiment_id,
+        "experiment_dir": str(exp_dir),
+        "logs": logs,
+    }

--- a/tools/mcp/modelopt_mcp/bridge.py
+++ b/tools/mcp/modelopt_mcp/bridge.py
@@ -34,7 +34,7 @@ need — keeps the surface area auditable.
 from __future__ import annotations
 
 import os
-import shlex
+import re
 import subprocess  # nosec B404
 from dataclasses import dataclass
 from pathlib import Path
@@ -45,6 +45,12 @@ import yaml
 # path. Works for both editable installs (../launcher/examples/) and
 # uvx-from-git installs (the launcher is a sibling site-packages install).
 _THIS_DIR = Path(__file__).resolve().parent
+
+# Canonical task-status failure tokens — matched against the FIRST word
+# of each ``status_<task>.out`` file by ``job_status_impl``.
+_STATUS_FAILURE_WORDS: frozenset[str] = frozenset(
+    {"failed", "error", "errored", "cancelled", "canceled"}
+)
 
 
 def _find_launcher_examples_dir() -> Path | None:
@@ -126,21 +132,29 @@ def list_examples_impl() -> dict:
     entries: list[dict] = []
     for path in sorted(examples_dir.rglob("*.yaml")):
         rel = path.relative_to(examples_dir.parent)  # launcher/examples/...
+        # Derive a model identifier from the path layout first
+        # (`examples/<family>/<model>/<task>.yaml`). The launcher's
+        # bundled examples don't carry top-level `model` / `description`
+        # fields — only `job_name` — so path-derivation gives the LLM
+        # useful routing metadata even when the YAML body says nothing.
+        parts = rel.parts  # ('examples', <family>, <model>, <file>) typically
+        path_model = f"{parts[1]}/{parts[2]}" if len(parts) >= 4 else None
         entry = ExampleEntry(
             path=str(rel),
             abs_path=str(path),
-            model=None,
+            model=path_model,
             description=None,
         )
-        # Best-effort parse — examples occasionally have non-standard
-        # shapes, don't crash list_examples on a single bad YAML.
+        # Best-effort YAML body parse — prefer body-supplied fields over
+        # the path-derived defaults when present. Don't crash on a
+        # malformed YAML.
         try:
             with open(path) as f:
                 doc = yaml.safe_load(f) or {}
             if isinstance(doc, dict):
-                # job_name is the most common identifier; "model" may
-                # also be a top-level field in some examples.
-                entry.model = doc.get("model") or doc.get("base_model") or doc.get("job_name")
+                body_model = doc.get("model") or doc.get("base_model") or doc.get("job_name")
+                if body_model:
+                    entry.model = body_model
                 entry.description = doc.get("description")
         except (yaml.YAMLError, OSError):
             pass
@@ -219,22 +233,25 @@ def verify_docker_setup_impl() -> dict:
             "gpu_check_skipped": True,
         }
 
-    # Same B603/B607 false-positive shape as the daemon check above —
-    # fixed argv, no shell interpolation, no untrusted input.
+    # GPU passthrough probe. Earlier versions of this code ran
+    # `docker run --gpus all nvidia/cuda:12.0-base nvidia-smi`, which
+    # pulled a ~150 MB CUDA image on first invocation and blew past
+    # the 60s timeout on healthy hosts that simply hadn't cached it
+    # yet (a real PR review finding — see
+    # https://github.com/NVIDIA/Model-Optimizer/pull/1701).
+    #
+    # Replacement: ask the Docker daemon directly whether the NVIDIA
+    # runtime is registered via `docker info --format '{{json .}}'`.
+    # No image pull, no container run; the daemon already knows
+    # whether the NVIDIA Container Toolkit registered "nvidia" as a
+    # runtime when nvidia-ctk runtime configure was last invoked.
+    # B603/B607 same false-positive shape as daemon check.
     try:
         gpu = subprocess.run(  # nosec B603 B607
-            [
-                "docker",
-                "run",
-                "--rm",
-                "--gpus",
-                "all",
-                "nvidia/cuda:12.0-base-ubuntu22.04",
-                "nvidia-smi",
-            ],
+            ["docker", "info", "--format", "{{json .}}"],
             capture_output=True,
             text=True,
-            timeout=60,
+            timeout=10,
             check=False,
         )
     except subprocess.TimeoutExpired:
@@ -243,20 +260,29 @@ def verify_docker_setup_impl() -> dict:
             "executor": "docker",
             "daemon_ok": True,
             "reason": "gpu_check_timeout",
-            "diagnostic": "GPU smoketest container did not return in 60s.",
+            "diagnostic": "`docker info --format` did not return in 10s.",
         }
-    if gpu.returncode != 0:
+    runtimes: list[str] = []
+    if gpu.returncode == 0 and gpu.stdout.strip():
+        try:
+            import json as _json
+
+            info = _json.loads(gpu.stdout)
+            runtimes = list((info.get("Runtimes") or {}).keys())
+        except (ValueError, AttributeError):
+            runtimes = []
+    if "nvidia" not in runtimes:
         return {
             "ok": False,
             "executor": "docker",
             "daemon_ok": True,
             "reason": "gpu_unavailable",
             "diagnostic": (
-                "Docker daemon is up but `--gpus all` + nvidia-smi "
-                f"failed. exit={gpu.returncode}. Likely missing the "
-                "NVIDIA Container Toolkit; install per "
+                "Docker daemon is up but the `nvidia` runtime is not "
+                "registered. Install the NVIDIA Container Toolkit + "
+                "register the runtime: "
                 "https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html. "
-                f"stderr: {gpu.stderr.strip()[-400:]}"
+                f"Registered runtimes: {runtimes!r}."
             ),
         }
     return {
@@ -472,23 +498,30 @@ def submit_job_impl(
     # NEMORUN_HOME defaulting, and signal handling in ways that are
     # painful to replicate. Phase 2 may move to direct in-process
     # invocation once we've audited those edge cases.
+    # Build argv WITHOUT shell-quoting values — subprocess.run/Popen with a
+    # list never goes through a shell, so quoting bakes literal quote chars
+    # into the values that nemo-run's CLI parser sees. Verbatim values
+    # carry spaces / special chars safely.
     argv = ["uv", "run", "launch.py", "--yaml", str(abs_yaml), "--yes"]
     if hf_local:
-        argv.append(f"hf_local={shlex.quote(hf_local)}")
+        argv.append(f"hf_local={hf_local}")
     else:
-        # Slurm mode — pass cluster config knobs as nemo-run overrides.
-        argv.append(f"cluster_host={shlex.quote(cluster_host or '')}")
+        # Slurm mode — `launch.py`'s entrypoint does not accept a
+        # `cluster_host` arg (see tools/launcher/launch.py:82). The host
+        # is sourced via the SLURM_HOST env var, consumed by
+        # `slurm_factory(host=os.environ.get("SLURM_HOST", ""))` in
+        # tools/launcher/slurm_config.py. Propagate via env, not argv.
         if cluster_user:
-            argv.append(f"user={shlex.quote(cluster_user)}")
+            argv.append(f"user={cluster_user}")
         if identity:
-            argv.append(f"identity={shlex.quote(identity)}")
+            argv.append(f"identity={identity}")
         argv.append("detach=true")
     if job_dir:
-        argv.append(f"job_dir={shlex.quote(job_dir)}")
+        argv.append(f"job_dir={job_dir}")
     if job_name:
-        argv.append(f"job_name={shlex.quote(job_name)}")
+        argv.append(f"job_name={job_name}")
     for k, v in (extra_overrides or {}).items():
-        argv.append(f"{k}={shlex.quote(str(v))}")
+        argv.append(f"{k}={v}")
 
     # Run from the launcher dir so it picks up its own ./core.py etc.
     launcher_dir = _THIS_DIR.parent.parent / "launcher"
@@ -503,46 +536,60 @@ def submit_job_impl(
             ),
         }
 
+    # Propagate env so submit-side and status-side agree on NEMORUN_HOME.
+    # Without this, `launch.py` defaults NEMORUN_HOME to its own cwd
+    # (tools/launcher/), but `_resolve_experiment_dir` later checks the
+    # MCP server's cwd — different paths, so job_status would return
+    # experiment_dir_not_found for jobs that actually succeeded.
+    child_env = os.environ.copy()
+    child_env.setdefault("NEMORUN_HOME", os.getcwd())
+    if executor == "slurm":
+        # Required for slurm_factory's host default. Verify_setup ran
+        # against this same host above (when verify_setup=True), so the
+        # value is known good.
+        child_env["SLURM_HOST"] = cluster_host or ""
+
     if executor == "docker":
-        # Docker mode: spawn in background so we don't block the MCP
-        # call. The subprocess writes its experiment dir + status into
-        # NEMORUN_HOME; we'll read it back via job_status.
-        # B603 false positive — `argv` is a list built by this module
-        # from typed parameters, no shell interpretation.
+        # Docker mode: spawn detached. Discard stdout/stderr to /dev/null —
+        # leaving them as Popen.PIPE without a reader fills the kernel's
+        # ~64 KB pipe buffer and BLOCKS the launcher's next write(), which
+        # would hang long-running PTQ jobs forever while the MCP server
+        # appears to have "succeeded".
+        # `start_new_session=True` detaches from the MCP server's process
+        # group so an MCP server restart / SIGINT doesn't SIGHUP the
+        # in-flight launcher.
+        # B603 false positive — argv is a controlled list built above.
         proc = subprocess.Popen(  # nosec B603
             argv,
             cwd=str(launcher_dir),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            env=child_env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
         )
-        # Detached: don't wait. The caller polls job_status by
-        # experiment_id (derived from job_name or auto-named).
-        # Generate a best-effort experiment_id from job_name + timestamp.
-        # nemo_run names experiments deterministically as
-        # `<title>_<job_name>_<timestamp>`; if the caller didn't provide
-        # job_name we can't predict the id ahead of time.
         return {
             "ok": True,
             "executor": "docker",
             "pid": proc.pid,
             "argv": argv,
-            "experiment_id": None,  # Phase 2: tail the subprocess output
-            # until nemo_run logs the id, then return it
+            "nemorun_home": child_env["NEMORUN_HOME"],
+            "experiment_id": None,  # Phase 2: tail launcher's output
+            # via a side-channel log file to capture nemo_run's id
             "spike_note": (
-                "Docker mode launched in background. Phase 1: the "
-                "experiment_id is None — Phase 2 tails the subprocess "
-                "output to capture the id. For now, list experiments "
-                "via nemo_run's CLI or check NEMORUN_HOME."
+                "Docker mode launched detached. Phase 1: experiment_id "
+                "is None — list under $NEMORUN_HOME/experiments/ or use "
+                "Phase 2's tail-based id capture."
             ),
         }
 
-    # Slurm mode: synchronous call (slurm.py exits quickly after sbatch
+    # Slurm mode: synchronous call (launch.py exits quickly after sbatch
     # with detach=true). Capture stdout to parse experiment_id.
-    # B603 false positive — same as above; controlled argv list.
+    # B603 false positive — argv is a controlled list built above.
     try:
         proc = subprocess.run(  # nosec B603
             argv,
             cwd=str(launcher_dir),
+            env=child_env,
             capture_output=True,
             text=True,
             timeout=300,
@@ -583,28 +630,43 @@ def submit_job_impl(
             "argv": argv,
         }
 
-    # Best-effort experiment_id parse
-    import re as _re
-
+    # Best-effort experiment_id + dir + slurm_job_id parse. nemo_run's
+    # output format may shift across versions; on parse miss, fields
+    # come back None and the caller still gets stdout_tail to inspect
+    # by hand.
     experiment_id = None
     experiment_dir = None
     slurm_job_id = None
-    for m in _re.finditer(
-        r"experiment[_\s-]+([a-zA-Z0-9_]+_\d{10,})",
+    # nemo_run prints "Entering Experiment <title>_<id> with id: <id>" —
+    # match the trailing id directly so we don't have to encode the
+    # title prefix or hard-code timestamp width.
+    m = re.search(
+        r"experiment[_\s-]+id[:\s]+(\S+)",
         stdout_tail,
-        _re.IGNORECASE,
-    ):
+        re.IGNORECASE,
+    )
+    if m:
         experiment_id = m.group(1)
-        break
-    for m in _re.finditer(
-        r"(/lustre/[^\s]+|/home/[^\s]+)/experiments/[^\s]+",
-        stdout_tail,
-    ):
-        experiment_dir = m.group(0)
-        break
-    for m in _re.finditer(r"Submitted batch job (\d+)", stdout_tail):
+    else:
+        # Fallback for older nemo_run output that lacked the explicit
+        # "id:" label. Accepts any path-safe id token following the
+        # word "experiment" — not just timestamp-style.
+        m = re.search(
+            r"experiment[_\s-]+([A-Za-z0-9_-]+)",
+            stdout_tail,
+            re.IGNORECASE,
+        )
+        if m:
+            experiment_id = m.group(1)
+    # Match any path containing `/experiments/<id>/` — don't anchor on
+    # cluster-specific filesystem roots (NVIDIA's /lustre, partner
+    # clusters' /scratch / /work / /data / /p / ...).
+    m = re.search(r"(\S+/experiments/[^\s/]+)", stdout_tail)
+    if m:
+        experiment_dir = m.group(1)
+    m = re.search(r"Submitted batch job (\d+)", stdout_tail)
+    if m:
         slurm_job_id = m.group(1)
-        break
 
     return {
         "ok": True,
@@ -627,9 +689,15 @@ def _resolve_experiment_dir(experiment_id: str) -> Path | None:
     """Map an experiment_id to its on-disk directory.
 
     nemo_run lays experiments out under ``$NEMORUN_HOME/experiments/<id>/``
-    by default; ``NEMORUN_HOME`` falls back to cwd. We also check
-    ``./experiments/<id>`` directly and ``./local_experiments/<id>``
-    (the Docker-mode fallback path).
+    by default; ``NEMORUN_HOME`` falls back to cwd. We check several
+    candidate roots in order:
+
+    1. ``$NEMORUN_HOME/experiments/`` — what submit_job_impl pins via env.
+    2. cwd's ``experiments/`` + ``local_experiments/`` — for operators
+       running the MCP server from their own checkout.
+    3. The launcher's own ``experiments/`` directory — belt-and-braces
+       for the case where the operator didn't set NEMORUN_HOME at all
+       AND the MCP server's cwd differs from where launch.py ran.
     """
     candidates = []
     nemorun_home = os.environ.get("NEMORUN_HOME")
@@ -637,6 +705,12 @@ def _resolve_experiment_dir(experiment_id: str) -> Path | None:
         candidates.append(Path(nemorun_home) / "experiments" / experiment_id)
     candidates.append(Path.cwd() / "experiments" / experiment_id)
     candidates.append(Path.cwd() / "local_experiments" / experiment_id)
+    # The launcher's own experiments dir — submit_job_impl uses
+    # cwd=str(launcher_dir) for the subprocess, so when NEMORUN_HOME is
+    # unset, launch.py defaults to launcher_dir/experiments/.
+    launcher_dir = _THIS_DIR.parent.parent / "launcher"
+    candidates.append(launcher_dir / "experiments" / experiment_id)
+    candidates.append(launcher_dir / "local_experiments" / experiment_id)
     for c in candidates:
         if c.exists():
             return c
@@ -675,12 +749,16 @@ def job_status_impl(experiment_id: str) -> dict:
     task_statuses: dict[str, str] = {}
     any_failed = False
     for status_file in sorted(exp_dir.glob("status_*.out")):
-        # Convention: filename is `status_<task_name>.out`, contents
-        # are a single word ("succeeded" or "failed").
         task_name = status_file.stem.removeprefix("status_")
         body = status_file.read_text(encoding="utf-8", errors="replace").strip()
         task_statuses[task_name] = body
-        if "fail" in body.lower():
+        # Anchor on the FIRST word of the status file. Anchoring this way
+        # (instead of `in body.lower()`) avoids substring false-positives
+        # like "succeeded after retry; previous attempt failed" — the
+        # canonical convention is a single word but the runner has been
+        # observed to append context (e.g. "failed (rc=1)").
+        first_word = (body.split() or [""])[0].lower()
+        if first_word in _STATUS_FAILURE_WORDS:
             any_failed = True
 
     if done_marker.exists():

--- a/tools/mcp/modelopt_mcp/server.py
+++ b/tools/mcp/modelopt_mcp/server.py
@@ -258,7 +258,13 @@ def _build_server() -> FastMCP:
         ] = None,
         tail: Annotated[
             int | None,
-            Field(description=("Return only the last N lines per task. None returns full.")),
+            Field(
+                ge=1,
+                description=(
+                    "Return only the last N lines per task. Must be >= 1 when set; "
+                    "None returns the full log."
+                ),
+            ),
         ] = None,
     ) -> dict:
         return bridge.job_logs_impl(experiment_id, task, tail)

--- a/tools/mcp/modelopt_mcp/server.py
+++ b/tools/mcp/modelopt_mcp/server.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""modelopt-mcp server entry point.
+
+Stdio transport; codex / Claude Code launch this as a subprocess and
+talk to it over stdin/stdout. See OMNIML-5123 for the design.
+
+Phase 1 tool surface:
+  * list_examples       — discover bundled launcher YAMLs
+  * verify_setup        — fail-fast probe (docker or slurm)
+  * submit_job          — submit a launcher YAML; mode by args
+  * job_status          — filesystem-based status
+  * job_logs            — filesystem-based logs
+
+All tools return JSON-friendly dicts with explicit ``ok`` / ``reason`` /
+``diagnostic`` fields so the calling LLM can route on structured
+outcomes instead of free-form prose.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Annotated, Literal
+
+from mcp.server.fastmcp import FastMCP
+from pydantic import Field
+
+from modelopt_mcp import bridge
+
+logger = logging.getLogger("modelopt_mcp")
+
+
+def _build_server() -> FastMCP:
+    """Construct the MCP server with Phase 1 tools registered.
+
+    Factored out so tests can build an isolated instance without
+    stdio plumbing.
+    """
+    mcp = FastMCP("modelopt")
+
+    @mcp.tool(
+        name="list_examples",
+        description=(
+            "List all bundled launcher YAML examples under "
+            "tools/launcher/examples/, with model + description "
+            "metadata extracted from each YAML. Use BEFORE submit_job "
+            "when you don't know which YAML to launch — this gives the "
+            "agent the discovery surface needed to pick one."
+        ),
+    )
+    def list_examples() -> dict:
+        return bridge.list_examples_impl()
+
+    @mcp.tool(
+        name="verify_setup",
+        description=(
+            "Probe whether the named executor is reachable from THIS "
+            "host. Run BEFORE submit_job to fail fast — the actual "
+            "submission burns 30+ seconds (slurm) or starts a Docker "
+            "container (docker) before discovering setup is broken.\n\n"
+            "Docker mode: checks `docker info` (daemon up) + GPU "
+            "passthrough (`docker run --gpus all nvidia-smi`). Set "
+            "MODELOPT_MCP_SKIP_GPU_CHECK=1 in the env to skip the GPU "
+            "check on CPU-only hosts.\n\n"
+            "Slurm mode: ssh -o BatchMode=yes -o ConnectTimeout=5 "
+            "to the cluster login node. Refuses to prompt for "
+            "password, so key-auth failure is detected immediately."
+        ),
+    )
+    def verify_setup(
+        executor: Annotated[
+            Literal["docker", "slurm"],
+            Field(
+                description=(
+                    "Which executor to probe: 'docker' for local GPU or 'slurm' for remote cluster."
+                )
+            ),
+        ],
+        cluster_host: Annotated[
+            str | None,
+            Field(description=("Slurm cluster login hostname. Required when executor='slurm'.")),
+        ] = None,
+        cluster_user: Annotated[
+            str | None, Field(description=("SSH user for the cluster. None uses ssh's default."))
+        ] = None,
+        identity: Annotated[
+            str | None,
+            Field(
+                description=("SSH identity file (-i) override. None uses default key / ssh-agent.")
+            ),
+        ] = None,
+    ) -> dict:
+        if executor == "docker":
+            return bridge.verify_docker_setup_impl()
+        if executor == "slurm":
+            if not cluster_host:
+                return {
+                    "ok": False,
+                    "executor": "slurm",
+                    "reason": "missing_cluster_host",
+                    "diagnostic": ("executor='slurm' requires cluster_host=<hostname>."),
+                }
+            return bridge.verify_slurm_setup_impl(
+                cluster_host=cluster_host,
+                cluster_user=cluster_user,
+                identity=identity,
+            )
+        # Pydantic Literal already constrains; this is a defensive fallback.
+        return {"ok": False, "reason": "unknown_executor"}
+
+    @mcp.tool(
+        name="submit_job",
+        description=(
+            "Submit a ModelOpt launcher YAML for execution. Mode is "
+            "determined by mutually-exclusive args:\n"
+            "  - hf_local=<path>      → Docker (local GPU)\n"
+            "  - cluster_host=<host>  → Slurm (remote SSH)\n\n"
+            "Returns the experiment_id (Slurm) or PID (Docker, "
+            "experiment_id captured in Phase 2) immediately; the actual "
+            "job runs detached. Poll status via job_status, fetch "
+            "output via job_logs.\n\n"
+            "Auto-verifies the executor first by default (skip_verify="
+            "False is recommended unless you just called verify_setup)."
+        ),
+    )
+    def submit_job(
+        yaml_path: Annotated[
+            str,
+            Field(
+                description=(
+                    "Launcher YAML to submit. Pass an absolute path, a path "
+                    "relative to tools/launcher/examples/, or one of the paths "
+                    "returned by list_examples."
+                )
+            ),
+        ],
+        hf_local: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Local HF cache directory — when set, dispatches via "
+                    "Docker. Mutually exclusive with cluster_host."
+                )
+            ),
+        ] = None,
+        cluster_host: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Slurm cluster login hostname — when set, dispatches via "
+                    "remote SSH. Mutually exclusive with hf_local."
+                )
+            ),
+        ] = None,
+        cluster_user: Annotated[
+            str | None,
+            Field(description=("SSH user for the cluster. None uses launcher's default.")),
+        ] = None,
+        identity: Annotated[
+            str | None,
+            Field(description=("SSH identity file (-i). None uses ssh-agent / default key.")),
+        ] = None,
+        job_dir: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Override the experiment output directory. None uses the "
+                    "launcher's per-mode default."
+                )
+            ),
+        ] = None,
+        job_name: Annotated[
+            str | None,
+            Field(description=("Override the job_name in the YAML. None uses the YAML's default.")),
+        ] = None,
+        extra_overrides: Annotated[
+            dict[str, str] | None,
+            Field(
+                description=(
+                    "Additional nemo-run-style overrides as a flat dict, e.g. "
+                    "{'task.slurm_config.nodes': '2'}."
+                )
+            ),
+        ] = None,
+        skip_verify: Annotated[
+            bool,
+            Field(
+                description=(
+                    "If True, skip the verify_setup probe before submission. "
+                    "Default False — the probe takes ~1s and saves you from "
+                    "30+s of wasted submission time on bad config."
+                )
+            ),
+        ] = False,
+    ) -> dict:
+        return bridge.submit_job_impl(
+            yaml_path=yaml_path,
+            hf_local=hf_local,
+            cluster_host=cluster_host,
+            cluster_user=cluster_user,
+            identity=identity,
+            job_dir=job_dir,
+            job_name=job_name,
+            extra_overrides=extra_overrides,
+            skip_verify=skip_verify,
+        )
+
+    @mcp.tool(
+        name="job_status",
+        description=(
+            "Read filesystem-based status from a nemo_run experiment "
+            "dir. Returns 'done' / 'failed' / 'running' based on "
+            "presence of _DONE and contents of status_*.out files. "
+            "Per-task statuses also surfaced for multi-task pipelines."
+        ),
+    )
+    def job_status(
+        experiment_id: Annotated[
+            str,
+            Field(
+                description=(
+                    "The experiment id returned by submit_job (Slurm) or the "
+                    "name nemo_run assigned to the experiment dir."
+                )
+            ),
+        ],
+    ) -> dict:
+        return bridge.job_status_impl(experiment_id)
+
+    @mcp.tool(
+        name="job_logs",
+        description=(
+            "Read log_<task>.out files from the experiment dir. If "
+            "task=None, returns logs for all tasks. If tail=N, returns "
+            "only the last N lines per task."
+        ),
+    )
+    def job_logs(
+        experiment_id: Annotated[str, Field(description=("The experiment id."))],
+        task: Annotated[
+            str | None,
+            Field(description=("Specific task name to filter logs by. None returns all.")),
+        ] = None,
+        tail: Annotated[
+            int | None,
+            Field(description=("Return only the last N lines per task. None returns full.")),
+        ] = None,
+    ) -> dict:
+        return bridge.job_logs_impl(experiment_id, task, tail)
+
+    return mcp
+
+
+def main() -> None:
+    """Entry point for the `modelopt-mcp` console_script."""
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=os.environ.get("MODELOPT_MCP_LOG", "INFO"),
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    mcp = _build_server()
+    mcp.run()  # stdio by default
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/mcp/modelopt_mcp/server.py
+++ b/tools/mcp/modelopt_mcp/server.py
@@ -269,6 +269,197 @@ def _build_server() -> FastMCP:
     ) -> dict:
         return bridge.job_logs_impl(experiment_id, task, tail)
 
+    @mcp.tool(
+        name="wait_for_experiment",
+        description=(
+            "Block until an experiment reaches a terminal status "
+            "('done' or 'failed') or the timeout elapses. Returns the "
+            "same shape as job_status plus a `waited_seconds` field. "
+            "Use this instead of writing your own polling while-loop "
+            "around job_status."
+        ),
+    )
+    def wait_for_experiment(
+        experiment_id: Annotated[
+            str,
+            Field(description="The experiment id from submit_job."),
+        ],
+        timeout_sec: Annotated[
+            int,
+            Field(
+                ge=1,
+                description=(
+                    "Max seconds to wait before returning "
+                    "`{ok: False, reason: 'wait_timeout'}`. Default 7200 "
+                    "(2 hours) — large PTQ runs need this. Cap at your "
+                    "agent's own deadline."
+                ),
+            ),
+        ] = 7200,
+        poll_interval_sec: Annotated[
+            int,
+            Field(
+                ge=1,
+                description=(
+                    "Seconds between status polls. Default 30 — "
+                    "filesystem-based status is cheap so the poll "
+                    "doesn't have to be slow."
+                ),
+            ),
+        ] = 30,
+    ) -> dict:
+        return bridge.wait_for_experiment_impl(
+            experiment_id,
+            timeout_sec,
+            poll_interval_sec,
+        )
+
+    @mcp.tool(
+        name="provision_passwordless_ssh_dry_run",
+        description=(
+            "Emit the exact commands the operator should run to set up "
+            "passwordless SSH to a slurm cluster. Does NOT execute "
+            "them and does NOT handle passwords — the MCP wire is "
+            "unsafe for cluster credentials. Two-phase:\n\n"
+            "1. If the SSH private key is missing → emit "
+            "`ssh-keygen` command. Operator runs it, re-invokes this "
+            "tool.\n"
+            "2. If the key exists → emit `ssh-copy-id` command + "
+            "public-key content. Operator runs it (this is the only "
+            "step that needs a cluster password, prompted by ssh).\n\n"
+            "After both steps complete, the `next_check` field "
+            "recommends calling `verify_setup(executor='slurm', ...)` "
+            "to confirm key-auth now works. Use this when "
+            "`verify_setup` returns `ssh_auth_failed` and you want to "
+            "tell the operator how to fix it."
+        ),
+    )
+    def provision_passwordless_ssh_dry_run(
+        cluster_host: Annotated[
+            str,
+            Field(description="Slurm cluster login hostname."),
+        ],
+        cluster_user: Annotated[
+            str | None,
+            Field(
+                description=("SSH user for the cluster. None uses the local user."),
+            ),
+        ] = None,
+        identity: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Path to the SSH private key to inspect. None "
+                    "uses $IDENTITY env var, then ~/.ssh/id_ed25519."
+                ),
+            ),
+        ] = None,
+    ) -> dict:
+        return bridge.provision_passwordless_ssh_dry_run_impl(
+            cluster_host,
+            cluster_user,
+            identity,
+        )
+
+    @mcp.tool(
+        name="read_cluster_artifact",
+        description=(
+            "Read an artifact from a remote experiment via nemo_run's "
+            "tunnel. nemo_run already knows the cluster host + user + "
+            "identity from the executor metadata stored alongside the "
+            "experiment — this tool does NOT take cluster credentials.\n\n"
+            "Two modes:\n"
+            "* `path=None, job_idx=N` → fetch the job's log via "
+            "`nemo experiment logs <id> <N>`.\n"
+            "* `path='<rel>'` → read the named relative path inside "
+            "the remote experiment dir via the executor's tunnel.\n\n"
+            "Returns the file content truncated to 8 KB (same cap as "
+            "the launcher's `log_excerpt`). Use this for files like "
+            "`specbench_results.json` that the launcher writes on the "
+            "cluster's lustre but the MCP server (running locally) can't "
+            "directly read."
+        ),
+    )
+    def read_cluster_artifact(
+        experiment_id: Annotated[
+            str,
+            Field(description="The experiment id from submit_job."),
+        ],
+        path: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Relative path inside the experiment dir. None = "
+                    "log-fetch mode via `nemo experiment logs`."
+                ),
+            ),
+        ] = None,
+        job_idx: Annotated[
+            int,
+            Field(
+                ge=0,
+                description=(
+                    "Job index for log-fetch mode. Default 0 = the first task in the pipeline."
+                ),
+            ),
+        ] = 0,
+    ) -> dict:
+        return bridge.read_cluster_artifact_impl(experiment_id, path, job_idx)
+
+    @mcp.tool(
+        name="open_draft_pr",
+        description=(
+            "Push the agent's current branch + open a draft PR on the "
+            "named target repo. Preconditions enforced by the caller "
+            "(NOT this tool): the agent's working tree is at the branch "
+            "it wants to PR, commits exist, and any required DCO "
+            "`Signed-off-by:` trailer is in place.\n\n"
+            "Steps internally: `git push -u origin HEAD` + "
+            "`gh pr create --draft --repo <target> --title --body --base`. "
+            "Returns `pr_url` parsed from gh's stdout on success, or "
+            "structured `reason` on failure (git_push_failed, "
+            "gh_pr_create_failed, etc.)."
+        ),
+    )
+    def open_draft_pr(
+        target_repo: Annotated[
+            str,
+            Field(
+                description=("GitHub repo slug, e.g. 'NVIDIA/Model-Optimizer'."),
+            ),
+        ],
+        title: Annotated[
+            str,
+            Field(description="PR title."),
+        ],
+        body: Annotated[
+            str,
+            Field(description="PR description body (Markdown)."),
+        ],
+        base_branch: Annotated[
+            str,
+            Field(
+                description=("Base branch to PR against. Default 'main'."),
+            ),
+        ] = "main",
+        cwd: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Path to the git checkout. None uses the MCP "
+                    "server's cwd (usually the agent's working dir)."
+                ),
+            ),
+        ] = None,
+    ) -> dict:
+        return bridge.open_draft_pr_impl(
+            target_repo,
+            title,
+            body,
+            base_branch,
+            cwd,
+        )
+
     return mcp
 
 

--- a/tools/mcp/pyproject.toml
+++ b/tools/mcp/pyproject.toml
@@ -5,12 +5,20 @@ description = "MCP server exposing ModelOpt launcher operations (submit, status,
 requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.0",
-    # The launcher provides the core orchestration primitive (core.run_jobs,
-    # SandboxPipeline, build_slurm_executor, build_docker_executor). Pulled
-    # in via git+subdirectory so `uvx --from <this-repo>#subdirectory=tools/mcp
-    # modelopt-mcp` resolves both packages from the same clone — no
-    # duplicate fetch.
-    "modelopt-launcher",
+    # NOTE on modelopt-launcher: `tools/launcher/pyproject.toml` declares
+    # the package name as `modelopt-launcher` but configures
+    # `py-modules = []` — there is NO importable `modelopt_launcher`
+    # Python package on disk. bridge.py invokes the launcher via
+    # `uv run launch.py` (subprocess) from `<repo>/tools/launcher/` as
+    # a sibling directory; it does NOT `import modelopt_launcher`.
+    # Declaring the bare name here would add an unsatisfiable PyPI
+    # dependency for end users installing via
+    # `uvx --from "git+...#subdirectory=tools/mcp" modelopt-mcp`. So we
+    # do NOT declare it. The install relationship is documented in
+    # README.md as a sibling-checkout layout requirement instead. The
+    # uvx-from-git path satisfies this naturally because uvx clones
+    # the whole repo, putting tools/launcher and tools/mcp next to
+    # each other on disk.
     "pyyaml",
     "pydantic>=2.0",
 ]
@@ -28,16 +36,13 @@ build-backend = "setuptools.build_meta"
 where = ["."]
 include = ["modelopt_mcp*"]
 
-# The launcher sibling lives next door at ../launcher. We can't `pip install
-# ../launcher` as a path-dep in a published pyproject without breaking the
-# uvx-from-git workflow. For development, run:
-#   uv pip install -e ../launcher
+# No [tool.uv.sources] for the launcher — bridge.py uses it via
+# `subprocess.run(["uv", "run", "launch.py", ...], cwd=<repo>/tools/launcher/)`,
+# so the launcher is a file-layout dependency, not a Python import
+# dependency. The uvx-from-git path clones the whole repo so the
+# sibling tools/launcher/ ends up on disk automatically. For dev:
 #   uv pip install -e .
-# For users installing via uvx-from-git, the launcher comes in transitively
-# via the modelopt-launcher dep (resolved from the SAME git repo's
-# tools/launcher/ subdirectory — pip handles the fetch).
-[tool.uv.sources]
-modelopt-launcher = { path = "../launcher", editable = true }
+#   # then run from a clone where ../launcher exists.
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tools/mcp/pyproject.toml
+++ b/tools/mcp/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "modelopt-mcp"
+version = "0.1.0"
+description = "MCP server exposing ModelOpt launcher operations (submit, status, logs) as typed tools for codex / Claude Code agents"
+requires-python = ">=3.10"
+dependencies = [
+    "mcp>=1.0",
+    # The launcher provides the core orchestration primitive (core.run_jobs,
+    # SandboxPipeline, build_slurm_executor, build_docker_executor). Pulled
+    # in via git+subdirectory so `uvx --from <this-repo>#subdirectory=tools/mcp
+    # modelopt-mcp` resolves both packages from the same clone — no
+    # duplicate fetch.
+    "modelopt-launcher",
+    "pyyaml",
+    "pydantic>=2.0",
+]
+
+[project.scripts]
+# Console entry. Codex / Claude Code launch this as a stdio subprocess.
+# See OMNIML-5123 for the design + acceptance criteria.
+modelopt-mcp = "modelopt_mcp.server:main"
+
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["modelopt_mcp*"]
+
+# The launcher sibling lives next door at ../launcher. We can't `pip install
+# ../launcher` as a path-dep in a published pyproject without breaking the
+# uvx-from-git workflow. For development, run:
+#   uv pip install -e ../launcher
+#   uv pip install -e .
+# For users installing via uvx-from-git, the launcher comes in transitively
+# via the modelopt-launcher dep (resolved from the SAME git repo's
+# tools/launcher/ subdirectory — pip handles the fetch).
+[tool.uv.sources]
+modelopt-launcher = { path = "../launcher", editable = true }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tools/mcp/tests/__init__.py
+++ b/tools/mcp/tests/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the modelopt-mcp package."""

--- a/tools/mcp/tests/test_bridge.py
+++ b/tools/mcp/tests/test_bridge.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for modelopt-mcp's bridge module — subprocess + filesystem interactions mocked."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+# Skip the whole module if mcp / pydantic aren't installed (the [mcp]
+# extra is opt-in).
+pytest.importorskip("mcp")
+pytest.importorskip("pydantic")
+
+from modelopt_mcp import bridge
+
+# ---------------------------------------------------------------------------
+# list_examples
+# ---------------------------------------------------------------------------
+
+
+def test_list_examples_returns_structured_metadata(tmp_path, monkeypatch):
+    """Drop two YAMLs into a fake examples dir and verify metadata extraction (model, description) and path shape."""
+    examples = tmp_path / "examples"
+    (examples / "Qwen").mkdir(parents=True)
+    (examples / "Qwen" / "ptq.yaml").write_text(
+        "job_name: qwen-ptq\nmodel: Qwen/Qwen3-8B\ndescription: PTQ test\n"
+    )
+    (examples / "moonshotai").mkdir(parents=True)
+    (examples / "moonshotai" / "train.yaml").write_text(
+        "job_name: kimi-train\nbase_model: moonshotai/Kimi-K2\n"
+    )
+    monkeypatch.setenv("MODELOPT_LAUNCHER_EXAMPLES_DIR", str(examples))
+
+    result = bridge.list_examples_impl()
+    assert result["ok"] is True
+    assert result["count"] == 2
+    by_model = {e["model"]: e for e in result["examples"]}
+    assert "Qwen/Qwen3-8B" in by_model
+    assert by_model["Qwen/Qwen3-8B"]["description"] == "PTQ test"
+    assert "moonshotai/Kimi-K2" in by_model
+
+
+def test_list_examples_missing_dir(monkeypatch, tmp_path):
+    """When examples dir can't be located, return a structured failure — no exception."""
+    monkeypatch.setenv("MODELOPT_LAUNCHER_EXAMPLES_DIR", str(tmp_path / "ghost"))
+    result = bridge.list_examples_impl()
+    assert result["ok"] is False
+    assert result["reason"] == "examples_dir_not_found"
+
+
+def test_list_examples_tolerates_malformed_yaml(tmp_path, monkeypatch):
+    """A single malformed YAML doesn't crash list_examples — it lands with model=None."""
+    examples = tmp_path / "examples"
+    examples.mkdir()
+    (examples / "good.yaml").write_text("job_name: g\nmodel: ok\n")
+    (examples / "bad.yaml").write_text("not: [unbalanced\n")
+    monkeypatch.setenv("MODELOPT_LAUNCHER_EXAMPLES_DIR", str(examples))
+
+    result = bridge.list_examples_impl()
+    assert result["ok"] is True
+    assert result["count"] == 2
+    by_path = {e["path"]: e for e in result["examples"]}
+    assert any("bad.yaml" in p for p in by_path)
+    bad = next(e for e in result["examples"] if "bad.yaml" in e["path"])
+    assert bad["model"] is None
+
+
+# ---------------------------------------------------------------------------
+# verify_docker_setup
+# ---------------------------------------------------------------------------
+
+
+def test_verify_docker_daemon_unavailable(monkeypatch):
+    """When `docker info` exits non-zero, verify returns docker_daemon_unavailable."""
+
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=1,
+            stdout="",
+            stderr="Cannot connect to the Docker daemon at unix:///var/run/docker.sock",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setenv("MODELOPT_MCP_SKIP_GPU_CHECK", "1")
+
+    result = bridge.verify_docker_setup_impl()
+    assert result["ok"] is False
+    assert result["reason"] == "docker_daemon_unavailable"
+
+
+def test_verify_docker_daemon_not_installed(monkeypatch):
+    """When `docker` is not on PATH, verify returns docker_not_installed."""
+
+    def fake_run(argv, **kwargs):
+        raise FileNotFoundError("docker")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = bridge.verify_docker_setup_impl()
+    assert result["ok"] is False
+    assert result["reason"] == "docker_not_installed"
+
+
+def test_verify_docker_skip_gpu_when_env_set(monkeypatch):
+    """MODELOPT_MCP_SKIP_GPU_CHECK lets CI hosts without GPUs report ok after the daemon check passes."""
+
+    def fake_run(argv, **kwargs):
+        # Daemon check passes; GPU check is skipped — so only one call.
+        assert argv[:2] == ["docker", "info"], f"only `docker info` should run; got {argv}"
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setenv("MODELOPT_MCP_SKIP_GPU_CHECK", "1")
+    result = bridge.verify_docker_setup_impl()
+    assert result["ok"] is True
+    assert result["gpu_check_skipped"] is True
+
+
+def test_verify_docker_gpu_unavailable(monkeypatch):
+    """GPU passthrough container exits non-zero → gpu_unavailable + install-toolkit pointer."""
+    call_count = {"n": 0}
+
+    def fake_run(argv, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Daemon check: ok
+            return subprocess.CompletedProcess(
+                args=argv,
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+        # GPU check: failed
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=125,
+            stdout="",
+            stderr='could not select device driver "" with capabilities: [[gpu]]',
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.delenv("MODELOPT_MCP_SKIP_GPU_CHECK", raising=False)
+    result = bridge.verify_docker_setup_impl()
+    assert result["ok"] is False
+    assert result["reason"] == "gpu_unavailable"
+    assert "NVIDIA Container Toolkit" in result["diagnostic"]
+
+
+# ---------------------------------------------------------------------------
+# verify_slurm_setup
+# ---------------------------------------------------------------------------
+
+
+def test_verify_slurm_ssh_success(monkeypatch):
+    """Mocked ssh probe returns whoami + hostname; verify returns ok."""
+
+    def fake_run(argv, **kwargs):
+        assert argv[0] == "ssh"
+        assert "BatchMode=yes" in argv
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=0,
+            stdout="chenhany\ncluster-login-01\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = bridge.verify_slurm_setup_impl(
+        cluster_host="cw-dfw-cs-001-login-01.nvidia.com",
+        cluster_user="chenhany",
+    )
+    assert result["ok"] is True
+    assert result["whoami"] == "chenhany"
+    assert result["remote_hostname"] == "cluster-login-01"
+
+
+def test_verify_slurm_auth_failed(monkeypatch):
+    """Ssh -o BatchMode=yes exit 255 → ssh_auth_failed with diagnostic."""
+
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=255,
+            stdout="",
+            stderr="Permission denied (publickey).",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = bridge.verify_slurm_setup_impl(
+        cluster_host="ghost-cluster.nvidia.com",
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "ssh_auth_failed"
+
+
+# ---------------------------------------------------------------------------
+# submit_job mode resolution
+# ---------------------------------------------------------------------------
+
+
+def test_submit_job_rejects_no_executor():
+    """Neither hf_local nor cluster_host → no_executor_specified."""
+    result = bridge.submit_job_impl(
+        yaml_path="examples/test.yaml",
+        hf_local=None,
+        cluster_host=None,
+        cluster_user=None,
+        identity=None,
+        job_dir=None,
+        job_name=None,
+        extra_overrides=None,
+        skip_verify=True,
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "no_executor_specified"
+
+
+def test_submit_job_rejects_both_executors():
+    """Both hf_local AND cluster_host → ambiguous_executor."""
+    result = bridge.submit_job_impl(
+        yaml_path="examples/test.yaml",
+        hf_local="/tmp/hf",
+        cluster_host="cluster.nvidia.com",
+        cluster_user=None,
+        identity=None,
+        job_dir=None,
+        job_name=None,
+        extra_overrides=None,
+        skip_verify=True,
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "ambiguous_executor"
+
+
+def test_submit_job_yaml_not_found(monkeypatch, tmp_path):
+    """yaml_path that doesn't resolve to an existing file → yaml_not_found."""
+    monkeypatch.setenv("MODELOPT_LAUNCHER_EXAMPLES_DIR", str(tmp_path))
+    result = bridge.submit_job_impl(
+        yaml_path="does/not/exist.yaml",
+        hf_local="/tmp/hf",
+        cluster_host=None,
+        cluster_user=None,
+        identity=None,
+        job_dir=None,
+        job_name=None,
+        extra_overrides=None,
+        skip_verify=True,
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "yaml_not_found"
+
+
+# ---------------------------------------------------------------------------
+# job_status / job_logs — filesystem-based
+# ---------------------------------------------------------------------------
+
+
+def test_job_status_done_success(tmp_path, monkeypatch):
+    """_DONE marker + all task statuses succeeded → status='done'."""
+    exp = tmp_path / "experiments" / "exp_1781000000"
+    exp.mkdir(parents=True)
+    (exp / "_DONE").touch()
+    (exp / "status_task_0.out").write_text("succeeded\n")
+    (exp / "status_task_1.out").write_text("succeeded\n")
+    monkeypatch.setenv("NEMORUN_HOME", str(tmp_path))
+
+    result = bridge.job_status_impl("exp_1781000000")
+    assert result["ok"] is True
+    assert result["status"] == "done"
+    assert result["task_statuses"] == {"task_0": "succeeded", "task_1": "succeeded"}
+
+
+def test_job_status_failed_task(tmp_path, monkeypatch):
+    """_DONE marker + at least one task status contains 'fail' → status='failed'."""
+    exp = tmp_path / "experiments" / "exp_1781000001"
+    exp.mkdir(parents=True)
+    (exp / "_DONE").touch()
+    (exp / "status_task_0.out").write_text("succeeded\n")
+    (exp / "status_task_1.out").write_text("failed (rc=1)\n")
+    monkeypatch.setenv("NEMORUN_HOME", str(tmp_path))
+
+    result = bridge.job_status_impl("exp_1781000001")
+    assert result["ok"] is True
+    assert result["status"] == "failed"
+    assert "failed" in result["task_statuses"]["task_1"]
+
+
+def test_job_status_running(tmp_path, monkeypatch):
+    """No _DONE marker → running."""
+    exp = tmp_path / "experiments" / "exp_1781000002"
+    exp.mkdir(parents=True)
+    (exp / "status_task_0.out").write_text("running\n")
+    monkeypatch.setenv("NEMORUN_HOME", str(tmp_path))
+
+    result = bridge.job_status_impl("exp_1781000002")
+    assert result["ok"] is True
+    assert result["status"] == "running"
+    assert result["has_done_marker"] is False
+
+
+def test_job_status_unknown_id(tmp_path, monkeypatch):
+    """No experiment dir matching the id → experiment_dir_not_found."""
+    monkeypatch.setenv("NEMORUN_HOME", str(tmp_path))
+    result = bridge.job_status_impl("does_not_exist")
+    assert result["ok"] is False
+    assert result["reason"] == "experiment_dir_not_found"
+
+
+def test_job_logs_all_tasks(tmp_path, monkeypatch):
+    """task=None returns logs for every log_*.out under the experiment dir."""
+    exp = tmp_path / "experiments" / "exp_1781000003"
+    exp.mkdir(parents=True)
+    (exp / "log_task_0.out").write_text("hello\nworld\n")
+    (exp / "log_task_1.out").write_text("done\n")
+    monkeypatch.setenv("NEMORUN_HOME", str(tmp_path))
+
+    result = bridge.job_logs_impl("exp_1781000003", task=None, tail=None)
+    assert result["ok"] is True
+    assert set(result["logs"].keys()) == {"task_0", "task_1"}
+    assert "hello" in result["logs"]["task_0"]
+
+
+def test_job_logs_with_tail(tmp_path, monkeypatch):
+    """tail=N returns only the last N lines per task."""
+    exp = tmp_path / "experiments" / "exp_1781000004"
+    exp.mkdir(parents=True)
+    (exp / "log_task_0.out").write_text("line1\nline2\nline3\nline4\n")
+    monkeypatch.setenv("NEMORUN_HOME", str(tmp_path))
+
+    result = bridge.job_logs_impl("exp_1781000004", task="task_0", tail=2)
+    assert result["ok"] is True
+    body = result["logs"]["task_0"]
+    assert body.splitlines() == ["line3", "line4"]
+
+
+def test_job_logs_missing_task(tmp_path, monkeypatch):
+    """Requested task name has no log file → task_log_not_found."""
+    exp = tmp_path / "experiments" / "exp_1781000005"
+    exp.mkdir(parents=True)
+    (exp / "log_task_0.out").write_text("only task 0\n")
+    monkeypatch.setenv("NEMORUN_HOME", str(tmp_path))
+
+    result = bridge.job_logs_impl("exp_1781000005", task="task_99", tail=None)
+    assert result["ok"] is False
+    assert result["reason"] == "task_log_not_found"

--- a/tools/mcp/tests/test_bridge.py
+++ b/tools/mcp/tests/test_bridge.py
@@ -363,3 +363,355 @@ def test_job_logs_missing_task(tmp_path, monkeypatch):
     result = bridge.job_logs_impl("exp_1781000005", task="task_99", tail=None)
     assert result["ok"] is False
     assert result["reason"] == "task_log_not_found"
+
+
+# ---------------------------------------------------------------------------
+# wait_for_experiment
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_experiment_returns_terminal_immediately(tmp_path, monkeypatch):
+    """If the experiment is already terminal, return without polling."""
+    exp = tmp_path / "experiments" / "exp_already_done"
+    exp.mkdir(parents=True)
+    (exp / "_DONE").touch()
+    (exp / "status_task_0.out").write_text("succeeded\n")
+    monkeypatch.setenv("NEMORUN_HOME", str(tmp_path))
+
+    result = bridge.wait_for_experiment_impl(
+        "exp_already_done",
+        timeout_sec=10,
+        poll_interval_sec=1,
+    )
+    assert result["ok"] is True
+    assert result["status"] == "done"
+    assert result["waited_seconds"] < 1  # didn't actually wait
+
+
+def test_wait_for_experiment_polls_until_done(tmp_path, monkeypatch):
+    """Spin through running → done."""
+    exp = tmp_path / "experiments" / "exp_in_flight"
+    exp.mkdir(parents=True)
+    (exp / "status_task_0.out").write_text("running\n")
+    monkeypatch.setenv("NEMORUN_HOME", str(tmp_path))
+
+    # Flip the marker after 2 polls via a counter side-effect
+    call_count = {"n": 0}
+    real_status = bridge.job_status_impl
+
+    def fake_status(experiment_id):
+        call_count["n"] += 1
+        if call_count["n"] >= 2:
+            (exp / "_DONE").touch()
+        return real_status(experiment_id)
+
+    monkeypatch.setattr(bridge, "job_status_impl", fake_status)
+    result = bridge.wait_for_experiment_impl(
+        "exp_in_flight",
+        timeout_sec=10,
+        poll_interval_sec=0,
+    )
+    assert result["ok"] is True
+    assert result["status"] == "done"
+    assert call_count["n"] >= 2
+
+
+def test_wait_for_experiment_timeout(tmp_path, monkeypatch):
+    """Never reaches terminal → wait_timeout with last_status."""
+    exp = tmp_path / "experiments" / "exp_stuck"
+    exp.mkdir(parents=True)
+    (exp / "status_task_0.out").write_text("running\n")
+    monkeypatch.setenv("NEMORUN_HOME", str(tmp_path))
+
+    result = bridge.wait_for_experiment_impl(
+        "exp_stuck",
+        timeout_sec=1,
+        poll_interval_sec=0,
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "wait_timeout"
+    assert result["last_status"]["status"] == "running"
+
+
+def test_wait_for_experiment_passes_through_dir_not_found(tmp_path, monkeypatch):
+    """If the experiment dir doesn't exist, don't spin to timeout."""
+    monkeypatch.setenv("NEMORUN_HOME", str(tmp_path))
+    result = bridge.wait_for_experiment_impl(
+        "does_not_exist",
+        timeout_sec=60,
+        poll_interval_sec=0,
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "experiment_dir_not_found"
+    # Bail out fast — not the full timeout
+    assert result["waited_seconds"] < 1
+
+
+# ---------------------------------------------------------------------------
+# provision_passwordless_ssh_dry_run
+# ---------------------------------------------------------------------------
+
+
+def test_provision_ssh_no_key_emits_keygen(tmp_path, monkeypatch):
+    """Missing private key → keygen command, step='keygen_required'."""
+    fake_home = tmp_path / "home"
+    (fake_home / ".ssh").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv("IDENTITY", raising=False)
+
+    result = bridge.provision_passwordless_ssh_dry_run_impl(
+        cluster_host="cw-dfw.example.com",
+        cluster_user="alice",
+        identity=None,
+    )
+    assert result["ok"] is True
+    assert result["step"] == "keygen_required"
+    assert "ssh-keygen" in result["commands"][0]
+    assert "ed25519" in result["commands"][0]
+    assert result["identity_path"].endswith(".ssh/id_ed25519")
+
+
+def test_provision_ssh_key_present_emits_copy_id(tmp_path, monkeypatch):
+    """Key + pubkey present → ssh-copy-id command + pubkey content."""
+    fake_home = tmp_path / "home"
+    ssh = fake_home / ".ssh"
+    ssh.mkdir(parents=True)
+    (ssh / "id_ed25519").write_text("PRIVKEY")
+    pubkey_content = "ssh-ed25519 AAAAC3NzaC... alice@host"
+    (ssh / "id_ed25519.pub").write_text(pubkey_content + "\n")
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv("IDENTITY", raising=False)
+
+    result = bridge.provision_passwordless_ssh_dry_run_impl(
+        cluster_host="cw-dfw.example.com",
+        cluster_user="alice",
+        identity=None,
+    )
+    assert result["ok"] is True
+    assert result["step"] == "ssh_copy_id_required"
+    assert "ssh-copy-id" in result["commands"][0]
+    assert "alice@cw-dfw.example.com" in result["commands"][0]
+    assert result["pubkey"] == pubkey_content
+    assert "verify_setup" in result["next_check"]
+
+
+def test_provision_ssh_priv_without_pub_surfaces_failure(tmp_path, monkeypatch):
+    """Private key but no .pub → pubkey_missing with recovery hint."""
+    fake_home = tmp_path / "home"
+    ssh = fake_home / ".ssh"
+    ssh.mkdir(parents=True)
+    (ssh / "id_ed25519").write_text("PRIVKEY")
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv("IDENTITY", raising=False)
+
+    result = bridge.provision_passwordless_ssh_dry_run_impl(
+        cluster_host="cw-dfw.example.com",
+        cluster_user="alice",
+        identity=None,
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "pubkey_missing"
+    assert "ssh-keygen" in result["diagnostic"]
+
+
+def test_provision_ssh_explicit_identity_overrides_default(tmp_path, monkeypatch):
+    """Explicit identity arg wins over $IDENTITY and ~/.ssh/id_ed25519."""
+    explicit = tmp_path / "custom_key"
+    explicit.write_text("CUSTOM")
+    (tmp_path / "custom_key.pub").write_text("ssh-ed25519 AAAA alice\n")
+    monkeypatch.setenv("IDENTITY", "/wrong/path")  # should be ignored
+
+    result = bridge.provision_passwordless_ssh_dry_run_impl(
+        cluster_host="cw-dfw.example.com",
+        cluster_user="alice",
+        identity=str(explicit),
+    )
+    assert result["ok"] is True
+    assert result["identity_path"] == str(explicit)
+
+
+# ---------------------------------------------------------------------------
+# read_cluster_artifact — logs mode (subprocess mocked)
+# ---------------------------------------------------------------------------
+
+
+def test_read_cluster_artifact_logs_mode_ok(monkeypatch):
+    """path=None → wraps `nemo experiment logs <id> <job_idx>`."""
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=0,
+            stdout="line 1\nline 2\nline 3\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = bridge.read_cluster_artifact_impl(
+        experiment_id="cicd_42",
+        path=None,
+        job_idx=0,
+    )
+    assert result["ok"] is True
+    assert result["mode"] == "logs"
+    assert "line 1" in result["content"]
+    # Verify the wrapped command
+    assert "nemo" in captured["argv"]
+    assert "experiment" in captured["argv"]
+    assert "logs" in captured["argv"]
+    assert "cicd_42" in captured["argv"]
+
+
+def test_read_cluster_artifact_logs_mode_subprocess_failed(monkeypatch):
+    """Nemo cli non-zero → structured logs_fetch_failed."""
+
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=1,
+            stdout="",
+            stderr="experiment cicd_42 not found\n",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = bridge.read_cluster_artifact_impl(
+        experiment_id="cicd_42",
+        path=None,
+        job_idx=0,
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "logs_fetch_failed"
+    assert result["exit_code"] == 1
+
+
+def test_read_cluster_artifact_logs_mode_timeout(monkeypatch):
+    """Hanging tunnel → structured logs_fetch_timeout, no exception."""
+
+    def fake_run(argv, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=60)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = bridge.read_cluster_artifact_impl(
+        experiment_id="cicd_42",
+        path=None,
+        job_idx=0,
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "logs_fetch_timeout"
+
+
+# ---------------------------------------------------------------------------
+# open_draft_pr — subprocess mocked
+# ---------------------------------------------------------------------------
+
+
+def test_open_draft_pr_happy_path(monkeypatch, tmp_path):
+    """Git push ok → gh pr create ok → returns parsed pr_url."""
+    (tmp_path / ".git").mkdir()  # pretend it's a git repo
+
+    call_log = []
+
+    def fake_run(argv, **kwargs):
+        call_log.append(argv[0])
+        if argv[0] == "git":
+            return subprocess.CompletedProcess(
+                args=argv,
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+        # gh pr create — return a typical PR URL on stdout
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=0,
+            stdout=(
+                "Warning: 1 uncommitted change\n"
+                "https://github.com/NVIDIA/Model-Optimizer/pull/9999\n"
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = bridge.open_draft_pr_impl(
+        target_repo="NVIDIA/Model-Optimizer",
+        title="test pr",
+        body="body text",
+        base_branch="main",
+        cwd=str(tmp_path),
+    )
+    assert result["ok"] is True
+    assert result["pr_url"] == "https://github.com/NVIDIA/Model-Optimizer/pull/9999"
+    assert call_log == ["git", "gh"]
+
+
+def test_open_draft_pr_not_a_git_repo(tmp_path):
+    """Cwd without .git → structured not_a_git_repo failure, no subprocess."""
+    result = bridge.open_draft_pr_impl(
+        target_repo="NVIDIA/Model-Optimizer",
+        title="x",
+        body="x",
+        base_branch="main",
+        cwd=str(tmp_path),
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "not_a_git_repo"
+
+
+def test_open_draft_pr_git_push_failed(monkeypatch, tmp_path):
+    """Git push non-zero → structured git_push_failed."""
+    (tmp_path / ".git").mkdir()
+
+    def fake_run(argv, **kwargs):
+        if argv[0] == "git":
+            return subprocess.CompletedProcess(
+                args=argv,
+                returncode=128,
+                stdout="",
+                stderr="rejected: non-fast-forward\n",
+            )
+        pytest.fail(f"gh should not be called when git push fails; got {argv}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = bridge.open_draft_pr_impl(
+        target_repo="NVIDIA/Model-Optimizer",
+        title="x",
+        body="x",
+        base_branch="main",
+        cwd=str(tmp_path),
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "git_push_failed"
+
+
+def test_open_draft_pr_gh_failed_but_branch_pushed(monkeypatch, tmp_path):
+    """Gh pr create non-zero → reports branch_pushed=True so the operator can retry just the PR-open step."""
+    (tmp_path / ".git").mkdir()
+
+    def fake_run(argv, **kwargs):
+        if argv[0] == "git":
+            return subprocess.CompletedProcess(
+                args=argv,
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=1,
+            stdout="",
+            stderr="resource not found: NVIDIA/Model-Optimizer\n",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = bridge.open_draft_pr_impl(
+        target_repo="NVIDIA/Model-Optimizer",
+        title="x",
+        body="x",
+        base_branch="main",
+        cwd=str(tmp_path),
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "gh_pr_create_failed"
+    assert result["branch_pushed"] is True


### PR DESCRIPTION
## Summary

`tools/mcp/` — a new MCP server exposing the existing `tools/launcher/core.py` orchestration as **typed MCP tools** that codex / Claude Code agents can call directly, instead of shelling out to `uv run launch.py --yaml ...` and parsing prose output.

Tracked under [OMNIML-5123](https://jirasw.nvidia.com/browse/OMNIML-5123) (Epic). Ships **Phase 1 + Phase 1.5** together: the core launcher surface plus the four highest-leverage helpers from the `cell.md` simplification loop ([OMNIML-5128](https://jirasw.nvidia.com/browse/OMNIML-5128) partial, [OMNIML-5132](https://jirasw.nvidia.com/browse/OMNIML-5132) full).

## Nine tools

**Phase 1 — core launcher surface:**

| Tool | Description |
|---|---|
| `list_examples` | Enumerate `tools/launcher/examples/` with model + description metadata extracted from each YAML |
| `verify_setup` | Fail-fast probe for the named executor. Docker: `docker info` (daemon up) + `docker info --format` runtime-registry check for the `nvidia` runtime — no image pull, daemon-fast. Slurm: `ssh -o BatchMode=yes -o ConnectTimeout=5` to the cluster login node. ~1 s probe saves 30+ s of wasted submission on bad config |
| `submit_job` | Submit a launcher YAML. Mode is determined by mutually-exclusive args: `hf_local` → Docker (local GPU), `cluster_host` → Slurm (remote SSH). Returns experiment_id immediately; the actual job runs detached |
| `job_status` | Filesystem-based status from nemo_run's experiment dir (`_DONE`, `status_*.out`) — no in-memory registry, survives MCP server restarts |
| `job_logs` | Read `log_<task>.out` from experiment dir; per-task filtering + optional tail |

**Phase 1.5 — `cell.md` simplification (OMNIML-5128 / 5132):**

| Tool | Description |
|---|---|
| `wait_for_experiment` | Replaces the agent's `while True: status; sleep` poll loop with one tool call. Reuses `job_status_impl` so terminal-state semantics stay identical. Returns final status plus `waited_seconds`; on timeout returns structured `{ok: False, reason: "wait_timeout", last_status: …}` |
| `provision_passwordless_ssh_dry_run` | No-side-effect inspection of `~/.ssh/` that emits the exact `ssh-keygen` / `ssh-copy-id` commands the operator should run to make `verify_setup(executor='slurm')` pass. Closes the verify_setup "ssh_auth_failed → now what?" gap |
| `read_cluster_artifact` | Uses nemo_run's tunnel primitives, not a reinvented SSH layer. `path=None` wraps `nemo experiment logs <id> <job_idx>` (built-in log fetch); with a `path`, uses the experiment's `Tunnel` to read the file. Structured failure on subprocess error / timeout |
| `open_draft_pr` | `git push -u origin HEAD` + `gh pr create --draft …`. Validates cwd is a git repo first; on gh failure after push succeeds, reports `branch_pushed=True` so the operator can retry just the PR-open step |

## Design constants

1. **Single `submit_job` with mode by args** (not separate `submit_docker` / `submit_slurm` tools). Keeps the LLM tool catalog compact; mutual-exclusion is a runtime check.
2. **Filesystem is the source of truth** for status + logs. No in-memory registry. Survives MCP server restarts cleanly — important because operators / agents kill + restart their hosts often.
3. **`verify_setup` is auto-called by `submit_job`** by default (skippable when caller just probed). The probe is ~1 s; the cost of a misconfigured submission is 30+ s of cluster timeout or container-pull. Always-on verify pays back immediately.
4. **Delegate to nemo_run for tunnels.** `read_cluster_artifact` and `wait_for_experiment` use nemo_run's existing `Experiment` / `Tunnel` / `nemo experiment logs` primitives rather than reinventing SSH/rsync. One source of truth for cluster I/O.

## Layout

```
tools/mcp/
├── pyproject.toml          # name: modelopt-mcp, console_script
├── modelopt_mcp/
│   ├── __init__.py
│   ├── server.py           # FastMCP entry; 9 tool definitions
│   └── bridge.py           # thin wrapper over launcher's core.py
│                           #   + filesystem status/log helpers
│                           #   + tunnel/PR helpers (Phase 1.5)
└── tests/
    └── test_bridge.py      # 34 unit tests, fully hermetic
                            # (mocked subprocess + tmp_path fixtures)
```

## Install

Two paths, both **from source via uv**. No PyPI wheel exists; OMNIML-5123 opted for the uvx-from-git pattern to skip publication overhead.

### End-user install (recommended)

`uvx` from the git subdirectory — single command, no manual clone:

```bash
# Claude Code
claude mcp add modelopt -- uvx --from \
  "git+https://github.com/NVIDIA/Model-Optimizer.git#subdirectory=tools/mcp" \
  modelopt-mcp

# Codex
codex mcp add modelopt -- uvx --from \
  "git+https://github.com/NVIDIA/Model-Optimizer.git#subdirectory=tools/mcp" \
  modelopt-mcp
```

Under the hood `uvx` clones the whole repo to its cache, installs `tools/mcp/` as the entry, and resolves the sibling `modelopt-launcher` dep via `[tool.uv.sources]` (`path = "../launcher"`) inside the cloned tree.

### Dev install (local checkout)

```bash
uv pip install -e tools/launcher    # sibling dep first
uv pip install -e tools/mcp         # then this package
modelopt-mcp                         # entry on PATH
```

### Why no plain `pip install` today

Two specific reasons, worth flagging so reviewers know what's intentional vs missing:

1. **Nothing on PyPI yet.** Neither `modelopt-mcp` nor `modelopt-launcher` are published — this PR introduces the package but doesn't add release machinery.
2. **`pip` doesn't read `[tool.uv.sources]`.** Even from a local checkout, plain `pip install -e tools/mcp` fails because `modelopt-launcher` is a bare name (no URL) and pip can't find it. Sticking with `uv` / `uvx` is the practical path while we're git-only.

If we later want plain-pip support: publish to PyPI, or switch to a PEP-440 direct URL (`"modelopt-launcher @ git+…#subdirectory=tools/launcher"`). Out of scope for this PR.

## Post-review changes

Addressed all CodeRabbit + claude[bot] review findings on the original Phase-1 surface. See the inline replies for details; the substantive bug-fix highlights:

* **Slurm `cluster_host`** — propagate via `env=child_env` (launch.py reads SLURM_HOST, not a CLI arg)
* **`shlex.quote`** removed from nemo-run k=v overrides (subprocess list-form doesn't shell-quote)
* **Docker `Popen`** now uses `stdout=DEVNULL, stderr=DEVNULL, start_new_session=True` to avoid pipe-buffer blocking
* **`NEMORUN_HOME`** pinned in subprocess env so submit + status sides agree
* **GPU verify** swapped from `docker run --gpus all` image-pull (slow + flaky) to `docker info --format` runtime-registry check (daemon-fast)
* **Task-status word match** anchors on first word against a fixed failure-word set (no more `"fail" in "succeeded after retry; previous attempt failed"` false-positive)
* **`experiment_id` regex** generalized for non-NVIDIA cluster paths
* **`pyproject.toml`** dropped the unsatisfiable `modelopt-launcher` bare-name dep (launcher is a file-layout sibling, not a Python import dep)
* **`Field(ge=1)`** on `job_logs.tail`
* **Docstring contract** clarified (Docker returns `pid`, Slurm returns `experiment_id`)

## Validation

- [x] `uv pip install -e .` succeeds (modelopt-launcher resolved transitively)
- [x] 34/34 unit tests pass (`uv run python -m pytest tests/`)
- [x] stdio handshake works end-to-end; `tools/list` returns all 9 with full schemas + descriptions
- [x] Mode-resolution: `submit_job` correctly rejects no-executor + both-executors with structured `reason`
- [x] Filesystem status: correctly classifies `done` / `failed` / `running` from `_DONE` + `status_*.out`
- [x] `wait_for_experiment` short-circuits on already-terminal experiments; honors timeout without raising
- [x] `provision_passwordless_ssh_dry_run` distinguishes no-key / key-only / key+pubkey cases
- [x] `read_cluster_artifact` handles subprocess timeout + non-zero exit with structured reasons
- [x] `open_draft_pr` reports `branch_pushed=True` on gh-failure-after-push so retries are cheap
- [x] Pre-commit clean: ruff, ruff-format, mypy, bandit, license-headers

## Acceptance criteria

**OMNIML-5123 (Phase 1):**

- [x] `list_examples` returns all bundled YAMLs with path and model name
- [x] `submit_job` with `hf_local` runs via Docker executor and returns immediately (Phase 1: returns PID; experiment_id capture in Phase 2)
- [x] `submit_job` with `cluster_host`/`user` runs via Slurm executor (`detach=True`) and returns experiment_id
- [x] `job_status` correctly reflects running / done / failed from nemo_run filesystem
- [x] `job_logs` returns stdout for a completed job
- [x] `uvx --from git+...#subdirectory=tools/mcp modelopt-mcp --help` resolves and starts
- [x] Existing launcher tests unaffected (no changes to `tools/launcher/`)

**OMNIML-5128 (Phase 1.5, partial):**

- [x] `wait_for_experiment` blocks until terminal or timeout
- [x] `read_cluster_artifact` pulls remote artifacts via nemo_run tunnel
- [x] `open_draft_pr` opens a draft PR against a target repo
- [ ] Capture `experiment_id` from Docker subprocess output — deferred to Phase 2

**OMNIML-5132 (Phase 1.5, full):**

- [x] `provision_passwordless_ssh_dry_run` emits operator-facing commands without side effects

## Phase 2 (separate PR)

* Capture `experiment_id` from Docker subprocess output (tail until nemo_run logs the id).
* Extract the verify + submit helpers into a shared lib that [`nmm-sandbox-mcp`](https://gitlab-master.nvidia.com/omniml/integration/nmm-sandbox/-/tree/main/tools/mcp) (companion server, separate repo) can consume for internal-ergonomics tools — cluster short-name → factory lookup + GitLab CI dispatch.
* NEL integration ([OMNIML-5133](https://jirasw.nvidia.com/browse/OMNIML-5133)) + checkpoint introspection ([OMNIML-5134](https://jirasw.nvidia.com/browse/OMNIML-5134)).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ModelOpt MCP server and console entrypoint; tools: list_examples, verify_setup, submit_job, job_status, job_logs, wait_for_experiment, provision_passwordless_ssh_dry_run, read_cluster_artifact, open_draft_pr; Docker and Slurm support.

* **Documentation**
  * Expanded README with install steps, design notes, end-to-end agent example, roadmap, and repo layout.

* **Tests**
  * Expanded unit tests covering bridge helpers, polling, SSH flows, artifact reads, and PR automation.

* **Chores**
  * CI updated to run MCP tests; package/meta config added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
