### PR TITLE
fix(quantization): detect fused MoE experts without act_fn (MiniMax-M3)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Changelog
 **Bug Fixes**
 
 - Fix ``ShapeInferenceError`` during ONNX INT8 + FP16 quantization (``--high_precision_dtype fp16``) of weakly-typed models (e.g. TensorFlow exports) that carry stale rank-0 ``graph.output`` shapes or ops such as ``TopK`` that ONNX's static shape inference cannot resolve. ``clear_stale_value_info`` now reconciles stale output shapes via symbolic shape inference (keeping every output's shape field populated), and AutoCast runs ONNX shape inference in strict mode and falls back to schema-based standalone type inference when it fails, so unresolved ops no longer leave tensors untyped.
+- Fused MoE expert auto-detection (``register_fused_experts_on_the_fly``) no longer requires an ``act_fn`` attribute. Some fused-expert modules (e.g. ``MiniMaxM3VLExperts``) apply a custom gated activation between the two ``F.linear`` calls instead of exposing ``act_fn``; they were silently skipped, leaving routed experts unquantized (an experts-only recipe matched nothing) and failing HF export with ``NotImplementedError``. ``_QuantFusedExperts`` is activation-agnostic (it only intercepts the two ``F.linear`` calls), so the requirement was unnecessary. This enables NVFP4/FP8 quantization and export for MiniMax-M2 / MiniMax-M3.
 
 0.45 (2026-07-02)
 ^^^^^^^^^^^^^^^^^

--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -1606,20 +1606,24 @@ def register_sparse_moe_on_the_fly(model):
 def _fused_experts_wrapper_class(module):
     """Return the _QuantFusedExperts subclass for a fused MoE expert container, or None.
 
-    Two 3-D fused layouts are recognized, both requiring ``num_experts`` + ``act_fn``
-    and a 3-D ``down_proj`` parameter:
+    Two 3-D fused layouts are recognized, both requiring ``num_experts`` and a
+    3-D ``down_proj`` parameter:
 
     * gated (``_QuantFusedExperts``): a 3-D ``gate_up_proj`` fusing gate+up. Matches
       ``MixtralExperts``, ``Qwen2MoeExperts``, ``Qwen3MoeExperts``,
       ``Qwen3_5MoeExperts``, ``DeepseekV3NaiveMoe``, ``JambaExperts``,
-      ``OlmoeExperts``, etc.
+      ``OlmoeExperts``, ``MiniMaxM2Experts``, ``MiniMaxM3VLExperts``, etc.
     * non-gated (``_QuantNonGatedFusedExperts``): a 3-D ``up_proj`` with no
       ``gate_proj`` and no ``gate_up_proj``. Matches NemotronH ``NemotronHExperts``.
 
     Returns ``None`` for non-standard layouts (DBRX, GptOss, GraniteMoE,
     Llama4TextExperts) which have their own explicit registrations.
+
+    ``act_fn`` is not required: these wrappers only intercept the two ``F.linear``
+    calls, so modules with a custom gated activation (e.g. ``MiniMaxM3VLExperts``)
+    are still supported.
     """
-    if not hasattr(module, "num_experts") or not hasattr(module, "act_fn"):
+    if not hasattr(module, "num_experts"):
         return None
     down = getattr(module, "down_proj", None)
     if not isinstance(down, (nn.Parameter, Tensor)) or down.dim() != 3:

--- a/tests/unit/torch/quantization/plugins/test_fused_experts.py
+++ b/tests/unit/torch/quantization/plugins/test_fused_experts.py
@@ -226,11 +226,6 @@ class TestIsFusedExpertsModule:
         assert _is_fused_experts_module(module) is False
 
     def test_module_missing_act_fn_still_detected(self):
-        # act_fn is intentionally not required: some fused-expert modules
-        # (e.g. MiniMaxM3VLExperts) apply a custom gated activation between the
-        # two F.linear calls instead of exposing an act_fn attribute.
-        # _QuantFusedExperts is activation-agnostic, so such modules must still
-        # be detected and quantized.
         module = nn.Module()
         module.gate_up_proj = nn.Parameter(torch.randn(4, 16, 8))
         module.down_proj = nn.Parameter(torch.randn(4, 8, 16))

