### PR TITLE
fix(autocast): add missing guard for use_standalone_type_inference

### DIFF
--- a/modelopt/onnx/autocast/precisionconverter.py
+++ b/modelopt/onnx/autocast/precisionconverter.py
@@ -330,9 +330,10 @@ class PrecisionConverter:
             else:
                 for vi in g.value_info:
                     vi.type.tensor_type.elem_type = onnx.TensorProto.UNDEFINED
-                    for idx, d in enumerate(vi.type.tensor_type.shape.dim):
-                        if d.dim_value:
-                            vi.type.tensor_type.shape.dim[idx].dim_param = "unk"
+                    if not self.use_standalone_type_inference:
+                        for idx, d in enumerate(vi.type.tensor_type.shape.dim):
+                            if d.dim_value:
+                                vi.type.tensor_type.shape.dim[idx].dim_param = "unk"
 
             # Clear outputs for both main graph and subgraphs
             for out in g.output:


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Adds a missing check for `use_standalone_type_inference` in AutoCast which can cause shape issues because some dims are replaces with `unk`.

### Testing
I have tested this with a model that previously failed after AutoCast conversion with the following error, but succeeds with this patch:

```
onnxruntime.capi.onnxruntime_pybind11_state.RuntimeException: [ONNXRuntimeError] : 6 : RUNTIME_EXCEPTION : Non-zero status code returned while running LayerNormalization node. Name:'node_layer_norm' Status Message: /onnxruntime_src/onnxruntime/core/framework/op_kernel.cc:83 virtual OrtValue* onnxruntime::OpKernelContext::OutputMLValue(int, const onnxruntime::TensorShape&) status.IsOK() was false. Shape mismatch attempting to re-use buffer. {1,1,768} != {1,261,768}. Validate usage of dim_value (values should be > 0) and dim_param (all values with the same string should equate to the same size) in shapes in the model.
```

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: N/A
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference accuracy when standalone type inference is enabled, ensuring proper handling of tensor dimensions in ONNX models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->