### PR TITLE
feat(tools/mcp): resolve launcher dir via env override + cwd walk-up

### DIFF
--- a/tools/mcp/modelopt_mcp/bridge.py
+++ b/tools/mcp/modelopt_mcp/bridge.py
@@ -54,6 +54,85 @@ _STATUS_FAILURE_WORDS: frozenset[str] = frozenset(
 )
 
 
+def _find_launcher_dir() -> Path | None:
+    """Resolve the modelopt launcher's directory.
+
+    Tries, in order:
+
+    1. ``$MODELOPT_LAUNCHER_DIR`` env override — the deterministic
+       path agents/operators can set when the package layout doesn't
+       match the in-repo expectation.
+    2. ``_THIS_DIR.parent.parent / "launcher"`` — the in-repo layout
+       (``tools/mcp/modelopt_mcp/bridge.py`` → ``tools/launcher/``).
+       Works in dev installs (``pip install -e tools/mcp``) and in
+       direct ``Model-Optimizer`` clones.
+    3. Walk up from ``os.getcwd()`` looking for
+       ``modules/Model-Optimizer/tools/launcher/`` (intern-agent
+       workspace layout) or ``tools/launcher/`` (direct
+       Model-Optimizer checkout) at each ancestor. Stops at the
+       filesystem root.
+
+    Returns ``None`` if no candidate resolves to an existing dir.
+    Callers surface that as a structured ``launcher_dir_not_found``
+    failure with the searched paths in the diagnostic.
+
+    Empirically: when modelopt-mcp is installed via ``uv tool install``
+    (intern-agent's CI install pattern, MR !226), ``_THIS_DIR`` lives
+    inside ``~/.local/share/uv/tools/modelopt-mcp/lib/.../site-packages/``
+    and step 2's parent-walk doesn't find the launcher. Step 3 (cwd
+    walk-up) handles that case — the agent's CWD is always inside
+    its cloned nmm-sandbox workspace where ``modules/Model-Optimizer/
+    tools/launcher/`` does exist.
+    """
+    env = os.environ.get("MODELOPT_LAUNCHER_DIR")
+    if env:
+        p = Path(env)
+        if p.exists():
+            return p
+
+    # In-repo layout (dev install / direct clone)
+    candidate = _THIS_DIR.parent.parent / "launcher"
+    if candidate.exists():
+        return candidate
+
+    # cwd walk-up (uv-tool-install + agent workspace layout)
+    cwd = Path.cwd().resolve()
+    for ancestor in (cwd, *cwd.parents):
+        for rel in ("modules/Model-Optimizer/tools/launcher", "tools/launcher"):
+            candidate = ancestor / rel
+            if candidate.exists():
+                return candidate
+
+    return None
+
+
+def _launcher_dir_not_found_response(*, dry_run: bool = False) -> dict:
+    """Structured failure when ``_find_launcher_dir()`` returns None.
+
+    Centralized so the five callsites that need the launcher dir
+    return a consistent diagnostic listing the searched paths.
+    """
+    env_path = os.environ.get("MODELOPT_LAUNCHER_DIR") or "(unset)"
+    in_repo = _THIS_DIR.parent.parent / "launcher"
+    resp: dict = {
+        "ok": False,
+        "reason": "launcher_dir_not_found",
+        "diagnostic": (
+            "Could not locate tools/launcher/. Searched:\n"
+            f"  1. $MODELOPT_LAUNCHER_DIR={env_path}\n"
+            f"  2. in-repo layout: {in_repo} (exists={in_repo.exists()})\n"
+            f"  3. cwd walk-up from {Path.cwd().resolve()} looking for "
+            "modules/Model-Optimizer/tools/launcher or tools/launcher\n"
+            "Fix: set $MODELOPT_LAUNCHER_DIR to the absolute path of your "
+            "Model-Optimizer checkout's tools/launcher/, or run modelopt-mcp "
+            "from inside such a checkout."
+        ),
+    }
+    if dry_run:
+        resp["dry_run"] = True
+    return resp
+
+
 def _find_launcher_examples_dir() -> Path | None:
     """Resolve the launcher examples directory.
 
@@ -547,17 +626,9 @@ def submit_job_impl(
         argv.append(f"{k}={v}")
 
     # Run from the launcher dir so it picks up its own ./core.py etc.
-    launcher_dir = _THIS_DIR.parent.parent / "launcher"
-    if not launcher_dir.exists():
-        return {
-            "ok": False,
-            "reason": "launcher_dir_not_found",
-            "diagnostic": (
-                f"Expected tools/launcher/ at {launcher_dir} but it "
-                f"doesn't exist. modelopt-mcp must be installed from a "
-                f"Model-Optimizer clone or via uvx-from-git."
-            ),
-        }
+    launcher_dir = _find_launcher_dir()
+    if launcher_dir is None:
+        return _launcher_dir_not_found_response()
 
     # Propagate env so submit-side and status-side agree on NEMORUN_HOME.
     # Without this, `launch.py` defaults NEMORUN_HOME to its own cwd
@@ -768,18 +839,9 @@ def _submit_job_dry_run(
     for k, v in (extra_overrides or {}).items():
         argv.append(f"{k}={v}")
 
-    launcher_dir = _THIS_DIR.parent.parent / "launcher"
-    if not launcher_dir.exists():
-        return {
-            "ok": False,
-            "dry_run": True,
-            "reason": "launcher_dir_not_found",
-            "diagnostic": (
-                f"Expected tools/launcher/ at {launcher_dir} but it "
-                f"doesn't exist. modelopt-mcp must be installed from a "
-                f"Model-Optimizer clone or via uvx-from-git."
-            ),
-        }
+    launcher_dir = _find_launcher_dir()
+    if launcher_dir is None:
+        return _launcher_dir_not_found_response(dry_run=True)
 
     # Propagate env so the launcher's factory resolution matches what
     # the live submit would see (mainly: SLURM_HOST for slurm-factory
@@ -888,10 +950,15 @@ def _resolve_experiment_dir(experiment_id: str) -> Path | None:
     candidates.append(Path.cwd() / "local_experiments" / experiment_id)
     # The launcher's own experiments dir — submit_job_impl uses
     # cwd=str(launcher_dir) for the subprocess, so when NEMORUN_HOME is
-    # unset, launch.py defaults to launcher_dir/experiments/.
-    launcher_dir = _THIS_DIR.parent.parent / "launcher"
-    candidates.append(launcher_dir / "experiments" / experiment_id)
-    candidates.append(launcher_dir / "local_experiments" / experiment_id)
+    # unset, launch.py defaults to launcher_dir/experiments/. If the
+    # launcher dir can't be resolved (uv-tool-install without an
+    # override + the agent's cwd doesn't see a launcher checkout),
+    # we skip this fallback rather than crashing — the env-vs-cwd
+    # candidates above still cover the common cases.
+    launcher_dir = _find_launcher_dir()
+    if launcher_dir is not None:
+        candidates.append(launcher_dir / "experiments" / experiment_id)
+        candidates.append(launcher_dir / "local_experiments" / experiment_id)
     for c in candidates:
         if c.exists():
             return c
@@ -1214,8 +1281,8 @@ def read_cluster_artifact_impl(
             experiment_id,
             str(job_idx),
         ]
-        launcher_dir = _THIS_DIR.parent.parent / "launcher"
-        cwd = str(launcher_dir) if launcher_dir.exists() else None
+        launcher_dir = _find_launcher_dir()
+        cwd = str(launcher_dir) if launcher_dir is not None else None
         try:
             proc = subprocess.run(  # nosec B603 B607
                 argv,

--- a/tools/mcp/tests/test_bridge.py
+++ b/tools/mcp/tests/test_bridge.py
@@ -861,3 +861,102 @@ def test_open_draft_pr_gh_failed_but_branch_pushed(monkeypatch, tmp_path):
     assert result["ok"] is False
     assert result["reason"] == "gh_pr_create_failed"
     assert result["branch_pushed"] is True
+
+
+# ---------------------------------------------------------------------------
+# _find_launcher_dir — env override + walk-up search
+# ---------------------------------------------------------------------------
+
+
+def test_find_launcher_dir_env_override(monkeypatch, tmp_path):
+    """`$MODELOPT_LAUNCHER_DIR` wins over in-repo / cwd-walk."""
+    launcher = tmp_path / "custom-launcher"
+    launcher.mkdir()
+    monkeypatch.setenv("MODELOPT_LAUNCHER_DIR", str(launcher))
+    monkeypatch.chdir(tmp_path)  # ensure no walk-up match interferes
+    assert bridge._find_launcher_dir() == launcher
+
+
+def test_find_launcher_dir_env_override_missing_dir_fallthrough(monkeypatch, tmp_path):
+    """`$MODELOPT_LAUNCHER_DIR` pointing at a nonexistent path → fall through."""
+    monkeypatch.setenv("MODELOPT_LAUNCHER_DIR", str(tmp_path / "ghost"))
+    monkeypatch.chdir(tmp_path)  # no walk-up candidate
+    # In-repo candidate may or may not exist depending on test env; in
+    # the uv-tool-install case + this cwd it won't, so we get None.
+    in_repo = bridge._THIS_DIR.parent.parent / "launcher"
+    result = bridge._find_launcher_dir()
+    if in_repo.exists():
+        assert result == in_repo
+    else:
+        assert result is None
+
+
+def test_find_launcher_dir_walk_up_modules_layout(monkeypatch, tmp_path):
+    """Walk-up finds `modules/Model-Optimizer/tools/launcher/` from a deep cwd."""
+    workspace = tmp_path / "nmm-sandbox"
+    launcher = workspace / "modules" / "Model-Optimizer" / "tools" / "launcher"
+    launcher.mkdir(parents=True)
+    # Agent cwds deep inside the workspace
+    deep_cwd = workspace / "experiments" / "cicd" / "cicd_42"
+    deep_cwd.mkdir(parents=True)
+    monkeypatch.chdir(deep_cwd)
+    monkeypatch.delenv("MODELOPT_LAUNCHER_DIR", raising=False)
+
+    found = bridge._find_launcher_dir()
+    # In-repo `_THIS_DIR.parent.parent / "launcher"` may also exist in dev mode;
+    # accept either, but if it doesn't exist we MUST have walked up to find the
+    # workspace launcher.
+    in_repo = bridge._THIS_DIR.parent.parent / "launcher"
+    if in_repo.exists():
+        assert found == in_repo
+    else:
+        assert found == launcher
+
+
+def test_find_launcher_dir_walk_up_tools_layout(monkeypatch, tmp_path):
+    """Walk-up finds plain `tools/launcher/` (direct Model-Optimizer checkout)."""
+    checkout = tmp_path / "Model-Optimizer-clone"
+    launcher = checkout / "tools" / "launcher"
+    launcher.mkdir(parents=True)
+    deep_cwd = checkout / "examples" / "speculative_decoding"
+    deep_cwd.mkdir(parents=True)
+    monkeypatch.chdir(deep_cwd)
+    monkeypatch.delenv("MODELOPT_LAUNCHER_DIR", raising=False)
+
+    found = bridge._find_launcher_dir()
+    in_repo = bridge._THIS_DIR.parent.parent / "launcher"
+    if in_repo.exists():
+        assert found == in_repo
+    else:
+        assert found == launcher
+
+
+def test_find_launcher_dir_returns_none_when_nothing_found(monkeypatch, tmp_path):
+    """No env, no in-repo, no walk-up candidate → None."""
+    monkeypatch.delenv("MODELOPT_LAUNCHER_DIR", raising=False)
+    isolated = tmp_path / "iso"
+    isolated.mkdir()
+    monkeypatch.chdir(isolated)
+    found = bridge._find_launcher_dir()
+    # In a dev-install test env, the in-repo path may resolve. Accept
+    # either None or that specific path — but NEVER something unrelated.
+    in_repo = bridge._THIS_DIR.parent.parent / "launcher"
+    assert found is None or found == in_repo
+
+
+def test_launcher_dir_not_found_response_shape():
+    """Helper returns the canonical structured-failure dict."""
+    resp = bridge._launcher_dir_not_found_response()
+    assert resp["ok"] is False
+    assert resp["reason"] == "launcher_dir_not_found"
+    assert "Searched" in resp["diagnostic"]
+    assert "MODELOPT_LAUNCHER_DIR" in resp["diagnostic"]
+    assert "dry_run" not in resp
+
+
+def test_launcher_dir_not_found_response_dry_run_flag():
+    """`dry_run=True` adds `dry_run: True` to the response."""
+    resp = bridge._launcher_dir_not_found_response(dry_run=True)
+    assert resp["ok"] is False
+    assert resp["dry_run"] is True
+    assert resp["reason"] == "launcher_dir_not_found"


### PR DESCRIPTION
## Summary

Fixes Symptom A of [OMNIML-5151](https://jirasw.nvidia.com/browse/OMNIML-5151): the bridge's launcher-dir resolution doesn't work in `uv tool install` layouts (which is how the intern-agent CI installs modelopt-mcp). Empirically validated by nmm-sandbox pipelines [54755376](https://gitlab-master.nvidia.com/omniml/integration/nmm-sandbox/-/pipelines/54755376) and [54829964](https://gitlab-master.nvidia.com/omniml/integration/nmm-sandbox/-/pipelines/54829964) — the agent reached for `mcp__modelopt__submit_job`, got `launcher_dir_not_found`, fell back to shell.

## Root cause

5 sites used:

```python
launcher_dir = _THIS_DIR.parent.parent / "launcher"
```

Works in:
- `pip install -e tools/mcp` (dev) — `_THIS_DIR` is `<repo>/tools/mcp/modelopt_mcp/`
- Direct `Model-Optimizer` clone — same path

Doesn't work in:
- `uv tool install --from "git+...#subdirectory=tools/mcp" modelopt-mcp` — `_THIS_DIR` is `~/.local/share/uv/tools/modelopt-mcp/lib/.../site-packages/modelopt_mcp/` and `parent.parent` doesn't reach a launcher

## How

New `_find_launcher_dir()` helper resolves in this order:

1. `$MODELOPT_LAUNCHER_DIR` env override (deterministic)
2. `_THIS_DIR.parent.parent / "launcher"` (in-repo layout)
3. Walk up from `os.getcwd()` looking for `modules/Model-Optimizer/tools/launcher` (agent workspace) or `tools/launcher` (direct clone)

Step 3 specifically unblocks intern-agent: the agent's cwd is inside its cloned nmm-sandbox workspace where `modules/Model-Optimizer/tools/launcher/` does exist — just needs the walk-up.

Centralizes the structured-failure response too — five callsites had slightly different `launcher_dir_not_found` shapes; new `_launcher_dir_not_found_response()` helper produces a consistent dict listing the searched paths so the next failure is obvious.

## Sites updated

- `submit_job_impl` — live submission
- `_submit_job_dry_run` — dry-run validation
- `_resolve_experiment_dir` — soft fallback (was crashing on `None.exists()` before)
- `read_cluster_artifact_impl` — cwd for `nemo experiment logs`

## Tests

7 new hermetic tests in `tests/test_bridge.py`:

- env override wins
- env-points-at-ghost falls through gracefully
- walk-up via `modules/Model-Optimizer/tools/launcher`
- walk-up via plain `tools/launcher`
- returns `None` when nothing is found
- structured-failure response shape (with and without `dry_run` flag)

All 45 tests pass (38 + 7 new). Pre-commit clean (ruff / mypy / bandit / license-headers).

## Out of scope

Symptom B of OMNIML-5151 — `NEMORUN_HOME` env not propagated to MCP subprocess, affecting `job_status` / `wait_for_experiment` / `read_cluster_artifact(path=None)`. That's a cross-repo change in pensieve-harness's `mcp_config` writer + pensieve-modelopt's `intern_runner`. Follow-up PR.

## Anchors

- [OMNIML-5151](https://jirasw.nvidia.com/browse/OMNIML-5151) — bug ticket
- [OMNIML-5142](https://jirasw.nvidia.com/browse/OMNIML-5142) (install + register), [OMNIML-5144](https://jirasw.nvidia.com/browse/OMNIML-5144) (SPEC migration), [OMNIML-5123](https://jirasw.nvidia.com/browse/OMNIML-5123) (Epic)
- nmm-sandbox MR !226 (CI install), !232 (PATH fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced launcher directory discovery mechanism with support for environment variable overrides and multiple search paths
  * Improved error diagnostics when launcher directory cannot be resolved

* **Tests**
  * Added comprehensive test coverage for launcher directory discovery and failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->