### PR TITLE
examples/llm_ptq: pin transformers>=4.56 in requirements.txt

### DIFF
--- a/examples/llm_ptq/requirements.txt
+++ b/examples/llm_ptq/requirements.txt
@@ -1,5 +1,6 @@
 compressed-tensors
 fire
 flash-attn>=2.6.0
+transformers>=4.56
 transformers_stream_generator
 zstandard


### PR DESCRIPTION
### What does this PR do?

**Type of change:** Bug fix (examples)

ModelOpt requires `transformers>=4.56`, but `examples/llm_ptq/requirements.txt` did not pin
`transformers`. So `pip install -r requirements.txt` does **not** repair an environment where an
older `transformers` was manually installed, and model loading then fails with:

```
TypeError: DeepseekV3ForCausalLM.__init__() got an unexpected keyword argument 'dtype'
```

(`transformers` 4.56 renamed `from_pretrained`'s `torch_dtype` argument to `dtype` —
[huggingface/transformers#39782](https://github.com/huggingface/transformers/pull/39782); on
older versions `dtype` is not consumed and leaks into the model constructor.)

This pins the supported floor in the example requirements so `pip install -r requirements.txt`
self-corrects. No library change — it only enforces the already-required minimum.

### Usage

```bash
cd examples/llm_ptq
pip install -r requirements.txt   # now ensures transformers>=4.56
```

### Testing

Verified on a GB200 node that the crash reproduces **only** below the floor and disappears at/above
it (loaded a model via `example_utils.get_model` / `from_pretrained` with ModelOpt save/restore):

| transformers | result |
|---|---|
| 4.53.3 | ❌ `TypeError: ...got an unexpected keyword argument 'dtype'` |
| 4.56.2 | ✅ loads |

Kimi-K2-Thinking int4 PTQ (the reported case) was validated on `transformers 4.57.1` in #669,
which is within this floor.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A (no new dependency; only adds a version floor to an existing transitive requirement)
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ✅ (developed and verified with Claude Code)

### Additional Information

Originally opened as a `dtype`/`torch_dtype` compatibility shim. Per @kevalmorabia97's review, the
root cause is that the reporter manually ran `pip install transformers==4.53.3` (below ModelOpt's
`>=4.56` minimum) — the TRT-LLM container actually ships `transformers 4.57`, and Kimi-K2-Thinking
works on it (#669). Replaced the shim with this one-line floor pin so the example install can't
silently run below the supported `transformers`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version requirements for LLM example code, ensuring compatibility with the latest versions of required packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->