### PR TITLE
[Fix](nvbug6304585): specdec README online base-model example should use Instruct model

### DIFF
--- a/examples/speculative_decoding/README.md
+++ b/examples/speculative_decoding/README.md
@@ -78,7 +78,7 @@ For small base models that fit in GPU memory, we can collocate them with draft m
 ```bash
 ./launch_train.sh \
     --config ../../modelopt_recipes/general/speculative_decoding/eagle3.yaml \
-    model.model_name_or_path=meta-llama/Llama-3.2-1B \
+    model.model_name_or_path=meta-llama/Llama-3.2-1B-Instruct \
     data.data_path=input_conversations/train.jsonl \
     training.output_dir=ckpts/llama-3.2-1b-online
 ```
@@ -123,7 +123,7 @@ Once we finish dumping hidden states, launch offline training pointing to the hi
 ```bash
 ./launch_train.sh \
     --config ../../modelopt_recipes/general/speculative_decoding/eagle3.yaml \
-    model.model_name_or_path=meta-llama/Llama-3.2-1B \
+    model.model_name_or_path=meta-llama/Llama-3.2-1B-Instruct \
     data.offline_data_path=$HIDDEN_STATES_DIR \
     training.output_dir=ckpts/llama-3.2-1b-offline
 ```

--- a/modelopt/torch/utils/plugins/transformers_dataset.py
+++ b/modelopt/torch/utils/plugins/transformers_dataset.py
@@ -160,7 +160,12 @@ class LanguageDataCollator:
 
         self._post_process_tokenizer()
         if self.tokenizer.chat_template is None:
-            raise ValueError("No valid chat template!")
+            raise ValueError(
+                "No valid chat template! The tokenizer for this model has no chat_template, "
+                "which is common for base / pretrained checkpoints. Use an instruction-tuned "
+                "model (e.g. a '*-Instruct' variant), or pass a custom chat_template via the "
+                "training config or LanguageDataCollator(chat_template=...)."
+            )
 
         if self.answer_only_loss:
             self._verify_generation_tags()


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

The **Training Draft Model with Online/Offline Base Model** examples in
`examples/speculative_decoding/README.md` used `meta-llama/Llama-3.2-1B`, a
base / pretrained checkpoint that ships **no chat template**. The online EAGLE3
flow tokenizes conversations through `tokenizer.apply_chat_template(...)`, so
the data collator fails fast at startup:

```
ValueError: No valid chat template!
```

This PR:

- Switches both README example commands (online and offline) to
  `meta-llama/Llama-3.2-1B-Instruct`, which carries a chat template.
- Makes the collator error message in
  `modelopt/torch/utils/plugins/transformers_dataset.py` actionable — it now
  explains the cause (base checkpoints have no chat template) and points users
  at an Instruct model or a custom `chat_template`.

### Usage

```bash
./launch_train.sh \
    --config ../../modelopt_recipes/general/speculative_decoding/eagle3.yaml \
    model.model_name_or_path=meta-llama/Llama-3.2-1B-Instruct \
    data.data_path=input_conversations/train.jsonl \
    training.output_dir=ckpts/llama-3.2-1b-online
```

### Testing

- Reproduced the original `No valid chat template!` failure with the base
  `Llama-3.2-1B` and confirmed the Instruct variant carries a chat template.
- Verified the new error message renders correctly when a template is missing.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌

### Additional Information

Fixes nvbug 6304585: https://nvbugspro.nvidia.com/bug/6304585


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated speculative decoding example training commands to reference the Llama-3.2-1B-Instruct model.

* **Bug Fixes**
  * Enhanced error message when chat template configuration is missing, providing actionable guidance for resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->