### PR TITLE
feat(launcher): add Megatron-Bridge quantize/generate/export wrappers

### DIFF
--- a/tools/launcher/common/megatron_bridge/export/export.sh
+++ b/tools/launcher/common/megatron_bridge/export/export.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Megatron-Bridge export: convert a quantized MCore checkpoint to HuggingFace format.
+# Wraps /opt/Megatron-Bridge/examples/quantization/export.py.
+# Assumes nvcr.io/nvidia/nemo:26.04+ container (megatron-bridge preinstalled at /opt/Megatron-Bridge).
+#
+# Required env:
+#   HF_MODEL_ID           HF model id used for architecture template + tokenizer.
+#   MEGATRON_LOAD_PATH    Quantized MCore ckpt dir produced by quantize.sh.
+# Optional env:
+#   OUTPUT_DIR            Parent dir for export (default: cwd).
+#   EXPORT_DIR            HF output dir
+#                         (default: ${OUTPUT_DIR}/<basename(HF_MODEL_ID)>_hf_export).
+#   TP, PP, EP, ETP       Parallelism degrees (defaults: 1, 1, 1, 1).
+#                         NOTE: HF exporter does not gather TP-sharded weights —
+#                         use PP > 1 to shard large models across GPUs.
+#   NPROC_PER_NODE        GPUs per node for torchrun (default: nvidia-smi GPU count).
+#   DTYPE                 Export dtype (default: bfloat16). One of bfloat16, float16, float32.
+#   EXPORT_EXTRA_MODULES  "true" to include Medusa / EAGLE / MTP heads.
+#   TRUST_REMOTE_CODE     "true" to pass --trust-remote-code.
+#
+# Extra positional args ("$@") are forwarded to export.py.
+
+set -e
+
+if [[ -z "${HF_MODEL_ID}" ]]; then
+    echo "[ERROR] HF_MODEL_ID is required" >&2
+    exit 1
+fi
+if [[ -z "${MEGATRON_LOAD_PATH}" ]]; then
+    echo "[ERROR] MEGATRON_LOAD_PATH is required" >&2
+    exit 1
+fi
+
+OUTPUT_DIR="${OUTPUT_DIR:-$(pwd)}"
+MODEL_NAME="$(basename "${HF_MODEL_ID}")"
+EXPORT_DIR="${EXPORT_DIR:-${OUTPUT_DIR}/${MODEL_NAME}_hf_export}"
+
+TP="${TP:-1}"
+PP="${PP:-1}"
+EP="${EP:-1}"
+ETP="${ETP:-1}"
+DTYPE="${DTYPE:-bfloat16}"
+
+if [[ -z "${NPROC_PER_NODE}" ]]; then
+    NPROC_PER_NODE=$(nvidia-smi --query-gpu=count --format=csv,noheader,nounits | head -n 1)
+fi
+
+# Multi-node torchrun: derive rendezvous from Slurm env. Falls back to standalone.
+NNODES="${SLURM_NNODES:-${NNODES:-1}}"
+NODE_RANK="${SLURM_NODEID:-${NODE_RANK:-0}}"
+if [[ "${NNODES}" -gt 1 ]]; then
+    if [[ -z "${MASTER_ADDR}" && -n "${SLURM_NODELIST}" ]]; then
+        MASTER_ADDR=$(scontrol show hostname "${SLURM_NODELIST}" 2>/dev/null | head -n 1)
+    fi
+    MASTER_PORT="${MASTER_PORT:-29500}"
+    RDZV_ARGS=("--nnodes=${NNODES}" "--node-rank=${NODE_RANK}" \
+               "--master-addr=${MASTER_ADDR}" "--master-port=${MASTER_PORT}")
+else
+    RDZV_ARGS=("--standalone" "--nnodes=1")
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+EXTRA_FLAGS=()
+[[ "${EXPORT_EXTRA_MODULES:-false}" == "true" ]] && EXTRA_FLAGS+=("--export-extra-modules")
+[[ "${TRUST_REMOTE_CODE:-false}" == "true" ]] && EXTRA_FLAGS+=("--trust-remote-code")
+
+cd /opt/Megatron-Bridge/examples/quantization
+
+echo "=== Exporting ${HF_MODEL_ID} (TP=${TP} PP=${PP} EP=${EP} ETP=${ETP}, ${NPROC_PER_NODE} GPUs, dtype=${DTYPE}) ==="
+echo "    load <- ${MEGATRON_LOAD_PATH}"
+echo "    save -> ${EXPORT_DIR}"
+
+python -m torch.distributed.run --nproc_per_node "${NPROC_PER_NODE}" "${RDZV_ARGS[@]}" export.py \
+    --hf-model-id "${HF_MODEL_ID}" \
+    --megatron-load-path "${MEGATRON_LOAD_PATH}" \
+    --export-dir "${EXPORT_DIR}" \
+    --tp "${TP}" \
+    --pp "${PP}" \
+    --ep "${EP}" \
+    --etp "${ETP}" \
+    --dtype "${DTYPE}" \
+    "${EXTRA_FLAGS[@]}" \
+    "$@"
+
+ls "${EXPORT_DIR}"
+if [[ -f "${EXPORT_DIR}/hf_quant_config.json" ]]; then
+    cat "${EXPORT_DIR}/hf_quant_config.json"
+fi

