### PR TITLE
[6281412] docs: update TensorRT-Edge-LLM CLI commands in torch_onnx example

### DIFF
--- a/examples/torch_onnx/README.md
+++ b/examples/torch_onnx/README.md
@@ -122,8 +122,8 @@ source venv/bin/activate
 pip3 install .
 
 # Verify installation
-tensorrt-edgellm-quantize-llm --help
-tensorrt-edgellm-export-llm --help
+tensorrt-edgellm-quantize --help
+tensorrt-edgellm-export --help
 ```
 
 **System requirements:**
@@ -137,11 +137,8 @@ tensorrt-edgellm-export-llm --help
 
 | Tool | Purpose |
 | :--- | :--- |
-| `tensorrt-edgellm-quantize-llm` | Quantize LLM models using ModelOpt (FP8, INT4 AWQ, NVFP4) |
-| `tensorrt-edgellm-export-llm` | Export LLM to ONNX with precision-specific optimizations |
-| `tensorrt-edgellm-export-visual` | Export visual encoders for multimodal VLM models |
-| `tensorrt-edgellm-quantize-draft` | Quantize EAGLE draft models for speculative decoding |
-| `tensorrt-edgellm-export-draft` | Export EAGLE draft models to ONNX |
+| `tensorrt-edgellm-quantize` | Quantize models using ModelOpt (FP8, INT4 AWQ, NVFP4); subcommands: `llm`, `draft` |
+| `tensorrt-edgellm-export` | Export quantized or FP16/BF16 checkpoint to ONNX; auto-detects VLM and audio components |
 | `tensorrt-edgellm-insert-lora` | Insert LoRA patterns into existing ONNX models |
 | `tensorrt-edgellm-process-lora` | Process LoRA adapter weights for runtime loading |
 
@@ -149,64 +146,58 @@ tensorrt-edgellm-export-llm --help
 
 ```bash
 # Step 1: Quantize with ModelOpt
-tensorrt-edgellm-quantize-llm \
+tensorrt-edgellm-quantize llm \
     --model_dir Qwen/Qwen2.5-3B-Instruct \
     --quantization fp8 \
     --output_dir quantized/qwen2.5-3b-fp8
 
 # Step 2: Export to ONNX
-tensorrt-edgellm-export-llm \
-    --model_dir quantized/qwen2.5-3b-fp8 \
-    --output_dir onnx_models/qwen2.5-3b
+tensorrt-edgellm-export \
+    quantized/qwen2.5-3b-fp8 \
+    onnx_models/qwen2.5-3b
 ```
 
 ### Example: Quantize and Export a VLM
 
 ```bash
-# Quantize the language model component
-tensorrt-edgellm-quantize-llm \
+# Quantize with ModelOpt (handles both LLM and visual components)
+tensorrt-edgellm-quantize llm \
     --model_dir Qwen/Qwen2.5-VL-3B-Instruct \
     --quantization fp8 \
     --output_dir quantized/qwen2.5-vl-3b
 
-# Export the language model
-tensorrt-edgellm-export-llm \
-    --model_dir quantized/qwen2.5-vl-3b \
-    --output_dir onnx_models/qwen2.5-vl-3b/llm
-
-# Export the visual encoder
-tensorrt-edgellm-export-visual \
-    --model_dir Qwen/Qwen2.5-VL-3B-Instruct \
-    --output_dir onnx_models/qwen2.5-vl-3b/visual
+# Export to ONNX (auto-detects VLM and exports LLM + visual encoder to separate subdirs)
+tensorrt-edgellm-export \
+    quantized/qwen2.5-vl-3b \
+    onnx_models/qwen2.5-vl-3b
 ```
 
 ### Example: EAGLE Speculative Decoding
 
 ```bash
 # Quantize base model
-tensorrt-edgellm-quantize-llm \
+tensorrt-edgellm-quantize llm \
     --model_dir meta-llama/Llama-3.1-8B-Instruct \
     --quantization fp8 \
     --output_dir quantized/llama3.1-8b-base
 
 # Export base model with EAGLE flag
-tensorrt-edgellm-export-llm \
-    --model_dir quantized/llama3.1-8b-base \
-    --output_dir onnx_models/llama3.1-8b/base \
-    --is_eagle_base
+tensorrt-edgellm-export \
+    quantized/llama3.1-8b-base \
+    onnx_models/llama3.1-8b/base \
+    --eagle-base
 
 # Quantize EAGLE draft model
-tensorrt-edgellm-quantize-draft \
+tensorrt-edgellm-quantize draft \
     --base_model_dir meta-llama/Llama-3.1-8B-Instruct \
     --draft_model_dir EAGLE3-LLaMA3.1-Instruct-8B \
     --quantization fp8 \
     --output_dir quantized/llama3.1-8b-draft
 
 # Export draft model
-tensorrt-edgellm-export-draft \
-    --draft_model_dir quantized/llama3.1-8b-draft \
-    --base_model_dir meta-llama/Llama-3.1-8B-Instruct \
-    --output_dir onnx_models/llama3.1-8b/draft
+tensorrt-edgellm-export \
+    quantized/llama3.1-8b-draft \
+    onnx_models/llama3.1-8b/draft
 ```
 
 ### Quantization Methods


### PR DESCRIPTION
### What does this PR do?

Type of change: documentation

TensorRT-Edge-LLM v0.8.0 consolidated its CLI entry points, leaving the example commands in `examples/torch_onnx/README.md` referencing tools that no longer exist (e.g. `tensorrt-edgellm-export-visual`). This updates the README to the current interface:

- `tensorrt-edgellm-quantize-llm` / `tensorrt-edgellm-quantize-draft` → `tensorrt-edgellm-quantize {llm,draft}` (subcommands)
- `tensorrt-edgellm-export-llm` / `-export-visual` / `-export-draft` → unified `tensorrt-edgellm-export` with positional `model` / `output_dir` args and automatic VLM/audio component detection
- `--is_eagle_base` → `--eagle-base`
- Updated the CLI Tools table and the LLM / VLM / EAGLE examples accordingly

### Usage

N/A — documentation change.

### Testing

Verified against the live `main` branch of TensorRT-Edge-LLM by running the actual entry-point code (`python -m tensorrt_edgellm.scripts.quantize/export`):

- `--help` runs cleanly for `quantize`, `quantize llm`, `quantize draft`, and `export`; all documented flags (`--model_dir`, `--output_dir`, `--quantization`, `--base_model_dir`, `--draft_model_dir`, positional `model`/`output_dir`, `--eagle-base`) are present.
- Drove the parser with the exact README commands — they parse and advance into the real quantize/export logic.
- Confirmed the old names are gone: `quantize-llm` subcommand rejected, `--is_eagle_base` rejected, `scripts.export_visual` module not found.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: N/A (documentation only)
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A (documentation only)
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A (minor docs change)

> 🤖 _Generated by Claude (AI agent)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TensorRT-Edge-LLM CLI documentation to reflect consolidated command structure
  * Updated command examples for LLM, VLM, and EAGLE speculative decoding workflows
  * Documented new unified CLI interfaces with updated subcommands and flags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->