### PR TITLE
fix(puzzletron): correct val_dataset_name from 'valid' to 'validation'

### DIFF
--- a/examples/puzzletron/configs/llama-3_1-8B_pruneffn_memory/validate_model_defaults.yaml
+++ b/examples/puzzletron/configs/llama-3_1-8B_pruneffn_memory/validate_model_defaults.yaml
@@ -3,7 +3,7 @@ autocast_dtype: torch.bfloat16 # dtype for torch.autocast for validate_model
 block_size: 8192
 bos_rate: 0.5
 data_column: messages
-val_dataset_name: valid
+val_dataset_name: validation
 shuffle_seed: 81436
 seed: 42
 fim_rate: 0


### PR DESCRIPTION
The `validate_model_defaults.yaml` file has `val_dataset_name` set to `valid`, but it should be `validation` per the dataset split expected by the tutorial configuration.

This causes the Puzzletron tutorial to fail at the subblock scoring step (6/8).

### What does this PR do?

Type of change: Bug fix

Updates the Puzzletron validation config to use the correct validation dataset split name:
- `val_dataset_name: valid` → `val_dataset_name: validation`

This fixes the tutorial configuration so the pipeline can proceed correctly during the validation/subblock scoring stage.

### Usage

No user-facing API changes. This is a config fix for the existing Puzzletron tutorial.

### Testing

Verified the YAML config was updated to use the correct dataset split name.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information

This addresses the tutorial failure at step 6/8 caused by the incorrect dataset split name in:

`examples/puzzletron/configs/llama-3_1-8B_pruneffn_memory/validate_model_defaults.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default validation dataset configuration parameter to correct dataset identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->