### PR TITLE
Fix autotune warm restart to retry failed schemes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 
 **New Features**
 
+- ONNX autotune: warm restart now ignores error records (e.g. from connection loss or TensorRT build timeout) and retries them automatically. Previously, failed schemes were permanently marked as profiled and skipped on resume.
 - Add the ``day0-release`` agent skill (``.agents/skills/day0-release/``), a deterministic end-to-end driver that chains the PTQ → evaluation → comparison skills (the evaluation stage deploys the checkpoint itself) with an enforced gate after each stage and returns a publish decision (ACCEPT / REGRESSION / ANOMALOUS / INFEASIBLE). Ships three GPU-free, unit-tested gate scripts (``gate_ptq.py``, ``gate_run.py``, ``gate_compare.py``) that validate checkpoint coverage, evaluation-run completeness, and baseline-vs-candidate accuracy threshold. v1 reports and stops on regression; the recipe-search loop is deferred.
 - Add **streaming** speculative-decoding training (EAGLE3 / DFlash): the draft trains on base-model hidden states produced on the fly by a co-located ``vllm serve`` (no disk dump), moved trainer-side over NIXL RDMA, scaling to multi-node (dedicated serve replicas + DDP trainers). New launcher examples for NVFP4 Kimi-K2.5 / K2.6 on GB200/aarch64 under ``tools/launcher/examples/moonshotai/``.
 

--- a/docs/source/guides/9_autotune.rst
+++ b/docs/source/guides/9_autotune.rst
@@ -209,6 +209,8 @@ A long run can be interrupted (Ctrl+C, preemption, or crash) and resumed later:
 
 When rerun with the same ``--output_dir``, the autotuner detects ``autotuner_state.yaml``, restores progress, and continues from the next unprofiled region.
 
+Schemes that previously failed due to transient errors (e.g. connection loss, TensorRT build timeout) are automatically reset on warm restart and retried. This means you do not need to manually clean the state file after infrastructure failures.
+
 Custom TensorRT Plugins
 -----------------------
 
@@ -648,6 +650,7 @@ The model may not benefit from quantization:
 * Use the same ``--output_dir`` (and ``--onnx_path``) as the original run
 * Confirm ``autotuner_state.yaml`` exists in that directory
 * If the state file is corrupted, remove it and start over
+* Schemes that failed due to connection loss or transient errors are automatically retried on restart
 
 Debugging
 ---------

--- a/modelopt/onnx/quantization/autotune/autotuner_base.py
+++ b/modelopt/onnx/quantization/autotune/autotuner_base.py
@@ -257,16 +257,32 @@ class QDQAutotunerBase:
             logger.debug(f"Pattern signature: {region_pattern.signature}")
             return
 
-        pattern_schemes, num_seeded = self._seed_from_cache(region_pattern)
-        if pattern_schemes is None:
-            pattern_schemes = PatternSchemes()
-            pattern_schemes.pattern = region_pattern
-            logger.debug("Initialized with empty scheme collection")
+        # Check if there's a partially-profiled entry in profiled_patterns
+        # (e.g. from warm restart with reset error schemes that need retry).
+        existing_pattern_schemes = None
+        for idx, p in enumerate(self.profiled_patterns):
+            if (
+                p.pattern is not None
+                and p.pattern.matches(region, self.graph)
+                and any(not s.is_profiled for s in p.schemes)
+            ):
+                existing_pattern_schemes = self.profiled_patterns.pop(idx)
+                break
+
+        if existing_pattern_schemes is not None:
+            pattern_schemes = existing_pattern_schemes
+            num_unprofiled = sum(1 for s in pattern_schemes.schemes if not s.is_profiled)
+            mode_info = f"resuming with {num_unprofiled} schemes to retry"
+        else:
+            pattern_schemes, num_seeded = self._seed_from_cache(region_pattern)
+            if pattern_schemes is None:
+                pattern_schemes = PatternSchemes()
+                pattern_schemes.pattern = region_pattern
+                logger.debug("Initialized with empty scheme collection")
+            mode_info = f"seeded with {num_seeded} schemes" if num_seeded > 0 else "starting fresh"
 
         self.current_profile_region = region
         self.current_profile_pattern_schemes = pattern_schemes
-
-        mode_info = f"seeded with {num_seeded} schemes" if num_seeded > 0 else "starting fresh"
         logger.info(
             f"Profiling region {region.id} [level {region.level}, size"
             f"{region.get_size_of_region_and_descendants()}, {mode_info}]"
@@ -784,10 +800,21 @@ class QDQAutotunerBase:
         if "patterns" in state:
             num_loaded_patterns = 0
             num_loaded_schemes = 0
+            num_reset_errors = 0
 
             for pattern_data in state["patterns"]:
                 try:
                     pattern_schemes = PatternSchemes.from_dict(pattern_data)
+
+                    # Reset error schemes so they can be retried on warm restart.
+                    # Errors are often transient (e.g. connection loss) and should
+                    # not permanently block a scheme from being re-profiled.
+                    for scheme in pattern_schemes.schemes:
+                        if scheme.error:
+                            scheme.error = False
+                            scheme.latency_ms = float("inf")
+                            scheme.profile_timestamp = None
+                            num_reset_errors += 1
 
                     if pattern_schemes.schemes:
                         self.profiled_patterns.append(pattern_schemes)
@@ -804,7 +831,7 @@ class QDQAutotunerBase:
 
             logger.info(
                 f"Loaded state from {input_path} ({num_loaded_patterns} patterns, "
-                f"{num_loaded_schemes} schemes)"
+                f"{num_loaded_schemes} schemes, {num_reset_errors} error records reset for retry)"
             )
 
         base_path, ext = os.path.splitext(input_path)


### PR DESCRIPTION
# Fix autotune warm restart to retry failed schemes

## Problem

When the ONNX autotuner encounters transient errors during profiling (e.g. connection loss to the TensorRT benchmark server, build timeouts), those schemes are marked with `error=True`. On warm restart, these error schemes are treated as "already profiled" (`is_profiled` returns `True` for error schemes), so they are permanently skipped. This means a single network hiccup can block an entire pattern from ever being fully explored.

## Solution

Two changes in `autotuner_base.py`:

1. **`load_state()`**: Reset all error schemes when loading from checkpoint — clear `error` flag, reset `latency_ms` to `inf`, and clear `profile_timestamp`. This makes them "unprofiled" so they re-enter the profiling queue.

2. **`set_profile_region()`**: Before seeding from pattern cache, check if there's an existing partially-profiled entry in `profiled_patterns` (i.e. one with unprofiled schemes from the reset above). If found, reuse it instead of starting fresh, so the previously-failed schemes get retried.

## Testing

- Verified that a state file with error records loads correctly and reports the number of reset errors.
- On warm restart, regions with reset-error schemes are no longer skipped by `_is_region_profiled()`.
- Patterns with a mix of successful + previously-failed schemes correctly resume profiling the failed ones.

## Files Changed

| File | Change |
|------|--------|
| `modelopt/onnx/quantization/autotune/autotuner_base.py` | Core fix: reset errors in `load_state`, reuse partial patterns in `set_profile_region` |
| `docs/source/guides/9_autotune.rst` | Document error-retry behavior in "Resume" section and troubleshooting |
| `CHANGELOG.rst` | Add entry under 0.46 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Warm restart now automatically retries schemes that previously failed due to transient errors (connection loss, TensorRT build timeouts) instead of permanently skipping them. No manual state file cleanup needed after infrastructure failures.

* **Documentation**
  * Updated crash recovery and troubleshooting guidance to reflect automatic error recovery on resume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->