--- a/tools/launcher/common/megatron_bridge/generate/generate.sh
+++ b/tools/launcher/common/megatron_bridge/generate/generate.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Megatron-Bridge PTQ generation: load a quantized MCore checkpoint and run text generation.
+# Wraps /opt/Megatron-Bridge/examples/quantization/ptq_generate.py.
+# Assumes nvcr.io/nvidia/nemo:26.04+ container (megatron-bridge preinstalled at /opt/Megatron-Bridge).
+#
+# Required env:
+#   HF_MODEL_ID           HF model id used for tokenizer and architecture template.
+#   MEGATRON_LOAD_PATH    Quantized MCore ckpt dir produced by quantize.sh.
+# Optional env:
+#   TP, PP, EP, ETP       Parallelism degrees (defaults: 1, 1, 1, 1).
+#   NPROC_PER_NODE        GPUs per node for torchrun (default: nvidia-smi GPU count).
+#   PROMPTS               |-separated input prompts.
+#   OSL                   Output sequence length (default: 32).
+#   TRUST_REMOTE_CODE     "true" to pass --trust-remote-code.
+#
+# Extra positional args ("$@") are forwarded to ptq_generate.py.
+
+set -e
+
+if [[ -z "${HF_MODEL_ID}" ]]; then
+    echo "[ERROR] HF_MODEL_ID is required" >&2
+    exit 1
+fi
+if [[ -z "${MEGATRON_LOAD_PATH}" ]]; then
+    echo "[ERROR] MEGATRON_LOAD_PATH is required" >&2
+    exit 1
+fi
+
+TP="${TP:-1}"
+PP="${PP:-1}"
+EP="${EP:-1}"
+ETP="${ETP:-1}"
+OSL="${OSL:-32}"
+
+if [[ -z "${NPROC_PER_NODE}" ]]; then
+    NPROC_PER_NODE=$(nvidia-smi --query-gpu=count --format=csv,noheader,nounits | head -n 1)
+fi
+
+# Multi-node torchrun: derive rendezvous from Slurm env. Falls back to standalone.
+NNODES="${SLURM_NNODES:-${NNODES:-1}}"
+NODE_RANK="${SLURM_NODEID:-${NODE_RANK:-0}}"
+if [[ "${NNODES}" -gt 1 ]]; then
+    if [[ -z "${MASTER_ADDR}" && -n "${SLURM_NODELIST}" ]]; then
+        MASTER_ADDR=$(scontrol show hostname "${SLURM_NODELIST}" 2>/dev/null | head -n 1)
+    fi
+    MASTER_PORT="${MASTER_PORT:-29500}"
+    RDZV_ARGS=("--nnodes=${NNODES}" "--node-rank=${NODE_RANK}" \
+               "--master-addr=${MASTER_ADDR}" "--master-port=${MASTER_PORT}")
+else
+    RDZV_ARGS=("--standalone" "--nnodes=1")
+fi
+
+EXTRA_FLAGS=()
+[[ "${TRUST_REMOTE_CODE:-false}" == "true" ]] && EXTRA_FLAGS+=("--trust-remote-code")
+[[ -n "${PROMPTS}" ]] && EXTRA_FLAGS+=("--prompts" "${PROMPTS}")
+
+# ptq_generate.py imports `quantize` as a sibling module — run from its directory.
+cd /opt/Megatron-Bridge/examples/quantization
+
+echo "=== Generating with ${HF_MODEL_ID} (TP=${TP} PP=${PP} EP=${EP} ETP=${ETP}, ${NPROC_PER_NODE} GPUs) ==="
+echo "    load <- ${MEGATRON_LOAD_PATH}"
+
+exec python -m torch.distributed.run --nproc_per_node "${NPROC_PER_NODE}" "${RDZV_ARGS[@]}" ptq_generate.py \
+    --hf-model-id "${HF_MODEL_ID}" \
+    --megatron-load-path "${MEGATRON_LOAD_PATH}" \
+    --tp "${TP}" \
+    --pp "${PP}" \
+    --ep "${EP}" \
+    --etp "${ETP}" \
+    --osl "${OSL}" \
+    "${EXTRA_FLAGS[@]}" \
+    "$@"

