### PR TITLE
chore: stop tracking .claude/scheduled_tasks.lock

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"c73837a8-dfc8-4c65-87dd-ba6efe62db78","pid":5301,"procStart":"863627582","acquiredAt":1780509271557}

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ AGENTS.override.md
 
 # Ignore SonarQube analysis
 .sonar/
+
+# Claude Code runtime lock (ephemeral process state — never commit)
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## What
Remove `.claude/scheduled_tasks.lock` from version control and add a `.gitignore` rule so it is never committed again.

## Why
This file is an **ephemeral Claude Code scheduler lock** — its contents are runtime process state (`sessionId`, `pid`, `procStart`, `acquiredAt`), not source. It was accidentally committed in #1623 and is currently tracked on `main`.

Reported by @sychen52 in [review of #1623](https://github.com/NVIDIA/Model-Optimizer/pull/1623#pullrequestreview-4510440829).

## Changes
- `git rm --cached .claude/scheduled_tasks.lock`
- Add `.claude/scheduled_tasks.lock` to `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude internal runtime lock files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->