### PR TITLE
[minor] Pre-build CUDA quantization extensions before unit tests run

### DIFF
--- a/tests/unit/torch/quantization/conftest.py
+++ b/tests/unit/torch/quantization/conftest.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+
+@pytest.fixture(scope="package", autouse=True)
+def _warm_cuda_extensions():
+    """Build the JIT CUDA quantization extensions once, before any test in this package runs.
+
+    Some quantization tests (e.g. NVFP4/MX dynamic-block quant) trigger a first-time
+    ``torch.utils.cpp_extension.load()`` build that can take ~60s+ on a cold cache. The
+    per-test cap from ``tests/conftest.py`` (``unit`` → 60s) would otherwise fire on that
+    first build and fail an otherwise-passing test.
+
+    Running the build here, in fixture *setup*, keeps it off the clock: the repo sets
+    ``timeout_func_only = true`` (see ``pyproject.toml``), so pytest-timeout only times the
+    test ``call`` phase, not fixture setup/teardown. The compiled ``.so`` is cached (in
+    memory for the session and on disk under ``~/.cache*/torch_extensions``), so subsequent
+    loads are instant.
+
+    Best-effort: ``precompile`` does not raise if an extension can't be built; tests that
+    require a specific extension guard on it (``get_cuda_ext_*() is None``) themselves.
+    """
+    if torch.cuda.is_available():
+        from modelopt.torch.quantization.extensions import precompile
+
+        precompile()


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix (test reliability)

Adds a package-scoped, autouse fixture in `tests/unit/torch/quantization/conftest.py`
that calls `modelopt.torch.quantization.extensions.precompile()` during fixture
*setup*, before any test in the package runs.

Some quantization tests (e.g. NVFP4/MX dynamic-block quant) trigger a first-time
`torch.utils.cpp_extension.load()` JIT build that can take ~60s+ on a cold cache.
The repo's per-test cap for the `unit` lane (`tests/conftest.py` → 60s) would
otherwise fire during that first build and fail an otherwise-passing test.

Because the repo sets `timeout_func_only = true` (`pyproject.toml`), pytest-timeout
only times the test `call` phase, not fixture setup/teardown. Running the build in
fixture setup therefore moves the cold compile off the timeout clock. The compiled
`.so` is cached (in-memory for the session and on disk under
`~/.cache*/torch_extensions`), so subsequent loads are instant. The fixture is
best-effort: `precompile()` does not raise if an extension can't be built, and tests
that require a specific extension already guard on `get_cuda_ext_*() is None`.

### Usage

No API change — the fixture runs automatically for the quantization unit-test
package. No user action required.

```python
# N/A — internal test infrastructure
```

### Testing

Reproduced locally: running the `tests/unit/torch/quantization` lane on a cold
extension cache, the first NVFP4/MX test failed on the unit 60s cap during the
JIT build. With this fixture, the cold build happens in setup and the lane passes.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ <!-- test-only change, no API/behavior change -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A <!-- test-infrastructure fixture, not a new feature/example -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A <!-- test-only change -->
- Did you get Claude approval on this PR?: N/A <!-- can self-trigger `/claude review` if desired -->

### Additional Information

Test-only change scoped to the `tests/unit/torch/quantization` package; no
production code paths are touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by pre-compiling CUDA extensions ahead of time, reducing timeout failures during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->