### PR TITLE
Mitigate CVE-2026-4372 transformers `kernels` RCE exposure

### DIFF
--- a/examples/gpt-oss/requirements.txt
+++ b/examples/gpt-oss/requirements.txt
@@ -1,3 +1,5 @@
 kernels>=0.9.0,<0.13
 trackio<0.21
+# transformers>=5.3 avoids CVE-2026-4372 (RCE via the `kernels` Hub download path, which this example installs)
+transformers>=5.3
 trl>=0.21.0

--- a/modelopt/torch/__init__.py
+++ b/modelopt/torch/__init__.py
@@ -16,6 +16,7 @@
 """Model optimization and deployment subpackage for torch."""
 
 import importlib
+import importlib.util
 import warnings as _warnings
 
 from packaging.version import Version as _Version
@@ -50,6 +51,15 @@ try:
         _warnings.warn(
             f"transformers {_transformers_version} is not tested with current version of modelopt and may cause issues."
             " Please install recommended version with `pip install -U nvidia-modelopt[hf]` if working with HF models.",
+        )
+
+    # CVE-2026-4372: transformers<5.3 + the optional `kernels` package allows remote code execution
+    # when loading untrusted models via the Hub kernel-download path. Fixed in 5.3.0. Only warn if
+    # `kernels` is actually installed, since ModelOpt's core install never pulls it in.
+    if _Version(_transformers_version) < _Version("5.3") and importlib.util.find_spec("kernels"):
+        _warnings.warn(
+            f"transformers {_transformers_version} with the `kernels` package is affected by"
+            ' CVE-2026-4372; consider `pip install -U "transformers>=5.3"` when loading untrusted models.',
         )
 except ImportError:
     pass


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix (security)

[CVE-2026-4372](https://nvd.nist.gov/vuln/detail/CVE-2026-4372): `transformers` versions `4.56.0`–`5.2.x` allow remote code execution when loading an untrusted model — a crafted `_attn_implementation_internal` field in `config.json` triggers an implicit kernel download/import from the Hub on a routine `from_pretrained()` call (bypassing `trust_remote_code=False`). It only triggers when the **optional `kernels` package** is installed, and is fixed in `transformers>=5.3`.

ModelOpt's own code does not use the vulnerable path, and ModelOpt's core install never pulls in `kernels`. The only place that does is the `examples/gpt-oss` example (it needs the Hub MXFP4 kernels). So:

- **Pin `transformers>=5.3` in `examples/gpt-oss/requirements.txt`** — the one environment that installs `kernels`, closing the CVE where both preconditions can coincide.
- **Add a runtime warning in `modelopt.torch`**, gated on `kernels` being importable, for affected `transformers<5.3`. The gate keeps it quiet for the majority of users (who don't have `kernels`) and only nudges genuinely-exposed setups, wherever they obtained `kernels`.

The global `transformers>=4.56,<5.10` constraint is intentionally **not** tightened, to avoid forcing all users (including the `transformers` 4.x line, which has no patched release) off their current version.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A <!-- import-time warning gated on optional dep; no new test infra added -->
- Did you update Changelog?: N/A <!-- intentionally omitted -->
- Did you get Claude approval on this PR?: TODO

### Additional Information

ModelOpt source uses no vulnerable code path (no `kernels` / `hub_kernels` import; only sets `_attn_implementation` to safe local values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)