### PR TITLE
Fix ImportError for is_torch_fx_available with transformers 5.x

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Changelog
 **Bug Fixes**
 
 - Fix ``ShapeInferenceError`` during ONNX INT8 + FP16 quantization (``--high_precision_dtype fp16``) of weakly-typed models (e.g. TensorFlow exports) that carry stale rank-0 ``graph.output`` shapes or ops such as ``TopK`` that ONNX's static shape inference cannot resolve. ``clear_stale_value_info`` now reconciles stale output shapes via symbolic shape inference (keeping every output's shape field populated), and AutoCast runs ONNX shape inference in strict mode and falls back to schema-based standalone type inference when it fails, so unresolved ops no longer leave tensors untyped.
+- Fix ``ImportError: cannot import name 'is_torch_fx_available'`` when loading ``trust_remote_code`` checkpoints (e.g. DeepSeek-V3 / Kimi-K2) with Transformers 5.x in ``examples/llm_ptq``. Transformers 5.0 removed the ``is_torch_fx_available`` helper that these models' bundled ``modeling_*.py`` still import at load time; ``get_model`` now reinstalls it as a backward-compatibility shim before loading the model.
 
 0.45 (2026-07-02)
 ^^^^^^^^^^^^^^^^^

--- a/examples/llm_ptq/example_utils.py
+++ b/examples/llm_ptq/example_utils.py
@@ -58,6 +58,41 @@ _QWEN36_AUTOQ_DISABLED_LAYERS = ("*shared_expert_gate*",)
 _VLM_AUTOQ_DISABLED_LAYERS = ("*visual*", "*mtp*", "*vision_tower*")
 
 
+def _restore_legacy_transformers_import_utils() -> None:
+    """Re-add ``transformers.utils.import_utils`` helpers that Transformers 5.0 removed.
+
+    Many ``trust_remote_code`` checkpoints (e.g. DeepSeek-V3 / Kimi-K2's
+    ``modeling_deepseek.py``) were written against Transformers 4.x and run
+    ``from transformers.utils.import_utils import is_torch_fx_available`` at import time.
+    Transformers 5.0 deleted that helper -- ``torch.fx`` has shipped unconditionally since
+    PyTorch 2.1 -- so loading such a checkpoint now raises ``ImportError`` before the model is
+    even built (https://github.com/huggingface/transformers/issues/44561).
+
+    Reinstall the removed names as faithful shims so the remote code imports cleanly. Each shim
+    is only installed when the symbol is missing, leaving older Transformers untouched.
+    """
+    import transformers.utils as tf_utils
+    import transformers.utils.import_utils as tf_import_utils
+
+    def is_torch_fx_available() -> bool:
+        # torch.fx is importable on every torch version ModelOpt supports (PyTorch >= 2.1).
+        try:
+            import torch.fx  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    legacy_shims = {"is_torch_fx_available": is_torch_fx_available}
+    for name, shim in legacy_shims.items():
+        if not hasattr(tf_import_utils, name):
+            setattr(tf_import_utils, name, shim)
+        # ``transformers.utils`` re-exports these helpers; keep both namespaces in sync so
+        # ``from transformers.utils import is_torch_fx_available`` also keeps working.
+        if not hasattr(tf_utils, name):
+            setattr(tf_utils, name, getattr(tf_import_utils, name))
+
+
 def _is_qwen_model(model) -> bool:
     """Return True when model/config identifiers indicate a Qwen-family model."""
     candidates = [type(model).__name__]
@@ -607,6 +642,10 @@ def get_model(
     attn_implementation=None,
 ):
     print(f"Initializing model from {ckpt_path}")
+
+    # Transformers 5.0 dropped ``is_torch_fx_available``; restore it so trust_remote_code
+    # checkpoints (e.g. DeepSeek-V3 / Kimi-K2) that still import it can be loaded.
+    _restore_legacy_transformers_import_utils()
 
     device_map = "auto"
     if device == "cpu":

--- a/tests/examples/llm_ptq/test_example_utils.py
+++ b/tests/examples/llm_ptq/test_example_utils.py
@@ -194,3 +194,27 @@ def test_get_original_hf_quant_method_none_for_unquantized():
         example_utils.get_original_hf_quant_method(SimpleNamespace(quantization_config=None))
         is None
     )
+
+
+# ---------- legacy transformers import_utils shim ---------------------------
+# Transformers 5.0 removed is_torch_fx_available, breaking trust_remote_code checkpoints
+# (DeepSeek-V3 / Kimi-K2) whose modeling_deepseek.py still imports it at module load.
+# get_model() restores it via _restore_legacy_transformers_import_utils().
+
+
+def test_restore_legacy_transformers_import_utils(monkeypatch):
+    import transformers.utils
+    import transformers.utils.import_utils as tf_import_utils
+
+    # Simulate Transformers 5.x, where the helper is gone from both namespaces.
+    monkeypatch.delattr(tf_import_utils, "is_torch_fx_available", raising=False)
+    monkeypatch.delattr(transformers.utils, "is_torch_fx_available", raising=False)
+
+    example_utils._restore_legacy_transformers_import_utils()
+
+    # The exact import the DeepSeek/Kimi remote code performs must now succeed...
+    from transformers.utils.import_utils import is_torch_fx_available
+
+    assert is_torch_fx_available() is True
+    # ...and the re-exported alias on transformers.utils is kept in sync.
+    assert hasattr(transformers.utils, "is_torch_fx_available")


### PR DESCRIPTION
### What does this PR do?

**Type of change:** Bug fix

Transformers 5.0 removed `is_torch_fx_available` from `transformers.utils.import_utils`
(`torch.fx` has been unconditionally available since PyTorch 2.1 — see
[huggingface/transformers#44561](https://github.com/huggingface/transformers/issues/44561)).
Many `trust_remote_code` checkpoints — e.g. DeepSeek-V3 and Kimi-K2 — still import that helper
at module load inside their bundled `modeling_*.py`, so loading them with
`examples/llm_ptq/hf_ptq.py` on transformers 5.x fails **before the model is even built**:

```
ImportError: cannot import name 'is_torch_fx_available' from 'transformers.utils.import_utils'
```

`example_utils.get_model` now reinstalls the removed helper as a faithful
backward-compatibility shim before loading the model. The shim only installs the symbol when it
is missing (so older transformers is untouched) and keeps `transformers.utils` and
`transformers.utils.import_utils` in sync.

### Usage

No new flags — the fix is transparent. The reported command now gets past model loading:

```bash
python hf_ptq.py --model /local/Kimi-K2-Thinking \
    --recipe general/ptq/nvfp4_mlp_only-kv_fp8 \
    --batch_size 1 --calib_size 32 \
    --export_path /local/B200-Kimi-K2-Thinking-nvfp4_mlp_only-kv_fp8 --trust_remote_code
```

### Testing

- New CPU-only unit test
  `tests/examples/llm_ptq/test_example_utils.py::test_restore_legacy_transformers_import_utils`
  deletes `is_torch_fx_available` (simulating transformers 5.x) and asserts the exact remote-code
  import (`from transformers.utils.import_utils import is_torch_fx_available`) succeeds afterwards.
- `pytest tests/examples/llm_ptq/test_example_utils.py` → **11 passed** (transformers 4.56.2 dev container).
- `ruff check` / `ruff format` clean.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ (shim only installs the symbol when missing; older transformers untouched)
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅
- Did you get Claude approval on this PR?: N/A

### Additional Information

Upstream issue: [huggingface/transformers#44561](https://github.com/huggingface/transformers/issues/44561).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
