### PR TITLE
Remove unsafe torch.load from examples/diffusers/fastgen

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,7 @@ modelopt/torch @NVIDIA/modelopt-torch-codeowners
 modelopt/torch/_deploy @NVIDIA/modelopt-torch-deploy-codeowners
 modelopt/torch/distill @NVIDIA/modelopt-torch-distill-codeowners
 modelopt/torch/export @NVIDIA/modelopt-torch-export-codeowners
+modelopt/torch/fastgen @NVIDIA/modelopt-torch-fastgen-codeowners
 modelopt/torch/nas @NVIDIA/modelopt-torch-nas-prune-codeowners
 modelopt/torch/opt @NVIDIA/modelopt-torch-opt-codeowners
 modelopt/torch/peft @NVIDIA/modelopt-torch-peft-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,6 @@ modelopt/torch @NVIDIA/modelopt-torch-codeowners
 modelopt/torch/_deploy @NVIDIA/modelopt-torch-deploy-codeowners
 modelopt/torch/distill @NVIDIA/modelopt-torch-distill-codeowners
 modelopt/torch/export @NVIDIA/modelopt-torch-export-codeowners
-modelopt/torch/fastgen @NVIDIA/modelopt-torch-fastgen-codeowners
 modelopt/torch/nas @NVIDIA/modelopt-torch-nas-prune-codeowners
 modelopt/torch/opt @NVIDIA/modelopt-torch-opt-codeowners
 modelopt/torch/peft @NVIDIA/modelopt-torch-peft-codeowners

--- a/examples/diffusers/fastgen/dmd2_recipe.py
+++ b/examples/diffusers/fastgen/dmd2_recipe.py
@@ -666,12 +666,12 @@ class DMD2DiffusionRecipe(TrainDiffusionRecipe):
             )
 
         if os.path.isfile(ema_path) and self._dmd_pipeline.ema is not None:
-            ema_state = torch.load(ema_path, map_location="cpu", weights_only=False)
+            ema_state = torch.load(ema_path, map_location="cpu")
             self._dmd_pipeline.ema.load_state_dict(ema_state)
             if is_main_process():
                 logging.info("[DMD2] restored ema_shadow <- %s", ema_path)
         if os.path.isfile(state_path):
-            state = torch.load(state_path, map_location="cpu", weights_only=False)
+            state = torch.load(state_path, map_location="cpu")
             self._dmd_pipeline._iteration = int(state.get("iteration", 0))
             if is_main_process():
                 logging.info(
@@ -684,7 +684,7 @@ class DMD2DiffusionRecipe(TrainDiffusionRecipe):
         if self._discriminator is not None:
             disc_path = os.path.join(ckpt_dir, "discriminator.pt")
             if os.path.isfile(disc_path):
-                disc_state = torch.load(disc_path, map_location="cpu", weights_only=False)
+                disc_state = torch.load(disc_path, map_location="cpu")
                 self._discriminator.load_state_dict(disc_state)
                 if is_main_process():
                     logging.info("[DMD2] restored discriminator <- %s", disc_path)
@@ -693,7 +693,7 @@ class DMD2DiffusionRecipe(TrainDiffusionRecipe):
         if self._discriminator_optimizer is not None:
             disc_opt_path = os.path.join(ckpt_dir, "discriminator_optimizer.pt")
             if os.path.isfile(disc_opt_path):
-                disc_opt_state = torch.load(disc_opt_path, map_location="cpu", weights_only=False)
+                disc_opt_state = torch.load(disc_opt_path, map_location="cpu")
                 self._discriminator_optimizer.load_state_dict(disc_opt_state)
                 if is_main_process():
                     logging.info("[DMD2] restored discriminator optimizer <- %s", disc_opt_path)

--- a/examples/diffusers/fastgen/inference_dmd2_qwen_image.py
+++ b/examples/diffusers/fastgen/inference_dmd2_qwen_image.py
@@ -150,7 +150,7 @@ class QwenImageDMDInferencePipeline:
 
         if ema_path is not None:
             logger.info("[DMD2-Inference] Overlaying EMA shadow from %s", ema_path)
-            ema_state = torch.load(str(ema_path), map_location="cpu", weights_only=False)
+            ema_state = torch.load(str(ema_path), map_location="cpu")
             shadow = (
                 ema_state.get("shadow", ema_state) if isinstance(ema_state, dict) else ema_state
             )


### PR DESCRIPTION
Follow-up to #1326 - Remove unsafe `torch.load(..., weights_only=False)` in `examples/diffusers/fastgen`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated checkpoint loading mechanisms in FastGen examples to improve compatibility and reliability during model restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->