### PR TITLE
Fix Step3.5 HF export RoPE metadata

### DIFF
--- a/modelopt/torch/export/plugins/__init__.py
+++ b/modelopt/torch/export/plugins/__init__.py
@@ -15,16 +15,26 @@
 
 """Export package plugin."""
 
+from typing import Any
+
 from modelopt.torch.utils import import_plugin
 
 with import_plugin("megatron_importer"):
     from .megatron_importer import *
 
 from .hf_spec_export import *
+
+with import_plugin("hf_checkpoint_utils"):
+    from .hf_checkpoint_utils import *
+
+if "sanitize_hf_config_for_deployment" not in globals():
+
+    def sanitize_hf_config_for_deployment(config_data: dict[str, Any], model: Any) -> None:
+        """No-op fallback when Hugging Face checkpoint utilities are unavailable."""
+        return None
+
+
 from .vllm_fakequant_hf import *
 
 with import_plugin("vllm_fakequant_megatron"):
     from .vllm_fakequant_megatron import *
-
-with import_plugin("hf_checkpoint_utils"):
-    from .hf_checkpoint_utils import *

--- a/modelopt/torch/export/plugins/hf_checkpoint_utils.py
+++ b/modelopt/torch/export/plugins/hf_checkpoint_utils.py
@@ -19,6 +19,7 @@ import json
 import os
 import shutil
 from pathlib import Path
+from typing import Any
 
 import torch
 from huggingface_hub import snapshot_download