--- a/tools/launcher/common/megatron_bridge/quantize/quantize.sh
+++ b/tools/launcher/common/megatron_bridge/quantize/quantize.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Megatron-Bridge PTQ quantization: HuggingFace -> quantized MCore checkpoint.
+# Wraps /opt/Megatron-Bridge/examples/quantization/quantize.py.
+# Assumes nvcr.io/nvidia/nemo:26.04+ container (megatron-bridge preinstalled at /opt/Megatron-Bridge).
+#
+# Required env: HF_MODEL_ID  (e.g. meta-llama/Llama-3.2-1B)
+# Optional env:
+#   OUTPUT_DIR             Parent dir for outputs (default: cwd).
+#   EXPORT_QUANT_CFG       ModelOpt quant config (default: fp8). Supported:
+#                          int8_sq, fp8, fp8_blockwise, int4_awq, w4a8_awq,
+#                          nvfp4, mamba_moe_fp8_aggressive, mamba_moe_fp8_conservative,
+#                          mamba_moe_nvfp4_aggressive, mamba_moe_nvfp4_conservative.
+#   MEGATRON_SAVE_PATH     Output MCore ckpt dir
+#                          (default: ${OUTPUT_DIR}/<basename(HF_MODEL_ID)>_quantized_${EXPORT_QUANT_CFG}).
+#   TP, PP, EP, ETP        Parallelism degrees (defaults: 1, 1, 1, 1).
+#   NPROC_PER_NODE         GPUs per node for torchrun (default: nvidia-smi GPU count).
+#   CALIB_SIZE             Calibration sample count (default: 512).
+#   COMPRESS               "true" to apply mtq.compress() for real low-bit weights.
+#   WEIGHT_ONLY            "true" to disable input quantization.
+#   EXPORT_KV_CACHE_QUANT  "true" to enable FP8 KV-cache quantization.
+#   TRUST_REMOTE_CODE      "true" to pass --trust-remote-code.
+#   PROMPTS                |-separated test prompts.
+#   DISABLE_HF_DATASETS_FILE_LOCK  "true" for read-only HF cache dirs.
+#
+# Extra positional args ("$@") are forwarded to quantize.py.
+
+set -e
+
+if [[ -z "${HF_MODEL_ID}" ]]; then
+    echo "[ERROR] HF_MODEL_ID is required" >&2
+    exit 1
+fi
+
+OUTPUT_DIR="${OUTPUT_DIR:-$(pwd)}"
+EXPORT_QUANT_CFG="${EXPORT_QUANT_CFG:-fp8}"
+MODEL_NAME="$(basename "${HF_MODEL_ID}")"
+MEGATRON_SAVE_PATH="${MEGATRON_SAVE_PATH:-${OUTPUT_DIR}/${MODEL_NAME}_quantized_${EXPORT_QUANT_CFG}}"
+
+TP="${TP:-1}"
+PP="${PP:-1}"
+EP="${EP:-1}"
+ETP="${ETP:-1}"
+CALIB_SIZE="${CALIB_SIZE:-512}"
+
+if [[ -z "${NPROC_PER_NODE}" ]]; then
+    NPROC_PER_NODE=$(nvidia-smi --query-gpu=count --format=csv,noheader,nounits | head -n 1)
+fi
+
+# Multi-node torchrun: derive rendezvous from Slurm env. Falls back to standalone.
+NNODES="${SLURM_NNODES:-${NNODES:-1}}"
+NODE_RANK="${SLURM_NODEID:-${NODE_RANK:-0}}"
+if [[ "${NNODES}" -gt 1 ]]; then
+    if [[ -z "${MASTER_ADDR}" && -n "${SLURM_NODELIST}" ]]; then
+        MASTER_ADDR=$(scontrol show hostname "${SLURM_NODELIST}" 2>/dev/null | head -n 1)
+    fi
+    MASTER_PORT="${MASTER_PORT:-29500}"
+    RDZV_ARGS=("--nnodes=${NNODES}" "--node-rank=${NODE_RANK}" \
+               "--master-addr=${MASTER_ADDR}" "--master-port=${MASTER_PORT}")
+else
+    RDZV_ARGS=("--standalone" "--nnodes=1")
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+EXTRA_FLAGS=()
+[[ "${COMPRESS:-false}" == "true" ]] && EXTRA_FLAGS+=("--compress")
+[[ "${WEIGHT_ONLY:-false}" == "true" ]] && EXTRA_FLAGS+=("--weight-only")
+[[ "${EXPORT_KV_CACHE_QUANT:-false}" == "true" ]] && EXTRA_FLAGS+=("--export-kv-cache-quant")
+[[ "${TRUST_REMOTE_CODE:-false}" == "true" ]] && EXTRA_FLAGS+=("--trust-remote-code")
+[[ "${DISABLE_HF_DATASETS_FILE_LOCK:-false}" == "true" ]] && EXTRA_FLAGS+=("--disable-hf-datasets-file-lock")
+[[ -n "${PROMPTS}" ]] && EXTRA_FLAGS+=("--prompts" "${PROMPTS}")
+
+# Workaround for upstream Megatron-Bridge using the deprecated dataset id
+# `cnn_dailymail` (no namespace). Newer huggingface_hub requires `namespace/name`
+# and rejects the bare form with HfUriError. Rewrite to `abisee/cnn_dailymail`,
+# which is the canonical id and is cached under /hf-local/abisee/cnn_dailymail.
+_UPSTREAM_QUANT=/opt/Megatron-Bridge/examples/quantization/quantize.py
+if [[ -w "${_UPSTREAM_QUANT}" ]] && grep -q 'load_dataset("cnn_dailymail"' "${_UPSTREAM_QUANT}"; then
+    sed -i 's|load_dataset("cnn_dailymail"|load_dataset("abisee/cnn_dailymail"|g' "${_UPSTREAM_QUANT}"
+fi
+
+# quantize.py imports `quantize_utils` as a sibling module — run from its directory.
+cd /opt/Megatron-Bridge/examples/quantization
+
+echo "=== Quantizing ${HF_MODEL_ID} with ${EXPORT_QUANT_CFG} (TP=${TP} PP=${PP} EP=${EP} ETP=${ETP}, ${NPROC_PER_NODE} GPUs) ==="
+echo "    save -> ${MEGATRON_SAVE_PATH}"
+
+exec python -m torch.distributed.run --nproc_per_node "${NPROC_PER_NODE}" "${RDZV_ARGS[@]}" quantize.py \
+    --hf-model-id "${HF_MODEL_ID}" \
+    --export-quant-cfg "${EXPORT_QUANT_CFG}" \
+    --megatron-save-path "${MEGATRON_SAVE_PATH}" \
+    --tp "${TP}" \
+    --pp "${PP}" \
+    --ep "${EP}" \
+    --etp "${ETP}" \
+    --calib-size "${CALIB_SIZE}" \
+    "${EXTRA_FLAGS[@]}" \
+    "$@"

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/megatron_bridge_export.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/megatron_bridge_export.yaml
@@ -1,0 +1,43 @@
+# Megatron-Bridge HF export for nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 (NVFP4).
+#
+# Converts the quantized MCore ckpt (from megatron_bridge_ptq.yaml) to a deployable
+# HuggingFace checkpoint. The HF exporter does not gather TP-sharded weights — TP=1
+# is required, PP is used to shard the model across GPUs.
+#
+# Cluster shape: 2 nodes x 4 GPUs = 8 ranks (PP=8, EP=1, TP=1).
+#
+# Usage:
+#   source .env-slurm
+#   cd tools/launcher
+#   uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/megatron_bridge_export.yaml --yes
+
+job_name: Nemotron-3-Nano_megatron_bridge_export
+pipeline:
+  skip: false
+  allow_to_fail: false
+  note: "Megatron-Bridge HF export for Nano-30B-A3B NVFP4: 2 nodes x 4 GPUs, TP=1 PP=8"
+
+  global_vars:
+    output_dir: /cicd/megatron-bridge
+
+  task_0:
+    script: common/megatron_bridge/export/export.sh
+    environment:
+      - HF_MODEL_ID: /hf-local/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+      - MEGATRON_LOAD_PATH: <<global_vars.output_dir>>/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4-MLM
+      - EXPORT_DIR: /cicd/export/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4-HF
+      - TP: "1"
+      - PP: "8"
+      - EP: "1"
+      - ETP: "1"
+      - DTYPE: bfloat16
+      - TRUST_REMOTE_CODE: "true"
+    slurm_config:
+      _factory_: "slurm_factory"
+      container: nvcr.io/nvidia/nemo:26.04
+      modelopt_install_path: /opt/venv/lib/python3.12/site-packages/modelopt
+      partition: batch
+      nodes: 2
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      time: "02:00:00"

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/megatron_bridge_generate.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/megatron_bridge_generate.yaml
@@ -1,0 +1,44 @@
+# Megatron-Bridge generation on quantized nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.
+#
+# Mirrors the user-provided reference command:
+#   torchrun --nproc_per_node 8 examples/quantization/ptq_generate.py \
+#     --megatron-load-path /models/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4-MLM \
+#     --hf-model-id /models/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 \
+#     --trust-remote-code --tp 8 --ep 8
+#
+# Cluster shape: 2 nodes x 4 GPUs = 8 ranks.
+# Loads the MCore ckpt written by megatron_bridge_ptq.yaml (same OUTPUT_DIR).
+#
+# Usage:
+#   source .env-slurm
+#   cd tools/launcher
+#   uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/megatron_bridge_generate.yaml --yes
+
+job_name: Nemotron-3-Nano_megatron_bridge_generate
+pipeline:
+  skip: false
+  allow_to_fail: false
+  note: "Megatron-Bridge PTQ generate on Nano-30B-A3B (nvfp4): 2 nodes x 4 GPUs, TP=8 EP=8"
+
+  global_vars:
+    output_dir: /cicd/megatron-bridge
+
+  task_0:
+    script: common/megatron_bridge/generate/generate.sh
+    environment:
+      - HF_MODEL_ID: /hf-local/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+      - MEGATRON_LOAD_PATH: <<global_vars.output_dir>>/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4-MLM
+      - TP: "8"
+      - PP: "1"
+      - EP: "8"
+      - ETP: "1"
+      - TRUST_REMOTE_CODE: "true"
+    slurm_config:
+      _factory_: "slurm_factory"
+      container: nvcr.io/nvidia/nemo:26.04
+      modelopt_install_path: /opt/venv/lib/python3.12/site-packages/modelopt
+      partition: batch
+      nodes: 2
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      time: "01:00:00"

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/megatron_bridge_ptq.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/megatron_bridge_ptq.yaml
@@ -1,0 +1,49 @@
+# Megatron-Bridge PTQ for nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16.
+#
+# Mirrors the user-provided reference command:
+#   torchrun --nproc_per_node 8 examples/quantization/quantize.py \
+#     --hf-model-id /models/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 \
+#     --calib-size 4 --export-quant-cfg nvfp4 \
+#     --megatron-save-path /models/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4-MLM \
+#     --pp 4 --tp 2 --ep 2 --trust-remote-code
+#
+# Cluster shape: 2 nodes x 4 GPUs = 8 ranks (matches --nproc_per_node 8 on
+# 8-GPU-per-node hardware; on 4-GPU-per-node clusters, multi-node torchrun
+# rendezvous is derived from SLURM_NODELIST inside quantize.sh).
+#
+# Usage:
+#   source .env-slurm
+#   cd tools/launcher
+#   uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/megatron_bridge_ptq.yaml --yes
+
+job_name: Nemotron-3-Nano_megatron_bridge_PTQ
+pipeline:
+  skip: false
+  allow_to_fail: false
+  note: "Megatron-Bridge PTQ on Nano-30B-A3B (nvfp4): 2 nodes x 4 GPUs, TP=2 PP=4 EP=2"
+
+  global_vars:
+    output_dir: /cicd/megatron-bridge
+
+  task_0:
+    script: common/megatron_bridge/quantize/quantize.sh
+    environment:
+      - HF_MODEL_ID: /hf-local/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+      - OUTPUT_DIR: <<global_vars.output_dir>>
+      - MEGATRON_SAVE_PATH: <<global_vars.output_dir>>/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4-MLM
+      - EXPORT_QUANT_CFG: nvfp4
+      - CALIB_SIZE: "4"
+      - TP: "2"
+      - PP: "4"
+      - EP: "2"
+      - ETP: "1"
+      - TRUST_REMOTE_CODE: "true"
+    slurm_config:
+      _factory_: "slurm_factory"
+      container: nvcr.io/nvidia/nemo:26.04
+      modelopt_install_path: /opt/venv/lib/python3.12/site-packages/modelopt
+      partition: batch
+      nodes: 2
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      time: "04:00:00"

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/megatron_bridge_export.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/megatron_bridge_export.yaml
@@ -1,0 +1,46 @@
+# Megatron-Bridge HF export for nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16 (NVFP4).
+#
+# Follows https://github.com/NVIDIA-NeMo/Nemotron/blob/main/docs/nemotron/super3/quantization.md:
+#   torchrun --nproc_per_node=16 examples/quantization/export.py \
+#     --hf-model-id $HF_MODEL --megatron-load-path $MEGATRON_SAVE_PATH \
+#     --export-dir $EXPORT_DIR --pp 8 --dtype bfloat16 --trust-remote-code
+#
+# Cluster shape: 2 nodes x 4 GPUs = 8 ranks (TP=1, PP=8, EP=1, ETP=1).
+# 88 layers / PP=8 = 11 layers/stage. The HF exporter does not gather TP-sharded
+# weights — TP is dropped to 1 for export.
+#
+# Usage:
+#   source .env-slurm
+#   cd tools/launcher
+#   uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/megatron_bridge_export.yaml --yes
+
+job_name: Nemotron-3-Super-120B_megatron_bridge_export
+pipeline:
+  skip: false
+  allow_to_fail: false
+  note: "Megatron-Bridge HF export for Super-120B mamba_moe_nvfp4_conservative: 2 nodes x 4 GPUs, TP=1 PP=8"
+
+  global_vars:
+    output_dir: /cicd/megatron-bridge
+
+  task_0:
+    script: common/megatron_bridge/export/export.sh
+    environment:
+      - HF_MODEL_ID: /hf-local/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+      - MEGATRON_LOAD_PATH: <<global_vars.output_dir>>/NVIDIA-Nemotron-3-Super-120B-A12B-mamba_moe_nvfp4_conservative
+      - EXPORT_DIR: /cicd/export/NVIDIA-Nemotron-3-Super-120B-A12B-mamba_moe_nvfp4_conservative-HF
+      - TP: "1"
+      - PP: "8"
+      - EP: "1"
+      - ETP: "1"
+      - DTYPE: bfloat16
+      - TRUST_REMOTE_CODE: "true"
+    slurm_config:
+      _factory_: "slurm_factory"
+      container: nvcr.io/nvidia/nemo:26.04
+      modelopt_install_path: /opt/venv/lib/python3.12/site-packages/modelopt
+      partition: batch
+      nodes: 2
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      time: "02:00:00"

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/megatron_bridge_generate.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/megatron_bridge_generate.yaml
@@ -1,0 +1,44 @@
+# Megatron-Bridge generation on quantized nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.
+#
+# Follows https://github.com/NVIDIA-NeMo/Nemotron/blob/main/docs/nemotron/super3/quantization.md:
+#   torchrun --nproc_per_node=16 examples/quantization/ptq_generate.py \
+#     --hf-model-id $HF_MODEL \
+#     --megatron-load-path $MEGATRON_SAVE_PATH \
+#     --pp 2 --tp 8 --ep 8 --trust-remote-code
+#
+# Cluster shape: 4 nodes x 4 GPUs = 16 ranks. Loads the MCore ckpt written by
+# megatron_bridge_ptq.yaml (same OUTPUT_DIR / MEGATRON_SAVE_PATH).
+#
+# Usage:
+#   source .env-slurm
+#   cd tools/launcher
+#   uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/megatron_bridge_generate.yaml --yes
+
+job_name: Nemotron-3-Super-120B_megatron_bridge_generate
+pipeline:
+  skip: false
+  allow_to_fail: false
+  note: "Megatron-Bridge PTQ generate on Super-120B (mamba_moe_nvfp4_conservative): 4 nodes x 4 GPUs, TP=8 PP=2 EP=8"
+
+  global_vars:
+    output_dir: /cicd/megatron-bridge
+
+  task_0:
+    script: common/megatron_bridge/generate/generate.sh
+    environment:
+      - HF_MODEL_ID: /hf-local/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+      - MEGATRON_LOAD_PATH: <<global_vars.output_dir>>/NVIDIA-Nemotron-3-Super-120B-A12B-mamba_moe_nvfp4_conservative
+      - TP: "8"
+      - PP: "2"
+      - EP: "8"
+      - ETP: "1"
+      - TRUST_REMOTE_CODE: "true"
+    slurm_config:
+      _factory_: "slurm_factory"
+      container: nvcr.io/nvidia/nemo:26.04
+      modelopt_install_path: /opt/venv/lib/python3.12/site-packages/modelopt
+      partition: batch
+      nodes: 4
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      time: "01:00:00"

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/megatron_bridge_ptq.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/megatron_bridge_ptq.yaml
@@ -1,0 +1,48 @@
+# Megatron-Bridge PTQ for nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16.
+#
+# Follows https://github.com/NVIDIA-NeMo/Nemotron/blob/main/docs/nemotron/super3/quantization.md:
+#   torchrun --nproc_per_node=16 examples/quantization/quantize.py \
+#     --hf-model-id $HF_MODEL \
+#     --export-quant-cfg mamba_moe_nvfp4_conservative \
+#     --megatron-save-path $MEGATRON_SAVE_PATH \
+#     --pp 2 --tp 8 --ep 8 --trust-remote-code
+#
+# Cluster shape: 4 nodes x 4 GPUs = 16 ranks (doc references 2 nodes x 8x H100).
+# Both shapes give world=16; multi-node torchrun rendezvous is derived from
+# SLURM_NODELIST inside quantize.sh.
+#
+# Usage:
+#   source .env-slurm
+#   cd tools/launcher
+#   uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16/megatron_bridge_ptq.yaml --yes
+
+job_name: Nemotron-3-Super-120B_megatron_bridge_PTQ
+pipeline:
+  skip: false
+  allow_to_fail: false
+  note: "Megatron-Bridge PTQ on Super-120B (mamba_moe_nvfp4_conservative): 4 nodes x 4 GPUs, TP=8 PP=2 EP=8"
+
+  global_vars:
+    output_dir: /cicd/megatron-bridge
+
+  task_0:
+    script: common/megatron_bridge/quantize/quantize.sh
+    environment:
+      - HF_MODEL_ID: /hf-local/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+      - OUTPUT_DIR: <<global_vars.output_dir>>
+      - MEGATRON_SAVE_PATH: <<global_vars.output_dir>>/NVIDIA-Nemotron-3-Super-120B-A12B-mamba_moe_nvfp4_conservative
+      - EXPORT_QUANT_CFG: mamba_moe_nvfp4_conservative
+      - TP: "8"
+      - PP: "2"
+      - EP: "8"
+      - ETP: "1"
+      - TRUST_REMOTE_CODE: "true"
+    slurm_config:
+      _factory_: "slurm_factory"
+      container: nvcr.io/nvidia/nemo:26.04
+      modelopt_install_path: /opt/venv/lib/python3.12/site-packages/modelopt
+      partition: batch
+      nodes: 4
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      time: "06:00:00"

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16/megatron_bridge_export.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16/megatron_bridge_export.yaml
@@ -1,0 +1,47 @@
+# Megatron-Bridge HF export for nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16 (NVFP4).
+#
+# Based on https://github.com/NVIDIA-NeMo/Nemotron/blob/main/docs/nemotron/ultra3/quantization.md:
+#   python examples/quantization/export.py \
+#     --hf-model-id $HF_MODEL --megatron-load-path $MEGATRON_SAVE_PATH \
+#     --export-dir $EXPORT_DIR --pp 9 --tp 1 --ep 8 --dtype bfloat16 --trust-remote-code
+#
+# 108-layer model. The HF exporter does not gather TP-sharded weights — TP=1.
+# Doc uses PP=9 (world=9 ranks, awkward on 4-GPU-per-node clusters). This yaml
+# uses PP=12 (108 layers / 12 = 9 layers/stage) so the world (12 ranks) maps
+# cleanly to 3 nodes x 4 GPUs. EP=8 is preserved from the doc.
+#
+# Usage:
+#   source .env-slurm
+#   cd tools/launcher
+#   uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16/megatron_bridge_export.yaml --yes
+
+job_name: Nemotron-3-Ultra-550B_megatron_bridge_export
+pipeline:
+  skip: false
+  allow_to_fail: false
+  note: "Megatron-Bridge HF export for Ultra-550B super-nvfp4-max-calib: 3 nodes x 4 GPUs, TP=1 PP=12 EP=8"
+
+  global_vars:
+    output_dir: /cicd/megatron-bridge
+
+  task_0:
+    script: common/megatron_bridge/export/export.sh
+    environment:
+      - HF_MODEL_ID: /hf-local/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
+      - MEGATRON_LOAD_PATH: <<global_vars.output_dir>>/NVIDIA-Nemotron-3-Ultra-550B-A55B-super-nvfp4-max-calib
+      - EXPORT_DIR: /cicd/export/NVIDIA-Nemotron-3-Ultra-550B-A55B-super-nvfp4-max-calib-HF
+      - TP: "1"
+      - PP: "12"
+      - EP: "8"
+      - ETP: "1"
+      - DTYPE: bfloat16
+      - TRUST_REMOTE_CODE: "true"
+    slurm_config:
+      _factory_: "slurm_factory"
+      container: nvcr.io/nvidia/nemo:26.04
+      modelopt_install_path: /opt/venv/lib/python3.12/site-packages/modelopt
+      partition: batch
+      nodes: 3
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      time: "04:00:00"

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16/megatron_bridge_generate.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16/megatron_bridge_generate.yaml
@@ -1,0 +1,45 @@
+# Megatron-Bridge generation on quantized nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16.
+#
+# Follows https://github.com/NVIDIA-NeMo/Nemotron/blob/main/docs/nemotron/ultra3/quantization.md:
+#   python examples/quantization/ptq_generate.py \
+#     --hf-model-id $HF_MODEL \
+#     --megatron-load-path $MEGATRON_SAVE_PATH \
+#     --pp 9 --tp 8 --ep 8 --trust-remote-code
+#
+# World size = TP * PP = 8 * 9 = 72. Cluster shape: 18 nodes x 4 GPUs = 72 ranks.
+# Loads the MCore ckpt written by megatron_bridge_ptq.yaml (same OUTPUT_DIR).
+#
+# Usage:
+#   source .env-slurm
+#   cd tools/launcher
+#   uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16/megatron_bridge_generate.yaml --yes
+
+job_name: Nemotron-3-Ultra-550B_megatron_bridge_generate
+pipeline:
+  skip: false
+  allow_to_fail: false
+  note: "Megatron-Bridge PTQ generate on Ultra-550B (super-nvfp4-max-calib): 18 nodes x 4 GPUs, TP=8 PP=9 EP=8"
+
+  global_vars:
+    output_dir: /cicd/megatron-bridge
+
+  task_0:
+    script: common/megatron_bridge/generate/generate.sh
+    environment:
+      - HF_MODEL_ID: /hf-local/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
+      - MEGATRON_LOAD_PATH: <<global_vars.output_dir>>/NVIDIA-Nemotron-3-Ultra-550B-A55B-super-nvfp4-max-calib
+      - TP: "8"
+      - PP: "9"
+      - EP: "8"
+      - ETP: "1"
+      - TRUST_REMOTE_CODE: "true"
+      - PYTORCH_ALLOC_CONF: "expandable_segments:True"
+    slurm_config:
+      _factory_: "slurm_factory"
+      container: nvcr.io/nvidia/nemo:26.04
+      modelopt_install_path: /opt/venv/lib/python3.12/site-packages/modelopt
+      partition: batch
+      nodes: 18
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      time: "02:00:00"

