### PR TITLE
fix(recipes): exclude Llama-4 vision branch from default PTQ quantization

### DIFF
--- a/modelopt_recipes/configs/ptq/units/default_disabled_quantizers.yaml
+++ b/modelopt_recipes/configs/ptq/units/default_disabled_quantizers.yaml
@@ -43,16 +43,23 @@
   # Multimodal vision branch: keep the vision encoder (SigLIP / ViT) and any
   # multimodal embedding projection in BF16 by default. Recipes that enable bare
   # `*weight_quantizer` / `*input_quantizer` or `*mlp*` wildcards otherwise also
-  # match the vision tower (`model.vision_tower.*`, `model.visual.*`) and the
-  # embedding projection (`model.embed_vision.*`); quantizing the vision branch
-  # crashes export / produces garbage image embeddings on VL models (gemma-4,
-  # Qwen3.5-VL — NVBugs 6293731, 6293762, 6294017). A recipe that intentionally
+  # match the vision tower (`model.vision_tower.*`, `model.visual.*`,
+  # Llama-4 `vision_model.*`) and the embedding projection (`model.embed_vision.*`,
+  # Llama-4 `multi_modal_projector.*`); quantizing the vision branch crashes
+  # export / produces garbage image embeddings on VL models (gemma-4,
+  # Qwen3.5-VL — NVBugs 6293731, 6293762, 6294017; Llama-4-Scout — NVBugs
+  # 6359097, where `vision_model.patch_embedding.linear` has in_features=588,
+  # not divisible by the NVFP4 block size). A recipe that intentionally
   # quantizes vision must re-enable these after importing this unit.
   - quantizer_name: '*embed_vision*'
     enable: false
   - quantizer_name: '*vision_tower*'
     enable: false
   - quantizer_name: '*visual*'
+    enable: false
+  - quantizer_name: '*vision_model*'
+    enable: false
+  - quantizer_name: '*multi_modal_projector*'
     enable: false
   - parent_class: 'nn.BatchNorm1d'
     quantizer_name: '*'


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:** Adds `*vision_model*` and `*multi_modal_projector*` to the `default_disabled_quantizers` PTQ unit so the Llama-4 vision branch stays in BF16 by default.

## Details

The vision-exclusion patterns in `modelopt_recipes/configs/ptq/units/default_disabled_quantizers.yaml` (`*embed_vision*` / `*vision_tower*` / `*visual*`) cover gemma / Qwen-VL / Kimi naming but miss Llama-4, whose encoder is named `vision_model` and whose projector is `multi_modal_projector`.

As a result, `general/ptq/nvfp4_default-kv_fp8` (and any recipe importing this unit) quantized the Llama-4-Scout vision tower. Export then crashed on `vision_model.patch_embedding.linear`, whose `in_features=588` (3×14×14) is not divisible by the NVFP4 block size:

```
AssertionError: Weight shape is not divisible for block size for block quantization.
Failed to export module 'vision_model.patch_embedding.linear' (type=QuantLinear)
```

Adding the two patterns keeps the Llama-4 vision branch in BF16 by default, matching the existing behavior for other VL models (gemma-4, Qwen3.5-VL, Kimi).

Fixes NVBugs 6359097.

## Testing

- YAML validates and pre-commit (incl. `validate modelopt recipes`) passes.
- The `-novit` recipes import this unit and inherit the fix automatically.

## Before your PR is "*Ready for review*"

- [x] Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed.
- [x] Is this change backward compatible? **Yes** — only expands the default disable list to additional vision-branch module names.
- [x] Did you write any new necessary tests? **N/A** — config-only change.
- [x] Did you add or update any necessary documentation? **Yes** — updated the inline rationale comment with the Llama-4 naming and NVBug reference.
- [x] Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)? **N/A** — recipe-config bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the default list of vision-related components that stay unquantized, improving support for multimodal models.
  * Added broader exclusions for additional vision and projector patterns to better preserve model quality by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->