### PR TITLE
[OMNIML-5024] cell_t0_d3

### DIFF
--- a/tools/launcher/common/specdec_bench/_cells/gemma-4-E4B-it_mtp_vllm_t0_d3.yaml
+++ b/tools/launcher/common/specdec_bench/_cells/gemma-4-E4B-it_mtp_vllm_t0_d3.yaml
@@ -1,0 +1,4 @@
+sampling_kwargs:
+  temperature: 0
+engine_args:
+  max_model_len: 40960

--- a/tools/launcher/examples/google/gemma-4-E4B-it/specdec_bench_mtp_vllm.yaml
+++ b/tools/launcher/examples/google/gemma-4-E4B-it/specdec_bench_mtp_vllm.yaml
@@ -1,13 +1,13 @@
 # SPEED-bench MTP speculative-decoding run for gemma-4-E4B-it via vLLM.
 #
 # Gemma 4 MTP support landed in vLLM PR vllm-project/vllm#41745 (2026-05-06)
-# and is in ``vllm/vllm-openai:v0.22.1`` (and later). Gemma 4 MTP uses a
-# separate assistant model passed via ``--draft_model_dir``; vLLM
-# auto-detects Gemma 4 from the assistant and does NOT take a ``method``
-# key in ``speculative_config``. The wrapper at
-# ``examples/specdec_bench/specdec_bench/models/vllm.py`` routes to the
-# assistant-model config shape when ``--speculative_algorithm MTP`` is
-# paired with ``--draft_model_dir``.
+# and is in the Gemma-specific vLLM image. Gemma 4 MTP uses a
+# separate assistant model passed via ``--draft_model_dir``. The wrapper at
+# ``examples/specdec_bench/specdec_bench/models/vllm.py`` emits
+# ``method=mtp`` plus the assistant model for this family.
+#
+# Use ``vllm/vllm-openai:gemma`` for this family; generic vLLM images can
+# fail Gemma 4 MTP startup or long-context throughput runs.
 #
 # Assistant model: ``google/gemma-4-E4B-it-assistant`` (public, ungated).
 #
@@ -52,7 +52,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: vllm/vllm-openai:v0.22.1
+      container: vllm/vllm-openai:gemma
 
   # task_1: SPEED throughput_32k split
   task_1:
@@ -80,4 +80,4 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: vllm/vllm-openai:v0.22.1
+      container: vllm/vllm-openai:gemma


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-5024](https://jirasw.nvidia.com/browse/OMNIML-5024).

Stage `cell_t0_d3` of Epic `OMNIML-5022`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._

_Pollution-strip removed `INTERN_LEARNING_TICKET.md` from this commit (sidecar narration and/or incidental lockfile regeneration are never part of the agent's intended deliverable)._