--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16/megatron_bridge_ptq.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16/megatron_bridge_ptq.yaml
@@ -1,0 +1,51 @@
+# Megatron-Bridge PTQ for nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16.
+#
+# Follows https://github.com/NVIDIA-NeMo/Nemotron/blob/main/docs/nemotron/ultra3/quantization.md:
+#   python examples/quantization/quantize.py \
+#     --hf-model-id $HF_MODEL \
+#     --export-quant-cfg $RECIPE_YAML \
+#     --megatron-save-path $MEGATRON_SAVE_PATH \
+#     --pp 9 --tp 8 --ep 8 --trust-remote-code
+#
+# 108-layer model. Doc requires --pp 9 (12 layers/stage) to fit calibration state.
+# World size = TP * PP = 8 * 9 = 72. Cluster shape: 18 nodes x 4 GPUs = 72 ranks.
+# Doc also recommends PYTORCH_ALLOC_CONF=expandable_segments:True for allocator headroom.
+#
+# The recipe YAML is the Super-NVFP4 max-calib config (verbatim path from the doc).
+#
+# Usage:
+#   source .env-slurm
+#   cd tools/launcher
+#   uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16/megatron_bridge_ptq.yaml --yes
+
+job_name: Nemotron-3-Ultra-550B_megatron_bridge_PTQ
+pipeline:
+  skip: false
+  allow_to_fail: false
+  note: "Megatron-Bridge PTQ on Ultra-550B (super-nvfp4-max-calib): 18 nodes x 4 GPUs, TP=8 PP=9 EP=8"
+
+  global_vars:
+    output_dir: /cicd/megatron-bridge
+
+  task_0:
+    script: common/megatron_bridge/quantize/quantize.sh
+    environment:
+      - HF_MODEL_ID: /hf-local/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16
+      - OUTPUT_DIR: <<global_vars.output_dir>>
+      - MEGATRON_SAVE_PATH: <<global_vars.output_dir>>/NVIDIA-Nemotron-3-Ultra-550B-A55B-super-nvfp4-max-calib
+      - EXPORT_QUANT_CFG: /opt/venv/lib/python3.12/site-packages/modelopt_recipes/models/Nemotron-3-Super-120B-A12B/super-nvfp4-max-calib.yaml
+      - TP: "8"
+      - PP: "9"
+      - EP: "8"
+      - ETP: "1"
+      - TRUST_REMOTE_CODE: "true"
+      - PYTORCH_ALLOC_CONF: "expandable_segments:True"
+    slurm_config:
+      _factory_: "slurm_factory"
+      container: nvcr.io/nvidia/nemo:26.04
+      modelopt_install_path: /opt/venv/lib/python3.12/site-packages/modelopt
+      partition: batch
+      nodes: 18
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      time: "12:00:00"