--- a/tests/unit/torch/quantization/plugins/test_fused_experts.py
+++ b/tests/unit/torch/quantization/plugins/test_fused_experts.py
@@ -225,12 +225,17 @@ class TestIsFusedExpertsModule:
         module.act_fn = nn.SiLU()
         assert _is_fused_experts_module(module) is False
 
-    def test_module_missing_act_fn_not_detected(self):
+    def test_module_missing_act_fn_still_detected(self):
+        # act_fn is intentionally not required: some fused-expert modules
+        # (e.g. MiniMaxM3VLExperts) apply a custom gated activation between the
+        # two F.linear calls instead of exposing an act_fn attribute.
+        # _QuantFusedExperts is activation-agnostic, so such modules must still
+        # be detected and quantized.
         module = nn.Module()
         module.gate_up_proj = nn.Parameter(torch.randn(4, 16, 8))
         module.down_proj = nn.Parameter(torch.randn(4, 8, 16))
         module.num_experts = 4
-        assert _is_fused_experts_module(module) is False
+        assert _is_fused_experts_module(module) is True
 
     def test_sparse_moe_block_not_detected_as_fused(self):
         block = _SyntheticSparseMoeBlock()


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fused MoE expert auto-detection (`register_fused_experts_on_the_fly` → `_is_fused_experts_module`) required every fused-expert container to expose an `act_fn` attribute. `MiniMaxM3VLExperts` (transformers 5.12.0) applies a custom GPT-OSS-style gated activation (`_apply_gate`, swiglu with clamp/alpha) *between* its two `F.linear` calls instead of exposing `act_fn`, so it failed detection and was never wrapped as `_QuantFusedExperts`. Consequences:

- routed experts stayed unquantized — an experts-only recipe (`*mlp.experts*`) matched nothing (only KV-cache quant applied), and
- HF export raised `NotImplementedError: MoE model with experts type 'MiniMaxM3VLExperts' is not supported in export`.

`_QuantFusedExperts` is **activation-agnostic** — it only intercepts the two `F.linear` calls (gate_up then down, in strict alternation) and never touches `act_fn`. So the `act_fn` requirement was unnecessary. This PR drops it (keeping the `num_experts` + 3-D `gate_up_proj`/`down_proj` checks), which enables NVFP4/FP8 PTQ and export for MiniMax-M2 / MiniMax-M3.

### Usage

```python
# MiniMax-M3 experts-only NVFP4 + FP8 KV now quantizes and exports:
python examples/llm_ptq/hf_ptq.py \
    --pyt_ckpt_path MiniMaxAI/MiniMax-M3 \
    --recipe general/ptq/nvfp4_experts_only_mse-kv_fp8_cast \
    --calib_size 512 --export_path ./m3-nvfp4
```

### Testing

- Updated `tests/unit/torch/quantization/plugins/test_fused_experts.py`: the previous `test_module_missing_act_fn_not_detected` (which asserted the old, now-incorrect behavior) is replaced by `test_module_missing_act_fn_still_detected`, asserting that a fused-expert module without `act_fn` is detected. Negative cases (2-D `gate_up`, plain `nn.Linear`) still rejected.
- Verified end-to-end on `MiniMaxAI/MiniMax-M3` (~428B-A23B, transformers 5.12.0, 8×B300): detection logs `Detected fused MoE experts ... of type MiniMaxM3VLExperts`, all 57 MoE layers' experts quantize to NVFP4 (21,888 expert weights with scales; 0 on attention/shared-experts/vision tower), KV cache to FP8, and the HF checkpoint exports successfully (854 GB → 260 GB).

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅ (updated the inverted detection test)
- Did you update Changelog?: ✅ (0.46 Bug Fixes)
- Did you get Claude approval on this PR?: ❌ (pending)

### Additional Information

`conversion.py::_normalize_fused_experts_quantizer_name` already maps the per-expert `gate_up_proj_weight_quantizers.N` names to the singular `*weight_quantizer` form, so existing stock configs/recipes match the newly-detected experts with no recipe changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved fused Mixture-of-Experts auto-detection so fused expert variants that don’t expose an activation function attribute are now correctly recognized.
  * Prevents eligible routed experts from being skipped during quantization, enabling NVFP4/FP8 quantization and resolving HuggingFace export failures for previously unsupported expert configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->