@@ -165,3 +166,35 @@ def copy_non_safetensor_files_from_ckpt(src: str | os.PathLike, dst: str | os.Pa
         if entry.endswith(".safetensors") or entry == "model.safetensors.index.json":
             continue
         shutil.copy2(sp, dst)
+
+
+def _get_rope_theta(config_data: dict[str, Any], model: Any) -> Any:
+    rope_theta = config_data.get("rope_theta")
+    if rope_theta is not None:
+        return rope_theta
+
+    model_config = getattr(model, "config", None)
+    if model_config is None:
+        return None
+
+    return getattr(model_config, "rope_theta", None)
+
+
+def _sanitize_llama3_rope_config(config_data: dict[str, Any], model: Any) -> None:
+    rope_theta = _get_rope_theta(config_data, model)
+    if rope_theta is None:
+        return
+
+    for key in ("rope_parameters", "rope_scaling"):
+        rope_config = config_data.get(key)
+        if not isinstance(rope_config, dict):
+            continue
+
+        rope_type = rope_config.get("rope_type", rope_config.get("type"))
+        if rope_type == "llama3" and "rope_theta" not in rope_config:
+            rope_config["rope_theta"] = rope_theta
+
+
+def sanitize_hf_config_for_deployment(config_data: dict[str, Any], model: Any) -> None:
+    """Sanitize exported Hugging Face config metadata for deployment runtimes."""
+    _sanitize_llama3_rope_config(config_data, model)

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -90,7 +90,7 @@ from .model_config import (
 )
 from .model_utils import get_language_model_from_vl, is_multimodal_model
 from .moe_utils import _export_fused_experts
-from .plugins import SpeculativeDecodingExporter, has_spec_opt
+from .plugins import SpeculativeDecodingExporter, has_spec_opt, sanitize_hf_config_for_deployment
 from .quant_utils import (
     fuse_prequant_layernorm,
     fuse_prequant_to_linear,
@@ -1380,6 +1380,8 @@ def export_hf_checkpoint(
 
         with open(original_config) as file:
             config_data = json.load(file)
+
+        sanitize_hf_config_for_deployment(config_data, model)
 
         if hf_quant_config is not None:
             config_data["quantization_config"] = hf_quant_config

--- a/tests/unit/torch/export/test_hf_checkpoint_utils.py
+++ b/tests/unit/torch/export/test_hf_checkpoint_utils.py
@@ -15,6 +15,7 @@
 
 """Tests for modelopt/torch/export/plugins/hf_checkpoint_utils.py"""
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -23,7 +24,7 @@ pytest.importorskip("huggingface_hub")
 hf_hub_errors = pytest.importorskip("huggingface_hub.errors")
 LocalEntryNotFoundError = hf_hub_errors.LocalEntryNotFoundError
 
-from modelopt.torch.export import copy_hf_ckpt_remote_code
+from modelopt.torch.export import copy_hf_ckpt_remote_code, sanitize_hf_config_for_deployment
 
 
 def test_copy_hf_ckpt_remote_code_local_dir(tmp_path):
@@ -118,3 +119,86 @@ def test_copy_hf_ckpt_remote_code_hub_id_offline_missing_cache_raises(tmp_path, 
         pytest.raises(RuntimeError, match="HF_HUB_OFFLINE"),
     ):
         copy_hf_ckpt_remote_code("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", tmp_path / "dst")
+
+
+def test_sanitize_hf_config_for_deployment_adds_rope_theta_to_llama3_rope_parameters():
+    """Transformers 5.x requires rope_theta inside llama3 rope_parameters."""
+    config_data = {
+        "rope_theta": 500000,
+        "rope_parameters": {
+            "rope_type": "llama3",
+            "factor": 8.0,
+            "original_max_position_embeddings": 4096,
+            "low_freq_factor": 1.0,
+            "high_freq_factor": 4.0,
+        },
+    }
+
+    sanitize_hf_config_for_deployment(config_data, SimpleNamespace(config=SimpleNamespace()))
+
+    assert config_data["rope_parameters"]["rope_theta"] == 500000
+
+
+def test_sanitize_hf_config_for_deployment_uses_model_rope_theta_for_rope_parameters():
+    """Use model.config.rope_theta when save_pretrained omits the top-level field."""
+    config_data = {
+        "rope_parameters": {
+            "rope_type": "llama3",
+            "factor": 8.0,
+            "original_max_position_embeddings": 4096,
+            "low_freq_factor": 1.0,
+            "high_freq_factor": 4.0,
+        },
+    }
+    model = SimpleNamespace(config=SimpleNamespace(rope_theta=500000))
+
+    sanitize_hf_config_for_deployment(config_data, model)
+
+    assert config_data["rope_parameters"]["rope_theta"] == 500000
+
+
+def test_sanitize_hf_config_for_deployment_adds_rope_theta_to_llama3_rope_scaling():
+    """Legacy rope_scaling metadata is normalized for llama3 configs as well."""
+    config_data = {
+        "rope_scaling": {
+            "type": "llama3",
+            "factor": 8.0,
+            "original_max_position_embeddings": 4096,
+            "low_freq_factor": 1.0,
+            "high_freq_factor": 4.0,
+        },
+    }
+    model = SimpleNamespace(config=SimpleNamespace(rope_theta=500000))
+
+    sanitize_hf_config_for_deployment(config_data, model)
+
+    assert config_data["rope_scaling"]["rope_theta"] == 500000
+
+
+def test_sanitize_hf_config_for_deployment_keeps_existing_rope_theta():
+    """Existing rope_theta in rope metadata is not overwritten."""
+    config_data = {
+        "rope_theta": 500000,
+        "rope_parameters": {
+            "rope_type": "llama3",
+            "rope_theta": 1000000,
+        },
+    }
+
+    sanitize_hf_config_for_deployment(config_data, SimpleNamespace(config=SimpleNamespace()))
+
+    assert config_data["rope_parameters"]["rope_theta"] == 1000000
+
+
+def test_sanitize_hf_config_for_deployment_ignores_non_llama3_rope_parameters():
+    """Only llama3 RoPE parameters need the Transformers 5.x compatibility fix."""
+    config_data = {
+        "rope_theta": 500000,
+        "rope_parameters": {
+            "rope_type": "default",
+        },
+    }
+
+    sanitize_hf_config_for_deployment(config_data, SimpleNamespace(config=SimpleNamespace()))
+
+    assert "rope_theta" not in config_data["rope_parameters"]


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fixes exported Step-3.5 Hugging Face checkpoints for Transformers 5.x/vLLM by adding `rope_theta` to `llama3` RoPE metadata when `save_pretrained()` emits `rope_parameters` or `rope_scaling` without that required key.

Transformers 5.10.2 validates `rope_parameters` during config construction and raises:

```text
KeyError: "Missing required keys in `rope_parameters` for 'rope_type'='llama3': {'rope_theta'}"
```

The sanitizer uses `config.json["rope_theta"]` when present, otherwise falls back to `model.config.rope_theta`.

### Usage

Export Step-3.5 HF checkpoints as usual with `hf_ptq.py`, then serve the exported checkpoint with vLLM/Transformers 5.x.

### Testing

- `pre-commit run ruff-format --files modelopt/torch/export/plugins/hf_checkpoint_utils.py modelopt/torch/export/plugins/__init__.py modelopt/torch/export/unified_export_hf.py tests/unit/torch/export/test_hf_checkpoint_utils.py`
- `pre-commit run ruff-check --files modelopt/torch/export/plugins/hf_checkpoint_utils.py modelopt/torch/export/plugins/__init__.py modelopt/torch/export/unified_export_hf.py tests/unit/torch/export/test_hf_checkpoint_utils.py`
- `pre-commit run mypy --files modelopt/torch/export/plugins/hf_checkpoint_utils.py modelopt/torch/export/plugins/__init__.py modelopt/torch/export/unified_export_hf.py tests/unit/torch/export/test_hf_checkpoint_utils.py`
- `pre-commit run mypy --all-files`
- `PYTHONPATH=/private/tmp/modelopt-step35-rope-fix python -m pytest tests/unit/torch/export/test_hf_checkpoint_utils.py -vv`
- Config-load E2E with Transformers 5.10.2 and a minimal vLLM Step3p5Config reproduction:
  - unsanitized config reproduced the reported `Missing required keys ... {'rope_theta'}` error
  - sanitized config loaded successfully with `rope_parameters["rope_theta"] == 500000`

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information

This is separate from PR #1693. PR #1693 handles `layer_types` length sanitization; this PR handles the earlier Step-3.5 RoPE config validation failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration sanitization for Hugging Face model exports to properly adjust LLaMA3 RoPE parameters and rope_theta values during the export process.

* **Tests**
  * Added comprehensive unit tests covering configuration sanitization scenarios, including rope_theta injection, parameter metadata updates, and non-LLaMA3 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->