### PR DESCRIPTION
### What does this PR do?

Type of change: new example

Adds Megatron-Bridge PTQ wrappers to the launcher so users can quantize / generate / export Hugging Face models through Megatron-Bridge on Slurm or Docker, mirroring the existing `common/megatron_lm/{quantize,export}/` and `common/megatron_bridge/import/` conventions.

- **Common scripts** (`tools/launcher/common/megatron_bridge/`):
  - `quantize/quantize.sh` — wraps `/opt/Megatron-Bridge/examples/quantization/quantize.py`
  - `generate/generate.sh` — wraps `/opt/Megatron-Bridge/examples/quantization/ptq_generate.py`
  - `export/export.sh` — wraps `/opt/Megatron-Bridge/examples/quantization/export.py`

  All three assume `nvcr.io/nvidia/nemo:26.04+` (Megatron-Bridge preinstalled), read configuration from env vars (`HF_MODEL_ID`, `MEGATRON_SAVE_PATH`/`MEGATRON_LOAD_PATH`, `EXPORT_QUANT_CFG`, `TP`/`PP`/`EP`/`ETP`, `DTYPE`, …), and launch via `python -m torch.distributed.run` with multi-node rendezvous (`--nnodes`/`--node-rank`/`--master-addr`/`--master-port`) derived from `SLURM_NNODES`/`SLURM_NODEID`/`SLURM_NODELIST`, falling back to `--standalone` for single-node.

