### PR TITLE
Add NVFP4 Conv3d export for diffusers VAE (Wan 2.2)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Changelog
 
 **New Features**
 
+- Add NVFP4 unified Hugging Face deployment-checkpoint export for Wan VAE ``WanCausalConv3d`` layers, including flattened-K packed weights, calibrated activation/weight scales, and correct ``Conv3d`` config targets.
 - Add the ``prepare_megatron_data_blend`` utility to prepare weighted Megatron data blends from YAML configs, including optional token-budgeted subsets for distillation workflows. See the `Megatron data preparation guide <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/dataset/MEGATRON_DATA_PREP.md#prepare-token-budgeted-data-blends>`_.
 - Add Learned Scale Quantization (LSQ) and Dual-LSQ support for quantization-aware distillation, including learnable ``amax`` parameters, tied-scale and pre-scale options, focused NVFP4 recipes, and scale-only training.
 - Add the **D-PACE** loss objective for DFlash speculative-decoding training (`arXiv:2605.18810 <https://arxiv.org/abs/2605.18810>`_) and make it the default (``dflash_loss_objective: dpace``). It replaces the static exponential position decay with dynamic, confidence-derived per-position weights that adapt to whichever block positions currently limit acceptance. Smoothing is controlled by ``dflash_dpace_alpha`` (default 0.5); set ``dflash_loss_objective: decay`` to restore the previous static schedule. Training-only and detached from the gradient (no architecture or inference change).

--- a/modelopt/torch/export/convert_hf_config.py
+++ b/modelopt/torch/export/convert_hf_config.py
@@ -17,6 +17,7 @@
 
 import warnings
 from collections import defaultdict
+from collections.abc import Collection
 from typing import Any
 
 
@@ -127,11 +128,17 @@ def _quant_algo_to_group_config(quant_algo: str, group_size: int | None = None) 
         return {"quant_algo": quant_algo}
 
 
