### PR TITLE
[OMNIML-5091] specdec_bench cell t0_d7 — nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 / MTP / trtllm

### DIFF
--- a/examples/specdec_bench/run.py
+++ b/examples/specdec_bench/run.py
@@ -178,6 +178,8 @@ def run_simple(args):
                 f"or extend _MAX_SEQ_LEN_KEY in run.py."
             )
         engine_args[key] = args.max_seq_len
+    if args.max_num_tokens is not None:
+        engine_args["max_num_tokens"] = args.max_num_tokens
     sampling_kwargs = args.runtime_params.get("sampling_kwargs", {"temperature": 0})
     if args.temperature is not None:
         sampling_kwargs["temperature"] = args.temperature
@@ -347,6 +349,17 @@ if __name__ == "__main__":
             "model config + memory budget, which can cap below the input "
             "length on tight GPUs. Set to 40960 for the SPEED-Bench "
             "throughput_32k split (32K input + 4K output + 4K headroom)."
+        ),
+    )
+    parser.add_argument(
+        "--max_num_tokens",
+        type=int,
+        required=False,
+        default=None,
+        help=(
+            "TRT-LLM token scheduling cap. Overrides engine_args.max_num_tokens "
+            "from --runtime_params if both are set. Increase when TRT-LLM raises "
+            "total_num_tokens should be less than or equal to max_num_tokens."
         ),
     )
     parser.add_argument(

--- a/tools/launcher/common/specdec_bench/run.sh
+++ b/tools/launcher/common/specdec_bench/run.sh
@@ -33,13 +33,21 @@ trap 'exit_handler' EXIT
 # Skip the install when the deps are already present (warm container or
 # previous task in the pipeline). Saves a few minutes per task and avoids
 # silently drifting versions if upstream wheels move between launches.
-if ! pip show boto3 >/dev/null 2>&1 || \
-   ! pip show datasets >/dev/null 2>&1 || \
-   ! pip show seaborn >/dev/null 2>&1; then
-    if ! pip install -r modules/Model-Optimizer/examples/specdec_bench/requirements.txt; then
-        report_result "FAIL: specdec_bench: pip install requirements.txt failed"
-        exit 1
+install_deps() {
+    if ! pip show boto3 >/dev/null 2>&1 || \
+       ! pip show datasets >/dev/null 2>&1 || \
+       ! pip show seaborn >/dev/null 2>&1; then
+        if ! pip install -r modules/Model-Optimizer/examples/specdec_bench/requirements.txt; then
+            report_result "FAIL: specdec_bench: pip install requirements.txt failed"
+            exit 1
+        fi
     fi
+}
+
+if [[ -n "${SLURM_PROCID:-}" ]]; then
+    flock /tmp/specdec_bench_deps.lock bash -c "$(declare -f install_deps); install_deps"
+else
+    install_deps
 fi
 
 # TensorRT-LLM jobs need to run through the launcher wrapper so spawned MPI

--- a/tools/launcher/common/specdec_bench/run.sh
+++ b/tools/launcher/common/specdec_bench/run.sh
@@ -42,7 +42,15 @@ if ! pip show boto3 >/dev/null 2>&1 || \
     fi
 fi
 
-if ! python3 modules/Model-Optimizer/examples/specdec_bench/run.py \
+# TensorRT-LLM jobs need to run through the launcher wrapper so spawned MPI
+# workers inherit the Slurm/container context. Other backends leave this unset.
+TRTLLM_LAUNCH_CMD=()
+if [[ -n "${TRTLLM_LAUNCH_SCRIPT:-}" ]]; then
+    # shellcheck disable=SC2206
+    TRTLLM_LAUNCH_CMD=(${TRTLLM_LAUNCH_SCRIPT})
+fi
+
+if ! "${TRTLLM_LAUNCH_CMD[@]}" python3 modules/Model-Optimizer/examples/specdec_bench/run.py \
     --model_dir ${HF_MODEL_CKPT} \
     --tokenizer ${HF_MODEL_CKPT} \
     "${@}"; then

--- a/tools/launcher/examples/Nemotron-h/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/specdec_bench_mtp_trtllm.yaml
+++ b/tools/launcher/examples/Nemotron-h/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/specdec_bench_mtp_trtllm.yaml
@@ -3,6 +3,8 @@
 # Nemotron-3-Super-120B-A12B is a 120B-total-parameter MoE model, so use
 # tensor parallel size 4 even though only 12B parameters are active per token.
 # TRT-LLM MTP is run with the TensorRT-LLM 1.3.0 release candidate container.
+# TensorRT-LLM jobs must use trtllm-llmapi-launch so MPI-spawned workers inherit
+# the Slurm/container context.
 #
 # Slurm run:
 #   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Nemotron-h/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/specdec_bench_mtp_trtllm.yaml --yes
@@ -32,10 +34,11 @@ pipeline:
     environment:
       - HF_MODEL_CKPT: <<global_vars.hf_model>>
       - HF_LOCAL: /hf-local
+      - TRTLLM_LAUNCH_SCRIPT: trtllm-llmapi-launch
     slurm_config:
       _factory_: "slurm_factory"
       nodes: 1
-      ntasks_per_node: 1
+      ntasks_per_node: 4
       gpus_per_node: 4
       container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
 
@@ -60,9 +63,10 @@ pipeline:
     environment:
       - HF_MODEL_CKPT: <<global_vars.hf_model>>
       - HF_LOCAL: /hf-local
+      - TRTLLM_LAUNCH_SCRIPT: trtllm-llmapi-launch
     slurm_config:
       _factory_: "slurm_factory"
       nodes: 1
-      ntasks_per_node: 1
+      ntasks_per_node: 4
       gpus_per_node: 4
       container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10

--- a/tools/launcher/examples/Nemotron-h/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/specdec_bench_mtp_trtllm.yaml
+++ b/tools/launcher/examples/Nemotron-h/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/specdec_bench_mtp_trtllm.yaml
@@ -55,7 +55,6 @@ pipeline:
       - --ep_size 1
       - --concurrency 8
       - --num_requests 80
-      - --runtime_params common/specdec_bench/runtime_params_throughput_32k.yaml
       - --output_length 4096
       - --aa_timing
       - --show_progress

--- a/tools/launcher/examples/Nemotron-h/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/specdec_bench_mtp_trtllm.yaml
+++ b/tools/launcher/examples/Nemotron-h/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/specdec_bench_mtp_trtllm.yaml
@@ -1,0 +1,68 @@
+# SPEED-bench MTP speculative-decoding run for NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 via TRT-LLM.
+#
+# Nemotron-3-Super-120B-A12B is a 120B-total-parameter MoE model, so use
+# tensor parallel size 4 even though only 12B parameters are active per token.
+# TRT-LLM MTP is run with the TensorRT-LLM 1.3.0 release candidate container.
+#
+# Slurm run:
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Nemotron-h/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/specdec_bench_mtp_trtllm.yaml --yes
+
+job_name: NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4_specdec_bench_mtp_trtllm
+
+pipeline:
+  global_vars:
+    hf_model: /hf-local/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+
+  # task_0: SPEED qualitative split
+  task_0:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/qualitative
+      - --engine TRTLLM
+      - --speculative_algorithm MTP
+      - --draft_length 3
+      - --tp_size 4
+      - --ep_size 1
+      - --concurrency 32
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/{sweep_name_default}/qualitative
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+
+  # task_1: SPEED throughput_32k split
+  task_1:
+    script: common/specdec_bench/run.sh
+    args:
+      - --dataset speed
+      - --dataset_path /hf-local/nvidia/SPEED-Bench-Internal/throughput_32k
+      - --engine TRTLLM
+      - --speculative_algorithm MTP
+      - --draft_length 3
+      - --tp_size 4
+      - --ep_size 1
+      - --concurrency 8
+      - --num_requests 80
+      - --runtime_params common/specdec_bench/runtime_params_throughput_32k.yaml
+      - --output_length 4096
+      - --aa_timing
+      - --show_progress
+      - --save_dir /scratchspace/{sweep_name_default}/throughput_32k
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - HF_LOCAL: /hf-local
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10


### PR DESCRIPTION
Adds the shared SPEED-bench parent YAML for `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` / MTP / TRTLLM. Cell-specific knobs remain CLI overrides at submission time.

Intern stage: OMNIML-5091 cell_t0_d7.