### PR TITLE
Deprecate examples/llm_autodeploy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -93,6 +93,10 @@ Changelog
 **Deprecations**
 
 - Deprecate the public ``QuantizationArgumentsWithConfig`` name in ``modelopt.torch.quantization.plugins.transformers_trainer``; it now aliases ``QuantizationArguments`` and will be removed in a future release.
+- Deprecate ``examples/llm_autodeploy``. The AutoQuant + TensorRT-LLM AutoDeploy
+  workflow it demonstrates will be removed in a future release; use TensorRT-LLM's
+  `AutoDeploy <https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/auto_deploy>`_
+  directly together with ModelOpt PTQ in ``examples/llm_ptq``.
 
 **Bug Fixes**
 

--- a/examples/llm_autodeploy/README.md
+++ b/examples/llm_autodeploy/README.md
@@ -1,5 +1,12 @@
 # Deploy AutoQuant Models with AutoDeploy
 
+> [!WARNING]
+> **Deprecated (ModelOpt 0.45).** This example is deprecated and will be removed in
+> a future release (0.46). For mixed-precision deployment, use TensorRT-LLM's
+> [AutoDeploy](https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/auto_deploy)
+> directly, combined with ModelOpt PTQ/AutoQuant from
+> [`examples/llm_ptq`](../llm_ptq/README.md).
+
 This guide demonstrates how to deploy mixed-precision models using ModelOpt's AutoQuant and TRT-LLM's AutoDeploy.
 
 [ModelOpt's AutoQuant](https://nvidia.github.io/Model-Optimizer/reference/generated/modelopt.torch.quantization.model_quant.html#modelopt.torch.quantization.model_quant.auto_quantize) is a post-training quantization (PTQ) algorithm that optimizes model quantization by selecting the best quantization format for each layer while adhering to user-defined compression constraints. This approach allows users to balance model accuracy and performance effectively.


### PR DESCRIPTION


### What does this PR do?

Type of change: deprecation <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

Mark the AutoQuant + TensorRT-LLM AutoDeploy example as deprecated per the deprecation policy: add a deprecation banner to the example README and a note under the 0.45 Deprecations section of the changelog. The example will be removed in a future release; users should use TensorRT-LLM's AutoDeploy directly together with ModelOpt PTQ in examples/llm_ptq.

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ❌ <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅  <!--- Mandatory -->
- Did you write any new necessary tests?: N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅  <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * The `examples/llm_autodeploy` example is deprecated and will be removed in a future release. Users should migrate to TensorRT-LLM's AutoDeploy directly with ModelOpt PTQ instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->