### PR TITLE
Pass USE_CUDA to compilation of cuda-ext to avoid failure on Windows

### DIFF
--- a/modelopt/torch/utils/cpp_extension.py
+++ b/modelopt/torch/utils/cpp_extension.py
@@ -73,7 +73,7 @@ def load_cpp_extension(
     else:
         if os.name == "nt":
             # Define USE_CUDA so PyTorch's compiled_autograd.h takes its Windows-safe branch;
-            # otherwise nvcc + MSVC fail with "error C2872: 'std': ambiguous symbol".
+            # otherwise, nvcc + MSVC fail with "error C2872: 'std': ambiguous symbol".
             # See https://github.com/pytorch/pytorch/issues/148317
             for key in ("extra_cflags", "extra_cuda_cflags"):
                 flags = list(load_kwargs.get(key, []))

--- a/modelopt/torch/utils/cpp_extension.py
+++ b/modelopt/torch/utils/cpp_extension.py
@@ -71,6 +71,15 @@ def load_cpp_extension(
             f" does not satisfy the specifiers {cuda_version_specifiers}."
         )
     else:
+        if os.name == "nt":
+            # Define USE_CUDA so PyTorch's compiled_autograd.h takes its Windows-safe branch;
+            # otherwise nvcc + MSVC fail with "error C2872: 'std': ambiguous symbol".
+            # See https://github.com/pytorch/pytorch/issues/148317
+            for key in ("extra_cflags", "extra_cuda_cflags"):
+                flags = list(load_kwargs.get(key, []))
+                if not any("USE_CUDA" in flag for flag in flags):
+                    flags.append("-DUSE_CUDA=1")
+                load_kwargs[key] = flags
         try:
             ext = load(name, sources, **load_kwargs)
         except Exception as e:


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug Fix

- Fixes a Windows-only failure when compiling ModelOpt CUDA extensions (e.g. modelopt_cuda_ext_mx for NVFP4/MX quantization) with torch 2.9 + CUDA 12.9:
`error C2872: 'std': ambiguous symbol   (torch/csrc/dynamo/compiled_autograd.h)
RuntimeError: Error building extension 'modelopt_cuda_ext_mx'`
- Compiled_autograd.h's IValuePacker<T>::packed_type() gates its std-heavy branch on a preprocessor guard that changed between 2.8 and 2.9:
```cpp
// torch 2.8 — blanket Windows guard
#ifdef _WIN32
    TORCH_CHECK_NOT_IMPLEMENTED(false, "torch.compile not supported on Windows");
#else
    ... else if constexpr (::std::is_same_v<T, ::std::string>) ...   // never compiled on Windows
#endif

// torch 2.9 — now also requires USE_CUDA/USE_ROCM
#if defined(_WIN32) && (defined(USE_CUDA) || defined(USE_ROCM))
    TORCH_CHECK_NOT_IMPLEMENTED(false, "torch.compile not supported on Windows");
#else
    ... else if constexpr (::std::is_same_v<T, ::std::string>) ...   // line 1134: C2872 under nvcc+MSVC
#endif
```
- `load_cpp_extension` now adds -DUSE_CUDA=1 on Windows (os.name == "nt") so the header compiles. No op on Linux.
- Open PyTorch issue - [pytorch/pytorch#148317](https://github.com/pytorch/pytorch/issues/148317) 

### Usage

```python
# On Windows + torch 2.9/CUDA 12.9 this previously failed to build; now succeeds:
from modelopt.torch.quantization import extensions as e
print(e.get_cuda_ext_mx(raise_if_failed=True))
```

### Testing
- Reproduced and verified on Windows (RTX 5090 / sm_120, MSVC 2022 14.44, CUDA 12.9, torch 2.9.0+cu129)
- Before: get_cuda_ext_mx / [quantize.py](https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/diffusers/quantization/quantize.py) --format fp4 (SD3.5) fail with C2872.
- After: extension compiles/loads and FP4 quantization proceeds and ONNX export completes.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed CUDA compilation issues on Windows systems. The extension loading mechanism now automatically applies Windows-specific compiler definitions, resolving previous build failures. Windows users no longer need manual configuration workarounds, ensuring consistent, seamless functionality across all supported platforms when using CUDA-enabled extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->