### PR TITLE
Fix DeepSeek V3 ptq.py inference-repo path resolution (nvbug 6311147)

### DIFF
--- a/examples/deepseek/deepseek_v3/ptq.py
+++ b/examples/deepseek/deepseek_v3/ptq.py
@@ -66,17 +66,18 @@ from modelopt.torch.quantization.utils import (
 from modelopt.torch.utils.dataset_utils import get_dataset_dataloader
 from modelopt.torch.utils.distributed import ParallelState
 
-DS_V3_PATH = Path(__file__).resolve().parent / "DeepSeek-V3/inference"
-DS_V3_2_PATH = Path(__file__).resolve().parent / "DeepSeek-V3.2-Exp/inference"
+# The DeepSeek-V3 / DeepSeek-V3.2-Exp inference repos are cloned into the parent
+# `examples/deepseek` directory (see README), one level up from this script.
+DEEPSEEK_DIR = Path(__file__).resolve().parent.parent
+DS_V3_PATH = DEEPSEEK_DIR / "DeepSeek-V3/inference"
+DS_V3_2_PATH = DEEPSEEK_DIR / "DeepSeek-V3.2-Exp/inference"
 
 if DS_V3_2_PATH.exists():
     sys.path.append(str(DS_V3_2_PATH))
 elif DS_V3_PATH.exists():
     sys.path.append(str(DS_V3_PATH))
 else:
-    raise ValueError(
-        f"DeepSeek-V3 or DeepSeek-V3.2-Exp not found in {Path(__file__).resolve().parent}"
-    )
+    raise ValueError(f"DeepSeek-V3 or DeepSeek-V3.2-Exp not found in {DEEPSEEK_DIR}")
 
 import model as deekseep_model  # noqa: E402
 from kernel import act_quant, fp8_gemm  # noqa: E402


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fixes nvbug **6311147** (OMNIML-5103). `examples/deepseek/deepseek_v3/ptq.py` resolved the cloned DeepSeek-V3 / DeepSeek-V3.2-Exp inference repos relative to its own directory (`deepseek_v3/`) via `Path(__file__).resolve().parent`. But the [README](https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/deepseek) clones those repos into the parent `examples/deepseek/` directory and runs the script from there, so the lookup landed one level too deep and raised `ValueError: DeepSeek-V3 or DeepSeek-V3.2-Exp not found` (the error message also printed the wrong directory).

The fix resolves from `parent.parent` via a single `DEEPSEEK_DIR` base shared by both repo paths and the error message.

### Usage

```bash
# Run from examples/deepseek/ as documented in the README, after cloning
# DeepSeek-V3 (or DeepSeek-V3.2-Exp) into that directory:
torchrun --nproc-per-node 8 --master_port=12346 deepseek_v3/ptq.py \
  --model_path $DS_CKPT \
  --config DeepSeek-V3/inference/configs/config_671B.json \
  --quant_cfg NVFP4_DEFAULT_CFG \
  --output_path $FP4_QUANT_PATH
```

### Testing

- Confirmed against the repro path: with the file at `examples/deepseek/deepseek_v3/ptq.py` and the repos cloned into `examples/deepseek/`, `Path(__file__).resolve().parent.parent` now points at `examples/deepseek/` so `DeepSeek-V3/inference` resolves correctly.
- Verified the sibling `examples/deepseek/deepseek_v4/` does not share the bug (it takes an explicit `--dsv4_inference_dir` argument instead).
- `pre-commit` clean.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A (one-line path fix in an example script that requires the DeepSeek repos + multi-GPU checkpoint to exercise)
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A (bug is in a 0.45-cycle example, not a regression from a released version)
- Did you get Claude approval on this PR?: ❌ (not yet run)

### Additional Information

nvbug 6311147 / OMNIML-5103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path resolution in the example script to more reliably locate the required inference repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->