-def convert_hf_quant_config_format(input_config: dict[str, Any]) -> dict[str, Any]:
+def convert_hf_quant_config_format(
+    input_config: dict[str, Any],
+    *,
+    target_types: Collection[str] | None = None,
+) -> dict[str, Any]:
     """Converts modelopt quantization config dictionary to align with llm-compressor config format.
 
     Args:
         input_config: The original quantization config dictionary.
+        target_types: Optional stable PyTorch module type names for homogeneous
+            config groups. ``None`` retains the historical Linear-only target.
 
     Note:
         The "targets" field specifies which PyTorch module types to quantize. Compressed-tensors
@@ -198,7 +205,7 @@ def convert_hf_quant_config_format(input_config: dict[str, Any]) -> dict[str, An
                 "group_size": group_size,
             },
             "weights": {"dynamic": False, "num_bits": 4, "type": "float", "group_size": group_size},
-            "targets": ["Linear"],
+            "targets": sorted(set(target_types)) if target_types else ["Linear"],
         }
         new_config["config_groups"] = {"group_0": config_group_details}
     elif quant_algo_value == "W4A16_NVFP4":

--- a/modelopt/torch/export/hf_export_handlers.py
+++ b/modelopt/torch/export/hf_export_handlers.py
@@ -18,14 +18,22 @@
 import collections.abc
 import warnings
 
+import torch
 import torch.nn as nn
 
-from modelopt.torch.quantization.utils import fsdp2_aware_weight_update
+from modelopt.torch.quantization.nn import TensorQuantizer
+from modelopt.torch.quantization.qtensor import NVFP4QTensor
+from modelopt.torch.quantization.utils import fsdp2_aware_weight_update, quantizer_attr_names
 
 from .layer_utils import get_expert_linear_names, is_quantlinear, set_expert_quantizer_amax
-from .model_config import QUANTIZATION_NONE
+from .model_config import QUANTIZATION_NONE, QUANTIZATION_NVFP4
 from .moe_utils import _export_fused_experts
-from .quant_utils import get_quantization_format
+from .quant_utils import (
+    get_activation_scaling_factor,
+    get_quantization_format,
+    get_weight_block_size,
+    to_quantized_weight,
+)
 from .registry import ExportContext, ExportModuleRegistry, PrepareMoEInputsRegistry
 
 __all__: list[str] = []
@@ -150,6 +158,146 @@ def _export_quant_linear(name: str, module: nn.Module, ctx: ExportContext) -> No
         raise AssertionError(
             f"Failed to export module '{name}' (type={type(module).__name__}): {e}"
         ) from e
+
+
+def _validate_dynamic_nvfp4_quantizer(
+    quantizer: TensorQuantizer | None,
+    role: str,
+) -> TensorQuantizer:
+    """Validate the exact quantizer contract used by Conv3d implicit GEMM."""
+    if not isinstance(quantizer, TensorQuantizer):
+        raise NotImplementedError(
+            f"Conv3d {role} quantizer must be a TensorQuantizer, got "
+            f"{type(quantizer).__name__ if quantizer is not None else 'None'}."
+        )
+    if not quantizer.is_enabled or not quantizer._if_quant:
+        raise NotImplementedError(f"Conv3d {role} quantizer must be enabled for quantization.")
+    if (
+        not quantizer.is_nvfp4_dynamic
+        or quantizer.block_sizes.get(-1) != 16
+        or quantizer.axis is not None
+    ):
+        raise NotImplementedError(
+            f"Conv3d {role} quantizer must use per-tensor dynamic block-16 NVFP4."
+        )
+    return quantizer
+
+
+def _export_quantized_conv3d_weight(
+    sub_module: nn.Module,
+    dtype: torch.dtype,
+    weight_name: str = "weight",
+) -> None:
+    """Export a supported Conv3d as logical flattened-K dynamic NVFP4 tensors.
+
+    The only supported contract is an ordinary, ungrouped Conv3d with full
+    NVFP4 weight/input quantization and a dynamic weight quantizer. Other
+    formats fail closed because their live fake-quant path does not share this
+    canonical flattened reduction axis.
+    """
+    if not isinstance(sub_module, nn.Conv3d):
+        raise TypeError(f"Expected nn.Conv3d, got {type(sub_module).__name__}.")
+    if sub_module.groups != 1:
+        raise NotImplementedError(
+            f"Grouped Conv3d export is not supported; got groups={sub_module.groups}."
+        )
+
+    quantizer_attrs = quantizer_attr_names(weight_name)
+    weight: nn.Parameter = getattr(sub_module, weight_name)
+    if weight.ndim != 5:
+        raise ValueError(f"Conv3d weight must be rank 5, got shape {tuple(weight.shape)}.")
+    if not weight.is_floating_point():
+        raise ValueError(f"Conv3d weight must be floating point, got {weight.dtype}.")
+
+    weight_quantizer = _validate_dynamic_nvfp4_quantizer(
+        getattr(sub_module, quantizer_attrs.weight_quantizer, None), "weight"
+    )
+    input_quantizer = _validate_dynamic_nvfp4_quantizer(
+        getattr(sub_module, quantizer_attrs.input_quantizer, None), "input"
+    )
+    output_quantizer = getattr(sub_module, quantizer_attrs.output_quantizer, None)
+    if output_quantizer is not None and getattr(output_quantizer, "is_enabled", False):
+        raise NotImplementedError("Conv3d output quantization is not supported for export.")
+    quantization_format = get_quantization_format(sub_module)
+    if quantization_format != QUANTIZATION_NVFP4:
+        raise NotImplementedError(
+            "Conv3d export supports only full dynamic NVFP4; "
+            f"got quantization format {quantization_format!r}."
+        )
+
+    block_size = get_weight_block_size(sub_module, weight_name)
+    weight_flat = weight.reshape(weight.shape[0], -1)
+    k_flat = weight_flat.shape[-1]
+    k_padded = ((k_flat + block_size - 1) // block_size) * block_size
+    if k_padded != k_flat:
+        weight_flat = torch.nn.functional.pad(weight_flat, (0, k_padded - k_flat))
+
+    weight_scale_2 = None
+    if weight_quantizer.amax is not None:
+        if weight_quantizer.amax.numel() != 1 or not torch.all(
+            torch.isfinite(weight_quantizer.amax) & (weight_quantizer.amax > 0)
+        ):
+            raise ValueError(
+                "Conv3d weight quantizer amax must be a finite positive scalar when calibrated."
+            )
+        weight_scale_2 = NVFP4QTensor.get_weights_scaling_factor_2_from_quantizer(weight_quantizer)
+    if weight_scale_2 is None:
+        weight_scale_2 = NVFP4QTensor.get_weights_scaling_factor_2(weight_flat)
+    weight_scale_2 = weight_scale_2.to(device=weight.device, dtype=torch.float32).squeeze()
+    if not torch.all(torch.isfinite(weight_scale_2)) or not torch.all(weight_scale_2 > 0):
+        raise ValueError(
+            f"Conv3d weight_scale_2 must be finite and positive, got {weight_scale_2}."
+        )
+    weight_scale = NVFP4QTensor.get_weights_scaling_factor(
+        weight_flat,
+        block_size=block_size,
+        weights_scaling_factor_2=weight_scale_2,
+    )[0]
+    quantized_weight = to_quantized_weight(
+        weight_flat.to(dtype),
+        weight_scale,
+        QUANTIZATION_NVFP4,
+        weight_scale_2,
+        block_size,
+    )
+
+    if input_quantizer.amax is None:
+        raise ValueError("Conv3d input quantizer must be calibrated before export.")
+    if input_quantizer.amax.numel() != 1 or not torch.all(
+        torch.isfinite(input_quantizer.amax) & (input_quantizer.amax > 0)
+    ):
+        raise ValueError("Conv3d input quantizer amax must be a finite positive scalar.")
+    input_scale = get_activation_scaling_factor(
+        sub_module, input_quantizer_name=quantizer_attrs.input_quantizer
+    )
+
+    # Commit only after every validation and tensor conversion succeeds.
+    setattr(sub_module, weight_name, nn.Parameter(quantized_weight, requires_grad=False))
+    sub_module.register_buffer(quantizer_attrs.weight_scale, weight_scale)
+    sub_module.register_buffer(quantizer_attrs.weight_scale_2, weight_scale_2)
+    sub_module.register_buffer(quantizer_attrs.input_scale, input_scale.squeeze())
+
+    torch.cuda.empty_cache()
+
+
+@ExportModuleRegistry.register(
+    "WanCausalConv3d", predicate=lambda module: hasattr(module, "weight_quantizer")
+)
+def _export_quant_conv3d(name: str, module: nn.Module, ctx: ExportContext) -> None:
+    """Export a supported quantized Wan Conv3d through its MRO registry match."""
+    quantizers = [
+        getattr(module, attr, None)
+        for attr in ("weight_quantizer", "input_quantizer", "output_quantizer")
+    ]
+    if not any(getattr(quantizer, "is_enabled", False) for quantizer in quantizers):
+        return
+
+    try:
+        with fsdp2_aware_weight_update(ctx.model, module, reshard=False):
+            _export_quantized_conv3d_weight(module, ctx.dtype)
+    except (AssertionError, NotImplementedError, TypeError, ValueError) as e:
+        message = f"Failed to export Conv3d '{name}' (type={type(module).__name__}): {e}"
+        raise type(e)(message) from e
 
 
 @ExportModuleRegistry.register(

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -827,6 +827,19 @@ def _process_quantized_modules(
             handler(name, sub_module, ctx)
 
 
+def _diffusion_quantization_target_types(model: nn.Module) -> list[str]:
+    """Return stable type targets for homogeneous NVFP4 diffusion modules."""
+    target_types = set()
+    for sub_module in model.modules():
+        if get_quantization_format(sub_module) != QUANTIZATION_NVFP4:
+            continue
+        if any(cls.__name__ == "WanCausalConv3d" for cls in type(sub_module).__mro__):
+            target_types.add("Conv3d")
+        elif is_quantlinear(sub_module):
+            target_types.add("Linear")
+    return sorted(target_types)
+
+
 def _export_transformers_checkpoint(
     model: nn.Module,
     dtype: torch.dtype | None = None,
@@ -1165,6 +1178,16 @@ def _export_diffusers_checkpoint(
             is_qwen_component = "qwen" in type(component).__name__.lower()
             _fuse_qkv_linears_diffusion(component, strict=is_qwen_component)
 
+            target_types = _diffusion_quantization_target_types(component)
+            if "Conv3d" in target_types and (
+                kwargs.get("padding_strategy") is not None
+                or kwargs.get("enable_swizzle_layout", False)
+            ):
+                raise NotImplementedError(
+                    "NVFP4 GEMM padding/swizzling is not defined for Conv3d exports. "
+                    "Export without padding_strategy/enable_swizzle_layout."
+                )
+
             # Process quantized modules (convert weights, register scales)
             _process_quantized_modules(component, component_dtype, is_modelopt_qlora=False)
 
@@ -1187,7 +1210,9 @@ def _export_diffusers_checkpoint(
                         if svdquant_rank is not None:
                             quantization_details["lora_rank"] = svdquant_rank
                 hf_quant_config = (
-                    convert_hf_quant_config_format(quant_config) if quant_config else None
+                    convert_hf_quant_config_format(quant_config, target_types=target_types)
+                    if quant_config
+                    else None
                 )
 
                 # Save the component

--- a/tests/unit/torch/export/test_nvfp4_conv3d_export.py
+++ b/tests/unit/torch/export/test_nvfp4_conv3d_export.py
@@ -1,0 +1,277 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Focused CPU coverage for registry-based NVFP4 Conv3d HF export."""
+
+import copy
+import json
+
+import pytest
+import torch
+import torch.nn as nn
+
+pytest.importorskip("diffusers")
+
+from diffusers.configuration_utils import ConfigMixin, register_to_config
+from diffusers.models.modeling_utils import ModelMixin
+from safetensors.torch import load_file
+
+import modelopt.torch.quantization as mtq
+from modelopt.torch.export.convert_hf_config import convert_hf_quant_config_format
+from modelopt.torch.export.hf_export_handlers import (
+    _export_quant_conv3d,
+    _export_quantized_conv3d_weight,
+)
+from modelopt.torch.export.registry import ExportModuleRegistry
+from modelopt.torch.export.unified_export_hf import _process_quantized_modules, export_hf_checkpoint
+from modelopt.torch.quantization.qtensor import NVFP4QTensor
+
+BLOCK_SIZE = 16
+
+
+class WanCausalConv3d(nn.Conv3d):
+    """Tiny stand-in that pins base-class/MRO dispatch for the Wan Conv3d type."""
+
+
+class TinyWanVaeComponent(ModelMixin, ConfigMixin):
+    @register_to_config
+    def __init__(
+        self,
+        in_channels: int = 5,
+        out_channels: int = 7,
+        kernel_size: int = 1,
+        groups: int = 1,
+    ):
+        super().__init__()
+        self.conv = WanCausalConv3d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            groups=groups,
+            bias=True,
+        )
+
+    def forward(self, sample: torch.Tensor) -> torch.Tensor:
+        return self.conv(sample)
+
+
+def _quantized_component(
+    *,
+    in_channels: int = 5,
+    out_channels: int = 7,
+    kernel_size: int = 1,
+    groups: int = 1,
+    quant_config: dict | None = None,
+) -> TinyWanVaeComponent:
+    model = TinyWanVaeComponent(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=kernel_size,
+        groups=groups,
+    ).eval()
+
+    def forward_loop(module):
+        module(torch.randn(1, in_channels, 3, 4, 4))
+
+    mtq.quantize(
+        model,
+        copy.deepcopy(quant_config or mtq.NVFP4_DEFAULT_CFG),
+        forward_loop=forward_loop,
+    )
+    model.eval()
+    return model
+
+
+def _flatten_and_pad(weight: torch.Tensor) -> torch.Tensor:
+    flattened = weight.reshape(weight.shape[0], -1)
+    padded_k = ((flattened.shape[-1] + BLOCK_SIZE - 1) // BLOCK_SIZE) * BLOCK_SIZE
+    return torch.nn.functional.pad(flattened, (0, padded_k - flattened.shape[-1]))
+
+
+def test_registry_matches_wan_conv3d_mro_only():
+    model = _quantized_component()
+
+    assert ExportModuleRegistry.match(model.conv) is _export_quant_conv3d
+    plain_conv = nn.Conv3d(2, 2, 1)
+    plain_conv.weight_quantizer = nn.Identity()
+    assert ExportModuleRegistry.match(plain_conv) is None
+
+    conv_transpose = nn.ConvTranspose3d(2, 2, 1)
+    conv_transpose.weight_quantizer = nn.Identity()
+    assert ExportModuleRegistry.match(conv_transpose) is None
+
+
+def test_conv3d_export_preserves_calibrated_global_scale_and_packing():
+    model = _quantized_component()
+    original_weight = model.conv.weight.detach().clone()
+
+    # Pin a calibrated global amax that is intentionally different from the
+    # tensor absmax. Export must match the live TensorQuantizer convention.
+    model.conv.weight_quantizer._amax = torch.tensor(0.5)
+    expected_scale_2 = NVFP4QTensor.get_weights_scaling_factor_2_from_quantizer(
+        model.conv.weight_quantizer
+    )
+    flattened = _flatten_and_pad(original_weight)
+    expected_packed, expected_scale, _ = NVFP4QTensor.quantize(
+        flattened,
+        BLOCK_SIZE,
+        weights_scaling_factor_2=expected_scale_2,
+    )
+
+    _export_quantized_conv3d_weight(model.conv, torch.float32)
+
+    assert model.conv.weight.dtype == torch.uint8
+    assert model.conv.weight.shape == (7, BLOCK_SIZE // 2)
+    assert torch.equal(model.conv.weight, expected_packed._quantized_data)
+    assert torch.equal(model.conv.weight_scale, expected_scale)
+    assert torch.equal(model.conv.weight_scale_2, expected_scale_2)
+    assert model.conv.input_scale.dtype == torch.float32
+    assert model.conv.input_scale.numel() == 1
+
+
+@pytest.mark.parametrize(
+    ("model_factory", "error"),
+    [
+        (
+            lambda: _quantized_component(
+                in_channels=4,
+                out_channels=4,
+                groups=2,
+            ),
+            "Grouped Conv3d",
+        ),
+        (
+            lambda: _quantized_component(quant_config=mtq.W4A16_NVFP4_CFG),
+            "input quantizer must be enabled",
+        ),
+    ],
+)
+def test_unsupported_conv3d_configs_fail_without_mutating_weight(model_factory, error):
+    model = model_factory()
+    original_weight = model.conv.weight.detach().clone()
+
+    with pytest.raises(NotImplementedError, match=error):
+        _process_quantized_modules(model, torch.float32)
+
+    assert model.conv.weight.dtype.is_floating_point
+    assert torch.equal(model.conv.weight, original_weight)
+    assert not hasattr(model.conv, "weight_scale")
+    assert not hasattr(model.conv, "weight_scale_2")
+
+
+def test_static_block_conv3d_fails_without_mutating_weight():
+    model = _quantized_component()
+    original_weight = model.conv.weight.detach().clone()
+    model.conv.weight_quantizer.block_sizes = {
+        **model.conv.weight_quantizer.block_sizes,
+        "type": "static",
+    }
+
+    with pytest.raises(NotImplementedError, match="dynamic block-16 NVFP4"):
+        _process_quantized_modules(model, torch.float32)
+
+    assert torch.equal(model.conv.weight, original_weight)
+    assert not hasattr(model.conv, "weight_scale")
+
+
+def test_partial_conv3d_quantization_fails_instead_of_silently_skipping():
+    model = _quantized_component()
+    original_weight = model.conv.weight.detach().clone()
+    model.conv.weight_quantizer.disable()
+
+    with pytest.raises(NotImplementedError, match="weight quantizer must be enabled"):
+        _process_quantized_modules(model, torch.float32)
+
+    assert torch.equal(model.conv.weight, original_weight)
+
+
+def test_uncalibrated_conv3d_input_fails_without_mutating_weight():
+    model = _quantized_component()
+    original_weight = model.conv.weight.detach().clone()
+    model.conv.input_quantizer._amax = None
+
+    with pytest.raises(ValueError, match="input quantizer must be calibrated"):
+        _process_quantized_modules(model, torch.float32)
+
+    assert torch.equal(model.conv.weight, original_weight)
+    assert not hasattr(model.conv, "weight_scale")
+
+
+def test_fully_disabled_conv3d_remains_unpacked():
+    model = _quantized_component()
+    original_weight = model.conv.weight.detach().clone()
+    for quantizer_name in ("weight_quantizer", "input_quantizer", "output_quantizer"):
+        getattr(model.conv, quantizer_name).disable()
+
+    _process_quantized_modules(model, torch.float32)
+
+    assert torch.equal(model.conv.weight, original_weight)
+    assert not hasattr(model.conv, "weight_scale")
+
+
+def test_nvfp4_config_targets_are_opt_in_and_stably_sorted():
+    quant_config = {"quantization": {"quant_algo": "NVFP4", "group_size": 16}}
+
+    legacy = convert_hf_quant_config_format(quant_config)
+    typed = convert_hf_quant_config_format(
+        quant_config,
+        target_types=["Linear", "Conv3d", "Linear"],
+    )
+
+    assert legacy["config_groups"]["group_0"]["targets"] == ["Linear"]
+    assert typed["config_groups"]["group_0"]["targets"] == ["Conv3d", "Linear"]
+
+
+def test_public_diffusers_export_writes_conv3d_target_and_schema(tmp_path):
+    model = _quantized_component()
+    export_hf_checkpoint(model, dtype=torch.float32, export_dir=tmp_path)
+
+    with open(tmp_path / "config.json") as file:
+        config = json.load(file)
+    quant_config = config["quantization_config"]
+    assert quant_config["quant_algo"] == "NVFP4"
+    assert quant_config["config_groups"]["group_0"]["targets"] == ["Conv3d"]
+
+    state_dict = {}
+    for path in tmp_path.glob("*.safetensors"):
+        state_dict.update(load_file(str(path)))
+
+    assert not any("_quantizer" in key for key in state_dict)
+    assert state_dict["conv.weight"].dtype == torch.uint8
+    assert state_dict["conv.weight_scale"].dtype == torch.float8_e4m3fn
+    assert state_dict["conv.weight_scale_2"].dtype == torch.float32
+    assert state_dict["conv.input_scale"].dtype == torch.float32
+    assert state_dict["conv.weight"].shape[1] == state_dict["conv.weight_scale"].shape[1] * 8
+
+
+@pytest.mark.parametrize(
+    "postprocess_kwargs", [{"padding_strategy": "row"}, {"enable_swizzle_layout": True}]
+)
+def test_public_diffusers_export_rejects_gemm_layout_options_for_conv3d(
+    tmp_path,
+    postprocess_kwargs,
+):
+    model = _quantized_component()
+    original_weight = model.conv.weight.detach().clone()
+
+    with pytest.raises(NotImplementedError, match="padding/swizzling"):
+        export_hf_checkpoint(
+            model,
+            dtype=torch.float32,
+            export_dir=tmp_path,
+            **postprocess_kwargs,
+        )
+
+    assert torch.equal(model.conv.weight, original_weight)


### PR DESCRIPTION
### What does this PR do?

Adds narrowly scoped NVFP4 Conv3d export support for the Wan VAE `WanCausalConv3d` stack in unified Hugging Face deployment checkpoints.

Previously, quantized Wan Conv3d modules had no unified-export handler, so their weights were not serialized in the packed NVFP4 schema. The converted quantization config also hardcoded `targets: ["Linear"]`, even for a Conv3d-only component.

This PR:

- registers a `WanCausalConv3d`-specific export handler through the existing export registry;
- flattens `[O, C, kt, kh, kw]` to logical `[O, K]`, pads `K` to block size 16, and writes packed `weight`, `weight_scale`, scalar `weight_scale_2`, and calibrated `input_scale` tensors;
- derives the NVFP4 config targets from the component's quantized module types, producing `targets: ["Conv3d"]` for a Conv3d-only VAE while preserving the historical Linear default for existing callers;
- rejects GEMM-specific padding/swizzle options when Conv3d is present instead of adding layer-exclusion plumbing; and
- fails before mutating a layer when the Conv3d configuration is unsupported or its activation quantizer was not calibrated.

### Scope

The supported contract is deliberately narrow: ungrouped Wan `WanCausalConv3d`, full dynamic block-16 NVFP4 weight/input quantization, and no output quantization. Grouped Conv3d, ConvTranspose, Conv1d/2d, static NVFP4, and W4A16 Conv3d fail closed or remain outside this handler.

This API produces a unified HF **deployment checkpoint** for downstream inference frameworks. Native Diffusers `from_pretrained()` loading uses a different `NVIDIAModelOptConfig`/ModelOpt-state contract and is out of scope.

Calibration must exercise every Conv3d selected for export. Workflows that only exercise VAE decode should quantize/export the decoder and leave uncalibrated encoder layers unquantized.

### Validation

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- 50 focused and adjacent export tests covering registry routing, byte-exact packing, scale preservation, target generation, schema, quantizer-state removal, unsupported configurations, missing calibration, and padding/swizzle rejection
- A real Wan 2.2 5B VAE checkpoint audit found 48 packed Conv3d layers and exposed 20 uncalibrated encoder activation quantizers; this PR now rejects that inconsistent full-VAE export instead of declaring static activations without `input_scale`

### Before your PR is ready for review

- Backward compatible: yes; the config-conversion argument is optional and defaults to the existing Linear target.
- New dependencies: none.
- Tests: added focused CPU coverage and ran adjacent export regressions.
- Changelog: updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NVFP4 Hugging Face deployment-checkpoint export support for Wan VAE `Conv3d` layers.
  * Exported checkpoints now include flattened, packed weights, calibrated quantization scales, and correct `Conv3d` targets.
  * Added validation for unsupported padding and swizzle configurations, with actionable export errors.
  * Preserved existing support for NVFP4 linear layers while adapting quantization metadata to detected module types.

* **Documentation**
  * Updated the changelog with the new Wan VAE export capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->