### PR TITLE
Account for CE loss for MTP heads in Megatron KD

### DIFF
--- a/modelopt/torch/distill/plugins/megatron.py
+++ b/modelopt/torch/distill/plugins/megatron.py
@@ -568,8 +568,14 @@ def adjust_distillation_model_for_mcore(
     model.sharded_state_dict = MethodType(_sharded_state_dict, model)
 
     # Skip `lm_loss` bypassing it when training if not needed for backprop.
+    # Uses a per-forward call counter so that MTP head calls (which always precede the
+    # main LM head call in _postprocess) still receive real CE loss even when
+    # skip_lm_loss=True — only the final main-head call is zeroed.
     def _compute_student_lm_loss(self, labels, logits) -> Tensor:
-        if distill_cfg.skip_lm_loss and self.training:
+        self._lm_loss_call_count += 1
+        mtp_num_layers = self.config.mtp_num_layers or 0
+        is_mtp_call = self._lm_loss_call_count <= mtp_num_layers
+        if distill_cfg.skip_lm_loss and self.training and not is_mtp_call:
             return torch.zeros_like(labels, dtype=logits.dtype)
         return type(self).compute_language_model_loss(self, labels, logits)
 
@@ -605,6 +611,9 @@ def adjust_distillation_model_for_mcore(
         with torch.no_grad():
             self._teacher_model.eval()
             teacher_output = self._teacher_model(*args, **kwargs)
+
+        self._lm_loss_call_count = 0  # reset loss-fn call counter for MTP tracking
+
         with self.only_student_forward():
             student_output = type(self).forward(self, *args, **kwargs)
 

--- a/tests/_test_utils/torch/megatron/models.py
+++ b/tests/_test_utils/torch/megatron/models.py
@@ -23,6 +23,7 @@ from megatron.core.models.gpt import GPTModel
 from megatron.core.models.gpt.gpt_layer_specs import (
     get_gpt_layer_local_spec,
     get_gpt_layer_with_transformer_engine_spec,
+    get_gpt_mtp_block_spec,
 )
 from megatron.core.models.mamba import MambaModel
 from megatron.core.parallel_state import (
@@ -277,9 +278,17 @@ def get_mcore_gpt_model(
                 multi_latent_attention=multi_latent_attention,
             )
 
+    mtp_block_spec = None
+    if config.mtp_num_layers:
+        use_te = transformer_impl != "local"
+        mtp_block_spec = get_gpt_mtp_block_spec(
+            config=config, spec=transformer_layer_spec, use_transformer_engine=use_te
+        )
+
     model = GPTModel(
         config=config,
         transformer_layer_spec=transformer_layer_spec,
+        mtp_block_spec=mtp_block_spec,
         vocab_size=vocab_size,
         max_sequence_length=max_sequence_length,
         pre_process=is_pipeline_first_stage(),

--- a/tests/gpu_megatron/torch/distill/plugins/test_distill_megatron.py
+++ b/tests/gpu_megatron/torch/distill/plugins/test_distill_megatron.py
@@ -212,6 +212,99 @@ def _test_topk_logits_kl_loss(top_k, rank, size):
     loss["kd_loss"].backward()
 
 
+def _test_skip_lm_loss_with_mtp(rank, size):
+    """Test that skip_lm_loss only zeroes the main LM head and not MTP heads."""
+    set_seed(SEED)
+
+    num_layers = 2
+    hidden_size = 8
+    num_attention_heads = 4
+    num_query_groups = 2
+    ffn_hidden_size = 8
+    max_sequence_length = 8
+    vocab_size = 32
+    batch_size = 2
+    mtp_num_layers = 1
+
+    teacher_model = get_mcore_gpt_model(
+        tensor_model_parallel_size=size,
+        pipeline_model_parallel_size=1,
+        initialize_megatron=True,
+        num_layers=num_layers,
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+        num_query_groups=num_query_groups,
+        ffn_hidden_size=ffn_hidden_size,
+        max_sequence_length=max_sequence_length,
+        vocab_size=vocab_size,
+        activation_func="squared_relu",
+        mtp_num_layers=mtp_num_layers,
+    ).cuda()
+
+    student_model = get_mcore_gpt_model(
+        tensor_model_parallel_size=size,
+        pipeline_model_parallel_size=1,
+        initialize_megatron=False,
+        num_layers=num_layers,
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+        num_query_groups=num_query_groups,
+        ffn_hidden_size=ffn_hidden_size,
+        max_sequence_length=max_sequence_length,
+        vocab_size=vocab_size,
+        activation_func="squared_relu",
+        mtp_num_layers=mtp_num_layers,
+    ).cuda()
+
+    distill_cfg = setup_distillation_config(
+        config_or_path=DistillationConfig(skip_lm_loss=True),
+        student_cfg=student_model.config,
+        teacher_cfg=teacher_model.config,
+    )
+    kd_config = {
+        "teacher_model": teacher_model,
+        "criterion": distill_cfg.criterion,
+        "loss_balancer": distill_cfg.loss_balancer,
+    }
+    distillation_model = mtd.convert(student_model, mode=[("kd_loss", kd_config)])
+    adjust_distillation_model_for_mcore(distillation_model, distill_cfg)
+
+    # Intercept each call to compute_language_model_loss and record return values.
+    recorded_losses = []
+    original_patched = distillation_model.compute_language_model_loss
+
+    def _recording_loss(labels, logits):
+        loss = original_patched(labels, logits)
+        recorded_losses.append(loss)
+        return loss
+
+    distillation_model.compute_language_model_loss = _recording_loss
+
+    distillation_model.train()
+    prompt_tokens = torch.randint(0, vocab_size, (batch_size, max_sequence_length)).cuda()
+    labels = torch.randint(0, vocab_size, (batch_size, max_sequence_length)).cuda()
+    position_ids = (
+        torch.arange(max_sequence_length, dtype=torch.long)
+        .unsqueeze(0)
+        .repeat(batch_size, 1)
+        .cuda()
+    )
+    attention_mask = torch.tril(
+        torch.ones((batch_size, 1, max_sequence_length, max_sequence_length), dtype=torch.bool)
+    ).cuda()
+
+    distillation_model(prompt_tokens, position_ids, attention_mask, labels=labels)
+
+    # Expect mtp_num_layers + 1 total calls: first mtp_num_layers are MTP heads,
+    # the last one is the main LM head.
+    assert len(recorded_losses) == mtp_num_layers + 1, (
+        f"Expected {mtp_num_layers + 1} loss calls, got {len(recorded_losses)}"
+    )
+    for i, loss in enumerate(recorded_losses[:-1]):
+        assert loss.any(), f"MTP head {i} loss should be non-zero with skip_lm_loss=True"
+    assert not recorded_losses[-1].any(), "Main LM head loss should be zero with skip_lm_loss=True"
+
+
 def test_logits_kl_loss(dist_workers):
     """Test LogitsKLLoss with TP parallelism."""
     dist_workers.run(_test_logits_kl_loss)
@@ -220,3 +313,8 @@ def test_logits_kl_loss(dist_workers):
 def test_topk_logits_kl_loss(dist_workers, top_k: int = 5):
     """Test TopKLogitsKLLoss with TP parallelism."""
     dist_workers.run(partial(_test_topk_logits_kl_loss, top_k))
+
+
+def test_skip_lm_loss_with_mtp(dist_workers):
+    """Test that skip_lm_loss only zeroes the main LM head, not MTP heads."""
+    dist_workers.run(_test_skip_lm_loss_with_mtp)


### PR DESCRIPTION
### What does this PR do?

Type of change: New Feature

Previously, MTP head loss was not accounted for in Megatron KD

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
New gpu test

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ 
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A 
- Did you write any new necessary tests?: ✅ 
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌ 
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of `skip_lm_loss` for Megatron distillation when multiple token prediction (MTP) heads are present, ensuring intermediate MTP head language modeling losses remain non-zero while only the main LM-head loss is zeroed per forward pass.

* **Tests**
  * Added GPU-distributed coverage validating `skip_lm_loss=True` with MTP configurations, including loss-call counting and assertions for non-zero MTP losses and a zeroed final LM-head loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->