### PR TITLE
fix(megatron): handle MambaMixer conv1d refactor in importer/exporter

### DIFF
--- a/modelopt/torch/export/plugins/mcore_nemotron.py
+++ b/modelopt/torch/export/plugins/mcore_nemotron.py
@@ -59,6 +59,8 @@ nemotron_h_causal_lm_import: dict[str, CustomModuleMapping] = {
     "D": NameRemapping("backbone.layers.{}.mixer.D", REPLICATE),
     "dt_bias": NameRemapping("backbone.layers.{}.mixer.dt_bias", REPLICATE),
     "conv1d": NameRemapping("backbone.layers.{}.mixer.conv1d.", REPLICATE),
+    "conv1d_weight": NameRemapping("backbone.layers.{}.mixer.conv1d.weight", REPLICATE),
+    "conv1d_bias": NameRemapping("backbone.layers.{}.mixer.conv1d.bias", REPLICATE),
     # mapping layer_norm_weight to None tells _name_remapping to skip it;
     # the fused layer_norm_weight is loaded separately via the "fused_norm" rule.
     "in_proj": NameRemapping(
@@ -124,6 +126,8 @@ nemotron_h_causal_lm_export: dict[str, CustomModuleMapping] = {
     "D": NameRemapping("backbone.layers.{}.mixer.D"),
     "dt_bias": NameRemapping("backbone.layers.{}.mixer.dt_bias"),
     "conv1d": NameRemapping("backbone.layers.{}.mixer.conv1d."),
+    "conv1d_weight": NameRemapping("backbone.layers.{}.mixer.conv1d.weight"),
+    "conv1d_bias": NameRemapping("backbone.layers.{}.mixer.conv1d.bias"),
     "in_proj": NameRemapping("backbone.layers.{}.mixer.in_proj."),
     "out_proj": NameRemapping("backbone.layers.{}.mixer.out_proj."),
     "fused_norm": NameRemapping("backbone.layers.{}.norm.weight"),

--- a/modelopt/torch/export/plugins/megatron_importer.py
+++ b/modelopt/torch/export/plugins/megatron_importer.py
@@ -561,7 +561,12 @@ class GPTModelImporter:
         self.rules["A_log"](layer.mixer.A_log, layer_id)
         self.rules["D"](layer.mixer.D, layer_id)
         self.rules["dt_bias"](layer.mixer.dt_bias, layer_id)
-        self.rules["conv1d"](layer.mixer.conv1d, layer_id)
+        if hasattr(layer.mixer, "conv1d"):
+            self.rules["conv1d"](layer.mixer.conv1d, layer_id)
+        else:
+            self.rules["conv1d_weight"](layer.mixer.conv1d_weight, layer_id)
+            if hasattr(layer.mixer, "conv1d_bias"):
+                self.rules["conv1d_bias"](layer.mixer.conv1d_bias, layer_id)
         self.rules["in_proj"](layer.mixer.in_proj, layer_id)
         self.rules["out_proj"](layer.mixer.out_proj, layer_id)
 

--- a/modelopt/torch/export/unified_export_megatron.py
+++ b/modelopt/torch/export/unified_export_megatron.py
@@ -664,7 +664,12 @@ class GPTModelExporter:
         self.rules["D"](layer.mixer.D, layer_id)
         self.rules["dt_bias"](layer.mixer.dt_bias, layer_id)
 
-        self.rules["conv1d"](layer.mixer.conv1d, layer_id)
+        if hasattr(layer.mixer, "conv1d"):
+            self.rules["conv1d"](layer.mixer.conv1d, layer_id)
+        else:
+            self.rules["conv1d_weight"](layer.mixer.conv1d_weight, layer_id)
+            if hasattr(layer.mixer, "conv1d_bias"):
+                self.rules["conv1d_bias"](layer.mixer.conv1d_bias, layer_id)
         self.rules["in_proj"](layer.mixer.in_proj, layer_id)
         self.rules["out_proj"](layer.mixer.out_proj, layer_id)
 


### PR DESCRIPTION
## Summary

- `MambaMixer` in some Megatron-LM branches replaced the `nn.Conv1d` submodule (`self.conv1d`) with raw `nn.Parameter`s (`self.conv1d_weight` / `self.conv1d_bias`)
- Add `hasattr(layer.mixer, "conv1d")` fallback in both the import path (`megatron_importer.py`) and export path (`unified_export_megatron.py`)
- Add corresponding `conv1d_weight` / `conv1d_bias` rules to `mcore_nemotron.py` for both import and export mappings

**Backward compatible:** old Megatron-LM versions with `nn.Conv1d` hit the existing `if` branch unchanged. The `else` branch only fires when `conv1d` is absent.

## Test plan

- [x] Verified quantize step completes end-to-end on Nemotron-3-Nano-30B-A3B with refactored MambaMixer branch
- [x] Old Megatron-LM versions unaffected (fallback via `hasattr`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Mamba convolution parameter handling during model import and export, including support for alternative mixer layouts.
  * Added explicit Hugging Face ↔ Megatron Core mappings for Nemotron Mamba `conv1d_weight` and `conv1d_bias`, ensuring consistent state-dict key generation across import/export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->