### PR TITLE
Detect fused experts using _apply_gate as activation marker

### DIFF
--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -1471,7 +1471,8 @@ def _is_fused_experts_module(module):
 
     Detects the standardized HuggingFace transformers 5.0+ fused expert pattern:
     ``gate_up_proj`` (3-D parameter), ``down_proj`` (3-D parameter), ``num_experts``,
-    and ``act_fn``.  Matches ``MixtralExperts``, ``Qwen2MoeExperts``,
+    and ``act_fn`` (or ``_apply_gate`` for clamped-swiglu experts such as
+    ``MiniMaxM3VLExperts``).  Matches ``MixtralExperts``, ``Qwen2MoeExperts``,
     ``Qwen3MoeExperts``, ``Qwen3_5MoeExperts``, ``DeepseekV3NaiveMoe``,
     ``JambaExperts``, ``OlmoeExperts``, etc.
 
@@ -1480,7 +1481,9 @@ def _is_fused_experts_module(module):
     """
     if not hasattr(module, "gate_up_proj") or not hasattr(module, "down_proj"):
         return False
-    if not hasattr(module, "num_experts") or not hasattr(module, "act_fn"):
+    if not hasattr(module, "num_experts") or not (
+        hasattr(module, "act_fn") or hasattr(module, "_apply_gate")
+    ):
         return False
     gate_up = getattr(module, "gate_up_proj")
     down = getattr(module, "down_proj")

--- a/tests/unit/torch/quantization/plugins/test_fused_experts.py
+++ b/tests/unit/torch/quantization/plugins/test_fused_experts.py
@@ -152,6 +152,21 @@ class TestIsFusedExpertsModule:
         module.num_experts = 4
         assert _is_fused_experts_module(module) is False
 
+    def test_module_with_apply_gate_detected(self):
+        """Clamped-swiglu experts (e.g. MiniMaxM3VLExperts) use _apply_gate instead of act_fn."""
+
+        class _ApplyGateExperts(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.gate_up_proj = nn.Parameter(torch.randn(4, 16, 8))
+                self.down_proj = nn.Parameter(torch.randn(4, 8, 16))
+                self.num_experts = 4
+
+            def _apply_gate(self, gate, up):
+                return up * torch.sigmoid(gate)
+
+        assert _is_fused_experts_module(_ApplyGateExperts()) is True
+
     def test_sparse_moe_block_not_detected_as_fused(self):
         block = _SyntheticSparseMoeBlock()
         assert _is_fused_experts_module(block) is False


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:** `_is_fused_experts_module()` requires an `act_fn` attribute, so fused expert modules that implement their gated activation as a method instead — e.g. transformers' `MiniMaxM3VLExperts`, whose GPT-OSS-style clamped swiglu lives in `_apply_gate()` — are silently left unquantized: PTQ completes without error, but all experts stay high-precision. This PR accepts `_apply_gate` as an alternative activation marker. The eager forward of such modules still performs the same two `F.linear` calls per expert that `_QuantFusedExperts` intercepts, so detection is the only change needed.

## Testing

- New unit test `test_module_with_apply_gate_detected` in `tests/unit/torch/quantization/plugins/test_fused_experts.py`; full `TestIsFusedExpertsModule` suite passes.
- End-to-end: with this fix, NVFP4 PTQ of MiniMax-M3 (854 GB BF16 → ~256 GB) produces a working checkpoint (GSM8K strict 92.6–93.6 across runs vs 93.9 for the official MXFP8 baseline, same engine and sampling). Without it, the exported "quantized" model silently keeps full-precision experts.

## Additional notes

Docstring of `_is_fused_experts_module` updated; no new dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quantization expert module detection to recognize alternative gate implementations such as clamped gates, expanding compatibility with diverse Mixture of Experts architectures and enabling broader support for specialized expert configurations used in advanced models.

* **Tests**
  * Added test coverage to verify expert module detection properly recognizes quantization modules using alternative gate implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->