### PR TITLE
Fix launcher Slurm mounts in installed MCP mode

### DIFF
--- a/tools/launcher/core.py
+++ b/tools/launcher/core.py
@@ -257,6 +257,7 @@ def build_slurm_executor(
     job_dir,
     task_name,
     packager,
+    modelopt_src_path=None,
     experiment_title="cicd",
 ):
     """Build a SlurmExecutor for remote job submission."""
@@ -264,25 +265,28 @@ def build_slurm_executor(
 
     scratch_dst = "/scratchspace"
     scratch_src = f"{job_dir}/{experiment_title}/{experiment_id}"
-    modelopt_dst = slurm_config.modelopt_install_path
-    modelopt_src = (
-        f"{job_dir}/{experiment_title}/{experiment_id}"
-        f"/{task_name}/code/modules/Model-Optimizer/modelopt"
-    )
-    modelopt_recipes_dst = os.path.join(
-        os.path.dirname(os.path.normpath(slurm_config.modelopt_install_path)),
-        "modelopt_recipes",
-    )
-    modelopt_recipes_src = (
-        f"{job_dir}/{experiment_title}/{experiment_id}"
-        f"/{task_name}/code/modules/Model-Optimizer/modelopt_recipes"
-    )
     container_mounts += [
         f"{scratch_src}:{scratch_dst}",
-        f"{modelopt_src}:{modelopt_dst}",
-        f"{modelopt_recipes_src}:{modelopt_recipes_dst}",
         f"{job_dir}/{experiment_title}:/{experiment_title}",
     ]
+    if modelopt_src_path:
+        modelopt_dst = slurm_config.modelopt_install_path
+        modelopt_src = (
+            f"{job_dir}/{experiment_title}/{experiment_id}"
+            f"/{task_name}/code/modules/Model-Optimizer/modelopt"
+        )
+        modelopt_recipes_dst = os.path.join(
+            os.path.dirname(os.path.normpath(slurm_config.modelopt_install_path)),
+            "modelopt_recipes",
+        )
+        modelopt_recipes_src = (
+            f"{job_dir}/{experiment_title}/{experiment_id}"
+            f"/{task_name}/code/modules/Model-Optimizer/modelopt_recipes"
+        )
+        container_mounts += [
+            f"{modelopt_src}:{modelopt_dst}",
+            f"{modelopt_recipes_src}:{modelopt_recipes_dst}",
+        ]
 
     # When launching from a login node inside the cluster (host is localhost),
     # use a LocalTunnel: nemo_run then runs sbatch and copies artifacts via local
@@ -567,6 +571,7 @@ def run_jobs(
                         job_dir,
                         task_name,
                         packager,
+                        modelopt_src_path,
                         experiment_title,
                     )
                     task_env.update(default_slurm_env)

--- a/tools/launcher/tests/test_slurm_executor.py
+++ b/tools/launcher/tests/test_slurm_executor.py
@@ -30,7 +30,7 @@ class TestBuildSlurmExecutor:
 
     @patch("core.run.SlurmExecutor")
     @patch("core.run.SSHTunnel")
-    def test_scratch_and_modelopt_mounts(self, mock_tunnel, mock_executor):
+    def test_installed_mode_skips_modelopt_source_mounts(self, mock_tunnel, mock_executor):
         mock_tunnel.return_value = MagicMock()
 
         slurm_config = MagicMock(
@@ -64,13 +64,60 @@ class TestBuildSlurmExecutor:
         mock_executor.assert_called_once()
         call_kwargs = mock_executor.call_args[1]
 
-        # Verify container mounts include scratch, modelopt, and experiment title
+        # Installed package mode packages only launcher examples/common. Do not
+        # mount ModelOpt source overlays that were not packaged into remote code.
         mounts = call_kwargs["container_mounts"]
         assert any("/scratchspace" in m for m in mounts)
-        assert any("/opt/modelopt" in m for m in mounts)
         assert any("/cicd" in m for m in mounts)
+        assert not any("/opt/modelopt" in m for m in mounts)
+        assert not any("modelopt_recipes" in m for m in mounts)
         # Original mount preserved
         assert any("/hf-local:/hf-local" in m for m in mounts)
+
+    @patch("core.run.SlurmExecutor")
+    @patch("core.run.SSHTunnel")
+    def test_source_mode_adds_modelopt_source_mounts(self, mock_tunnel, mock_executor):
+        mock_tunnel.return_value = MagicMock()
+
+        slurm_config = MagicMock(
+            requeue=False,
+            host="test-host",
+            port=22,
+            account="test_account",
+            partition="batch",
+            container="nvcr.io/test:latest",
+            modelopt_install_path="/opt/modelopt",
+            container_mounts=[],
+            srun_args=["--no-container-mount-home"],
+            nodes=1,
+            ntasks_per_node=4,
+            gpus_per_node=4,
+            array=None,
+        )
+
+        build_slurm_executor(
+            user="testuser",
+            identity=None,
+            slurm_config=slurm_config,
+            experiment_id="exp_001",
+            job_dir="/lustre/experiments",
+            task_name="job_0",
+            packager=MagicMock(),
+            modelopt_src_path="/checkout/modelopt",
+            experiment_title="cicd",
+        )
+
+        mounts = mock_executor.call_args[1]["container_mounts"]
+        assert any(
+            "/lustre/experiments/cicd/exp_001/job_0/code/modules/Model-Optimizer/modelopt:"
+            "/opt/modelopt" in m
+            for m in mounts
+        )
+        assert any(
+            "/lustre/experiments/cicd/exp_001/job_0/code/modules/Model-Optimizer/"
+            "modelopt_recipes:/opt/modelopt_recipes" in m
+            for m in mounts
+        )
 
     @patch("core.run.SlurmExecutor")
     @patch("core.run.SSHTunnel")
@@ -265,9 +312,10 @@ class TestBuildSlurmExecutor:
             packager=MagicMock(),
         )
 
-        # Should not crash; mounts should still include scratch + modelopt + title
+        # Should not crash; installed mode still includes scratch + title mounts.
         mounts = mock_executor.call_args[1]["container_mounts"]
-        assert len(mounts) >= 3
+        assert "/j/cicd/e:/scratchspace" in mounts
+        assert "/j/cicd:/cicd" in mounts
 
     @patch("core.run.SlurmExecutor")
     @patch("core.run.SSHTunnel")

--- a/tools/mcp/modelopt_mcp/bridge.py
+++ b/tools/mcp/modelopt_mcp/bridge.py
@@ -464,6 +464,8 @@ def _launcher_argv(abs_yaml: Path, checkout: SourceCheckout | None, *flags: str)
     return [
         _uv_binary(),
         "run",
+        "--reinstall-package",
+        "modelopt-launcher",
         "--project",
         str(checkout.launcher_dir),
         "modelopt-launcher",

--- a/tools/mcp/tests/test_bridge.py
+++ b/tools/mcp/tests/test_bridge.py
@@ -349,9 +349,11 @@ def test_submit_job_dry_run_uses_managed_source_checkout(monkeypatch, tmp_path):
     assert result["ok"] is True
     assert result["source_ref"] == "feature/ref"
     assert result["source_sha"] == "b" * 40
-    assert captured["argv"][:5] == [
+    assert captured["argv"][:7] == [
         "uv",
         "run",
+        "--reinstall-package",
+        "modelopt-launcher",
         "--project",
         str(checkout_root / "tools" / "launcher"),
         "modelopt-launcher",


### PR DESCRIPTION
## Summary
- make Slurm ModelOpt source overlay mounts conditional on source-checkout mode
- force managed-source MCP launches to reinstall `modelopt-launcher` from the selected checkout so source refs do not reuse a stale cached package
- add regression coverage for installed-mode Slurm mounts and managed-source launcher argv construction

## Root cause
PR #1799 correctly stopped packaging `modules/Model-Optimizer/*` when `modelopt-launcher` runs from an installed package. However, `build_slurm_executor()` still unconditionally added container mounts for `code/modules/Model-Optimizer/modelopt` and `modelopt_recipes`. In installed MCP mode those paths do not exist in the remote package, so the container runtime fails before the job script starts.

A second issue appeared during validation: the MCP managed-source path can materialize the right git checkout but still execute a cached `modelopt-launcher` package with the same version. Adding `uv run --reinstall-package modelopt-launcher` ensures the selected source ref is what actually runs.

## Validation
- `uv run pytest tests/test_bridge.py -q` from `tools/mcp`: 51 passed
- `uv run pytest tests/test_slurm_executor.py tests/test_core.py -q` from `tools/launcher`: 24 passed
- `pre-commit run --files tools/launcher/core.py tools/launcher/tests/test_slurm_executor.py tools/mcp/modelopt_mcp/bridge.py tools/mcp/tests/test_bridge.py`: passed
- Live Slurm GPU smoke validated with patched launcher path; `nvidia-smi` ran successfully and the smoke script completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured container mount assembly for Slurm job execution to conditionally mount ModelOpt directories based on optional source path parameter.
  * Enhanced launcher command-line generation with package management improvements.
  * Replaced unconditional mount paths with conditional behavior for more flexible resource utilization.

* **Tests**
  * Expanded container mount scenario test coverage for installed and source execution modes.
  * Tightened test assertions for comprehensive mount behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->