### PR TITLE
[OMNIML-5025] cell_t0_d7

### DIFF
--- a/tools/launcher/examples/google/gemma-4-E4B-it/specdec_bench_mtp_vllm.yaml
+++ b/tools/launcher/examples/google/gemma-4-E4B-it/specdec_bench_mtp_vllm.yaml
@@ -1,13 +1,13 @@
 # SPEED-bench MTP speculative-decoding run for gemma-4-E4B-it via vLLM.
 #
 # Gemma 4 MTP support landed in vLLM PR vllm-project/vllm#41745 (2026-05-06)
-# and is in ``vllm/vllm-openai:v0.22.1`` (and later). Gemma 4 MTP uses a
-# separate assistant model passed via ``--draft_model_dir``; vLLM
-# auto-detects Gemma 4 from the assistant and does NOT take a ``method``
-# key in ``speculative_config``. The wrapper at
-# ``examples/specdec_bench/specdec_bench/models/vllm.py`` routes to the
-# assistant-model config shape when ``--speculative_algorithm MTP`` is
-# paired with ``--draft_model_dir``.
+# and is in the Gemma-specific vLLM image. Gemma 4 MTP uses a
+# separate assistant model passed via ``--draft_model_dir``. The wrapper at
+# ``examples/specdec_bench/specdec_bench/models/vllm.py`` emits
+# ``method=mtp`` plus the assistant model for this family.
+#
+# Use ``vllm/vllm-openai:gemma`` for this family; generic vLLM images can
+# fail Gemma 4 MTP startup or long-context throughput runs.
 #
 # Assistant model: ``google/gemma-4-E4B-it-assistant`` (public, ungated).
 #
@@ -52,7 +52,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: vllm/vllm-openai:v0.22.1
+      container: vllm/vllm-openai:gemma
 
   # task_1: SPEED throughput_32k split
   task_1:
@@ -80,4 +80,4 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: vllm/vllm-openai:v0.22.1
+      container: vllm/vllm-openai:gemma


### PR DESCRIPTION
Draft PR opened by **pensieve-intern** for [OMNIML-5025](https://jirasw.nvidia.com/browse/OMNIML-5025).

Stage `cell_t0_d7` of Epic `OMNIML-5022`. The agent ran from the SPEC on the ticket description; review every change before marking ready.

_Always-draft is enforced — the bot never auto-merges._

---

**Agent's self-narration** (stripped from PR diff; surfaced here for context):

`INTERN_ARTIFACTS.json`:
```
{
  "sweep_name": "gemma-4-E4B-it_mtp_vllm_t0_d7",
  "experiment_id": "cicd_1781548540",
  "experiment_dir": "/lustre/fsw/portfolios/coreai/projects/coreai_dlalgo_modelopt/cicd/cicd/cicd_1781548540/",
  "AL_qualitative_overall": 3.2945,
  "AL_qualitative_categories": {
    "coding": 4.8883,
    "humanities": 2.703,
    "math": 4.1139,
    "multilingual": 4.1401,
    "qa": 2.59,
    "rag": 3.9329,
    "reasoning": 3.6251,
    "roleplay": 1.8026,
    "stem": 3.2041,
    "summarization": 2.8275,
    "writing": 2.4118
  },
  "AL_throughput_32k_overall": 3.3803,
  "AL_throughput_32k_categories": {
    "high_entropy": 2.0839,
    "low_entropy": 4.3797,
    "mixed": 3.7143
  }
}
```

`VERIFICATION_COMMENT.txt`:
```
Completed OMNIML-5025 cell_t0_d7 for `google/gemma-4-E4B-it` / MTP / vLLM.

What was done:
- Authored/kept `tools/launcher/common/specdec_bench/_cells/gemma-4-E4B-it_mtp_vllm_t0_d7.yaml` for sweep `gemma-4-E4B-it_mtp_vllm_t0_d7`.
- Updated/kept `tools/launcher/examples/google/gemma-4-E4B-it/specdec_bench_mtp_vllm.yaml` with the Gemma-specific `vllm/vllm-openai:gemma` container after generic v0.22.1 failed startup.
- Verified HF Hub model endpoints for `google/gemma-4-E4B-it` and `google/gemma-4-E4B-it-assistant` returned HTTP 200.
- Wrote `INTERN_ARTIFACTS.json` with parsed AL metrics from the successful cluster run.

Metrics extracted:
- experiment_id: `cicd_1781548540`
- experiment_dir: `/lustre/fsw/portfolios/coreai/projects/coreai_dlalgo_modelopt/cicd/cicd/cicd_1781548540/`
- qualitative Average_AL: `3.2945`
- throughput_32k Average_AL: `3.3803`

PR status:
- PR opened: NONE — this runner prompt says not to commit, push, or create PRs because the runner handles that.

What's next:
- Engine should consume `INTERN_ARTIFACTS.json` and advance the downstream wrap-up/aggregation stage.

Trigger pipeline URL:
- `https://gitlab-master.nvidia.com/omniml/integration/nmm-sandbox/-/pipelines/54841359`

Slurm job status:
- submission: completed successfully
- experiment_id: `cicd_1781548540`
- experiment_dir: `/lustre/fsw/portfolios/coreai/projects/coreai_dlalgo_modelopt/cicd/cicd/cicd_1781548540/`
```



_Pollution-strip removed `INTERN_ARTIFACTS.json`, `INTERN_LEARNING_TICKET.md`, `VERIFICATION_COMMENT.txt` from this commit (sidecar narration and/or incidental lockfile regeneration are never part of the agent's intended deliverable)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark configuration to use an optimized container image for Gemma 4 MTP speculative-decoding benchmarks.
  * Revised documentation in the configuration to reflect the current image and its capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->