- **Per-model example YAMLs** (`tools/launcher/examples/nvidia/`):
  - `NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/megatron_bridge_{ptq,generate,export}.yaml` — 2 nodes × 4 GPUs (TP=2 PP=4 EP=2 for PTQ, TP=8 EP=8 for generate, TP=1 PP=8 for export), `nvfp4` config.
  - `NVIDIA-Nemotron-3-Super-120B-A12B-BF16/megatron_bridge_{ptq,generate,export}.yaml` — 4 nodes × 4 GPUs for PTQ/generate (TP=8 PP=2 EP=8), 2 nodes × 4 GPUs for export (TP=1 PP=8), `mamba_moe_nvfp4_conservative` per [super3 docs](https://github.com/NVIDIA-NeMo/Nemotron/blob/main/docs/nemotron/super3/quantization.md).
  - `NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16/megatron_bridge_{ptq,generate,export}.yaml` — 18 nodes × 4 GPUs for PTQ/generate (TP=8 PP=9 EP=8, `super-nvfp4-max-calib.yaml` recipe, `PYTORCH_ALLOC_CONF=expandable_segments:True`), 3 nodes × 4 GPUs for export (TP=1 PP=12 EP=8 — PP bumped from doc's 9 so the world maps cleanly to 4-GPU nodes; 108 layers / 12 = 9 layers/stage), per [ultra3 docs](https://github.com/NVIDIA-NeMo/Nemotron/blob/main/docs/nemotron/ultra3/quantization.md).

### Usage

```bash
# Quantize Nemotron-3-Nano-30B-A3B to NVFP4 via Megatron-Bridge:
cd tools/launcher
uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/megatron_bridge_ptq.yaml --yes

# Smoke-test generation on the quantized MCore checkpoint:
uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/megatron_bridge_generate.yaml --yes

# Export to deployable HF format:
uv run launch.py --yaml examples/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/megatron_bridge_export.yaml --yes

# Same three-step flow works for Super and Ultra by swapping the model subdir.
```

### Testing

- `bash -n` syntax check on all three shell scripts (pass).
- `uv run launch.py --dryrun --yes` on all 9 example YAMLs (all parse, resolve `<<global_vars.X>>`, and build the Fiddle `SandboxPipeline` cleanly).
- End-to-end Slurm runs not yet exercised; need cluster access with the right node count for super (16 GPUs) and ultra (72 GPUs).

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ — all files are new; no existing files modified.
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A — no copied code, no new PIP dependencies.
- Did you write any new necessary tests?: ❌ — the launcher's existing `--dryrun` path is the validation surface for example YAMLs and was used here; no new unit tests added. Happy to add launcher YAML regression tests if requested.
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌ — pure launcher-example addition, no library API change. Can add a one-liner under 0.46 "New Features" if preferred (prior precedent: the `moonshotai/` launcher examples were mentioned in 0.46).
- Did you get Claude approval on this PR?: ❌ — to be run via `/claude review` after PR creation.

### Additional Information

- Upstream reference scripts: <https://github.com/NVIDIA-NeMo/Megatron-Bridge/tree/main/examples/quantization>
- Note on `trust_remote_code=True`: the Nemotron-3 family requires it, and all three Nemotron YAMLs set `TRUST_REMOTE_CODE=true` consistent with the upstream NVIDIA-NeMo/Nemotron docs.
- The Ultra-export YAML deliberately deviates from the upstream doc's `--pp 9` to `PP=12` so the world (12 ranks) maps cleanly to 3 × 4-GPU nodes; this is called out in the YAML's header comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Megatron-Bridge tools for model quantization, text generation, and checkpoint export workflows.
  * Added pre-configured job templates for three NVIDIA Nemotron model variants (Nano-30B, Super-120B, Ultra-550B) to streamline distributed training and inference operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->