### PR TITLE
[Fix](nvbug6304444): make_dataset.py always strips all conversations but the first user turn for UltraChat

### DIFF
--- a/examples/dataset/make_dataset.py
+++ b/examples/dataset/make_dataset.py
@@ -276,10 +276,20 @@ async def _load_ultrachat_conversations(
     ds = ds.shuffle(seed=42)
     yield len(ds)
     for i in range(len(ds)):
-        prompt = ds[i]["prompt"].strip()
         prompt_id = ds[i]["prompt_id"].strip()
-        if prompt:
-            msgs = [{"role": "user", "content": prompt}]
+        # UltraChat records carry the full multi-turn conversation in "messages";
+        # fall back to the single-turn "prompt" only if it is unavailable.
+        raw_msgs = ds[i].get("messages") or []
+        msgs = [
+            {"role": turn["role"], "content": turn["content"].strip()}
+            for turn in raw_msgs
+            if turn.get("content", "").strip()
+        ]
+        if not msgs:
+            prompt = ds[i]["prompt"].strip()
+            if prompt:
+                msgs = [{"role": "user", "content": prompt}]
+        if msgs:
             if not prompt_id:
                 prompt_id = id_for_conversation(msgs)
             prompt_id = f"ultrachat-{split_name}-{prompt_id}"


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

`examples/dataset/make_dataset.py` discarded every turn but the first user
prompt for UltraChat, even with `--full-conversations`. The UltraChat loader
only read the single-turn `prompt` field, so the multi-turn conversation stored
in `messages` was never loaded — leaving the downstream `strip_last_completion`
logic and the `--full-conversations` flag with nothing to act on.

The loader now reads the full `messages` field (falling back to `prompt` only
when `messages` is unavailable), matching how the daring-anteater and
nemotron-post-training-v2 loaders already handle multi-turn data. No other
dataset loader is touched.

### Usage

```bash
python examples/dataset/make_dataset.py -f example_data_config.yaml --full-conversations
# UltraChat records in the output now keep all turns instead of just the first user prompt.
```

### Testing

- Verified the UltraChat loader yields full multi-turn conversations (2000/2000
  sampled records are multi-turn with alternating user/assistant turns).
- Verified downstream behavior: default (strip) ends each conversation on a
  `user` turn; `--full-conversations` preserves the trailing `assistant` turn.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌

### Additional Information

Fixes nvbug 6304444: https://nvbugspro.nvidia.com/bug/6304444
