### PR TITLE
launcher: gemma-4-E4B-it MTP — switch vLLM image to vllm-openai:gemma

### DIFF
--- a/tools/launcher/examples/google/gemma-4-E4B-it/specdec_bench_mtp_vllm.yaml
+++ b/tools/launcher/examples/google/gemma-4-E4B-it/specdec_bench_mtp_vllm.yaml
@@ -1,13 +1,14 @@
 # SPEED-bench MTP speculative-decoding run for gemma-4-E4B-it via vLLM.
 #
 # Gemma 4 MTP support landed in vLLM PR vllm-project/vllm#41745 (2026-05-06)
-# and is in ``vllm/vllm-openai:v0.22.1`` (and later). Gemma 4 MTP uses a
-# separate assistant model passed via ``--draft_model_dir``; vLLM
-# auto-detects Gemma 4 from the assistant and does NOT take a ``method``
-# key in ``speculative_config``. The wrapper at
-# ``examples/specdec_bench/specdec_bench/models/vllm.py`` routes to the
-# assistant-model config shape when ``--speculative_algorithm MTP`` is
-# paired with ``--draft_model_dir``.
+# and is in the Gemma-specific vLLM image. Gemma 4 MTP uses a
+# separate assistant model passed via ``--draft_model_dir``. The wrapper at
+# ``examples/specdec_bench/specdec_bench/models/vllm.py`` emits
+# ``method=mtp`` plus the assistant model for this family.
+#
+# Use ``vllm/vllm-openai:gemma`` for this family; generic vLLM images
+# (``v0.22.1`` and similar) fail Gemma 4 MTP engine startup. Surfaced
+# 2026-06-15 on OMNIML-5025 cell_t0_d7 (intern-agent job 341631795).
 #
 # Assistant model: ``google/gemma-4-E4B-it-assistant`` (public, ungated).
 #
@@ -52,7 +53,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: vllm/vllm-openai:v0.22.1
+      container: vllm/vllm-openai:gemma
 
   # task_1: SPEED throughput_32k split
   task_1:
@@ -80,4 +81,4 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: vllm/vllm-openai:v0.22.1
+      container: vllm/vllm-openai:gemma


### PR DESCRIPTION
## What

Switch the gemma-4-E4B-it specdec_bench_mtp_vllm parent YAML from `vllm/vllm-openai:v0.22.1` to `vllm/vllm-openai:gemma` (both task_0 and task_1).

## Why

`v0.22.1` fails Gemma 4 MTP engine startup with an assertion error. The Gemma-specific image (`vllm-openai:gemma`) ships the patches Gemma 4 MTP needs; same image was used successfully on the sister cell (OMNIML-5024 cell_t0_d3, branch `pensieve-intern/OMNIML-5023/t0_d3`).

## How surfaced

Diagnosed 2026-06-15 on OMNIML-5025 cell_t0_d7 ([intern-agent job 341631795](https://gitlab-master.nvidia.com/omniml/integration/nmm-sandbox/-/jobs/341631795)):

1. Agent submitted via the parent YAML with `v0.22.1`
2. Task 0 failed at vLLM engine init with an assertion error
3. Agent diff'd against the sister branch, identified the working image, patched locally, and resubmitted successfully

This PR applies the same patch to `main` so the next cell to dispatch doesn't re-derive the workaround.

## Doc-comment also updated

Replaces the misleading "`v0.22.1` (and later)" claim with the actual image name + a footnote citing the failure surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemma 4 MTP launcher support by updating configuration to ensure proper engine initialization and prevent startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->