### PR TITLE
Add quant+sparse attention for vLLM serving

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -79,12 +79,18 @@ decode V **must** be on-write:
 - Needs the graph-safe `(batch, n_kv, 1)` decode-grid repair so the bake kernel
   composes with the captured decode step.
 
-Because written tokens are immutable, on-write is **bit-identical** to on-read for
-every complete block (same 16 elements → same amax → same result) and the trailing
-tile is handled identically — so this is a **pure speedup, no accuracy change**.
-K escapes the problem entirely: the pre-step quantizes each K once. (This is
-"Option 3" of the trailing-block methods: quantize the tail from pristine bf16
-each step — no accumulation, uniform-precision kernel.)
+Because written tokens are immutable, on-write reproduces the on-read fake-quant
+**bit-for-bit** at the V‑value level. Validated on B200 (NVFP4, fp16/bf16 cache):
+(A) FQ-all on the baked cache equals FQ-all on the raw cache — `maxabs = 0`; (B)
+incremental per-tile baking (the decode pattern) yields a bit-identical cache to a
+single-shot bake — **no cross-step accumulation**. The dequantized V is stored at
+the buffer (cache) dtype, which the NVFP4 dequant already hits exactly. The
+attention *output* of read-as-is vs FQ-on-read can differ by ≤~1e-5 — fp32-reduction
+scheduling between the two compiled kernel variants on **identical** V values, not a
+quantization difference. So this is a **pure speedup, no accuracy change**. K escapes
+the problem entirely: the pre-step quantizes each K once. (This is "Option 3" of the
+trailing-block methods: quantize the tail from pristine bf16 each step — no
+accumulation, uniform-precision kernel.)
 
 ## Fidelity to true NVFP4
 
@@ -114,16 +120,15 @@ sparsity/attention_sparsity/plugins/vllm.py
 Implemented: paged decode kernel + skip-softmax; in-kernel `P_QDQ` and `V_QDQ`
 helpers in both prefill and decode; plugin wiring that drives P/V quant from the
 exported `p/v_bmm_quantizer` and engages the kernel for quant-only launches.
+**Decode V on-write** (`fake_quant_v_onwrite` + `V_CACHE_QUANTIZED` gating + graph-safe
+`(batch, n_kv, 1)` grid): prefill bakes the prompt's complete tiles after its on-read
+attention; decode bakes each newly-complete tile and reads complete tiles as-is,
+re-FQ'ing only the trailing tile → `O(S)`. **Validated on B200** as exactly Option 3
+(bake == on-read FQ bit-for-bit; incremental == single-shot cache; output diff ≤~1e-5
+is fp32-reduction scheduling, not a value change).
 
 Remaining:
 
-- **Decode V → on-write** (the `O(S²)` fix above). Port the `fake_quant_kv_onwrite`
-  V-path + `V_CACHE_QUANTIZED` boundary gating + graph-safe decode grid from
-  `kaix/sparse_attn_integration` onto this config-driven chassis (V-only; K/Q stay
-  pre-step, P stays straight). The current in-kernel `V_QDQ` stays as the
-  **prefill** path and as the **trailing-tile** FQ; the decode kernel flips from
-  "FQ every tile" to "read baked blocks + FQ the trailing tile." Numerically
-  identical, so no accuracy rework.
 - Un-skip `p_bmm_quantizer` / `v_bmm_quantizer` in the vLLM reload + add their
   slots to `_QuantVLLMAttention`, so the exported config reaches the served layer.
 - Unified serve worker: quant restore (gives `_QuantVLLMAttention` with Q/K

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -88,13 +88,18 @@ softmax normalization. **So prefill `P·V` stays bf16**: fp32 accumulation is mo
 faithful to native FP4 in principle, but here it costs ~2.4× for no measurable eval
 benefit.
 
-## V: on-read for prefill, on-write for decode (required)
+## V: baked on write for both phases (required for decode)
 
 The keys axis means V cannot be quantized by a per-token write, so it is
 fake-quantized around the kernel. But the *cost* differs sharply by phase:
 
-- **Prefill** is a single pass that touches each tile once → on-read FQ is
-  `O(S)`. Fine; the kernel FQs V tiles as it reads them.
+- **Prefill** is a single pass that touches each tile once → `O(S)` either way. It
+  bakes its complete tiles on write *before* the kernel and reads them as-is
+  (`V_CACHE_QUANTIZED`, same as decode), re-FQ'ing only the trailing partial, so V is
+  **quantized exactly once** — a *chunked* prefill never re-FQ's an earlier chunk's
+  baked tiles. (That double-quant is usually a no-op anyway: NVFP4 QDQ is a near
+  fixed-point — measured `maxabs 0` on B200 random data — but the gate makes
+  quantize-once exact.)
 - **Decode** is autoregressive: every step re-reads the whole growing cache, so
   on-read re-FQ's the entire cache each step → `Σ O(s) = O(S²)`, and it is almost
   all redundant (a written token is immutable, so re-quantizing token 5 at steps

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,8 +10,10 @@ how the attention operands are represented. The two are orthogonal in code and
 compose in one Triton kernel launch.
 
 This is a **fake-quantization accuracy study**: operands are rounded to the
-NVFP4/FP8 grid and dequantized to bf16 for the matmul. Real KV-cache *memory*
-savings are a downstream deployment concern (see "On-write V, deferred").
+NVFP4/FP8 grid and dequantized back to a float type for the matmul. Real KV-cache
+*memory* savings are a downstream deployment concern (see "On-write V, deferred").
+The matmul precision is **phase-specific** — bf16 tensor-core in prefill, fp32 in
+decode — see "Matmul precision by phase" below.
 
 ## The two matmuls set the quantization axis
 
@@ -52,6 +54,34 @@ write as that axis allows; the operands whose axis a per-token write cannot form
   V; 16-blocks along axis 0 of the loaded tile `[BLOCK_N keys, BLOCK_D head_dim]`;
   masked-to-0 loads keep a partial tail from poisoning a block amax). *Where* it
   runs differs by phase — see below.
+
+## Matmul precision by phase (prefill bf16 tensor-core, decode fp32)
+
+The NVFP4/FP8 operand *grid* is identical in both phases, but the matmuls run at
+different precision, by design:
+
+- **Prefill** (a GEMM over `BLOCK_M` query rows) uses `tl.dot` on **bf16** operands
+  for both `Q·Kᵀ` and `P·V` (`p.to(v.dtype)` before BMM2). Tensor-core throughput,
+  at the cost of rounding the dequantized operands to bf16.
+- **Decode** (a GEMV — one query row) uses **fp32** elementwise reductions for both
+  matmuls (`tl.sum(q[:,None]*kᵀ)`, `tl.sum(p[:,None]*v)`); P stays fp32 (V is still
+  dequantized to bf16 to match the on-write cache, then upcast). `tl.dot` is
+  wasteful at M=1, and fp32 is more accurate: vs an fp64-exact reference the
+  fp32-elementwise decode is **5.70e-8** (the fp32 floor) while a bf16/tf32x3
+  `tl.dot` is **1.39e-4** (~2400× worse); the fp32 decode also reproduces the
+  reference branch's default decode bit-for-bit.
+
+Consequence: the **P dtype entering `P·V` differs** — bf16 in prefill, fp32 in
+decode. This is an intentional phase-specific asymmetry (prefill trades precision
+for GEMM throughput; decode, cheap at M=1, keeps full fp32), not a bug. Note
+`tl.dot` does not *require* bf16 (it also accepts fp32 via
+`input_precision=tf32|tf32x3|ieee`); the bf16 prefill path is a throughput choice,
+not a hard constraint. A `P·V`-tile micro-benchmark (A6000, vs fp64, V held at
+bf16) puts numbers on it: fp32 `tf32x3` is **~9000× more accurate** than bf16
+(rel-L2 ~1.6e-7 vs ~1.5e-3) at **~1.3×** the matmul latency, `ieee` ~1.6×. So
+switching prefill to fp32 is viable and much more accurate; it is left as bf16 for
+GEMM throughput, and revisiting it is a measured, deliberate choice (re-measure on
+target hardware).
 
 ## V: on-read for prefill, on-write for decode (required)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -77,11 +77,16 @@ for GEMM throughput; decode, cheap at M=1, keeps full fp32), not a bug. Note
 `tl.dot` does not *require* bf16 (it also accepts fp32 via
 `input_precision=tf32|tf32x3|ieee`); the bf16 prefill path is a throughput choice,
 not a hard constraint. A `P·V`-tile micro-benchmark (A6000, vs fp64, V held at
-bf16) puts numbers on it: fp32 `tf32x3` is **~9000× more accurate** than bf16
-(rel-L2 ~1.6e-7 vs ~1.5e-3) at **~1.3×** the matmul latency, `ieee` ~1.6×. So
-switching prefill to fp32 is viable and much more accurate; it is left as bf16 for
-GEMM throughput, and revisiting it is a measured, deliberate choice (re-measure on
-target hardware).
+bf16) shows fp32 `tf32x3` is ~9000× more accurate than bf16 on the tile (rel-L2
+~1.6e-7 vs ~1.5e-3) at ~1.3× the *tile* matmul latency. **That gain does not reach
+the attention output.** Re-measured on **B200** (full-quant prefill, 4096-tok GQA),
+fp32 `tf32x3` prefill is **2.4× end-to-end** — not the 1.3× tile ratio; the tf32x3
+3-pass dominates the whole kernel — for a **negligible** accuracy change: cos-vs-dense
+is unchanged (**0.9918** either way), because the NVFP4 *quantization* error (~8e-3)
+dominates the output and the bf16-accumulation artifact (~1.5e-3) washes out after
+softmax normalization. **So prefill `P·V` stays bf16**: fp32 accumulation is more
+faithful to native FP4 in principle, but here it costs ~2.4× for no measurable eval
+benefit.
 
 ## V: on-read for prefill, on-write for decode (required)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,133 @@
+# Attention quantization + skip-softmax sparsity (vLLM)
+
+## Goal
+
+Serve a checkpoint that is **both attention-quantized and skip-softmax-sparse**,
+composed in a single attention pass (prefill *and* decode), driven entirely by
+the exported `*_bmm_quantizer` / sparse-attention config — no `MODELOPT_ATTN_*`
+env knobs. Skip-softmax selects which KV tiles to compute; quantization controls
+how the attention operands are represented. The two are orthogonal in code and
+compose in one Triton kernel launch.
+
+This is a **fake-quantization accuracy study**: operands are rounded to the
+NVFP4/FP8 grid and dequantized to bf16 for the matmul. Real KV-cache *memory*
+savings are a downstream deployment concern (see "On-write V, deferred").
+
+## The two matmuls set the quantization axis
+
+NVFP4 blocks (16 elements sharing an E4M3 scale) must lie along the GEMM
+**contraction** axis. Attention has two matmuls with *different* contraction
+axes:
+
+| BMM | operands | contraction axis | block-16 axis |
+|-----|----------|------------------|---------------|
+| BMM1 `Q · Kᵀ` | Q, K | head_dim | head_dim |
+| BMM2 `P · V`  | P, V | **keys**     | **keys**      |
+
+A vLLM decode step writes **one token = one key** at a time. So a per-token
+cache write can form the **head_dim** axis (fully present per token) but *not*
+the **keys** axis (a 16-key block spans 16 decode steps). That single fact
+decides where each operand is quantized.
+
+## Per-operand mechanism
+
+| operand | BMM | block axis | where quantized | producible at write? |
+|---------|-----|-----------|-----------------|----------------------|
+| Q | 1 | head_dim | pre-step (`_QuantVLLMAttention.forward`, `q_bmm_quantizer`) | n/a (current query) |
+| K | 1 | head_dim | pre-step → written to cache (`k_bmm_quantizer`) | yes (quantize-once) |
+| V | 2 | keys | **on-write bake (decode) / on-read (prefill)** (`v_bmm_quantizer` → `_v_qdq_nvfp4`) | no |
+| P | 2 | keys | **in-kernel** (`p_bmm_quantizer` → `_p_qdq_nvfp4`) | no (P is transient) |
+| skip | – | – | in-kernel tile selection on the quantized scores | – |
+
+Principle: quantize each operand once, on its correct axis, as close to the
+write as that axis allows; the operands whose axis a per-token write cannot form
+(P always; V at decode) are handled in/around the kernel.
+
+- **Q, K** stay on the `_QuantVLLMAttention` pre-step: head_dim is present per
+  token, so the pre-step is quantize-once-at-write for free and reuses standard
+  ModelOpt machinery with stock vLLM cache writes.
+- **P** is fake-quantized **in-kernel** by `_p_qdq_nvfp4` (plain max, P ≥ 0;
+  16-blocks along keys). It is transient, so in-kernel is its only home.
+- **V** is fake-quantized along the keys axis by `_v_qdq_nvfp4` (`abs` for signed
+  V; 16-blocks along axis 0 of the loaded tile `[BLOCK_N keys, BLOCK_D head_dim]`;
+  masked-to-0 loads keep a partial tail from poisoning a block amax). *Where* it
+  runs differs by phase — see below.
+
+## V: on-read for prefill, on-write for decode (required)
+
+The keys axis means V cannot be quantized by a per-token write, so it is
+fake-quantized around the kernel. But the *cost* differs sharply by phase:
+
+- **Prefill** is a single pass that touches each tile once → on-read FQ is
+  `O(S)`. Fine; the kernel FQs V tiles as it reads them.
+- **Decode** is autoregressive: every step re-reads the whole growing cache, so
+  on-read re-FQ's the entire cache each step → `Σ O(s) = O(S²)`, and it is almost
+  all redundant (a written token is immutable, so re-quantizing token 5 at steps
+  6…1000 yields the identical result 995×).
+
+That `O(S²)` is not academic: it **made long-context evals (HLE) infeasible** —
+the original on-read decode design timed out, which is why PR #1635 switched to
+**on-write** (≈8–18× decode-kernel speedup). So for the long-context campaign,
+decode V **must** be on-write:
+
+- **Bake** complete 16-key V blocks once, in place in the paged cache
+  (`fake_quant_kv_onwrite` V-path, driven by `v_bmm_quantizer`). Prefill bakes the
+  prompt so decode inherits a pre-quantized cache; decode bakes each newly-complete
+  block.
+- The decode kernel reads complete blocks **as-is** (`V_CACHE_QUANTIZED`) and
+  re-FQ's only the trailing `s mod 16` tile via `_v_qdq_nvfp4` → `O(S)` total.
+- Needs the graph-safe `(batch, n_kv, 1)` decode-grid repair so the bake kernel
+  composes with the captured decode step.
+
+Because written tokens are immutable, on-write is **bit-identical** to on-read for
+every complete block (same 16 elements → same amax → same result) and the trailing
+tile is handled identically — so this is a **pure speedup, no accuracy change**.
+K escapes the problem entirely: the pre-step quantizes each K once. (This is
+"Option 3" of the trailing-block methods: quantize the tail from pristine bf16
+each step — no accumulation, uniform-precision kernel.)
+
+## Fidelity to true NVFP4
+
+True NVFP4 = E2M1 element × dynamic E4M3 per-16 block scale (`amax(block)/6`) ×
+FP32 per-tensor global. The **per-16 block scale is the real quantizer** and is
+computed dynamically per block in-kernel for both P and V; the partial trailing
+tile gets its scale from its own valid keys (zeros from masked loads never raise
+the amax). For V the per-tensor global barely matters — the block amax carries
+the range and V does not saturate E4M3 — so `v_qdq_amax=None` uses the constant
+`1.0` global. A frozen first-chunk global is the only scheme that diverges (it
+saturates E4M3 on long context) and is intentionally not used.
+
+## Code layout
+
+```text
+quantization/attention/p_qdq.py     _p_qdq_nvfp4 (P), _v_qdq_nvfp4 (V) — BMM2 helpers
+quantization/common/nvfp4_quant.py  nvfp4_scalar_qdq (elementwise primitive)
+common/attention/triton_fa.py       prefill kernel: P_QDQ + V_QDQ constexprs
+common/attention/decode_attention.py paged decode kernel: P_QDQ + V_QDQ + skip
+sparsity/attention_sparsity/plugins/vllm.py
+    _p_qdq_from_layer / _v_qdq_from_layer  read p/v_bmm_quantizer -> (mode, amax)
+    ModelOptSparseAttentionImpl.forward     threads p_qdq + v_qdq + skip into both kernels
+```
+
+## Build status
+
+Implemented: paged decode kernel + skip-softmax; in-kernel `P_QDQ` and `V_QDQ`
+helpers in both prefill and decode; plugin wiring that drives P/V quant from the
+exported `p/v_bmm_quantizer` and engages the kernel for quant-only launches.
+
+Remaining:
+
+- **Decode V → on-write** (the `O(S²)` fix above). Port the `fake_quant_kv_onwrite`
+  V-path + `V_CACHE_QUANTIZED` boundary gating + graph-safe decode grid from
+  `kaix/sparse_attn_integration` onto this config-driven chassis (V-only; K/Q stay
+  pre-step, P stays straight). The current in-kernel `V_QDQ` stays as the
+  **prefill** path and as the **trailing-tile** FQ; the decode kernel flips from
+  "FQ every tile" to "read baked blocks + FQ the trailing tile." Numerically
+  identical, so no accuracy rework.
+- Un-skip `p_bmm_quantizer` / `v_bmm_quantizer` in the vLLM reload + add their
+  slots to `_QuantVLLMAttention`, so the exported config reaches the served layer.
+- Unified serve worker: quant restore (gives `_QuantVLLMAttention` with Q/K
+  pre-step quant) then swap in `ModelOptSparseAttentionImpl`.
+- Calibrate skip-softmax on the **quantized** model (the skip decision sees
+  quantized `Q·K` scores).
+- GPU validation of the full quant + skip path on B200; README / CHANGELOG.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -37,7 +37,7 @@ decides where each operand is quantized.
 |---------|-----|-----------|-----------------|----------------------|
 | Q | 1 | head_dim | pre-step (`_QuantVLLMAttention.forward`, `q_bmm_quantizer`) | n/a (current query) |
 | K | 1 | head_dim | pre-step → written to cache (`k_bmm_quantizer`) | yes (quantize-once) |
-| V | 2 | keys | **on-write bake (decode) / on-read (prefill)** (`v_bmm_quantizer` → `_v_qdq_nvfp4`) | no |
+| V | 2 | keys | **on-write bake (both phases)** (`v_bmm_quantizer` → `_v_qdq_nvfp4`) | no |
 | P | 2 | keys | **in-kernel** (`p_bmm_quantizer` → `_p_qdq_nvfp4`) | no (P is transient) |
 | skip | – | – | in-kernel tile selection on the quantized scores | – |
 
@@ -49,7 +49,16 @@ write as that axis allows; the operands whose axis a per-token write cannot form
   token, so the pre-step is quantize-once-at-write for free and reuses standard
   ModelOpt machinery with stock vLLM cache writes.
 - **P** is fake-quantized **in-kernel** by `_p_qdq_nvfp4` (plain max, P ≥ 0;
-  16-blocks along keys). It is transient, so in-kernel is its only home.
+  16-blocks along keys). It is transient, so in-kernel is its only home. It quantizes
+  the *tile-local unnormalized* numerator `exp2(scores − m_new)` (vs the running max,
+  before the `/l` normalization), so the autotuned prefill `BLOCK_N` and the
+  auto-selected decode split count perturb the quantized P — E4M3 scale rounding is
+  not scale-equivariant across the online-softmax max-shift. This is inherent to
+  flash-attention P fake-quant (the mni reference and real FP4-attention hardware
+  quantize tile-local P too), ~cos 0.9998 on the output (inside the NVFP4 quant
+  floor), **not a bug**. For bitwise reproducibility across runs/hardware, pin the
+  tiling (`PYTEST_VERSION` → fixed `BLOCK_M/BLOCK_N`; `num_kv_splits` → fixed decode
+  splits) — a determinism knob, not an accuracy fix.
 - **V** is fake-quantized along the keys axis by `_v_qdq_nvfp4` (`abs` for signed
   V; 16-blocks along axis 0 of the loaded tile `[BLOCK_N keys, BLOCK_D head_dim]`;
   masked-to-0 loads keep a partial tail from poisoning a block amax). *Where* it
@@ -142,6 +151,20 @@ the amax). For V the per-tensor global barely matters — the block amax carries
 the range and V does not saturate E4M3 — so `v_qdq_amax=None` uses the constant
 `1.0` global. A frozen first-chunk global is the only scheme that diverges (it
 saturates E4M3 on long context) and is intentionally not used.
+
+The per-block scale is clamped to `[2**-9, 448]` in `fp8_quantize_scale`, matching
+the canonical NVFP4 path (`qtensor/nvfp4_tensor.py`): the upper bound caps at the
+E4M3 max, and the `2**-9` lower bound floors an underflowed block at the smallest
+subnormal instead of letting the scale round to 0 (which would zero the block). A
+block below the floor still rounds to 0 on the E2M1 grid; one in the `[~1.8e-7,
+2.2e-6]` band reconstructs nonzero (e.g. amax `2e-6` → `2.179827e-6`). This keeps the
+in-kernel fake-quant bit-consistent with the exported NVFP4 checkpoint in the
+underflow regime, and lets the P/V and Q/K (`fp4_kernel_hopper.py`) paths share one
+scale contract without the ad-hoc `<1e-5 → 1.0` guard. On the output it is a no-op:
+underflowed P/V blocks carry weights `< ~2.2e-6` (keys many log2-units below the row
+max), a B200 A/B (current-vs-clamped, up to 98% of P underflowing) is bit-identical,
+and Q/K never underflow on real data — it is a fidelity/consistency guarantee, not an
+accuracy change.
 
 ## Code layout
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,7 +11,7 @@ compose in one Triton kernel launch.
 
 This is a **fake-quantization accuracy study**: operands are rounded to the
 NVFP4/FP8 grid and dequantized back to a float type for the matmul. Real KV-cache
-*memory* savings are a downstream deployment concern (see "On-write V, deferred").
+*memory* savings (packed FP4) are a deferred deployment concern (see "Build status").
 The matmul precision is **phase-specific** — bf16 tensor-core in prefill, fp32 in
 decode — see "Matmul precision by phase" below.
 
@@ -119,12 +119,13 @@ the original on-read decode design timed out, which is why PR #1635 switched to
 **on-write** (≈8–18× decode-kernel speedup). So for the long-context campaign,
 decode V **must** be on-write:
 
-- **Bake** complete 16-key V blocks once, in place in the paged cache
-  (`fake_quant_kv_onwrite` V-path, driven by `v_bmm_quantizer`). Prefill bakes the
-  prompt so decode inherits a pre-quantized cache; decode bakes each newly-complete
-  block.
-- The decode kernel reads complete blocks **as-is** (`V_CACHE_QUANTIZED`) and
-  re-FQ's only the trailing `s mod 16` tile via `_v_qdq_nvfp4` → `O(S)` total.
+- **Bake** complete 128-token V tiles once, in place in the paged cache
+  (`fake_quant_v_onwrite`, tile size `_ONWRITE_BLOCK_N = 128`, driven by
+  `v_bmm_quantizer`); each 128-token tile is internally 8 × 16-key NVFP4 blocks.
+  Prefill bakes the prompt so decode inherits a pre-quantized cache; decode bakes
+  each newly-complete tile.
+- The decode kernel reads complete tiles **as-is** (`V_CACHE_QUANTIZED`) and
+  re-FQ's only the trailing `s mod 128` partial tile via `_v_qdq_nvfp4` → `O(S)` total.
 - Needs the graph-safe `(batch, n_kv, 1)` decode-grid repair so the bake kernel
   composes with the captured decode step.
 
@@ -166,36 +167,72 @@ max), a B200 A/B (current-vs-clamped, up to 98% of P underflowing) is bit-identi
 and Q/K never underflow on real data — it is a fidelity/consistency guarantee, not an
 accuracy change.
 
+## Supported configuration (fail-loud)
+
+The served checkpoint runs the ModelOpt attention kernel only when **every** requested layer
+satisfies all of these; anything else fails at startup with a single layer-qualified error (no
+requested quant or sparsity transform is ever silently dropped):
+
+- Decoder self-attention (`AttentionType.DECODER`) on the FlashAttention or FlashInfer backend.
+- Q/K/P/V use the supported fake-quant recipe: dynamic block-16 NVFP4 (P/V BMM2 may also be
+  per-tensor FP8), Q per-step dynamic, K/V calibrated-or-default global scale.
+- FP16/BF16 KV cache (every `fp8*` cache dtype is rejected); cache page size a multiple of 16.
+- `decode_context_parallel_size == 1`; no sliding window, ALiBi, logits soft-cap, or sinks.
+- No prefix caching, cross-layer KV sharing, KV connector, speculative decoding, or cascade.
+
+Launch with `--enforce-eager` and prefix caching disabled until the retained code has CUDA-graph
+evidence. Cascade is disabled automatically when quant is active — but disabling cascade does **not**
+make prefix-cache storage reuse safe (V is baked in place; a shared prefix would read another
+request's quantized V), which is why prefix caching is rejected outright.
+
 ## Code layout
 
 ```text
-quantization/attention/p_qdq.py     _p_qdq_nvfp4 (P), _v_qdq_nvfp4 (V) — BMM2 helpers
-quantization/common/nvfp4_quant.py  nvfp4_scalar_qdq (elementwise primitive)
-common/attention/triton_fa.py       prefill kernel: P_QDQ + V_QDQ constexprs
-common/attention/decode_attention.py paged decode kernel: P_QDQ + V_QDQ + skip
+kernels/quantization/attention/p_qdq.py   _p_qdq_nvfp4 (P BMM2 helper)
+kernels/quantization/attention/v_qdq.py   _v_qdq_nvfp4 (V BMM2 helper)
+kernels/quantization/common/nvfp4_quant.py  nvfp4_scalar_qdq + fp8_quantize_scale ([2^-9,448] clamp)
+kernels/common/attention/triton_fa.py     prefill kernel: P_QDQ + V_QDQ constexprs
+kernels/common/attention/decode_attention.py paged decode kernel + fake_quant_v_onwrite (128-token V bake)
+quantization/plugins/vllm.py
+    _import_attention_module   select the vLLM Attention class by exported symbol
+    _QuantVLLMAttention        Q/K head_dim pre-step; holds q/k/v/p_bmm_quantizer
 sparsity/attention_sparsity/plugins/vllm.py
-    _p_qdq_from_layer / _v_qdq_from_layer  read p/v_bmm_quantizer -> (mode, amax)
-    ModelOptSparseAttentionImpl.forward     threads p_qdq + v_qdq + skip into both kernels
+    _p_qdq_from_layer / _v_qdq_from_layer  read p/v_bmm_quantizer -> (mode, amax); fail-loud on unmapped
+    ModelOptSparseAttentionImpl / ModelOptSparseFlashInferImpl  P/V + skip in both kernels
+    select_sparse_impl_cls / _clone_sparse_impl / patch_flashinfer_metadata_builder  backend routing
+examples/vllm_serve/quant_sparse_attn_worker.py
+    _preflight_quant_sparse_attn            pure support-matrix validation (fail-loud, no mutation)
+    _prepare_ / _commit_quant_sparse_attn   two-pass atomic install (build all, then assign + flip V gate)
 ```
 
 ## Build status
 
-Implemented: paged decode kernel + skip-softmax; in-kernel `P_QDQ` and `V_QDQ`
-helpers in both prefill and decode; plugin wiring that drives P/V quant from the
-exported `p/v_bmm_quantizer` and engages the kernel for quant-only launches.
-**Decode V on-write** (`fake_quant_v_onwrite` + `V_CACHE_QUANTIZED` gating + graph-safe
-`(batch, n_kv, 1)` grid): prefill bakes the prompt's complete tiles after its on-read
-attention; decode bakes each newly-complete tile and reads complete tiles as-is,
-re-FQ'ing only the trailing tile → `O(S)`. **Validated on B200** as exactly Option 3
-(bake == on-read FQ bit-for-bit; incremental == single-shot cache; output diff ≤~1e-5
-is fp32-reduction scheduling, not a value change).
+Implemented and validated: paged decode kernel + skip-softmax; in-kernel `P_QDQ`/`V_QDQ` in
+prefill and decode; **decode V on-write** (`fake_quant_v_onwrite` 128-token tiles +
+`V_CACHE_QUANTIZED` gating + graph-safe `(batch, n_kv, 1)` grid), reproducing on-read FQ
+bit-for-bit (incremental == single-shot; output diff ≤~1e-5 is fp32-reduction scheduling, not a
+value change); plugin wiring that drives P/V from the exported `p/v_bmm_quantizer`; a unified serve
+worker that attaches attention quant (impl-swap default, composes with a realquant checkpoint; a
+legacy `mtq` mode) then installs the sparse impl; FlashAttention **and** FlashInfer backends.
 
-Remaining:
+Gate A safety: a pure capability **preflight** validates the support matrix above and fails at
+startup with one layer-qualified error; installation is a two-pass **prepare/commit** transaction,
+so a failure leaves every original impl and V-ownership gate unchanged.
 
-- Un-skip `p_bmm_quantizer` / `v_bmm_quantizer` in the vLLM reload + add their
-  slots to `_QuantVLLMAttention`, so the exported config reaches the served layer.
-- Unified serve worker: quant restore (gives `_QuantVLLMAttention` with Q/K
-  pre-step quant) then swap in `ModelOptSparseAttentionImpl`.
-- Calibrate skip-softmax on the **quantized** model (the skip decision sees
-  quantized `Q·K` scores).
-- GPU validation of the full quant + skip path on B200; README / CHANGELOG.
+Validated on **B200** (on-write V numerics) and **GB300 / sm_100** (aws-cmh, vLLM 0.22): the NVFP4
+attention kernel suite (68 tests, incl. the V-bake lifecycle) and the install/logic suite (32 tests)
+pass, with no sm_100 kernel fault.
+
+End-to-end serve evidence (GB300 / sm_100, Qwen3-8B bf16, vLLM 0.22 / Triton 3.6 / CUDA 13,
+`ATTN_QUANT_MODE=impl_swap --enforce-eager --no-enable-prefix-caching --enable-chunked-prefill`):
+the impl-swap installs NVFP4 on all 36 attention layers and prefill / decode / chunked-prefill
+produce coherent output on **both** the FlashAttention and FlashInfer backends ("The capital of
+France is" → " Paris"; correct counting continuation). FlashInfer (the deployed path) runs
+prefill/decode/chunked ≈ 0.11 / 1.8 / 0.5 s; the FlashAttention path is slower, dominated by
+first-request Triton autotune under eager. Output equivalence to bf16 is covered separately by the
+eval numbers (AA-LCR, HLE), not a per-token tolerance here.
+
+Remaining (Gate B/C follow-ups): CUDA-graph capture validation for the retained path (the E2E above
+ran under `--enforce-eager`); a framework-neutral numerical spec + immutable per-layer plan consumed
+at runtime (so serving reads plans, not mutable quant modules); calibrate skip-softmax on the
+**quantized** model; real packed-FP4 KV-cache memory savings.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -97,58 +97,34 @@ softmax normalization. **So prefill `P·V` stays bf16**: fp32 accumulation is mo
 faithful to native FP4 in principle, but here it costs ~2.4× for no measurable eval
 benefit.
 
-## V: baked on write for both phases (required for decode)
+## V: block-16 finalization with a pristine tail
 
-The keys axis means V cannot be quantized by a per-token write, so it is
-fake-quantized around the kernel. But the *cost* differs sharply by phase:
+V's NVFP4 blocks run along the key axis, so a per-token cache write cannot form a
+complete scale group. Quantizing the entire cache on every decode step would cost
+`Σ O(s) = O(S²)`, while reading the current partial group as BF16 during attention
+would make the `P @ V` operands mixed precision. The serving path therefore uses the
+paged-cache tail itself as the high-precision buffer:
 
-- **Prefill** is a single pass that touches each tile once → `O(S)` either way. It
-  bakes its complete tiles on write *before* the kernel and reads them as-is
-  (`V_CACHE_QUANTIZED`, same as decode), re-FQ'ing only the trailing partial, so V is
-  **quantized exactly once** — a *chunked* prefill never re-FQ's an earlier chunk's
-  baked tiles. (That double-quant is usually a no-op anyway: NVFP4 QDQ is a near
-  fixed-point — measured `maxabs 0` on B200 random data — but the gate makes
-  quantize-once exact.)
-- **Decode** is autoregressive: every step re-reads the whole growing cache, so
-  on-read re-FQ's the entire cache each step → `Σ O(s) = O(S²)`, and it is almost
-  all redundant (a written token is immutable, so re-quantizing token 5 at steps
-  6…1000 yields the identical result 995×).
+1. Every complete 16-key group remains QDQ in the paged cache; the incomplete
+   `s mod 16` group remains pristine FP16/BF16 between attention calls.
+2. Before attention, newly completed groups are QDQ once from their pristine values.
+3. Prefill and decode read completed groups as-is and QDQ only the pristine partial
+   group in registers. Thus every valid V value entering `P @ V` is QDQ.
 
-That `O(S²)` is not academic: it **made long-context evals (HLE) infeasible** —
-the original on-read decode design timed out, which is why PR #1635 switched to
-**on-write** (≈8–18× decode-kernel speedup). So for the long-context campaign,
-decode V **must** be on-write:
-
-- **Bake** complete 128-token V tiles once, in place in the paged cache
-  (`fake_quant_v_onwrite`, tile size `_ONWRITE_BLOCK_N = 128`, driven by
-  `v_bmm_quantizer`); each 128-token tile is internally 8 × 16-key NVFP4 blocks.
-  Prefill bakes the prompt so decode inherits a pre-quantized cache; decode bakes
-  each newly-complete tile.
-- The decode kernel reads complete tiles **as-is** (`V_CACHE_QUANTIZED`) and
-  re-FQ's only the trailing `s mod 128` partial tile via `_v_qdq_nvfp4` → `O(S)` total.
-- Needs the graph-safe `(batch, n_kv, 1)` decode-grid repair so the bake kernel
-  composes with the captured decode step.
-
-Because written tokens are immutable, on-write reproduces the on-read fake-quant
-**bit-for-bit** at the V‑value level. Validated on B200 (NVFP4, fp16/bf16 cache):
-(A) FQ-all on the baked cache equals FQ-all on the raw cache — `maxabs = 0`; (B)
-incremental per-tile baking (the decode pattern) yields a bit-identical cache to a
-single-shot bake — **no cross-step accumulation**. The dequantized V is stored at
-the buffer (cache) dtype, which the NVFP4 dequant already hits exactly. The
-attention *output* of read-as-is vs FQ-on-read can differ by ≤~1e-5 — fp32-reduction
-scheduling between the two compiled kernel variants on **identical** V values, not a
-quantization difference. So this is a **pure speedup, no accuracy change**. K escapes
-the problem entirely: the pre-step quantizes each K once. (This is "Option 3" of the
-trailing-block methods: quantize the tail from pristine bf16 each step — no
-accumulation, uniform-precision kernel.)
+This keeps the attention arithmetic uniform without an auxiliary buffer, temporary
+cache mutation, or restore kernel. It also avoids cumulative `QDQ(QDQ(V))` error, and
+the complete history is quantized once, so decode remains `O(S)` in V quantization work.
+NVFP4 QDQ is not generally idempotent: for example,
+`0.017578125 -> 0.015625 -> 0.01171875`, which is why preserving the pristine tail is
+a numerical requirement rather than only a performance optimization.
 
 ## Fidelity to true NVFP4
 
 True NVFP4 = E2M1 element × dynamic E4M3 per-16 block scale (`amax(block)/6`) ×
 FP32 per-tensor global. The **per-16 block scale is the real quantizer** and is
-computed dynamically per block in-kernel for both P and V; the partial trailing
-tile gets its scale from its own valid keys (zeros from masked loads never raise
-the amax). For V the per-tensor global barely matters — the block amax carries
+computed dynamically in the attention kernel for P and the partial V group, and in
+the cache preparation kernel for complete V groups. The partial V group gets its scale from its valid keys; masked
+positions are zero and never raise the amax. For V the per-tensor global barely matters — the block amax carries
 the range and V does not saturate E4M3 — so `v_qdq_amax=None` uses the constant
 `1.0` global. A frozen first-chunk global is the only scheme that diverges (it
 saturates E4M3 on long context) and is intentionally not used.
@@ -159,7 +135,7 @@ E4M3 max, and the `2**-9` lower bound floors an underflowed block at the smalles
 subnormal instead of letting the scale round to 0 (which would zero the block). A
 block below the floor still rounds to 0 on the E2M1 grid; one in the `[~1.8e-7,
 2.2e-6]` band reconstructs nonzero (e.g. amax `2e-6` → `2.179827e-6`). This keeps the
-in-kernel fake-quant bit-consistent with the exported NVFP4 checkpoint in the
+fake-quant path bit-consistent with the exported NVFP4 checkpoint in the
 underflow regime, and lets the P/V and Q/K (`fp4_kernel_hopper.py`) paths share one
 scale contract without the ad-hoc `<1e-5 → 1.0` guard. On the output it is a no-op:
 underflowed P/V blocks carry weights `< ~2.2e-6` (keys many log2-units below the row
@@ -177,13 +153,12 @@ requested quant or sparsity transform is ever silently dropped):
 - Q/K/P/V use the supported fake-quant recipe: dynamic block-16 NVFP4 (P/V BMM2 may also be
   per-tensor FP8), Q per-step dynamic, K/V calibrated-or-default global scale.
 - FP16/BF16 KV cache (every `fp8*` cache dtype is rejected); cache page size a multiple of 16.
-- `decode_context_parallel_size == 1`; no sliding window, ALiBi, logits soft-cap, or sinks.
+- `decode_context_parallel_size == 1`; no dual batch overlap, sliding window, ALiBi,
+  logits soft-cap, or sinks.
 - No prefix caching, cross-layer KV sharing, KV connector, speculative decoding, or cascade.
 
-Launch with `--enforce-eager` and prefix caching disabled until the retained code has CUDA-graph
-evidence. Cascade is disabled automatically when quant is active — but disabling cascade does **not**
-make prefix-cache storage reuse safe (V is baked in place; a shared prefix would read another
-request's quantized V), which is why prefix caching is rejected outright.
+Launch with `--enforce-eager` and prefix caching disabled until CUDA-graph capture and shared-cache
+reuse have been validated for this path. Cascade is disabled automatically when quant is active.
 
 ## Code layout
 
@@ -191,8 +166,8 @@ request's quantized V), which is why prefix caching is rejected outright.
 kernels/quantization/attention/p_qdq.py   _p_qdq_nvfp4 (P BMM2 helper)
 kernels/quantization/attention/v_qdq.py   _v_qdq_nvfp4 (V BMM2 helper)
 kernels/quantization/common/nvfp4_quant.py  nvfp4_scalar_qdq + fp8_quantize_scale ([2^-9,448] clamp)
-kernels/common/attention/triton_fa.py     prefill kernel: P_QDQ + V_QDQ constexprs
-kernels/common/attention/decode_attention.py paged decode kernel + fake_quant_v_onwrite (128-token V bake)
+kernels/common/attention/triton_fa.py     prefill kernel: P QDQ + on-read partial-V QDQ
+kernels/common/attention/decode_attention.py paged decode + block-16 V finalization/partial-V QDQ
 quantization/plugins/vllm.py
     _import_attention_module   select the vLLM Attention class by exported symbol
     _QuantVLLMAttention        Q/K head_dim pre-step; holds q/k/v/p_bmm_quantizer
@@ -207,30 +182,22 @@ examples/vllm_serve/quant_sparse_attn_worker.py
 
 ## Build status
 
-Implemented and validated: paged decode kernel + skip-softmax; in-kernel `P_QDQ`/`V_QDQ` in
-prefill and decode; **decode V on-write** (`fake_quant_v_onwrite` 128-token tiles +
-`V_CACHE_QUANTIZED` gating + graph-safe `(batch, n_kv, 1)` grid), reproducing on-read FQ
-bit-for-bit (incremental == single-shot; output diff ≤~1e-5 is fp32-reduction scheduling, not a
-value change); plugin wiring that drives P/V from the exported `p/v_bmm_quantizer`; a unified serve
-worker that attaches attention quant (impl-swap default, composes with a realquant checkpoint; a
-legacy `mtq` mode) then installs the sparse impl; FlashAttention **and** FlashInfer backends.
+Implemented: paged decode + skip-softmax; in-kernel P QDQ; block-16 V finalization and on-read
+partial-group QDQ for prefill and decode; plugin wiring that drives P/V from the exported
+`p/v_bmm_quantizer`; and a unified serve worker for FlashAttention and FlashInfer.
 
 Gate A safety: a pure capability **preflight** validates the support matrix above and fails at
 startup with one layer-qualified error; installation is a two-pass **prepare/commit** transaction,
 so a failure leaves every original impl and V-ownership gate unchanged.
 
-Validated on **B200** (on-write V numerics) and **GB300 / sm_100** (aws-cmh, vLLM 0.22): the NVFP4
-attention kernel suite (68 tests, incl. the V-bake lifecycle) and the install/logic suite (32 tests)
-pass, with no sm_100 kernel fault.
+The eager orchestration, install, and non-NVFP4 kernel tests pass locally. The block-16 finalization,
+on-read tail selection, and canonical cache-value conformance matrix require SM89+/B200 and must be
+rerun there before the new lifecycle is considered hardware-validated; earlier B200/GB300 evidence
+used the superseded 128-token implementation.
 
-End-to-end serve evidence (GB300 / sm_100, Qwen3-8B bf16, vLLM 0.22 / Triton 3.6 / CUDA 13,
-`ATTN_QUANT_MODE=impl_swap --enforce-eager --no-enable-prefix-caching --enable-chunked-prefill`):
-the impl-swap installs NVFP4 on all 36 attention layers and prefill / decode / chunked-prefill
-produce coherent output on **both** the FlashAttention and FlashInfer backends ("The capital of
-France is" → " Paris"; correct counting continuation). FlashInfer (the deployed path) runs
-prefill/decode/chunked ≈ 0.11 / 1.8 / 0.5 s; the FlashAttention path is slower, dominated by
-first-request Triton autotune under eager. Output equivalence to bf16 is covered separately by the
-eval numbers (AA-LCR, HLE), not a per-token tolerance here.
+Earlier GB300 end-to-end serving confirmed the impl-swap and both backend integrations, but used the
+superseded 128-token lifecycle. Prefill, decode, chunked-prefill, and decode latency must be rerun for
+this block-16 implementation.
 
 Remaining (Gate B/C follow-ups): CUDA-graph capture validation for the retained path (the E2E above
 ran under `--enforce-eager`); a framework-neutral numerical spec + immutable per-layer plan consumed

--- a/examples/vllm_serve/README.md
+++ b/examples/vllm_serve/README.md
@@ -114,12 +114,40 @@ Workflow:
    python vllm_serve_sparse_attn.py <EXPORT_DIR> --enforce-eager -tp 8 --host 0.0.0.0 --port 8000
    ```
 
-If the checkpoint has no `sparse_attention_config`, the worker logs a message and passes through — vLLM runs unchanged. Quant-only flows are handled by `vllm_serve_fakequant.py`; combined sparse + quant will land in a follow-up PR.
+If the checkpoint has no `sparse_attention_config`, the worker logs a message and passes through — vLLM runs unchanged. Quant-only flows are handled by `vllm_serve_fakequant.py`; combined attention quantization + sparse attention is covered in the next section.
 
 Limitations:
 
 - vLLM V1 chunked prefill and prefix-cache suffix attention are supported by offsetting query positions into the longer KV span.
 - CUDA graph capture is not validated yet — use `--enforce-eager`.
+
+## Serve a model with attention quantization + sparse attention in vLLM
+
+Run **attention quantization and sparse attention together** on a single served checkpoint. `vllm_serve_quant_sparse_attn.py` restores ModelOpt fakequant (same env knobs as `vllm_serve_fakequant.py`) **and** installs `ModelOptSparseAttentionImpl` on each attention layer, so one launch does both:
+
+- **Quantized attention** — the Triton kernel fake-quantizes the attention BMMs. Q and K are quantized in a pre-step along `head_dim` (by the restored `q/k_bmm_quantizer`); P (softmax probabilities) and V are quantized in-kernel along the keys axis (V's keys-axis blocks cannot be formed per token, so its `head_dim` pre-step is skipped). Supported BMM2 formats are per-tensor **FP8** and block-16 dynamic **NVFP4**; an enabled quantizer in any other format raises rather than serving silently unquantized.
+- **Sparse attention** — skip-softmax and N:M sparse-softmax, read from the checkpoint's `sparse_attention_config` (as in the sparse-only launcher above).
+
+A layer gets the ModelOpt impl when it has **either** active attention quant (an enabled `p/v_bmm_quantizer`) **or** a sparse feature; layers with neither fall back to vLLM's native attention.
+
+NVFP4 scale convention: K and V default to a **constant global scale of 1.0** (their per-16 E4M3 block scales carry the range), while Q uses a per-step dynamic scale. A calibrated per-tensor `_amax` on any of these quantizers overrides the default.
+
+Workflow:
+
+1. Export a checkpoint that carries **both** attention quantization (the attention BMM quantizers, e.g. via `examples/hf_ptq/hf_ptq.py --vllm_fakequant_export` with an attention-quant recipe) **and** a `sparse_attention_config` block (via `examples/llm_sparsity/attention_sparsity/hf_sa.py`).
+2. Serve it with `--enforce-eager`, passing the quant state through the same env knobs as the fakequant launcher:
+
+   ```bash
+   MODELOPT_STATE_PATH=<EXPORT_DIR>/vllm_fq_modelopt_state.pth \
+       python vllm_serve_quant_sparse_attn.py <EXPORT_DIR> --enforce-eager -tp 8 --host 0.0.0.0 --port 8000
+   ```
+
+Test the server with the same `curl` / `lm_eval` commands shown above.
+
+Limitations:
+
+- Use `--enforce-eager` — CUDA graph capture is not validated with the ModelOpt attention kernel.
+- vLLM cascade (prefix-cache) attention is disabled automatically when any layer has active attention quant: it would route shared-prefix batches through native attention and silently drop the in-kernel P/V quant.
 
 ## Known Problems
 

--- a/examples/vllm_serve/README.md
+++ b/examples/vllm_serve/README.md
@@ -132,22 +132,36 @@ A layer gets the ModelOpt impl when it has **either** active attention quant (an
 
 NVFP4 scale convention: K and V default to a **constant global scale of 1.0** (their per-16 E4M3 block scales carry the range), while Q uses a per-step dynamic scale. A calibrated per-tensor `_amax` on any of these quantizers overrides the default.
 
+Attention-quant attach is selected by `ATTN_QUANT_MODE`:
+
+- `impl_swap` (default) configures the fixed dynamic block-16 NVFP4 recipe directly on each decoder attention module. It touches only attention (never Linear/MoE), so it **composes with an already-realquant checkpoint** and needs no exported attention-quant state.
+- `mtq` runs the legacy whole-model fakequant restore prolog (same env knobs as `vllm_serve_fakequant.py`, e.g. `MODELOPT_STATE_PATH`).
+
 Workflow:
 
-1. Export a checkpoint that carries **both** attention quantization (the attention BMM quantizers, e.g. via `examples/hf_ptq/hf_ptq.py --vllm_fakequant_export` with an attention-quant recipe) **and** a `sparse_attention_config` block (via `examples/llm_sparsity/attention_sparsity/hf_sa.py`).
-2. Serve it with `--enforce-eager`, passing the quant state through the same env knobs as the fakequant launcher:
+1. Provide a checkpoint with a `sparse_attention_config` block (via `examples/llm_sparsity/attention_sparsity/hf_sa.py`). For the default `impl_swap` path the base weights may be bf16 or already realquant-NVFP4; for `mtq` also export the fakequant state (`examples/hf_ptq/hf_ptq.py --vllm_fakequant_export` with an attention-quant recipe).
+2. Serve with `--enforce-eager` and prefix caching disabled (see Limitations):
 
    ```bash
-   MODELOPT_STATE_PATH=<EXPORT_DIR>/vllm_fq_modelopt_state.pth \
-       python vllm_serve_quant_sparse_attn.py <EXPORT_DIR> --enforce-eager -tp 8 --host 0.0.0.0 --port 8000
+   # impl_swap (default): NVFP4 attention configured on the fly; composes with a realquant ckpt
+   python vllm_serve_quant_sparse_attn.py <EXPORT_DIR> \
+       --enforce-eager --no-enable-prefix-caching -tp 8 --host 0.0.0.0 --port 8000
+
+   # legacy mtq: restore exported fakequant state
+   ATTN_QUANT_MODE=mtq MODELOPT_STATE_PATH=<EXPORT_DIR>/vllm_fq_modelopt_state.pth \
+       python vllm_serve_quant_sparse_attn.py <EXPORT_DIR> \
+       --enforce-eager --no-enable-prefix-caching -tp 8 --host 0.0.0.0 --port 8000
    ```
 
 Test the server with the same `curl` / `lm_eval` commands shown above.
 
+Supported configuration (validated at startup — anything else fails with one layer-qualified error, never a silent drop): decoder self-attention on the FlashAttention or FlashInfer backend; FP16/BF16 KV cache; cache page size a multiple of 16; `decode_context_parallel_size == 1`; no sliding window, ALiBi, logits soft-cap, sinks, prefix caching, cross-layer KV sharing, KV connector, or speculative decoding.
+
 Limitations:
 
-- Use `--enforce-eager` — CUDA graph capture is not validated with the ModelOpt attention kernel.
-- vLLM cascade (prefix-cache) attention is disabled automatically when any layer has active attention quant: it would route shared-prefix batches through native attention and silently drop the in-kernel P/V quant.
+- Use `--enforce-eager` — CUDA graph capture is not yet validated for the retained code path.
+- Disable prefix caching (`--no-enable-prefix-caching`). V is baked in place, so a shared prefix would read another request's quantized V; disabling cascade alone does **not** make prefix-cache reuse safe, which is why prefix caching is rejected at startup.
+- vLLM cascade attention is disabled automatically when any layer has active attention quant (it would route shared-prefix batches through native attention and silently drop the in-kernel P/V quant).
 
 ## Known Problems
 

--- a/examples/vllm_serve/README.md
+++ b/examples/vllm_serve/README.md
@@ -125,7 +125,7 @@ Limitations:
 
 Run **attention quantization and sparse attention together** on a single served checkpoint. `vllm_serve_quant_sparse_attn.py` restores ModelOpt fakequant (same env knobs as `vllm_serve_fakequant.py`) **and** installs `ModelOptSparseAttentionImpl` on each attention layer, so one launch does both:
 
-- **Quantized attention** — the Triton kernel fake-quantizes the attention BMMs. Q and K are quantized in a pre-step along `head_dim` (by the restored `q/k_bmm_quantizer`); P (softmax probabilities) and V are quantized in-kernel along the keys axis (V's keys-axis blocks cannot be formed per token, so its `head_dim` pre-step is skipped). Supported BMM2 formats are per-tensor **FP8** and block-16 dynamic **NVFP4**; an enabled quantizer in any other format raises rather than serving silently unquantized.
+- **Quantized attention** — Q and K are quantized in a pre-step along `head_dim` (by the restored `q/k_bmm_quantizer`), and P (softmax probabilities) is quantized in the attention kernel. NVFP4 V uses block-16 cache preparation along the keys axis: complete groups remain QDQ in the paged cache, while the pristine partial group is QDQ on read. Supported BMM2 formats are per-tensor **FP8** and block-16 dynamic **NVFP4**; an enabled quantizer in any other format raises rather than serving silently unquantized.
 - **Sparse attention** — skip-softmax and N:M sparse-softmax, read from the checkpoint's `sparse_attention_config` (as in the sparse-only launcher above).
 
 A layer gets the ModelOpt impl when it has **either** active attention quant (an enabled `p/v_bmm_quantizer`) **or** a sparse feature; layers with neither fall back to vLLM's native attention.
@@ -155,13 +155,13 @@ Workflow:
 
 Test the server with the same `curl` / `lm_eval` commands shown above.
 
-Supported configuration (validated at startup — anything else fails with one layer-qualified error, never a silent drop): decoder self-attention on the FlashAttention or FlashInfer backend; FP16/BF16 KV cache; cache page size a multiple of 16; `decode_context_parallel_size == 1`; no sliding window, ALiBi, logits soft-cap, sinks, prefix caching, cross-layer KV sharing, KV connector, or speculative decoding.
+Supported configuration (validated at startup — anything else fails with one layer-qualified error, never a silent drop): decoder self-attention on the FlashAttention or FlashInfer backend; FP16/BF16 KV cache; cache page size a multiple of 16; `decode_context_parallel_size == 1`; no dual batch overlap, sliding window, ALiBi, logits soft-cap, sinks, prefix caching, cross-layer KV sharing, KV connector, or speculative decoding.
 
 Limitations:
 
 - Use `--enforce-eager` — CUDA graph capture is not yet validated for the retained code path.
-- Disable prefix caching (`--no-enable-prefix-caching`). V is baked in place, so a shared prefix would read another request's quantized V; disabling cascade alone does **not** make prefix-cache reuse safe, which is why prefix caching is rejected at startup.
-- vLLM cascade attention is disabled automatically when any layer has active attention quant (it would route shared-prefix batches through native attention and silently drop the in-kernel P/V quant).
+- Disable prefix caching (`--no-enable-prefix-caching`). Sharing permanently finalized V-cache groups has not been validated for this path; disabling cascade alone does **not** establish prefix-cache compatibility.
+- vLLM cascade attention is disabled automatically when any layer has active attention quant (it would route shared-prefix batches through native attention and silently drop the requested P/V quantization).
 
 ## Known Problems
 

--- a/examples/vllm_serve/fakequant_worker.py
+++ b/examples/vllm_serve/fakequant_worker.py
@@ -34,6 +34,7 @@ import modelopt.torch.quantization as mtq
 from modelopt.torch.export.plugins.vllm_fakequant_hf import is_weight_quantizer_state_key
 from modelopt.torch.quantization.plugins.vllm import (
     disable_compilation,
+    post_restore_vllm_attentions,
     post_restore_vllm_parallel_linears,
 )
 from modelopt.torch.utils import safe_load
@@ -138,6 +139,8 @@ def _fakequant_run_prolog_worker(self) -> None:
             # Only barrier if distributed is actually initialized (avoids deadlocks).
             if torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1:
                 torch.distributed.barrier()
+
+    post_restore_vllm_attentions(model)
 
     if not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0:
         mtq.print_quant_summary(model)

--- a/examples/vllm_serve/fakequant_worker.py
+++ b/examples/vllm_serve/fakequant_worker.py
@@ -32,6 +32,7 @@ from vllm_reload_utils import (
 
 import modelopt.torch.quantization as mtq
 from modelopt.torch.export.plugins.vllm_fakequant_hf import is_weight_quantizer_state_key
+from modelopt.torch.quantization.config import need_calibration
 from modelopt.torch.quantization.plugins.vllm import (
     disable_compilation,
     post_restore_vllm_attentions,
@@ -114,13 +115,15 @@ def _fakequant_run_prolog_worker(self) -> None:
             print("Will load quant, so only do a single sample calibration")
             quant_config["calib_size"] = 1
 
-        if os.environ.get("QUANT_SKIP_CALIB", "0") == "1":
-            # Dynamic-only recipes (e.g. NVFP4 attention BMM: dynamic per-block scales +
-            # runtime-default global scale) need no calibration, so skip the dataset
-            # dataloader (avoids the HF `datasets` stack) and apply the config directly.
-            print("QUANT_SKIP_CALIB=1: applying quant config without calibration (dynamic quant).")
-            calibrate_loop = None
-        else:
+        quant_cfg = get_quant_config(quant_config, model)
+
+        # Config-driven calibration (replaces the removed QUANT_SKIP_CALIB env flag): build the
+        # calibration dataset only when the recipe needs it. ``need_calibration`` returns True for
+        # any enabled quantizer not marked ``type: "dynamic"``, so a static/calibrated recipe can
+        # never silently skip its required calibration; a fully dynamic recipe skips the dataset
+        # (and the HF ``datasets`` stack). Attention-only NVFP4 is served via the impl-swap worker,
+        # which never enters this calibration path.
+        if need_calibration(quant_cfg):
             calib_dataloader = get_dataset_dataloader(
                 dataset_name=quant_config["dataset"],
                 tokenizer=tokenizer,
@@ -129,8 +132,9 @@ def _fakequant_run_prolog_worker(self) -> None:
                 device=self.device,
             )
             calibrate_loop = calibrate_fun(calib_dataloader, self)
-
-        quant_cfg = get_quant_config(quant_config, model)
+        else:
+            print("Dynamic-only recipe: no calibration needed, skipping calibration dataset.")
+            calibrate_loop = None
 
         with disable_compilation(model):
             print("Quantizing model...")

--- a/examples/vllm_serve/fakequant_worker.py
+++ b/examples/vllm_serve/fakequant_worker.py
@@ -114,15 +114,21 @@ def _fakequant_run_prolog_worker(self) -> None:
             print("Will load quant, so only do a single sample calibration")
             quant_config["calib_size"] = 1
 
-        calib_dataloader = get_dataset_dataloader(
-            dataset_name=quant_config["dataset"],
-            tokenizer=tokenizer,
-            batch_size=quant_config["calib_batch_size"],
-            num_samples=quant_config["calib_size"],
-            device=self.device,
-        )
-
-        calibrate_loop = calibrate_fun(calib_dataloader, self)
+        if os.environ.get("QUANT_SKIP_CALIB", "0") == "1":
+            # Dynamic-only recipes (e.g. NVFP4 attention BMM: dynamic per-block scales +
+            # runtime-default global scale) need no calibration, so skip the dataset
+            # dataloader (avoids the HF `datasets` stack) and apply the config directly.
+            print("QUANT_SKIP_CALIB=1: applying quant config without calibration (dynamic quant).")
+            calibrate_loop = None
+        else:
+            calib_dataloader = get_dataset_dataloader(
+                dataset_name=quant_config["dataset"],
+                tokenizer=tokenizer,
+                batch_size=quant_config["calib_batch_size"],
+                num_samples=quant_config["calib_size"],
+                device=self.device,
+            )
+            calibrate_loop = calibrate_fun(calib_dataloader, self)
 
         quant_cfg = get_quant_config(quant_config, model)
 

--- a/examples/vllm_serve/quant_sparse_attn_worker.py
+++ b/examples/vllm_serve/quant_sparse_attn_worker.py
@@ -99,6 +99,19 @@ def _install_quant_sparse_attn(worker) -> None:
         # Active attention quant on this (restored) layer.
         p_qdq, _ = _p_qdq_from_layer(module)
         v_qdq, _ = _v_qdq_from_layer(module)
+        # Fail loud on an enabled BMM2 quantizer whose format the kernel cannot map
+        # (only per-tensor FP8 or block-16 dynamic NVFP4). Otherwise it is dropped
+        # silently: the kernel skips it (qdq=None) and, for V, _value_quant_in_kernel
+        # below would also skip the v_bmm_quantizer pre-step -> V never quantized at all.
+        # This must run before the `continue` so an unmapped-only layer cannot slip past.
+        for attr, qdq in (("p_bmm_quantizer", p_qdq), ("v_bmm_quantizer", v_qdq)):
+            q = getattr(module, attr, None)
+            if qdq is None and q is not None and getattr(q, "is_enabled", False):
+                raise NotImplementedError(
+                    f"{name}.{attr} is enabled but its quant format is unsupported by the "
+                    f"sparse attention kernel (supported: per-tensor FP8, block-16 dynamic "
+                    f"NVFP4). Re-export with a supported format or disable this quantizer."
+                )
         quant_active = p_qdq is not None or v_qdq is not None
 
         if not sparse_kw and not quant_active:
@@ -107,10 +120,15 @@ def _install_quant_sparse_attn(worker) -> None:
         new_impl = _clone_sparse_impl(module.impl)
         new_impl.sparse_kw = sparse_kw
         module.impl = new_impl
-        if quant_active and hasattr(module, "_value_quant_in_kernel"):
+        # Only let the kernel own V quant when V maps to a supported in-kernel format.
+        # _value_quant_in_kernel tells _QuantVLLMAttention.forward to skip its own
+        # v_bmm_quantizer pre-step (V's keys-axis NVFP4 blocks can't be formed per token);
+        # gating on quant_active instead would skip that pre-step even when V is unquantized.
+        if v_qdq is not None and hasattr(module, "_value_quant_in_kernel"):
             module._value_quant_in_kernel = True
+        if quant_active:
             quant_layers += 1
-        elif not quant_active:
+        else:
             sparse_only += 1
         patched += 1
 

--- a/examples/vllm_serve/quant_sparse_attn_worker.py
+++ b/examples/vllm_serve/quant_sparse_attn_worker.py
@@ -57,6 +57,7 @@ from modelopt.torch.sparsity.attention_sparsity.plugins.sparse_attn_config impor
     match_sparse_config,
 )
 from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
+    _assert_bmm_quant_supported,
     _build_sparse_kw,
     _clone_sparse_impl,
     _p_qdq_from_layer,
@@ -99,19 +100,11 @@ def _install_quant_sparse_attn(worker) -> None:
         # Active attention quant on this (restored) layer.
         p_qdq, _ = _p_qdq_from_layer(module)
         v_qdq, _ = _v_qdq_from_layer(module)
-        # Fail loud on an enabled BMM2 quantizer whose format the kernel cannot map
-        # (only per-tensor FP8 or block-16 dynamic NVFP4). Otherwise it is dropped
-        # silently: the kernel skips it (qdq=None) and, for V, _value_quant_in_kernel
-        # below would also skip the v_bmm_quantizer pre-step -> V never quantized at all.
-        # This must run before the `continue` so an unmapped-only layer cannot slip past.
-        for attr, qdq in (("p_bmm_quantizer", p_qdq), ("v_bmm_quantizer", v_qdq)):
-            q = getattr(module, attr, None)
-            if qdq is None and q is not None and getattr(q, "is_enabled", False):
-                raise NotImplementedError(
-                    f"{name}.{attr} is enabled but its quant format is unsupported by the "
-                    f"sparse attention kernel (supported: per-tensor FP8, block-16 dynamic "
-                    f"NVFP4). Re-export with a supported format or disable this quantizer."
-                )
+        # Fail loud on an enabled BMM2 quantizer the kernel cannot map (else it is
+        # dropped silently -- the kernel skips it and, for V, _value_quant_in_kernel
+        # below would skip the pre-step too). Before the `continue` so an unmapped-only
+        # layer cannot slip past.
+        _assert_bmm_quant_supported(module, name)
         quant_active = p_qdq is not None or v_qdq is not None
 
         if not sparse_kw and not quant_active:
@@ -136,6 +129,16 @@ def _install_quant_sparse_attn(worker) -> None:
         f"[ModelOpt] Quant+sparse attention: installed sparse impl on {patched} layers "
         f"({quant_layers} quant-active, {sparse_only} sparse-only)"
     )
+
+    if quant_layers:
+        # vLLM cascade attention routes shared-prefix batches through native attention,
+        # silently dropping the NVFP4 P/V quant. Disable it so every request goes through
+        # the quantized ModelOpt kernel. No-op where cascade is already off (e.g. vLLM
+        # 0.22 FlashInfer hardcodes it off); pairs with the fail-loud guard in the impl.
+        runner = worker.model_runner
+        if getattr(runner, "cascade_attn_enabled", False):
+            runner.cascade_attn_enabled = False
+            print("[ModelOpt] Disabled vLLM cascade attention (incompatible with attention quant)")
 
 
 class QuantSparseAttnWorker(FakeQuantWorker):

--- a/examples/vllm_serve/quant_sparse_attn_worker.py
+++ b/examples/vllm_serve/quant_sparse_attn_worker.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom vLLM worker for combined attention quantization + sparse attention.
+
+``QuantSparseAttnWorker`` runs ModelOpt fakequant restore **and** installs
+``ModelOptSparseAttentionImpl`` on each attention layer, so a single served
+checkpoint runs attention quant (Q/K quantized by the ``_QuantVLLMAttention``
+pre-step, P/V quantized in-kernel) together with skip-softmax sparsity.
+
+Ordering matters: the quant-restore prolog runs first so the attention layers
+become ``_QuantVLLMAttention`` carrying the ``q/k/v/p_bmm_quantizer`` config; the
+sparse impl is then installed and the ``_value_quant_in_kernel`` gate is flipped
+so V is fake-quantized along the *keys* axis in-kernel by the sparse impl rather
+than along head_dim by the (now-skipped) pre-step.
+
+Configuration:
+- Quantization: the same env knobs as ``fakequant_worker`` (``MODELOPT_STATE_PATH``,
+  ``QUANT_CFG``, ``KV_QUANT_CFG``, ...).
+- Sparsity: the checkpoint's ``sparse_attention_config`` block (as in ``sparse_attn_worker``).
+
+Usage:
+    python vllm_serve_quant_sparse_attn.py <path/to/modelopt-exported-ckpt>
+"""
+
+import importlib
+
+try:
+    _has_legacy_attention_layer = importlib.util.find_spec("vllm.attention.layer") is not None
+except (ModuleNotFoundError, ValueError):
+    _has_legacy_attention_layer = False
+
+if _has_legacy_attention_layer:
+    from vllm.attention.layer import Attention as VLLMAttention
+else:
+    from vllm.model_executor.layers.attention import Attention as VLLMAttention
+
+# Reuse the env-driven quant config + restore prolog from the fakequant worker (sibling module;
+# the launcher puts examples/vllm_serve on sys.path so this import resolves in each worker).
+from fakequant_worker import FakeQuantWorker, _fakequant_run_prolog_worker, quant_config
+from vllm.v1.worker.gpu_worker import Worker as BaseWorker
+
+from modelopt.torch.sparsity.attention_sparsity.plugins.sparse_attn_config import (
+    load_from_checkpoint_metadata,
+    match_sparse_config,
+)
+from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
+    _build_sparse_kw,
+    _clone_sparse_impl,
+    _p_qdq_from_layer,
+    _v_qdq_from_layer,
+)
+
+
+def _install_quant_sparse_attn(worker) -> None:
+    """Install ``ModelOptSparseAttentionImpl`` on attention layers (quant + sparse together).
+
+    Runs AFTER the quant-restore prolog. A layer gets the sparse impl when it has *either* a
+    sparse feature (skip-softmax / N:M from ``sparse_attention_config``) *or* active attention
+    quant (an enabled ``p/v_bmm_quantizer``) — the sparse impl is also what applies in-kernel
+    P/V quant, so a quant-only layer still needs it. For quant-active layers the
+    ``_value_quant_in_kernel`` gate is set so the head_dim V pre-step is skipped and V is
+    fake-quantized along the keys axis in-kernel instead (avoiding a double-quant of V).
+    """
+    hf_config = getattr(worker.model_runner.model_config, "hf_config", None)
+    detected = load_from_checkpoint_metadata(hf_config)
+    cfg, preset = detected if detected is not None else (None, None)
+    if preset is not None:
+        print(f"[ModelOpt] Sparse attention config: algo -> {preset}")
+
+    model = worker.model_runner.model
+    if hasattr(model, "unwrap"):
+        model = model.unwrap()
+
+    patched = sparse_only = quant_layers = 0
+    for name, module in model.named_modules():
+        if not isinstance(module, VLLMAttention):
+            continue
+
+        # Sparse features for this layer (empty dict if no/disabled sparse config).
+        sparse_kw: dict = {}
+        if cfg is not None:
+            layer_cfg = match_sparse_config(name, cfg)
+            if layer_cfg is not None and layer_cfg.get("enable", True):
+                sparse_kw = _build_sparse_kw(layer_cfg)
+
+        # Active attention quant on this (restored) layer.
+        p_qdq, _ = _p_qdq_from_layer(module)
+        v_qdq, _ = _v_qdq_from_layer(module)
+        quant_active = p_qdq is not None or v_qdq is not None
+
+        if not sparse_kw and not quant_active:
+            continue  # neither sparse nor quant active -> keep vLLM's native impl
+
+        new_impl = _clone_sparse_impl(module.impl)
+        new_impl.sparse_kw = sparse_kw
+        module.impl = new_impl
+        if quant_active and hasattr(module, "_value_quant_in_kernel"):
+            module._value_quant_in_kernel = True
+            quant_layers += 1
+        elif not quant_active:
+            sparse_only += 1
+        patched += 1
+
+    print(
+        f"[ModelOpt] Quant+sparse attention: installed sparse impl on {patched} layers "
+        f"({quant_layers} quant-active, {sparse_only} sparse-only)"
+    )
+
+
+class QuantSparseAttnWorker(FakeQuantWorker):
+    """vLLM worker that restores quantization and installs the sparse attention impl.
+
+    Inherits ``determine_available_memory`` (compilation disabled during profiling) from
+    ``FakeQuantWorker`` and runs both the quant restore and the sparse-impl install in
+    ``compile_or_warm_up_model`` (after memory profiling, before the warm-up forward).
+    """
+
+    def compile_or_warm_up_model(self) -> float:
+        # 1) Quant-restore -> attention layers become _QuantVLLMAttention with their quantizers.
+        if (
+            quant_config["quant_cfg"]
+            or quant_config["kv_quant_cfg"]
+            or quant_config["modelopt_state_path"]
+            or quant_config["recipe_path"]
+        ):
+            _fakequant_run_prolog_worker(self)
+        # 2) Install the sparse impl + flip the in-kernel-V gate (needs the restored quantizers).
+        _install_quant_sparse_attn(self)
+        # 3) Base worker warm-up (skip FakeQuantWorker's prolog — already run above). Must return
+        # the compilation time (seconds): vLLM V1 takes max() across TP workers.
+        return BaseWorker.compile_or_warm_up_model(self)

--- a/examples/vllm_serve/quant_sparse_attn_worker.py
+++ b/examples/vllm_serve/quant_sparse_attn_worker.py
@@ -131,10 +131,14 @@ def _validate_global_runtime(worker) -> list[str]:
     dcp = getattr(parallel, "decode_context_parallel_size", 1)
     if dcp != 1:
         reasons.append(f"decode_context_parallel_size={dcp} (only 1 is supported)")
+    if getattr(parallel, "enable_dbo", False) or getattr(parallel, "use_ubatching", False):
+        reasons.append(
+            "dual batch overlap is enabled (concurrent microbatches can race while finalizing "
+            "shared V-cache groups)"
+        )
     if getattr(cache, "enable_prefix_caching", False):
         reasons.append(
-            "prefix caching is enabled (V is baked in place, so cross-request prefix reuse "
-            "would read another request's quantized V)"
+            "prefix caching is enabled (sharing in-place-finalized V-cache blocks is not validated)"
         )
     if getattr(config, "kv_transfer_config", None) is not None:
         reasons.append(

--- a/examples/vllm_serve/quant_sparse_attn_worker.py
+++ b/examples/vllm_serve/quant_sparse_attn_worker.py
@@ -147,6 +147,12 @@ def _validate_global_runtime(worker) -> list[str]:
             f"cache page size {block_size} is not a positive multiple of the NVFP4 group size "
             f"{_NVFP4_GROUP_SIZE}"
         )
+    model_config = getattr(config, "model_config", None)
+    if model_config is not None and not getattr(model_config, "enforce_eager", False):
+        reasons.append(
+            "enforce_eager is not set (CUDA-graph capture is not yet validated for the ModelOpt "
+            "attention path; launch with --enforce-eager)"
+        )
     return reasons
 
 
@@ -159,9 +165,25 @@ def _unsupported_attention_reasons(module) -> list[str]:
     """
     reasons: list[str] = []
 
+    # Regular Q/K/V paged attention only. MLA is a distinct class (not an ``Attention`` subclass);
+    # cross/encoder-only subclass ``Attention`` but are caught by the attn_type check below. MLA has
+    # ``attn_type == DECODER``, so it would slip past that check -- reject it by layout here.
+    if not isinstance(module, VLLMAttention):
+        reasons.append(
+            f"attention layout {type(module).__name__} is unsupported "
+            "(needs regular decoder self-attention with a Q/K/V paged cache; MLA is not supported)"
+        )
+
     attn_type = getattr(module, "attn_type", AttentionType.DECODER)
     if attn_type != AttentionType.DECODER:
         reasons.append(f"attn_type={attn_type} (only DECODER self-attention is supported)")
+
+    head_size = getattr(module, "head_size", None)
+    if isinstance(head_size, int) and head_size % _NVFP4_GROUP_SIZE != 0:
+        reasons.append(
+            f"head_size={head_size} is not a multiple of the NVFP4 block size {_NVFP4_GROUP_SIZE} "
+            "(Q/K are block-quantized on the flattened head axis, so a block would span two heads)"
+        )
 
     impl = getattr(module, "impl", None)
     impl_name = type(impl).__name__ if impl is not None else "None"
@@ -251,8 +273,11 @@ def _unwrapped_model(worker):
 
 
 def _named_vllm_attentions(model):
+    # Enumerate ALL attention layouts (regular + MLA/cross/encoder), not just regular ``Attention``,
+    # so an unsupported layout (e.g. an all-MLA model) is surfaced and rejected by preflight rather
+    # than yielding an empty plan that serves with no requested transform.
     for name, module in model.named_modules():
-        if isinstance(module, VLLMAttention):
+        if isinstance(module, _ATTENTION_TYPES):
             yield name, module
 
 
@@ -435,15 +460,44 @@ def _install_quant_sparse_attn(worker, records) -> None:
         f"({quant_layers} quant-active, {sparse_only} sparse-only)"
     )
 
-    if quant_layers:
+    if prepared:
         # vLLM cascade attention routes shared-prefix batches through native attention, silently
-        # dropping the NVFP4 P/V quant. Disable it so every request goes through the quantized
-        # ModelOpt kernel. No-op where cascade is already off (e.g. vLLM 0.22 FlashInfer hardcodes
-        # it off); pairs with the fail-loud guard in the impl.
+        # dropping the ModelOpt transform — the NVFP4 P/V quant AND the skip-softmax sparsity. Disable
+        # it for ANY installed plan (quant- or sparse-only) so every request goes through the ModelOpt
+        # kernel. No-op where cascade is already off (e.g. vLLM 0.22 FlashInfer hardcodes it off);
+        # pairs with the fail-loud guard in the impl.
         runner = worker.model_runner
         if getattr(runner, "cascade_attn_enabled", False):
             runner.cascade_attn_enabled = False
-            print("[ModelOpt] Disabled vLLM cascade attention (incompatible with attention quant)")
+            print(
+                "[ModelOpt] Disabled vLLM cascade attention (incompatible with the ModelOpt plan)"
+            )
+
+
+def _resolve_attn_quant_mode() -> str:
+    """Return the validated ``ATTN_QUANT_MODE`` or raise (no silent fall-through to un-quantized).
+
+    A typo must not silently enter the legacy ``mtq`` branch, and ``mtq`` with no quant source would
+    serve un-quantized -- both raise here rather than serving the wrong thing.
+    """
+    mode = os.environ.get("ATTN_QUANT_MODE", "impl_swap")
+    if mode not in ("impl_swap", "mtq"):
+        raise ValueError(
+            f"ATTN_QUANT_MODE={mode!r} is invalid (expected 'impl_swap' or 'mtq'). "
+            "A typo must not silently fall through to an un-quantized serve."
+        )
+    if mode == "mtq" and not (
+        quant_config["quant_cfg"]
+        or quant_config["kv_quant_cfg"]
+        or quant_config["modelopt_state_path"]
+        or quant_config["recipe_path"]
+    ):
+        raise ValueError(
+            "ATTN_QUANT_MODE=mtq requires a quant source (QUANT_CFG / KV_QUANT_CFG / "
+            "MODELOPT_STATE_PATH / RECIPE_PATH); none set, which would serve un-quantized. "
+            "Use ATTN_QUANT_MODE=impl_swap to configure NVFP4 attention without a checkpoint."
+        )
+    return mode
 
 
 class QuantSparseAttnWorker(FakeQuantWorker):
@@ -461,20 +515,14 @@ class QuantSparseAttnWorker(FakeQuantWorker):
         #   Preflight runs on the raw decoder attention layers, then only approved layers convert.
         # - "mtq": legacy mtq.quantize restore prolog (whole-model replace_quant_module); preflight
         #   then runs against the restored quantizers.
-        attn_quant_mode = os.environ.get("ATTN_QUANT_MODE", "impl_swap")
+        attn_quant_mode = _resolve_attn_quant_mode()
         if attn_quant_mode == "impl_swap":
             records = _preflight_quant_sparse_attn(self, quant_will_be_configured=True)
             _attach_attention_quant_impl_swap(
                 self.model_runner.model, {record.name for record in records}
             )
-        else:
-            if (
-                quant_config["quant_cfg"]
-                or quant_config["kv_quant_cfg"]
-                or quant_config["modelopt_state_path"]
-                or quant_config["recipe_path"]
-            ):
-                _fakequant_run_prolog_worker(self)
+        else:  # "mtq": legacy whole-model restore prolog (quant source verified above).
+            _fakequant_run_prolog_worker(self)
             records = _preflight_quant_sparse_attn(self, quant_will_be_configured=False)
 
         # Install the sparse impl + flip the in-kernel-V gate (needs the restored quantizers).

--- a/examples/vllm_serve/quant_sparse_attn_worker.py
+++ b/examples/vllm_serve/quant_sparse_attn_worker.py
@@ -20,15 +20,22 @@
 checkpoint runs attention quant (Q/K quantized by the ``_QuantVLLMAttention``
 pre-step, P/V quantized in-kernel) together with skip-softmax sparsity.
 
-Ordering matters: the quant-restore prolog runs first so the attention layers
+Ordering matters: the attention-quant attach runs first so the attention layers
 become ``_QuantVLLMAttention`` carrying the ``q/k/v/p_bmm_quantizer`` config; the
 sparse impl is then installed and the ``_value_quant_in_kernel`` gate is flipped
 so V is fake-quantized along the *keys* axis in-kernel by the sparse impl rather
 than along head_dim by the (now-skipped) pre-step.
 
+Attention-quant attach is selected by ``ATTN_QUANT_MODE``:
+- ``"impl_swap"`` (default): attention-ONLY conversion (``_attach_attention_quant_impl_swap``).
+  It converts just the vLLM ``Attention`` modules and never touches Linear/MoE, so it composes
+  with an already-realquant checkpoint (whose Linears would otherwise trip the
+  ``_VLLMParallelLinear`` ``quant_method`` assert under ``mtq.quantize``).
+- ``"mtq"``: the legacy ``fakequant_worker`` restore prolog (whole-model ``replace_quant_module``).
+
 Configuration:
-- Quantization: the same env knobs as ``fakequant_worker`` (``MODELOPT_STATE_PATH``,
-  ``QUANT_CFG``, ``KV_QUANT_CFG``, ...).
+- Quantization: ``ATTN_QUANT_MODE`` (see above); in ``"mtq"`` mode the same env knobs as
+  ``fakequant_worker`` (``MODELOPT_STATE_PATH``, ``QUANT_CFG``, ``KV_QUANT_CFG``, ...).
 - Sparsity: the checkpoint's ``sparse_attention_config`` block (as in ``sparse_attn_worker``).
 
 Usage:
@@ -36,6 +43,7 @@ Usage:
 """
 
 import importlib
+import os
 
 try:
     _has_legacy_attention_layer = importlib.util.find_spec("vllm.attention.layer") is not None
@@ -52,6 +60,9 @@ else:
 from fakequant_worker import FakeQuantWorker, _fakequant_run_prolog_worker, quant_config
 from vllm.v1.worker.gpu_worker import Worker as BaseWorker
 
+from modelopt.torch.quantization.conversion import set_quantizer_by_cfg
+from modelopt.torch.quantization.nn import QuantModuleRegistry
+from modelopt.torch.quantization.plugins.vllm import _ATTENTION_TYPES, post_restore_vllm_attentions
 from modelopt.torch.sparsity.attention_sparsity.plugins.sparse_attn_config import (
     load_from_checkpoint_metadata,
     match_sparse_config,
@@ -62,7 +73,57 @@ from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
     _clone_sparse_impl,
     _p_qdq_from_layer,
     _v_qdq_from_layer,
+    select_sparse_impl_cls,
 )
+
+
+def _attach_attention_quant_impl_swap(model) -> None:
+    """Attach NVFP4 attention quant by converting ONLY the attention modules (no ``mtq.quantize``).
+
+    Why not ``mtq.quantize`` / ``_fakequant_run_prolog_worker``: that path calls
+    ``replace_quant_module``, which walks the whole model and wraps every registered module type,
+    including ``RowParallelLinear`` / ``ColumnParallelLinear`` / ``QKVParallelLinear`` / ``FusedMoE``.
+    On an already-**realquant** checkpoint those Linears carry a real quant method (e.g.
+    ``ModelOptFp8LinearMethod``), and ``_VLLMParallelLinear._setup`` asserts
+    ``type(self.quant_method) is UnquantizedLinearMethod`` -> ``AssertionError`` at serve time.
+
+    This attach is attention-ONLY: it converts each vLLM ``Attention`` in place to
+    ``_QuantVLLMAttention`` (adding the ``q/k/v/p_bmm_quantizer`` sub-quantizers) and never touches
+    any Linear/MoE module, so it composes cleanly with a realquant checkpoint. It then configures the
+    four BMM quantizers to dynamic block-16 NVFP4 via ``set_quantizer_by_cfg`` (deny-all first, then
+    enable+configure the targets) and applies the K/V global-scale-1.0 default via
+    ``post_restore_vllm_attentions``. ``_install_quant_sparse_attn`` must run AFTER this to read the
+    quantizers and install ``ModelOptSparseAttentionImpl``.
+    """
+    if hasattr(model, "unwrap"):
+        model = model.unwrap()
+
+    def _convert_attention_only(parent) -> None:
+        for name, child in parent.named_children():
+            if isinstance(child, _ATTENTION_TYPES) and type(child) in QuantModuleRegistry:
+                # Convert on the parent (mirrors conversion.py:_replace_quant_module). Do NOT
+                # convert any non-attention module -- that is what avoids the Linear/MoE assert.
+                setattr(parent, name, QuantModuleRegistry.convert(child))
+            # Recurse into whichever module now lives at parent.name so nested modules are covered.
+            _convert_attention_only(getattr(parent, name))
+
+    _convert_attention_only(model)
+
+    # Dynamic block-16 NVFP4 (num_bits (2,1), dynamic scale (4,3)); matches the KV-default test cfg.
+    nvfp4 = {"num_bits": (2, 1), "block_sizes": {-1: 16, "type": "dynamic", "scale_bits": (4, 3)}}
+    set_quantizer_by_cfg(
+        model,
+        [
+            {"quantizer_name": "*", "enable": False},
+            {"quantizer_name": "*q_bmm_quantizer", "cfg": nvfp4, "enable": True},
+            {"quantizer_name": "*k_bmm_quantizer", "cfg": nvfp4, "enable": True},
+            {"quantizer_name": "*v_bmm_quantizer", "cfg": nvfp4, "enable": True},
+            {"quantizer_name": "*p_bmm_quantizer", "cfg": nvfp4, "enable": True},
+        ],
+    )
+
+    # Apply the K/V global-scale-1.0 default to layers with no calibrated _amax (dynamic Q/P skip it).
+    post_restore_vllm_attentions(model)
 
 
 def _install_quant_sparse_attn(worker) -> None:
@@ -86,6 +147,7 @@ def _install_quant_sparse_attn(worker) -> None:
         model = model.unwrap()
 
     patched = sparse_only = quant_layers = 0
+    skipped_backends: set[str] = set()
     for name, module in model.named_modules():
         if not isinstance(module, VLLMAttention):
             continue
@@ -110,7 +172,19 @@ def _install_quant_sparse_attn(worker) -> None:
         if not sparse_kw and not quant_active:
             continue  # neither sparse nor quant active -> keep vLLM's native impl
 
-        new_impl = _clone_sparse_impl(module.impl)
+        # Select the sparse impl for this layer's attention backend (FlashAttention
+        # vs FlashInfer). For FlashInfer this also installs the metadata-builder patch
+        # that exposes the dense paged metadata the Triton kernel needs; None means an
+        # unsupported backend, which we leave on vLLM's native impl.
+        new_cls = select_sparse_impl_cls(module.impl)
+        if new_cls is None:
+            skipped_backends.add(type(module.impl).__name__)
+            continue
+        try:
+            new_impl = _clone_sparse_impl(module.impl, new_cls)
+        except NotImplementedError:
+            skipped_backends.add(type(module.impl).__name__)
+            continue
         new_impl.sparse_kw = sparse_kw
         module.impl = new_impl
         # Only let the kernel own V quant when V maps to a supported in-kernel format.
@@ -129,6 +203,11 @@ def _install_quant_sparse_attn(worker) -> None:
         f"[ModelOpt] Quant+sparse attention: installed sparse impl on {patched} layers "
         f"({quant_layers} quant-active, {sparse_only} sparse-only)"
     )
+    if skipped_backends:
+        print(
+            f"[ModelOpt] Quant+sparse attention: left {sorted(skipped_backends)} layers unchanged "
+            "(unsupported backend — serve under FLASH_ATTN or FLASHINFER)."
+        )
 
     if quant_layers:
         # vLLM cascade attention routes shared-prefix batches through native attention,
@@ -150,8 +229,15 @@ class QuantSparseAttnWorker(FakeQuantWorker):
     """
 
     def compile_or_warm_up_model(self) -> float:
-        # 1) Quant-restore -> attention layers become _QuantVLLMAttention with their quantizers.
-        if (
+        # 1) Attach attention quant -> attention layers become _QuantVLLMAttention with quantizers.
+        #    ATTN_QUANT_MODE selects how:
+        #    - "impl_swap" (default): attention-ONLY convert (composes with a realquant checkpoint;
+        #      never touches Linear/MoE, so it avoids the _VLLMParallelLinear quant_method assert).
+        #    - "mtq": legacy mtq.quantize restore prolog (whole-model replace_quant_module).
+        attn_quant_mode = os.environ.get("ATTN_QUANT_MODE", "impl_swap")
+        if attn_quant_mode == "impl_swap":
+            _attach_attention_quant_impl_swap(self.model_runner.model)
+        elif (
             quant_config["quant_cfg"]
             or quant_config["kv_quant_cfg"]
             or quant_config["modelopt_state_path"]

--- a/examples/vllm_serve/quant_sparse_attn_worker.py
+++ b/examples/vllm_serve/quant_sparse_attn_worker.py
@@ -20,23 +20,32 @@
 checkpoint runs attention quant (Q/K quantized by the ``_QuantVLLMAttention``
 pre-step, P/V quantized in-kernel) together with skip-softmax sparsity.
 
-Ordering matters: the attention-quant attach runs first so the attention layers
-become ``_QuantVLLMAttention`` carrying the ``q/k/v/p_bmm_quantizer`` config; the
-sparse impl is then installed and the ``_value_quant_in_kernel`` gate is flipped
-so V is fake-quantized along the *keys* axis in-kernel by the sparse impl rather
-than along head_dim by the (now-skipped) pre-step.
+Install is a fail-loud, two-pass transaction:
+
+1. **Preflight** (:func:`_preflight_quant_sparse_attn`) is a pure resolver: it validates
+   the engine-wide and per-layer support matrix and returns one install record per
+   decoder self-attention layer to transform. It never converts a module or assigns an
+   impl. Any unsupported configuration aggregates into a single ``NotImplementedError``
+   raised at startup with layer-qualified reasons — no requested quant or sparsity
+   transform is ever silently dropped.
+2. **Attach quant** makes the attention layers carry ``q/k/v/p_bmm_quantizer`` config.
+3. **Prepare then commit** (:func:`_prepare_quant_sparse_attn` / :func:`_commit_quant_sparse_attn`)
+   constructs every replacement impl first and only assigns them once the whole model
+   prepared successfully, so a failure leaves every original ``module.impl`` and
+   ``_value_quant_in_kernel`` gate unchanged.
 
 Attention-quant attach is selected by ``ATTN_QUANT_MODE``:
-- ``"impl_swap"`` (default): attention-ONLY conversion (``_attach_attention_quant_impl_swap``).
-  It converts just the vLLM ``Attention`` modules and never touches Linear/MoE, so it composes
-  with an already-realquant checkpoint (whose Linears would otherwise trip the
-  ``_VLLMParallelLinear`` ``quant_method`` assert under ``mtq.quantize``).
-- ``"mtq"``: the legacy ``fakequant_worker`` restore prolog (whole-model ``replace_quant_module``).
+- ``"impl_swap"`` (default): attention-ONLY conversion (:func:`_attach_attention_quant_impl_swap`).
+  It converts just the preflight-approved decoder ``Attention`` modules and never touches
+  Linear/MoE, so it composes with an already-realquant checkpoint (whose Linears would
+  otherwise trip the ``_VLLMParallelLinear`` ``quant_method`` assert under ``mtq.quantize``).
+- ``"mtq"``: the legacy ``fakequant_worker`` restore prolog (whole-model ``replace_quant_module``);
+  preflight then runs against the restored quantizers.
 
-Configuration:
-- Quantization: ``ATTN_QUANT_MODE`` (see above); in ``"mtq"`` mode the same env knobs as
-  ``fakequant_worker`` (``MODELOPT_STATE_PATH``, ``QUANT_CFG``, ``KV_QUANT_CFG``, ...).
-- Sparsity: the checkpoint's ``sparse_attention_config`` block (as in ``sparse_attn_worker``).
+Supported configuration (everything else fails at startup): decoder self-attention on the
+FlashAttention or FlashInfer backend, fp16/bf16 KV cache, ``dcp_world_size == 1``, page size a
+multiple of 16, and no sliding window / ALiBi / logits soft-cap / sinks / prefix caching /
+cross-layer KV sharing / KV connector / speculative decoding / cascade.
 
 Usage:
     python vllm_serve_quant_sparse_attn.py <path/to/modelopt-exported-ckpt>
@@ -44,25 +53,19 @@ Usage:
 
 import importlib
 import os
+from collections.abc import Mapping
+from dataclasses import dataclass
 
-try:
-    _has_legacy_attention_layer = importlib.util.find_spec("vllm.attention.layer") is not None
-except (ModuleNotFoundError, ValueError):
-    _has_legacy_attention_layer = False
-
-if _has_legacy_attention_layer:
-    from vllm.attention.layer import Attention as VLLMAttention
-else:
-    from vllm.model_executor.layers.attention import Attention as VLLMAttention
-
-# Reuse the env-driven quant config + restore prolog from the fakequant worker (sibling module;
-# the launcher puts examples/vllm_serve on sys.path so this import resolves in each worker).
 from fakequant_worker import FakeQuantWorker, _fakequant_run_prolog_worker, quant_config
 from vllm.v1.worker.gpu_worker import Worker as BaseWorker
 
 from modelopt.torch.quantization.conversion import set_quantizer_by_cfg
 from modelopt.torch.quantization.nn import QuantModuleRegistry
-from modelopt.torch.quantization.plugins.vllm import _ATTENTION_TYPES, post_restore_vllm_attentions
+from modelopt.torch.quantization.plugins.vllm import (
+    _ATTENTION_TYPES,
+    post_restore_vllm_attentions,
+    vllm_attention,
+)
 from modelopt.torch.sparsity.attention_sparsity.plugins.sparse_attn_config import (
     load_from_checkpoint_metadata,
     match_sparse_config,
@@ -76,9 +79,226 @@ from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
     select_sparse_impl_cls,
 )
 
+# Reuse the concrete vLLM ``Attention`` class the quantization plugin resolved (via its
+# ``_import_attention_module`` symbol-based selection) so isinstance/registry checks here match
+# the class the plugin registered and the served model instantiates.
+VLLMAttention = vllm_attention.Attention
 
-def _attach_attention_quant_impl_swap(model) -> None:
-    """Attach NVFP4 attention quant by converting ONLY the attention modules (no ``mtq.quantize``).
+
+def _import_attention_type():
+    """Return vLLM's ``AttentionType`` enum from whichever path this version exposes."""
+    for path in (
+        "vllm.v1.attention.backend",
+        "vllm.attention",
+        "vllm.attention.backends.abstract",
+    ):
+        try:
+            module = importlib.import_module(path)
+        except ImportError:
+            continue
+        if hasattr(module, "AttentionType"):
+            return module.AttentionType
+    raise ImportError("Could not import vLLM AttentionType from any supported path")
+
+
+AttentionType = _import_attention_type()
+
+# The NVFP4 group size; the paged-cache page size must be a whole multiple of it.
+_NVFP4_GROUP_SIZE = 16
+# vLLM attention-backend impl class names whose layout the ModelOpt sparse kernel supports.
+_SUPPORTED_BACKEND_IMPLS = ("FlashAttentionImpl", "FlashInferImpl")
+
+# Dynamic block-16 NVFP4 (num_bits (2,1), dynamic scale (4,3)); matches the KV-default test cfg.
+_NVFP4_ATTN_CFG = {
+    "num_bits": (2, 1),
+    "block_sizes": {-1: 16, "type": "dynamic", "scale_bits": (4, 3)},
+}
+
+
+# ---------------------------------------------------------------------------
+# Capability preflight (pure: no module conversion, no impl assignment)
+# ---------------------------------------------------------------------------
+
+
+def _validate_global_runtime(worker) -> list[str]:
+    """Return engine-wide reasons the ModelOpt attention plan cannot be served."""
+    config = worker.model_runner.vllm_config
+    parallel = config.parallel_config
+    cache = config.cache_config
+    reasons: list[str] = []
+
+    dcp = getattr(parallel, "decode_context_parallel_size", 1)
+    if dcp != 1:
+        reasons.append(f"decode_context_parallel_size={dcp} (only 1 is supported)")
+    if getattr(cache, "enable_prefix_caching", False):
+        reasons.append(
+            "prefix caching is enabled (V is baked in place, so cross-request prefix reuse "
+            "would read another request's quantized V)"
+        )
+    if getattr(config, "kv_transfer_config", None) is not None:
+        reasons.append(
+            "a KV transfer/connector config is set (external KV movement is unsupported)"
+        )
+    if getattr(config, "speculative_config", None) is not None:
+        reasons.append("speculative decoding is enabled (V is baked in place)")
+    block_size = getattr(cache, "block_size", None)
+    if not isinstance(block_size, int) or block_size <= 0 or block_size % _NVFP4_GROUP_SIZE:
+        reasons.append(
+            f"cache page size {block_size} is not a positive multiple of the NVFP4 group size "
+            f"{_NVFP4_GROUP_SIZE}"
+        )
+    return reasons
+
+
+def _unsupported_attention_reasons(module) -> list[str]:
+    """Return per-layer reasons this attention module cannot run the ModelOpt kernel.
+
+    Pure: inspects the module and its backend impl by name/attribute only. Backend support is
+    checked by impl class name so this does not trigger the FlashInfer metadata-builder patch
+    (that side effect is deferred to :func:`_prepare_quant_sparse_attn`).
+    """
+    reasons: list[str] = []
+
+    attn_type = getattr(module, "attn_type", AttentionType.DECODER)
+    if attn_type != AttentionType.DECODER:
+        reasons.append(f"attn_type={attn_type} (only DECODER self-attention is supported)")
+
+    impl = getattr(module, "impl", None)
+    impl_name = type(impl).__name__ if impl is not None else "None"
+    if impl_name not in _SUPPORTED_BACKEND_IMPLS:
+        reasons.append(
+            f"attention backend {impl_name} is not supported "
+            f"(need one of {', '.join(_SUPPORTED_BACKEND_IMPLS)})"
+        )
+    if getattr(module, "sliding_window", None) is not None:
+        reasons.append("sliding_window is set")
+    if getattr(module, "kv_sharing_target_layer_name", None) is not None:
+        reasons.append("kv_sharing_target_layer_name is set (cross-layer KV sharing)")
+    kv_cache_dtype = str(getattr(module, "kv_cache_dtype", "") or "")
+    if kv_cache_dtype.startswith("fp8"):
+        reasons.append(f"kv_cache_dtype={kv_cache_dtype!r} (only fp16/bf16 KV cache is supported)")
+    if getattr(impl, "alibi_slopes", None) is not None:
+        reasons.append("alibi_slopes are set")
+    logits_soft_cap = getattr(impl, "logits_soft_cap", None)
+    if logits_soft_cap:  # None or 0 == disabled
+        reasons.append(f"logits_soft_cap={logits_soft_cap} is set")
+    if getattr(impl, "sinks", None) is not None or getattr(impl, "has_sinks", False):
+        reasons.append("attention sinks are set")
+
+    # An enabled P/V BMM2 quantizer whose format the kernel cannot map must fail loud: the
+    # kernel would skip it and (for V) ``_value_quant_in_kernel`` would skip the pre-step too,
+    # leaving the operand silently un-quantized. (No-op pre-conversion under impl_swap, where the
+    # quantizers do not exist yet; re-checked with layer context in prepare.)
+    if getattr(getattr(module, "p_bmm_quantizer", None), "is_enabled", False) and (
+        _p_qdq_from_layer(module)[0] is None
+    ):
+        reasons.append(
+            "p_bmm_quantizer is enabled but its quant format is unsupported "
+            "(supported: per-tensor FP8, block-16 dynamic NVFP4)"
+        )
+    if getattr(getattr(module, "v_bmm_quantizer", None), "is_enabled", False) and (
+        _v_qdq_from_layer(module)[0] is None
+    ):
+        reasons.append(
+            "v_bmm_quantizer is enabled but its quant format is unsupported "
+            "(supported: per-tensor FP8, block-16 dynamic NVFP4)"
+        )
+    return reasons
+
+
+def _attention_quant_requested(module, quant_will_be_configured: bool) -> bool:
+    """Whether attention quant is (or will be) active on this layer.
+
+    ``quant_will_be_configured`` is True for the impl-swap attach (which configures the fixed
+    NVFP4 recipe on every decoder self-attention layer) and False for the legacy mtq path (quant
+    is active where a P/V BMM2 quantizer is enabled after restore — mappable or not; an unmappable
+    one is reported as a support error rather than skipped).
+    """
+    if quant_will_be_configured:
+        return getattr(module, "attn_type", AttentionType.DECODER) == AttentionType.DECODER
+    return any(
+        getattr(getattr(module, attr, None), "is_enabled", False)
+        for attr in ("p_bmm_quantizer", "v_bmm_quantizer")
+    )
+
+
+@dataclass(frozen=True)
+class _AttentionInstallRecord:
+    """One decoder attention layer the ModelOpt plan will transform (resolved, immutable)."""
+
+    name: str
+    sparse_kw: Mapping[str, object]
+
+
+def _load_sparse_config(worker):
+    hf_config = getattr(worker.model_runner.model_config, "hf_config", None)
+    detected = load_from_checkpoint_metadata(hf_config)
+    return detected if detected is not None else (None, None)
+
+
+def _sparse_kw_for_layer(name: str, cfg) -> dict:
+    if cfg is None:
+        return {}
+    layer_cfg = match_sparse_config(name, cfg)
+    if layer_cfg is not None and layer_cfg.get("enable", True):
+        return _build_sparse_kw(layer_cfg)
+    return {}
+
+
+def _unwrapped_model(worker):
+    model = worker.model_runner.model
+    return model.unwrap() if hasattr(model, "unwrap") else model
+
+
+def _named_vllm_attentions(model):
+    for name, module in model.named_modules():
+        if isinstance(module, VLLMAttention):
+            yield name, module
+
+
+def _preflight_quant_sparse_attn(worker, quant_will_be_configured: bool):
+    """Resolve the per-layer install plan and validate the full support matrix.
+
+    Pure resolver: inspects model/engine state but does not convert modules, assign
+    ``module.impl``, or flip ``_value_quant_in_kernel``. Aggregates every global and per-layer
+    problem and raises a single ``NotImplementedError`` before returning any records, so an
+    unsupported configuration fails at startup with layer-qualified diagnostics rather than
+    silently dropping a requested transform.
+    """
+    model = _unwrapped_model(worker)
+
+    cfg, preset = _load_sparse_config(worker)
+    if preset is not None:
+        print(f"[ModelOpt] Sparse attention config: algo -> {preset}")
+
+    errors: list[str] = list(_validate_global_runtime(worker))
+    records: list[_AttentionInstallRecord] = []
+    for name, module in _named_vllm_attentions(model):
+        sparse_kw = _sparse_kw_for_layer(name, cfg)
+        quant_requested = _attention_quant_requested(module, quant_will_be_configured)
+        if not sparse_kw and not quant_requested:
+            continue  # neither sparse nor quant active -> keep vLLM's native impl
+        reasons = _unsupported_attention_reasons(module)
+        if reasons:
+            errors.extend(f"{name}: {reason}" for reason in reasons)
+            continue
+        records.append(_AttentionInstallRecord(name=name, sparse_kw=sparse_kw))
+
+    if errors:
+        raise NotImplementedError(
+            "Unsupported ModelOpt attention plan (no transform will be silently dropped):\n  - "
+            + "\n  - ".join(errors)
+        )
+    return tuple(records)
+
+
+# ---------------------------------------------------------------------------
+# Attach attention quant (impl-swap): convert only preflight-approved layers
+# ---------------------------------------------------------------------------
+
+
+def _attach_attention_quant_impl_swap(model, allowed_names) -> None:
+    """Attach NVFP4 attention quant by converting ONLY the preflight-approved decoder layers.
 
     Why not ``mtq.quantize`` / ``_fakequant_run_prolog_worker``: that path calls
     ``replace_quant_module``, which walks the whole model and wraps every registered module type,
@@ -87,38 +307,45 @@ def _attach_attention_quant_impl_swap(model) -> None:
     ``ModelOptFp8LinearMethod``), and ``_VLLMParallelLinear._setup`` asserts
     ``type(self.quant_method) is UnquantizedLinearMethod`` -> ``AssertionError`` at serve time.
 
-    This attach is attention-ONLY: it converts each vLLM ``Attention`` in place to
+    This attach is attention-ONLY: it converts each approved vLLM ``Attention`` in place to
     ``_QuantVLLMAttention`` (adding the ``q/k/v/p_bmm_quantizer`` sub-quantizers) and never touches
-    any Linear/MoE module, so it composes cleanly with a realquant checkpoint. It then configures the
-    four BMM quantizers to dynamic block-16 NVFP4 via ``set_quantizer_by_cfg`` (deny-all first, then
-    enable+configure the targets) and applies the K/V global-scale-1.0 default via
+    any Linear/MoE module, so it composes cleanly with a realquant checkpoint. It then configures
+    the four BMM quantizers to dynamic block-16 NVFP4 via ``set_quantizer_by_cfg`` (deny-all first,
+    then enable+configure the targets) and applies the K/V global-scale-1.0 default via
     ``post_restore_vllm_attentions``. ``_install_quant_sparse_attn`` must run AFTER this to read the
     quantizers and install ``ModelOptSparseAttentionImpl``.
+
+    ``allowed_names`` is the set of ``model.named_modules`` names preflight approved for
+    conversion; every other module (including any non-decoder attention) is left untouched.
     """
     if hasattr(model, "unwrap"):
         model = model.unwrap()
+    allowed = set(allowed_names)
 
-    def _convert_attention_only(parent) -> None:
+    def _convert_approved(parent, prefix) -> None:
         for name, child in parent.named_children():
-            if isinstance(child, _ATTENTION_TYPES) and type(child) in QuantModuleRegistry:
+            full = f"{prefix}.{name}" if prefix else name
+            if (
+                isinstance(child, _ATTENTION_TYPES)
+                and type(child) in QuantModuleRegistry
+                and full in allowed
+            ):
                 # Convert on the parent (mirrors conversion.py:_replace_quant_module). Do NOT
                 # convert any non-attention module -- that is what avoids the Linear/MoE assert.
                 setattr(parent, name, QuantModuleRegistry.convert(child))
             # Recurse into whichever module now lives at parent.name so nested modules are covered.
-            _convert_attention_only(getattr(parent, name))
+            _convert_approved(getattr(parent, name), full)
 
-    _convert_attention_only(model)
+    _convert_approved(model, "")
 
-    # Dynamic block-16 NVFP4 (num_bits (2,1), dynamic scale (4,3)); matches the KV-default test cfg.
-    nvfp4 = {"num_bits": (2, 1), "block_sizes": {-1: 16, "type": "dynamic", "scale_bits": (4, 3)}}
     set_quantizer_by_cfg(
         model,
         [
             {"quantizer_name": "*", "enable": False},
-            {"quantizer_name": "*q_bmm_quantizer", "cfg": nvfp4, "enable": True},
-            {"quantizer_name": "*k_bmm_quantizer", "cfg": nvfp4, "enable": True},
-            {"quantizer_name": "*v_bmm_quantizer", "cfg": nvfp4, "enable": True},
-            {"quantizer_name": "*p_bmm_quantizer", "cfg": nvfp4, "enable": True},
+            {"quantizer_name": "*q_bmm_quantizer", "cfg": _NVFP4_ATTN_CFG, "enable": True},
+            {"quantizer_name": "*k_bmm_quantizer", "cfg": _NVFP4_ATTN_CFG, "enable": True},
+            {"quantizer_name": "*v_bmm_quantizer", "cfg": _NVFP4_ATTN_CFG, "enable": True},
+            {"quantizer_name": "*p_bmm_quantizer", "cfg": _NVFP4_ATTN_CFG, "enable": True},
         ],
     )
 
@@ -126,94 +353,93 @@ def _attach_attention_quant_impl_swap(model) -> None:
     post_restore_vllm_attentions(model)
 
 
-def _install_quant_sparse_attn(worker) -> None:
-    """Install ``ModelOptSparseAttentionImpl`` on attention layers (quant + sparse together).
+# ---------------------------------------------------------------------------
+# Two-pass install: prepare all replacements, then commit atomically
+# ---------------------------------------------------------------------------
 
-    Runs AFTER the quant-restore prolog. A layer gets the sparse impl when it has *either* a
-    sparse feature (skip-softmax / N:M from ``sparse_attention_config``) *or* active attention
-    quant (an enabled ``p/v_bmm_quantizer``) — the sparse impl is also what applies in-kernel
-    P/V quant, so a quant-only layer still needs it. For quant-active layers the
-    ``_value_quant_in_kernel`` gate is set so the head_dim V pre-step is skipped and V is
-    fake-quantized along the keys axis in-kernel instead (avoiding a double-quant of V).
+
+@dataclass
+class _PreparedInstall:
+    """A constructed-but-not-yet-assigned sparse impl for one attention layer."""
+
+    module: object
+    new_impl: object
+    quant_active: bool
+    value_in_kernel: bool
+
+
+def _prepare_quant_sparse_attn(worker, records) -> list[_PreparedInstall]:
+    """Construct every replacement impl WITHOUT assigning it (all-or-nothing).
+
+    Reads the live (converted/restored) module for each record, validates its BMM2 quant format
+    with layer context, resolves the backend sparse impl (patching the FlashInfer metadata builder
+    here, not in the pure preflight), and clones it. A failure — unsupported format, unclonable
+    impl (e.g. FlashAttention sinks) — raises before any assignment, leaving every original
+    ``module.impl`` and ``_value_quant_in_kernel`` gate unchanged.
     """
-    hf_config = getattr(worker.model_runner.model_config, "hf_config", None)
-    detected = load_from_checkpoint_metadata(hf_config)
-    cfg, preset = detected if detected is not None else (None, None)
-    if preset is not None:
-        print(f"[ModelOpt] Sparse attention config: algo -> {preset}")
+    modules = dict(_unwrapped_model(worker).named_modules())
 
-    model = worker.model_runner.model
-    if hasattr(model, "unwrap"):
-        model = model.unwrap()
-
-    patched = sparse_only = quant_layers = 0
-    skipped_backends: set[str] = set()
-    for name, module in model.named_modules():
-        if not isinstance(module, VLLMAttention):
-            continue
-
-        # Sparse features for this layer (empty dict if no/disabled sparse config).
-        sparse_kw: dict = {}
-        if cfg is not None:
-            layer_cfg = match_sparse_config(name, cfg)
-            if layer_cfg is not None and layer_cfg.get("enable", True):
-                sparse_kw = _build_sparse_kw(layer_cfg)
-
-        # Active attention quant on this (restored) layer.
+    prepared: list[_PreparedInstall] = []
+    for record in records:
+        module = modules[record.name]
+        # Fail loud on an enabled BMM2 quantizer the kernel cannot map (layer-qualified). Not
+        # caught here -- an unsupported quant format is a startup error, never a silent drop.
+        _assert_bmm_quant_supported(module, record.name)
         p_qdq, _ = _p_qdq_from_layer(module)
         v_qdq, _ = _v_qdq_from_layer(module)
-        # Fail loud on an enabled BMM2 quantizer the kernel cannot map (else it is
-        # dropped silently -- the kernel skips it and, for V, _value_quant_in_kernel
-        # below would skip the pre-step too). Before the `continue` so an unmapped-only
-        # layer cannot slip past.
-        _assert_bmm_quant_supported(module, name)
-        quant_active = p_qdq is not None or v_qdq is not None
 
-        if not sparse_kw and not quant_active:
-            continue  # neither sparse nor quant active -> keep vLLM's native impl
-
-        # Select the sparse impl for this layer's attention backend (FlashAttention
-        # vs FlashInfer). For FlashInfer this also installs the metadata-builder patch
-        # that exposes the dense paged metadata the Triton kernel needs; None means an
-        # unsupported backend, which we leave on vLLM's native impl.
         new_cls = select_sparse_impl_cls(module.impl)
         if new_cls is None:
-            skipped_backends.add(type(module.impl).__name__)
-            continue
-        try:
-            new_impl = _clone_sparse_impl(module.impl, new_cls)
-        except NotImplementedError:
-            skipped_backends.add(type(module.impl).__name__)
-            continue
-        new_impl.sparse_kw = sparse_kw
-        module.impl = new_impl
-        # Only let the kernel own V quant when V maps to a supported in-kernel format.
-        # _value_quant_in_kernel tells _QuantVLLMAttention.forward to skip its own
-        # v_bmm_quantizer pre-step (V's keys-axis NVFP4 blocks can't be formed per token);
-        # gating on quant_active instead would skip that pre-step even when V is unquantized.
-        if v_qdq is not None and hasattr(module, "_value_quant_in_kernel"):
-            module._value_quant_in_kernel = True
-        if quant_active:
-            quant_layers += 1
-        else:
-            sparse_only += 1
-        patched += 1
+            raise NotImplementedError(
+                f"{record.name}: attention backend {type(module.impl).__name__} has no supported "
+                "ModelOpt sparse impl (preflight should have rejected this)."
+            )
+        new_impl = _clone_sparse_impl(module.impl, new_cls)
+        new_impl.sparse_kw = dict(record.sparse_kw)
+        prepared.append(
+            _PreparedInstall(
+                module=module,
+                new_impl=new_impl,
+                quant_active=p_qdq is not None or v_qdq is not None,
+                # Let the kernel own V quant only when V maps to a supported in-kernel format;
+                # gating on quant_active would skip the head_dim pre-step even for unquantized V.
+                value_in_kernel=v_qdq is not None and hasattr(module, "_value_quant_in_kernel"),
+            )
+        )
+    return prepared
 
+
+def _commit_quant_sparse_attn(prepared) -> None:
+    """Assign every prepared impl, then transfer in-kernel V ownership.
+
+    Pure assignment (cannot fail): after prepare succeeds for the whole model, install all impls,
+    then flip ``_value_quant_in_kernel`` only on V-quantized layers so the head_dim V pre-step is
+    skipped in favor of keys-axis in-kernel V quant (avoiding a double-quant of V).
+    """
+    for item in prepared:
+        item.module.impl = item.new_impl
+    for item in prepared:
+        if item.value_in_kernel:
+            item.module._value_quant_in_kernel = True
+
+
+def _install_quant_sparse_attn(worker, records) -> None:
+    """Two-pass, fail-loud install of ``ModelOptSparseAttentionImpl`` on the plan's layers."""
+    prepared = _prepare_quant_sparse_attn(worker, records)
+    _commit_quant_sparse_attn(prepared)
+
+    quant_layers = sum(1 for item in prepared if item.quant_active)
+    sparse_only = len(prepared) - quant_layers
     print(
-        f"[ModelOpt] Quant+sparse attention: installed sparse impl on {patched} layers "
+        f"[ModelOpt] Quant+sparse attention: installed sparse impl on {len(prepared)} layers "
         f"({quant_layers} quant-active, {sparse_only} sparse-only)"
     )
-    if skipped_backends:
-        print(
-            f"[ModelOpt] Quant+sparse attention: left {sorted(skipped_backends)} layers unchanged "
-            "(unsupported backend — serve under FLASH_ATTN or FLASHINFER)."
-        )
 
     if quant_layers:
-        # vLLM cascade attention routes shared-prefix batches through native attention,
-        # silently dropping the NVFP4 P/V quant. Disable it so every request goes through
-        # the quantized ModelOpt kernel. No-op where cascade is already off (e.g. vLLM
-        # 0.22 FlashInfer hardcodes it off); pairs with the fail-loud guard in the impl.
+        # vLLM cascade attention routes shared-prefix batches through native attention, silently
+        # dropping the NVFP4 P/V quant. Disable it so every request goes through the quantized
+        # ModelOpt kernel. No-op where cascade is already off (e.g. vLLM 0.22 FlashInfer hardcodes
+        # it off); pairs with the fail-loud guard in the impl.
         runner = worker.model_runner
         if getattr(runner, "cascade_attn_enabled", False):
             runner.cascade_attn_enabled = False
@@ -224,28 +450,36 @@ class QuantSparseAttnWorker(FakeQuantWorker):
     """vLLM worker that restores quantization and installs the sparse attention impl.
 
     Inherits ``determine_available_memory`` (compilation disabled during profiling) from
-    ``FakeQuantWorker`` and runs both the quant restore and the sparse-impl install in
-    ``compile_or_warm_up_model`` (after memory profiling, before the warm-up forward).
+    ``FakeQuantWorker`` and runs the preflight, the quant attach, and the atomic sparse-impl
+    install in ``compile_or_warm_up_model`` (after memory profiling, before the warm-up forward).
     """
 
     def compile_or_warm_up_model(self) -> float:
-        # 1) Attach attention quant -> attention layers become _QuantVLLMAttention with quantizers.
-        #    ATTN_QUANT_MODE selects how:
-        #    - "impl_swap" (default): attention-ONLY convert (composes with a realquant checkpoint;
-        #      never touches Linear/MoE, so it avoids the _VLLMParallelLinear quant_method assert).
-        #    - "mtq": legacy mtq.quantize restore prolog (whole-model replace_quant_module).
+        # ATTN_QUANT_MODE selects how attention quant is attached:
+        # - "impl_swap" (default): attention-ONLY convert (composes with a realquant checkpoint;
+        #   never touches Linear/MoE, so it avoids the _VLLMParallelLinear quant_method assert).
+        #   Preflight runs on the raw decoder attention layers, then only approved layers convert.
+        # - "mtq": legacy mtq.quantize restore prolog (whole-model replace_quant_module); preflight
+        #   then runs against the restored quantizers.
         attn_quant_mode = os.environ.get("ATTN_QUANT_MODE", "impl_swap")
         if attn_quant_mode == "impl_swap":
-            _attach_attention_quant_impl_swap(self.model_runner.model)
-        elif (
-            quant_config["quant_cfg"]
-            or quant_config["kv_quant_cfg"]
-            or quant_config["modelopt_state_path"]
-            or quant_config["recipe_path"]
-        ):
-            _fakequant_run_prolog_worker(self)
-        # 2) Install the sparse impl + flip the in-kernel-V gate (needs the restored quantizers).
-        _install_quant_sparse_attn(self)
-        # 3) Base worker warm-up (skip FakeQuantWorker's prolog — already run above). Must return
-        # the compilation time (seconds): vLLM V1 takes max() across TP workers.
+            records = _preflight_quant_sparse_attn(self, quant_will_be_configured=True)
+            _attach_attention_quant_impl_swap(
+                self.model_runner.model, {record.name for record in records}
+            )
+        else:
+            if (
+                quant_config["quant_cfg"]
+                or quant_config["kv_quant_cfg"]
+                or quant_config["modelopt_state_path"]
+                or quant_config["recipe_path"]
+            ):
+                _fakequant_run_prolog_worker(self)
+            records = _preflight_quant_sparse_attn(self, quant_will_be_configured=False)
+
+        # Install the sparse impl + flip the in-kernel-V gate (needs the restored quantizers).
+        _install_quant_sparse_attn(self, records)
+
+        # Base worker warm-up (skip FakeQuantWorker's prolog — already run above). Must return the
+        # compilation time (seconds): vLLM V1 takes max() across TP workers.
         return BaseWorker.compile_or_warm_up_model(self)

--- a/examples/vllm_serve/quant_sparse_attn_worker.py
+++ b/examples/vllm_serve/quant_sparse_attn_worker.py
@@ -56,6 +56,7 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+import torch
 from fakequant_worker import FakeQuantWorker, _fakequant_run_prolog_worker, quant_config
 from vllm.v1.worker.gpu_worker import Worker as BaseWorker
 
@@ -148,11 +149,22 @@ def _validate_global_runtime(worker) -> list[str]:
             f"{_NVFP4_GROUP_SIZE}"
         )
     model_config = getattr(config, "model_config", None)
-    if model_config is not None and not getattr(model_config, "enforce_eager", False):
-        reasons.append(
-            "enforce_eager is not set (CUDA-graph capture is not yet validated for the ModelOpt "
-            "attention path; launch with --enforce-eager)"
-        )
+    if model_config is not None:
+        if not getattr(model_config, "enforce_eager", False):
+            reasons.append(
+                "enforce_eager is not set (CUDA-graph capture is not yet validated for the ModelOpt "
+                "attention path; launch with --enforce-eager)"
+            )
+        # Validate the RESOLVED KV-cache dtype, not just the kv_cache_dtype string: with
+        # kv_cache_dtype="auto" the cache takes the model's compute dtype, so a string check alone
+        # would let an fp32 model's cache through the fp16/bf16 contract. (Explicit fp8* is still
+        # caught per-layer in _unsupported_attention_reasons.)
+        resolved_dtype = getattr(model_config, "dtype", None)
+        if resolved_dtype is not None and resolved_dtype not in (torch.float16, torch.bfloat16):
+            reasons.append(
+                f"resolved KV-cache/compute dtype {resolved_dtype} is not fp16/bf16 "
+                "(the on-write V bake and NVFP4 QDQ require a fp16/bf16 cache)"
+            )
     return reasons
 
 
@@ -335,8 +347,9 @@ def _attach_attention_quant_impl_swap(model, allowed_names) -> None:
     This attach is attention-ONLY: it converts each approved vLLM ``Attention`` in place to
     ``_QuantVLLMAttention`` (adding the ``q/k/v/p_bmm_quantizer`` sub-quantizers) and never touches
     any Linear/MoE module, so it composes cleanly with a realquant checkpoint. It then configures
-    the four BMM quantizers to dynamic block-16 NVFP4 via ``set_quantizer_by_cfg`` (deny-all first,
-    then enable+configure the targets) and applies the K/V global-scale-1.0 default via
+    the four BMM quantizers to dynamic block-16 NVFP4 via ``set_quantizer_by_cfg`` (reset the
+    ``*_bmm_quantizer`` set first, then enable+configure the targets) and applies the K/V
+    global-scale-1.0 default via
     ``post_restore_vllm_attentions``. ``_install_quant_sparse_attn`` must run AFTER this to read the
     quantizers and install ``ModelOptSparseAttentionImpl``.
 
@@ -366,7 +379,9 @@ def _attach_attention_quant_impl_swap(model, allowed_names) -> None:
     set_quantizer_by_cfg(
         model,
         [
-            {"quantizer_name": "*", "enable": False},
+            # Reset only the attention BMM quantizers (the ones this attach owns), not every
+            # TensorQuantizer in the model, before enabling the four as NVFP4.
+            {"quantizer_name": "*_bmm_quantizer", "enable": False},
             {"quantizer_name": "*q_bmm_quantizer", "cfg": _NVFP4_ATTN_CFG, "enable": True},
             {"quantizer_name": "*k_bmm_quantizer", "cfg": _NVFP4_ATTN_CFG, "enable": True},
             {"quantizer_name": "*v_bmm_quantizer", "cfg": _NVFP4_ATTN_CFG, "enable": True},
@@ -496,6 +511,16 @@ def _resolve_attn_quant_mode() -> str:
             "ATTN_QUANT_MODE=mtq requires a quant source (QUANT_CFG / KV_QUANT_CFG / "
             "MODELOPT_STATE_PATH / RECIPE_PATH); none set, which would serve un-quantized. "
             "Use ATTN_QUANT_MODE=impl_swap to configure NVFP4 attention without a checkpoint."
+        )
+    if mode == "mtq":
+        # De-scope note: the mtq path serves the checkpoint's exported attention recipe as-is. The
+        # preflight validates only the P/V (BMM2) operand format; Q/K (BMM1 pre-step) format is NOT
+        # enforced, so mtq does NOT guarantee the dynamic block-16 NVFP4 Q/K/P/V contract that
+        # impl_swap configures by construction. Prefer impl_swap for the enforced recipe.
+        print(
+            "[ModelOpt] WARNING: ATTN_QUANT_MODE=mtq serves the checkpoint's exported attention "
+            "recipe as-is and does NOT enforce the block-16 NVFP4 Q/K/P/V contract (Q/K format is "
+            "unvalidated). Use ATTN_QUANT_MODE=impl_swap for the enforced recipe."
         )
     return mode
 

--- a/examples/vllm_serve/sparse_attn_worker.py
+++ b/examples/vllm_serve/sparse_attn_worker.py
@@ -26,8 +26,8 @@ Configuration flows exclusively through the loaded checkpoint's
 checkpoint has no such block, the worker logs a message and passes through
 unchanged.
 
-Quantization combined with sparse attention is not handled by this worker
-and will land in a follow-up PR once the combined path is tested.
+Quantization combined with sparse attention is handled by the separate
+``quant_sparse_attn_worker.QuantSparseAttnWorker``; this worker is sparse-only.
 
 Usage:
     python vllm_serve_sparse_attn.py <path/to/modelopt-exported-ckpt>

--- a/examples/vllm_serve/sparse_attn_worker.py
+++ b/examples/vllm_serve/sparse_attn_worker.py
@@ -54,6 +54,7 @@ from modelopt.torch.sparsity.attention_sparsity.plugins.sparse_attn_config impor
 from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
     _build_sparse_kw,
     _clone_sparse_impl,
+    select_sparse_impl_cls,
 )
 
 
@@ -94,10 +95,27 @@ def _replace_attention_impl(worker):
             # Keep vLLM's original impl when the exported layer config does not
             # enable any sparse feature.
             continue
-        new_impl = _clone_sparse_impl(module.impl)
+        # Select the backend-correct sparse impl (FlashAttention vs FlashInfer) instead of
+        # defaulting to FlashAttention, and fail loud on an unsupported backend rather than
+        # installing a mismatched impl.
+        new_cls = select_sparse_impl_cls(module.impl)
+        if new_cls is None:
+            raise NotImplementedError(
+                f"{name}: attention backend {type(module.impl).__name__} is not supported by the "
+                "ModelOpt sparse kernel (need FlashAttention or FlashInfer)."
+            )
+        new_impl = _clone_sparse_impl(module.impl, new_cls)
         new_impl.sparse_kw = sparse_kw
         module.impl = new_impl
         patched += 1
+    if patched:
+        # Disable cascade so shared-prefix batches don't hit the impl's request-time cascade guard
+        # (the ModelOpt sparse kernel cannot consume cascade's split KV layout). Fail-loud at
+        # startup here is preferable to a per-request raise later.
+        runner = worker.model_runner
+        if getattr(runner, "cascade_attn_enabled", False):
+            runner.cascade_attn_enabled = False
+            print("[ModelOpt] Disabled vLLM cascade attention (incompatible with the sparse plan)")
     print(f"[ModelOpt] Sparse attention: replaced impl on {patched} attention layers")
 
 

--- a/examples/vllm_serve/vllm_reload_utils.py
+++ b/examples/vllm_serve/vllm_reload_utils.py
@@ -89,8 +89,10 @@ def _convert_key_for_vllm(key: str, value: Any) -> tuple[str, str | None, Any]:
     if "quantizer" not in key:
         return ("copy", key, value)
 
-    # Skip p_bmm_quantizer (softmax-P) and lm_head quantizers (not needed in vLLM).
-    if "p_bmm_quantizer" in key or (key.startswith("lm_head.") and "quantizer" in key):
+    # Skip lm_head quantizers (not used in vLLM). p_bmm_quantizer is NOT skipped: the sparse Triton
+    # attention applies softmax-P quant in-kernel from it (ModelOptSparseAttentionImpl), so its config
+    # must reach the served _QuantVLLMAttention.p_bmm_quantizer carrier (see the bmm transform below).
+    if key.startswith("lm_head.") and "quantizer" in key:
         return ("skip", None, None)
 
     # Check if this is a q/k/v projection that needs merging
@@ -123,9 +125,9 @@ def _convert_key_for_vllm(key: str, value: Any) -> tuple[str, str | None, Any]:
         group_key = expert_down_match.group(1) + ".w2_" + expert_down_match.group(2) + suffix
         return ("group", group_key, value)
 
-    # Transform bmm_quantizer keys: self_attn.q/k/v_bmm_quantizer -> self_attn.attn.q/k/v_bmm_quantizer
-    bmm_match = re.search(r"(.*\.self_attn)\.([qkv]_bmm_quantizer.*)$", key) or re.search(
-        r"(.*\.mixer)\.([qkv]_bmm_quantizer.*)$", key
+    # Transform bmm_quantizer keys: self_attn.q/k/v/p_bmm_quantizer -> self_attn.attn.{...}
+    bmm_match = re.search(r"(.*\.self_attn)\.([qkvp]_bmm_quantizer.*)$", key) or re.search(
+        r"(.*\.mixer)\.([qkvp]_bmm_quantizer.*)$", key
     )
     if bmm_match:
         new_key = bmm_match.group(1) + ".attn." + bmm_match.group(2)

--- a/examples/vllm_serve/vllm_serve_quant_sparse_attn.py
+++ b/examples/vllm_serve/vllm_serve_quant_sparse_attn.py
@@ -13,19 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Launch vLLM with sparse attention.
+"""Launch vLLM with combined attention quantization + sparse attention.
 
-Configuration is read exclusively from ``<ckpt>/config.json``'s
-``sparse_attention_config`` block, written during calibration by
-``examples/llm_sparsity/attention_sparsity/hf_sa.py``. If the checkpoint has
-no such block, the worker logs a message and the server runs as standard
-vLLM.
-
-Combined sparse attention + quantization is handled by the separate
-``vllm_serve_quant_sparse_attn.py`` launcher; this one is sparse-only.
+Restores ModelOpt fakequant (env knobs: ``MODELOPT_STATE_PATH`` / ``QUANT_CFG`` /
+``KV_QUANT_CFG`` / ...) **and** installs the sparse attention impl driven by the
+checkpoint's ``sparse_attention_config`` block. A single served checkpoint then
+runs attention quant (Q/K pre-step, P/V in-kernel) together with skip-softmax
+sparsity. Layers with neither active quant nor a sparse feature fall back to
+vLLM's native attention.
 
 Usage:
-    python vllm_serve_sparse_attn.py <path/to/modelopt-exported-ckpt>
+    MODELOPT_STATE_PATH=<ckpt>/modelopt_state.pth \\
+        python vllm_serve_quant_sparse_attn.py <path/to/modelopt-exported-ckpt>
 """
 
 import os
@@ -46,19 +45,21 @@ else:
 
 
 def main():
-    """Launch vLLM with sparse attention worker."""
-    parser = FlexibleArgumentParser(description="vLLM model server with sparse attention")
+    """Launch vLLM with the combined quant + sparse attention worker."""
+    parser = FlexibleArgumentParser(
+        description="vLLM model server with attention quantization + sparse attention"
+    )
     parser.add_argument("model", type=str, help="The path or name of the model to serve")
     parser = make_arg_parser(parser)
 
-    # Ensure workers can import our custom worker module
+    # Ensure workers can import our custom worker modules (and its fakequant_worker sibling).
     repo_root = str(Path(__file__).resolve().parent)
     if repo_root not in sys.path:
         sys.path.insert(0, repo_root)
     current = os.environ.get("PYTHONPATH")
     os.environ["PYTHONPATH"] = os.pathsep.join([current, repo_root]) if current else repo_root
 
-    parser.set_defaults(worker_cls="sparse_attn_worker.SparseAttnWorker")
+    parser.set_defaults(worker_cls="quant_sparse_attn_worker.QuantSparseAttnWorker")
 
     args = parser.parse_args()
     uvloop.run(run_server(args))

--- a/examples/vllm_serve/vllm_serve_quant_sparse_attn.py
+++ b/examples/vllm_serve/vllm_serve_quant_sparse_attn.py
@@ -15,16 +15,22 @@
 
 """Launch vLLM with combined attention quantization + sparse attention.
 
-Restores ModelOpt fakequant (env knobs: ``MODELOPT_STATE_PATH`` / ``QUANT_CFG`` /
-``KV_QUANT_CFG`` / ...) **and** installs the sparse attention impl driven by the
-checkpoint's ``sparse_attention_config`` block. A single served checkpoint then
-runs attention quant (Q/K pre-step, P/V in-kernel) together with skip-softmax
-sparsity. Layers with neither active quant nor a sparse feature fall back to
-vLLM's native attention.
+Attaches NVFP4 attention quant (``ATTN_QUANT_MODE=impl_swap`` default, or the legacy ``mtq``
+restore prolog with env knobs ``MODELOPT_STATE_PATH`` / ``QUANT_CFG`` / ...) **and** installs the
+sparse attention impl driven by the checkpoint's ``sparse_attention_config`` block. A single served
+checkpoint then runs attention quant (Q/K pre-step, P/V in-kernel) together with skip-softmax
+sparsity. Layers with neither active quant nor a sparse feature fall back to vLLM's native attention.
+
+Launch with ``--enforce-eager`` and prefix caching disabled (both enforced at startup; see the
+support contract in ``examples/vllm_serve/README.md``).
 
 Usage:
-    MODELOPT_STATE_PATH=<ckpt>/modelopt_state.pth \\
-        python vllm_serve_quant_sparse_attn.py <path/to/modelopt-exported-ckpt>
+    # impl_swap (default): NVFP4 attention configured on the fly; composes with a realquant ckpt
+    python vllm_serve_quant_sparse_attn.py <ckpt> --enforce-eager --no-enable-prefix-caching
+
+    # legacy mtq: restore exported fakequant state (requires ATTN_QUANT_MODE=mtq + a quant source)
+    ATTN_QUANT_MODE=mtq MODELOPT_STATE_PATH=<ckpt>/modelopt_state.pth \\
+        python vllm_serve_quant_sparse_attn.py <ckpt> --enforce-eager --no-enable-prefix-caching
 """
 
 import os

--- a/modelopt/torch/kernels/common/attention/__init__.py
+++ b/modelopt/torch/kernels/common/attention/__init__.py
@@ -35,6 +35,7 @@ if torch.cuda.is_available():
             "kernel. Try to install triton with `pip install triton`."
         ),
     ):
+        from .decode_attention import attention_decode
         from .hf_triton_attention import (
             register_triton_attention,
             triton_attention_forward,
@@ -47,6 +48,7 @@ if torch.cuda.is_available():
 __all__ = [
     "IS_AVAILABLE",
     "attention",
+    "attention_decode",
     "register_triton_attention",
     "triton_attention_forward",
     "validate_triton_attention_envelope",

--- a/modelopt/torch/kernels/common/attention/__init__.py
+++ b/modelopt/torch/kernels/common/attention/__init__.py
@@ -23,6 +23,7 @@ from modelopt.torch.utils import import_plugin
 
 IS_AVAILABLE = False
 attention: Callable | None = None
+attention_decode: Callable | None = None
 register_triton_attention: Callable | None = None
 triton_attention_forward: Callable | None = None
 validate_triton_attention_envelope: Callable | None = None

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -1,0 +1,395 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: N803, N806 — Triton kernels use uppercase for constexpr and tensor args by convention
+
+"""Triton decode attention with optional fused skip-softmax over a paged KV cache.
+
+The general var-len flash-attention kernel (``triton_fa._attn_fwd``) is built for
+prefill: it tiles queries into ``BLOCK_M`` rows. In decode there is one query
+token per request, so 127/128 of every query tile is padding — the kernel does
+~128x the needed query-side work. This kernel is decode-shaped: one query vector
+per ``(request, query head)``, looping the paged KV cache.
+
+Split-K (flash-decoding): decode batches are small, so a grid of just
+``(batch, num_q_heads)`` leaves most SMs idle while each program walks the whole
+KV cache serially. We add a third grid axis that partitions the KV sequence into
+``num_kv_splits`` contiguous chunks, so a single ``(request, head)`` is computed
+by ``num_kv_splits`` programs in parallel; a small second kernel combines their
+partial softmaxes with the standard log-sum-exp rescaling (numerically exact).
+
+Skip-softmax: a KV tile whose peak score is negligible versus the running max
+(``tile_max - running_max < log(lambda)``) contributes ~0 to the softmax, so its
+V load and accumulation are skipped — a bandwidth saving that is largest exactly
+in long-context decode. The skip uses the same single-pass *prefix-max* criterion
+as ``attention_calibrate`` (per query head), so the realized sparsity matches the
+calibrated decode ``(a, b)``.
+
+Skip vs split-K interaction: each split builds its own prefix max from
+``-inf``, so the first tile of every split never skips and a split never sees a
+dominant max living in an earlier split. Splitting therefore makes skipping
+strictly *more conservative* (fewer skips) the more splits there are. Split-K is
+the universal small-batch win (exact, parallelism); skip is most effective at low
+split counts. ``num_kv_splits`` is exposed so callers can trade between them.
+"""
+
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from modelopt.torch.kernels.common.attention.triton_fa import (
+    LOG2E,
+    _load_paged_k_tile,
+    _load_paged_v_tile,
+)
+
+# Cap on the auto-chosen split count. Decode KV reads dominate, so a handful of
+# splits is enough to fill the SMs at small batch; more just fragments skipping.
+MAX_KV_SPLITS = 8
+
+
+@triton.jit
+def _attn_decode_split_fwd(
+    Q,  # [batch, num_q_heads, head_dim] — one query token per request
+    qk_scale,  # softmax_scale * log2(e)
+    B_seq_len_k,  # [batch] total KV length per request
+    M_partial,  # [batch, num_q_heads, num_kv_splits] per-split running max
+    L_partial,  # [batch, num_q_heads, num_kv_splits] per-split softmax denom
+    Acc_partial,  # [batch, num_q_heads, num_kv_splits, BLOCK_D] per-split weighted V sum
+    stride_qb,
+    stride_qh,
+    stride_mb,
+    stride_mh,
+    stride_ab,
+    stride_ah,
+    stride_as,
+    K_cache,  # [num_blocks, page_size, num_kv_heads, head_dim]
+    V_cache,
+    Block_table,  # [batch, max_blocks_per_seq]
+    stride_kc_block,
+    stride_kc_pos,
+    stride_kc_head,
+    stride_vc_block,
+    stride_vc_pos,
+    stride_vc_head,
+    Sparsity_total,  # optional int64 scalar (atomic) — total tiles
+    Sparsity_skipped,  # optional int64 scalar (atomic) — skipped tiles
+    kv_group_num: tl.constexpr,  # GQA ratio num_q_heads // num_kv_heads
+    BLOCK_D: tl.constexpr,  # next_power_of_2(head_dim)
+    BLOCK_N: tl.constexpr,  # KV tile size (128 to match the calibration granularity)
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    max_blocks_per_seq,
+    NUM_KV_SPLITS: tl.constexpr,
+    APPLY_SKIP: tl.constexpr,
+    SKIP_THRESHOLD_LOG2: tl.constexpr,  # log2(lambda) in the scaled-log2 score space
+    MEASURE_SPARSITY: tl.constexpr,
+):
+    """One (request, head, KV split): partial GEMV attention with skip."""
+    batch_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    split_idx = tl.program_id(2)
+    kv_head_idx = head_idx // kv_group_num
+
+    seq_len_kv = tl.load(B_seq_len_k + batch_idx)
+
+    # Partition whole BLOCK_N tiles (calibration-aligned) evenly across splits.
+    num_tiles = (seq_len_kv + BLOCK_N - 1) // BLOCK_N
+    tiles_per_split = (num_tiles + NUM_KV_SPLITS - 1) // NUM_KV_SPLITS
+    tile_lo = split_idx * tiles_per_split
+    tile_hi = tl.minimum(tile_lo + tiles_per_split, num_tiles)
+    kv_lo = tile_lo * BLOCK_N
+    kv_hi = tile_hi * BLOCK_N  # may exceed seq_len_kv; masked by kv_valid below
+
+    dim_pos = tl.arange(0, BLOCK_D)
+    d_mask = dim_pos < HEAD_DIM
+    kv_pos = tl.arange(0, BLOCK_N)
+
+    # Single query vector [BLOCK_D] for this (request, head); stays in registers.
+    # Upcast to fp32 so the QK dot product accumulates in fp32 (matches torch matmul).
+    q = tl.load(
+        Q + batch_idx * stride_qb + head_idx * stride_qh + dim_pos, mask=d_mask, other=0.0
+    ).to(tl.float32)
+
+    m_i = -float("inf")  # running max (prefix, scalar) within this split
+    l_i = 0.0  # running softmax denominator (scalar)
+    acc = tl.zeros([BLOCK_D], dtype=tl.float32)  # running weighted V sum
+
+    for kv_start in range(kv_lo, kv_hi, BLOCK_N):
+        kv_start = tl.multiple_of(kv_start, BLOCK_N)
+        kv_valid = (kv_start + kv_pos) < seq_len_kv
+
+        # K^T tile [BLOCK_D, BLOCK_N]; scores[BLOCK_N] = q . K^T (GEMV, M=1).
+        kt = _load_paged_k_tile(
+            K_cache,
+            Block_table,
+            batch_idx,
+            kv_head_idx,
+            kv_start,
+            kv_pos,
+            dim_pos,
+            seq_len_kv,
+            stride_kc_block,
+            stride_kc_pos,
+            stride_kc_head,
+            PAGE_SIZE,
+            BLOCK_N,
+            BLOCK_D,
+            HEAD_DIM,
+            max_blocks_per_seq,
+        )
+        scores = tl.sum(q[:, None] * kt.to(tl.float32), axis=0) * qk_scale  # [BLOCK_N], fp32 accum
+        scores = tl.where(kv_valid, scores, -float("inf"))
+
+        tile_max = tl.max(scores, axis=0)  # scalar
+
+        skip = False
+        if APPLY_SKIP:
+            # Same prefix-max criterion as attention_calibrate (single query row).
+            skip = tile_max < (m_i + SKIP_THRESHOLD_LOG2)
+        if MEASURE_SPARSITY:
+            tl.atomic_add(Sparsity_total, 1)
+            if skip:
+                tl.atomic_add(Sparsity_skipped, 1)
+
+        if not skip:
+            m_new = tl.maximum(m_i, tile_max)
+            p = tl.math.exp2(scores - m_new)  # [BLOCK_N]
+            p = tl.where(kv_valid, p, 0.0)
+            correction = tl.math.exp2(m_i - m_new)
+            l_i = l_i * correction + tl.sum(p, axis=0)
+            acc = acc * correction
+            vt = _load_paged_v_tile(
+                V_cache,
+                Block_table,
+                batch_idx,
+                kv_head_idx,
+                kv_start,
+                kv_pos,
+                dim_pos,
+                seq_len_kv,
+                stride_vc_block,
+                stride_vc_pos,
+                stride_vc_head,
+                PAGE_SIZE,
+                BLOCK_N,
+                BLOCK_D,
+                HEAD_DIM,
+                max_blocks_per_seq,
+            )
+            acc += tl.sum(p[:, None] * vt.to(tl.float32), axis=0)  # [BLOCK_D], fp32 accum
+            m_i = m_new
+
+    # Store this split's partial softmax state (undivided acc + max + denom).
+    off_ml = batch_idx * stride_mb + head_idx * stride_mh + split_idx
+    tl.store(M_partial + off_ml, m_i)
+    tl.store(L_partial + off_ml, l_i)
+    off_a = batch_idx * stride_ab + head_idx * stride_ah + split_idx * stride_as + dim_pos
+    tl.store(Acc_partial + off_a, acc, mask=d_mask)
+
+
+@triton.jit
+def _attn_decode_combine(
+    M_partial,  # [batch, num_q_heads, num_kv_splits]
+    L_partial,
+    Acc_partial,  # [batch, num_q_heads, num_kv_splits, BLOCK_D]
+    Out,  # [batch, num_q_heads, head_dim]
+    stride_mb,
+    stride_mh,
+    stride_ab,
+    stride_ah,
+    stride_as,
+    stride_ob,
+    stride_oh,
+    BLOCK_D: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+):
+    """Merge per-split partial softmaxes into the final output (exact)."""
+    batch_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+
+    dim_pos = tl.arange(0, BLOCK_D)
+    d_mask = dim_pos < HEAD_DIM
+
+    m = -float("inf")  # global running max across splits
+    l_acc = 0.0  # global softmax denominator
+    acc = tl.zeros([BLOCK_D], dtype=tl.float32)
+
+    base_ml = batch_idx * stride_mb + head_idx * stride_mh
+    base_a = batch_idx * stride_ab + head_idx * stride_ah
+    for s in range(NUM_KV_SPLITS):
+        l_s = tl.load(L_partial + base_ml + s)
+        if l_s > 0.0:  # skip empty splits (l == 0 -> contributed nothing)
+            m_s = tl.load(M_partial + base_ml + s)
+            acc_s = tl.load(Acc_partial + base_a + s * stride_as + dim_pos, mask=d_mask, other=0.0)
+            m_new = tl.maximum(m, m_s)
+            scale = tl.math.exp2(m - m_new)  # rescale the running totals
+            scale_s = tl.math.exp2(m_s - m_new)  # rescale this split
+            acc = acc * scale + acc_s * scale_s
+            l_acc = l_acc * scale + l_s * scale_s
+            m = m_new
+
+    out = acc / tl.maximum(l_acc, 1e-6)  # 0/eps = 0 if every tile skipped
+    tl.store(Out + batch_idx * stride_ob + head_idx * stride_oh + dim_pos, out, mask=d_mask)
+
+
+def _auto_num_kv_splits(device: torch.device, num_programs: int) -> int:
+    """Pick a split count that roughly fills the SMs without over-fragmenting."""
+    num_sms = torch.cuda.get_device_properties(device).multi_processor_count
+    # ceil(num_sms / num_programs), clamped to [1, MAX_KV_SPLITS].
+    return max(1, min(MAX_KV_SPLITS, -(-num_sms // max(num_programs, 1))))
+
+
+def attention_decode(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    b_seq_len_k: torch.Tensor,
+    *,
+    softmax_scale: float | None = None,
+    skip_softmax_threshold: float | None = None,
+    page_size: int = 16,
+    num_kv_splits: int | None = None,
+    measure_sparsity: bool = False,
+) -> torch.Tensor:
+    """Decode attention (one query token per request) over a paged KV cache.
+
+    Args:
+        q: ``[batch, num_q_heads, head_dim]`` — the single decode query per request.
+        k_cache, v_cache: paged caches ``[num_blocks, page_size, num_kv_heads, head_dim]``.
+        block_table: ``[batch, max_blocks_per_seq]`` page table.
+        b_seq_len_k: ``[batch]`` total KV length per request (including the new token).
+        softmax_scale: scale (default ``1/sqrt(head_dim)``).
+        skip_softmax_threshold: BLASST lambda; skip KV tiles whose peak score is
+            negligible versus the running max. ``None``/``0`` disables skipping
+            (exact dense decode).
+        page_size: tokens per page.
+        num_kv_splits: split-K factor — how many programs cooperate on one
+            ``(request, head)``. ``None`` auto-picks from the SM count and batch.
+            More splits raise small-batch occupancy but make skipping more
+            conservative (each split restarts its prefix max); pass ``1`` to keep
+            skipping maximally effective.
+        measure_sparsity: when skipping is active, count total/skipped tiles and
+            attach them as ``_sparsity_total`` / ``_sparsity_skipped`` on the output.
+
+    Returns:
+        ``[batch, num_q_heads, head_dim]`` attention output.
+    """
+    assert q.dim() == 3, "decode query must be [batch, num_q_heads, head_dim]"
+    q = q.contiguous()
+    batch, num_q_heads, head_dim = q.shape
+    num_kv_heads = k_cache.shape[2]
+    kv_group_num = num_q_heads // num_kv_heads
+
+    sm_scale = 1.0 / (head_dim**0.5) if softmax_scale is None else softmax_scale
+    qk_scale = sm_scale * LOG2E
+    BLOCK_D = triton.next_power_of_2(head_dim)
+    BLOCK_N = 128  # match attention_calibrate's KV tile granularity
+
+    if skip_softmax_threshold is not None and skip_softmax_threshold > 0.0:
+        apply_skip = True
+        skip_threshold_log2 = math.log2(skip_softmax_threshold)
+    else:
+        apply_skip = False
+        skip_threshold_log2 = 0.0
+    do_measure = measure_sparsity and apply_skip
+
+    if num_kv_splits is None:
+        num_kv_splits = _auto_num_kv_splits(q.device, batch * num_q_heads)
+    num_kv_splits = max(1, num_kv_splits)
+
+    # Per-split partial softmax state, merged by the combine kernel.
+    m_partial = torch.empty(batch, num_q_heads, num_kv_splits, dtype=torch.float32, device=q.device)
+    l_partial = torch.zeros(batch, num_q_heads, num_kv_splits, dtype=torch.float32, device=q.device)
+    acc_partial = torch.empty(
+        batch, num_q_heads, num_kv_splits, BLOCK_D, dtype=torch.float32, device=q.device
+    )
+
+    out = torch.empty_like(q)
+    if do_measure:
+        sparsity_total = torch.zeros(1, dtype=torch.int64, device=q.device)
+        sparsity_skipped = torch.zeros(1, dtype=torch.int64, device=q.device)
+    else:
+        sparsity_total = None
+        sparsity_skipped = None
+
+    with torch.cuda.device(q.device):
+        _attn_decode_split_fwd[(batch, num_q_heads, num_kv_splits)](
+            q,
+            qk_scale,
+            b_seq_len_k,
+            m_partial,
+            l_partial,
+            acc_partial,
+            q.stride(0),
+            q.stride(1),
+            m_partial.stride(0),
+            m_partial.stride(1),
+            acc_partial.stride(0),
+            acc_partial.stride(1),
+            acc_partial.stride(2),
+            k_cache,
+            v_cache,
+            block_table,
+            k_cache.stride(0),
+            k_cache.stride(1),
+            k_cache.stride(2),
+            v_cache.stride(0),
+            v_cache.stride(1),
+            v_cache.stride(2),
+            sparsity_total,
+            sparsity_skipped,
+            kv_group_num=kv_group_num,
+            BLOCK_D=BLOCK_D,
+            BLOCK_N=BLOCK_N,
+            HEAD_DIM=head_dim,
+            PAGE_SIZE=page_size,
+            max_blocks_per_seq=block_table.shape[1],
+            NUM_KV_SPLITS=num_kv_splits,
+            APPLY_SKIP=apply_skip,
+            SKIP_THRESHOLD_LOG2=skip_threshold_log2,
+            MEASURE_SPARSITY=do_measure,
+            num_warps=4,
+            num_stages=2,
+        )
+        _attn_decode_combine[(batch, num_q_heads)](
+            m_partial,
+            l_partial,
+            acc_partial,
+            out,
+            m_partial.stride(0),
+            m_partial.stride(1),
+            acc_partial.stride(0),
+            acc_partial.stride(1),
+            acc_partial.stride(2),
+            out.stride(0),
+            out.stride(1),
+            BLOCK_D=BLOCK_D,
+            HEAD_DIM=head_dim,
+            NUM_KV_SPLITS=num_kv_splits,
+            num_warps=4,
+        )
+
+    if do_measure:
+        out._sparsity_total = sparsity_total.item()
+        out._sparsity_skipped = sparsity_skipped.item()
+    return out
+
+
+__all__ = ["attention_decode"]

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -105,6 +105,7 @@ def _attn_decode_split_fwd(
     p_qdq_scale=1.0,  # per-tensor P-qdq scale (runtime scalar; amax/448 or amax/(6*448))
     V_QDQ: tl.constexpr = 0,  # value quant-dequant: 0=off, 1=FP8 E4M3, 2=NVFP4 (block-16 along keys)
     v_qdq_scale=1.0,  # per-tensor V-qdq scale (runtime scalar; amax/448 or amax/(6*448))
+    V_CACHE_QUANTIZED: tl.constexpr = False,  # V baked on write -> read complete tiles as-is, FQ only the tail
 ):
     """One (request, head, KV split): partial GEMV attention with skip."""
     batch_idx = tl.program_id(0)
@@ -113,6 +114,9 @@ def _attn_decode_split_fwd(
     kv_head_idx = head_idx // kv_group_num
 
     seq_len_kv = tl.load(B_seq_len_k + batch_idx)
+    # Last complete BLOCK_N tile boundary: with V baked on write, tiles below this are on the NVFP4
+    # grid (read as-is); the trailing partial tile is still raw and re-fake-quantized on read.
+    v_dense_boundary = (seq_len_kv // BLOCK_N) * BLOCK_N
 
     # Partition whole BLOCK_N tiles (calibration-aligned) evenly across splits.
     num_tiles = (seq_len_kv + BLOCK_N - 1) // BLOCK_N
@@ -209,11 +213,18 @@ def _attn_decode_split_fwd(
             vt = vt.to(tl.float32)
             # V is the B-side of BMM2; its NVFP4 blocks of 16 run along the key axis
             # (axis 0 of [BLOCK_N, BLOCK_D]). _load_paged_v_tile masks out-of-range keys
-            # to 0, so a partial trailing tile cannot poison a block amax.
-            if V_QDQ == 1:
-                vt = _qdq_fp8(vt, v_qdq_scale)
-            elif V_QDQ == 2:
-                vt = _v_qdq_nvfp4(vt, v_qdq_scale, BLOCK_N, BLOCK_D)
+            # to 0, so a partial trailing tile cannot poison a block amax. When V is baked
+            # on write (V_CACHE_QUANTIZED), complete tiles are already on the grid -> skip
+            # the redundant re-quant and FQ only the trailing partial tile.
+            if V_QDQ != 0 and ((not V_CACHE_QUANTIZED) or (kv_start + BLOCK_N > v_dense_boundary)):
+                if V_QDQ == 1:
+                    vt = _qdq_fp8(vt, v_qdq_scale)
+                else:  # V_QDQ == 2 (NVFP4)
+                    vt = _v_qdq_nvfp4(vt, v_qdq_scale, BLOCK_N, BLOCK_D)
+                # Round the dequantized V to the cache (bf16) dtype so an on-read tile matches a
+                # baked-on-write tile bit-for-bit: on-write stores bf16(FQ) in the cache, so the
+                # on-read path must dequant at the same bf16 precision. Makes on-read == on-write.
+                vt = vt.to(V_cache.dtype.element_ty).to(tl.float32)
             acc += tl.sum(p[:, None] * vt, axis=0)  # [BLOCK_D], fp32 accum
             m_i = m_new
 
@@ -278,6 +289,118 @@ def _auto_num_kv_splits(device: torch.device, num_programs: int) -> int:
     return max(1, min(MAX_KV_SPLITS, -(-num_sms // max(num_programs, 1))))
 
 
+# BLOCK_N tile size for the V cache bake — matches the decode/prefill kernels' tile so a baked
+# tile and the kernels' read tile coincide (each tile is fake-quantized exactly once).
+_ONWRITE_BLOCK_N = 128
+
+
+@triton.jit
+def _onwrite_fq_v_kernel(
+    V_cache,  # [num_blocks, page_size, num_kv_heads, head_dim]
+    Block_table,  # [batch, max_blocks_per_seq]
+    V_lo,  # [batch] per-request bake range [lo, hi) in key positions (BLOCK_N-aligned, device)
+    V_hi,
+    stride_vc_block,
+    stride_vc_pos,
+    stride_vc_head,
+    v_qdq_scale,  # per-tensor NVFP4 global scale (constant runtime scalar)
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    max_blocks_per_seq,
+):
+    """In-place NVFP4 fake-quant of complete BLOCK_N V tiles in the paged cache (quantize-on-write).
+
+    Each program bakes one complete ``BLOCK_N`` tile of one ``(request, kv_head)``: load the tile,
+    fake-quant it with the SAME ``_v_qdq_nvfp4`` the decode/prefill kernels apply on read, and store
+    it back. The per-request range ``[V_lo, V_hi)`` is read from device tensors and the tile index from
+    ``program_id(2)``, so the launch grid never needs a host ``.item()`` — CUDA-graph-capturable. A
+    pure-decode step appends one key that completes at most one tile, so a fixed ``(batch, n_kv, 1)``
+    grid covers it (empty ranges mask to a no-op).
+    """
+    batch_idx = tl.program_id(0)
+    kv_head_idx = tl.program_id(1)
+    vlo = tl.load(V_lo + batch_idx)
+    vhi = tl.load(V_hi + batch_idx)
+    tile = (vlo // BLOCK_N) + tl.program_id(2)
+    kv_start = tile * BLOCK_N
+    kv_pos = tl.arange(0, BLOCK_N)
+    dim_pos = tl.arange(0, BLOCK_D)
+    d_mask = dim_pos < HEAD_DIM
+    kv_abs = kv_start + kv_pos
+    v_in = (kv_abs >= vlo) & (kv_abs < vhi)
+
+    page_local = kv_abs // PAGE_SIZE
+    offset_in_page = kv_abs % PAGE_SIZE
+    page_global = tl.load(
+        Block_table + batch_idx * max_blocks_per_seq + page_local, mask=v_in, other=0
+    )
+    # V layout [BLOCK_N keys, BLOCK_D]; int64 offsets so a large paged cache cannot overflow int32.
+    v_ptrs = (
+        page_global[:, None].to(tl.int64) * stride_vc_block
+        + offset_in_page[:, None] * stride_vc_pos
+        + kv_head_idx * stride_vc_head
+        + dim_pos[None, :]
+    )
+    vt = tl.load(V_cache + v_ptrs, mask=v_in[:, None] & d_mask[None, :], other=0.0).to(tl.float32)
+    vq = _v_qdq_nvfp4(vt, v_qdq_scale, BLOCK_N, BLOCK_D)
+    tl.store(
+        V_cache + v_ptrs, vq.to(V_cache.dtype.element_ty), mask=v_in[:, None] & d_mask[None, :]
+    )
+
+
+def fake_quant_v_onwrite(
+    v_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    v_lo: torch.Tensor,  # [batch] int32 device tensor, BLOCK_N-aligned bake range [lo, hi)
+    v_hi: torch.Tensor,
+    *,
+    page_size: int = 16,
+    v_qdq_scale: float = 1.0,
+    decode: bool = False,
+) -> None:
+    """NVFP4 quantize-on-write for V: fake-quant complete ``BLOCK_N`` tiles in ``[v_lo, v_hi)`` in place.
+
+    Bakes V tiles once at write so the decode kernel reads complete tiles as-is (``O(S)`` decode)
+    instead of re-fake-quantizing the whole cache every step (``O(S²)`` on-read). Because written
+    tokens are immutable and the same ``_v_qdq_nvfp4`` is used, the baked tile is bit-identical to the
+    on-read result — a pure speedup.
+
+    ``decode=True`` fixes the grid to one tile/request (graph-capturable, no host sync); otherwise the
+    grid spans the largest per-request range (eager prefill).
+    """
+    batch, max_blocks = block_table.shape
+    num_kv, head_dim = v_cache.shape[2], v_cache.shape[3]
+    BLOCK_N = _ONWRITE_BLOCK_N
+    BLOCK_D = triton.next_power_of_2(head_dim)
+    if decode:
+        n_tiles = 1  # one appended key completes at most one tile; fixed grid => graph-safe
+    else:
+        base = v_lo // BLOCK_N
+        span = int((v_hi - base * BLOCK_N).max().item())
+        if span <= 0:
+            return
+        n_tiles = (span + BLOCK_N - 1) // BLOCK_N
+    with torch.cuda.device(v_cache.device):
+        _onwrite_fq_v_kernel[(batch, num_kv, n_tiles)](
+            v_cache,
+            block_table,
+            v_lo,
+            v_hi,
+            v_cache.stride(0),
+            v_cache.stride(1),
+            v_cache.stride(2),
+            v_qdq_scale,
+            BLOCK_N=BLOCK_N,
+            BLOCK_D=BLOCK_D,
+            HEAD_DIM=head_dim,
+            PAGE_SIZE=page_size,
+            max_blocks_per_seq=max_blocks,
+            num_warps=4,
+        )
+
+
 def attention_decode(
     q: torch.Tensor,
     k_cache: torch.Tensor,
@@ -294,6 +417,7 @@ def attention_decode(
     p_qdq_amax: float = 1.0,
     v_qdq: str | None = None,
     v_qdq_amax: float | None = None,
+    v_cache_quantized: bool = False,
 ) -> torch.Tensor:
     """Decode attention (one query token per request) over a paged KV cache.
 
@@ -326,6 +450,10 @@ def attention_decode(
         v_qdq_amax: per-tensor amax for the V qdq. ``None`` uses the constant 1.0
             global scale (V's dynamic per-16 block amax carries the range and does not
             saturate E4M3); a calibrated amax is converted as for ``p_qdq_amax``.
+        v_cache_quantized: when True, V was already NVFP4-baked on write
+            (``fake_quant_v_onwrite``), so complete BLOCK_N tiles are on the grid — the
+            kernel reads them as-is and re-fake-quantizes only the trailing partial tile,
+            avoiding the O(S²) on-read re-quant during decode.
 
     Returns:
         ``[batch, num_q_heads, head_dim]`` attention output.
@@ -434,6 +562,7 @@ def attention_decode(
             p_qdq_scale=p_qdq_scale,
             V_QDQ=v_qdq_mode,
             v_qdq_scale=v_qdq_scale,
+            V_CACHE_QUANTIZED=v_cache_quantized,
             num_warps=4,
             num_stages=2,
         )
@@ -461,4 +590,4 @@ def attention_decode(
     return out
 
 
-__all__ = ["attention_decode"]
+__all__ = ["attention_decode", "fake_quant_v_onwrite"]

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -57,8 +57,8 @@ from modelopt.torch.kernels.common.attention.triton_fa import (
     _load_paged_k_tile,
     _load_paged_v_tile,
 )
-from modelopt.torch.kernels.quantization.attention.p_qdq import _p_qdq_nvfp4
-from modelopt.torch.kernels.quantization.common.fp8_quant import fp8_scalar_qdq as _p_qdq_fp8
+from modelopt.torch.kernels.quantization.attention.p_qdq import _p_qdq_nvfp4, _v_qdq_nvfp4
+from modelopt.torch.kernels.quantization.common.fp8_quant import fp8_scalar_qdq as _qdq_fp8
 
 # Cap on the auto-chosen split count. Decode KV reads dominate, so a handful of
 # splits is enough to fill the SMs at small batch; more just fragments skipping.
@@ -103,6 +103,8 @@ def _attn_decode_split_fwd(
     MEASURE_SPARSITY: tl.constexpr,
     P_QDQ: tl.constexpr = 0,  # softmax-P quant-dequant: 0=off, 1=FP8 E4M3, 2=NVFP4
     p_qdq_scale=1.0,  # per-tensor P-qdq scale (runtime scalar; amax/448 or amax/(6*448))
+    V_QDQ: tl.constexpr = 0,  # value quant-dequant: 0=off, 1=FP8 E4M3, 2=NVFP4 (block-16 along keys)
+    v_qdq_scale=1.0,  # per-tensor V-qdq scale (runtime scalar; amax/448 or amax/(6*448))
 ):
     """One (request, head, KV split): partial GEMV attention with skip."""
     batch_idx = tl.program_id(0)
@@ -178,10 +180,10 @@ def _attn_decode_split_fwd(
             correction = tl.math.exp2(m_i - m_new)
             l_i = l_i * correction + tl.sum(p, axis=0)  # denominator: unquantized p
             acc = acc * correction
-            # Optional softmax-P quant-dequant for the P @ V weighting (BMM2); the
-            # denominator above stays unquantized, matching the prefill kernel.
+            # Optional in-kernel quant-dequant of the BMM2 operands (P and V); the
+            # softmax denominator above stays unquantized, matching the prefill kernel.
             if P_QDQ == 1:
-                p = _p_qdq_fp8(p, p_qdq_scale)
+                p = _qdq_fp8(p, p_qdq_scale)
             elif P_QDQ == 2:
                 p = tl.reshape(
                     _p_qdq_nvfp4(tl.reshape(p, (1, BLOCK_N)), p_qdq_scale, 1, BLOCK_N), (BLOCK_N,)
@@ -204,7 +206,15 @@ def _attn_decode_split_fwd(
                 HEAD_DIM,
                 max_blocks_per_seq,
             )
-            acc += tl.sum(p[:, None] * vt.to(tl.float32), axis=0)  # [BLOCK_D], fp32 accum
+            vt = vt.to(tl.float32)
+            # V is the B-side of BMM2; its NVFP4 blocks of 16 run along the key axis
+            # (axis 0 of [BLOCK_N, BLOCK_D]). _load_paged_v_tile masks out-of-range keys
+            # to 0, so a partial trailing tile cannot poison a block amax.
+            if V_QDQ == 1:
+                vt = _qdq_fp8(vt, v_qdq_scale)
+            elif V_QDQ == 2:
+                vt = _v_qdq_nvfp4(vt, v_qdq_scale, BLOCK_N, BLOCK_D)
+            acc += tl.sum(p[:, None] * vt, axis=0)  # [BLOCK_D], fp32 accum
             m_i = m_new
 
     # Store this split's partial softmax state (undivided acc + max + denom).
@@ -282,6 +292,8 @@ def attention_decode(
     measure_sparsity: bool = False,
     p_qdq: str | None = None,
     p_qdq_amax: float = 1.0,
+    v_qdq: str | None = None,
+    v_qdq_amax: float | None = None,
 ) -> torch.Tensor:
     """Decode attention (one query token per request) over a paged KV cache.
 
@@ -307,6 +319,13 @@ def attention_decode(
             disable. The softmax denominator stays unquantized (straight-through).
         p_qdq_amax: per-tensor amax for the P qdq (default 1.0, the upper bound of the
             unnormalized P). Converted to amax/448 (FP8) or amax/(6*448) (NVFP4).
+        v_qdq: fake quant-dequant of the value operand V before P @ V — ``"fp8"`` or
+            ``"nvfp4"`` (E2M1, block-16 along keys, the BMM2 contraction axis), or
+            ``None``. V is quantized on read here because its keys-axis blocks cannot
+            be formed by a per-token cache write.
+        v_qdq_amax: per-tensor amax for the V qdq. ``None`` uses the constant 1.0
+            global scale (V's dynamic per-16 block amax carries the range and does not
+            saturate E4M3); a calibrated amax is converted as for ``p_qdq_amax``.
 
     Returns:
         ``[batch, num_q_heads, head_dim]`` attention output.
@@ -334,6 +353,19 @@ def attention_decode(
         if not (math.isfinite(p_qdq_amax) and p_qdq_amax > 0):
             raise ValueError(f"p_qdq_amax must be finite and positive, got {p_qdq_amax}")
         p_qdq_scale = p_qdq_amax / 448.0 if p_qdq == "fp8" else p_qdq_amax / (6.0 * 448.0)
+
+    if v_qdq not in _P_QDQ_MODES:
+        raise ValueError(
+            f"v_qdq must be one of {sorted(k for k in _P_QDQ_MODES if k)} or None, got {v_qdq!r}"
+        )
+    v_qdq_mode = _P_QDQ_MODES[v_qdq]
+    # V has no natural amax bound; v_qdq_amax=None -> constant 1.0 global scale (the
+    # per-16 block amax carries the range, and V does not saturate E4M3).
+    v_qdq_scale = 1.0
+    if v_qdq_mode and v_qdq_amax is not None:
+        if not (math.isfinite(v_qdq_amax) and v_qdq_amax > 0):
+            raise ValueError(f"v_qdq_amax must be finite and positive, got {v_qdq_amax}")
+        v_qdq_scale = v_qdq_amax / 448.0 if v_qdq == "fp8" else v_qdq_amax / (6.0 * 448.0)
 
     if skip_softmax_threshold is not None and skip_softmax_threshold > 0.0:
         apply_skip = True
@@ -400,6 +432,8 @@ def attention_decode(
             MEASURE_SPARSITY=do_measure,
             P_QDQ=p_qdq_mode,
             p_qdq_scale=p_qdq_scale,
+            V_QDQ=v_qdq_mode,
+            v_qdq_scale=v_qdq_scale,
             num_warps=4,
             num_stages=2,
         )

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -52,10 +52,13 @@ import triton
 import triton.language as tl
 
 from modelopt.torch.kernels.common.attention.triton_fa import (
+    _P_QDQ_MODES,
     LOG2E,
     _load_paged_k_tile,
     _load_paged_v_tile,
 )
+from modelopt.torch.kernels.quantization.attention.p_qdq import _p_qdq_nvfp4
+from modelopt.torch.kernels.quantization.common.fp8_quant import fp8_scalar_qdq as _p_qdq_fp8
 
 # Cap on the auto-chosen split count. Decode KV reads dominate, so a handful of
 # splits is enough to fill the SMs at small batch; more just fragments skipping.
@@ -98,6 +101,8 @@ def _attn_decode_split_fwd(
     APPLY_SKIP: tl.constexpr,
     SKIP_THRESHOLD_LOG2: tl.constexpr,  # log2(lambda) in the scaled-log2 score space
     MEASURE_SPARSITY: tl.constexpr,
+    P_QDQ: tl.constexpr = 0,  # softmax-P quant-dequant: 0=off, 1=FP8 E4M3, 2=NVFP4
+    p_qdq_scale=1.0,  # per-tensor P-qdq scale (runtime scalar; amax/448 or amax/(6*448))
 ):
     """One (request, head, KV split): partial GEMV attention with skip."""
     batch_idx = tl.program_id(0)
@@ -171,8 +176,16 @@ def _attn_decode_split_fwd(
             p = tl.math.exp2(scores - m_new)  # [BLOCK_N]
             p = tl.where(kv_valid, p, 0.0)
             correction = tl.math.exp2(m_i - m_new)
-            l_i = l_i * correction + tl.sum(p, axis=0)
+            l_i = l_i * correction + tl.sum(p, axis=0)  # denominator: unquantized p
             acc = acc * correction
+            # Optional softmax-P quant-dequant for the P @ V weighting (BMM2); the
+            # denominator above stays unquantized, matching the prefill kernel.
+            if P_QDQ == 1:
+                p = _p_qdq_fp8(p, p_qdq_scale)
+            elif P_QDQ == 2:
+                p = tl.reshape(
+                    _p_qdq_nvfp4(tl.reshape(p, (1, BLOCK_N)), p_qdq_scale, 1, BLOCK_N), (BLOCK_N,)
+                )
             vt = _load_paged_v_tile(
                 V_cache,
                 Block_table,
@@ -267,6 +280,8 @@ def attention_decode(
     page_size: int = 16,
     num_kv_splits: int | None = None,
     measure_sparsity: bool = False,
+    p_qdq: str | None = None,
+    p_qdq_amax: float = 1.0,
 ) -> torch.Tensor:
     """Decode attention (one query token per request) over a paged KV cache.
 
@@ -287,6 +302,11 @@ def attention_decode(
             skipping maximally effective.
         measure_sparsity: when skipping is active, count total/skipped tiles and
             attach them as ``_sparsity_total`` / ``_sparsity_skipped`` on the output.
+        p_qdq: fake quant-dequant of the softmax probabilities P before P @ V —
+            ``"fp8"`` (E4M3) or ``"nvfp4"`` (E2M1, block-16 along keys), or ``None`` to
+            disable. The softmax denominator stays unquantized (straight-through).
+        p_qdq_amax: per-tensor amax for the P qdq (default 1.0, the upper bound of the
+            unnormalized P). Converted to amax/448 (FP8) or amax/(6*448) (NVFP4).
 
     Returns:
         ``[batch, num_q_heads, head_dim]`` attention output.
@@ -301,6 +321,19 @@ def attention_decode(
     qk_scale = sm_scale * LOG2E
     BLOCK_D = triton.next_power_of_2(head_dim)
     BLOCK_N = 128  # match attention_calibrate's KV tile granularity
+
+    if p_qdq not in _P_QDQ_MODES:
+        raise ValueError(
+            f"p_qdq must be one of {sorted(k for k in _P_QDQ_MODES if k)} or None, got {p_qdq!r}"
+        )
+    p_qdq_mode = _P_QDQ_MODES[p_qdq]
+    # Per-tensor amax -> kernel scale (q = cast(p / scale) * scale): FP8 uses amax/448,
+    # NVFP4 the global scale amax/(6*448). amax=1 (P lies in [0, 1]) = full-range scale.
+    p_qdq_scale = 1.0
+    if p_qdq_mode:
+        if not (math.isfinite(p_qdq_amax) and p_qdq_amax > 0):
+            raise ValueError(f"p_qdq_amax must be finite and positive, got {p_qdq_amax}")
+        p_qdq_scale = p_qdq_amax / 448.0 if p_qdq == "fp8" else p_qdq_amax / (6.0 * 448.0)
 
     if skip_softmax_threshold is not None and skip_softmax_threshold > 0.0:
         apply_skip = True
@@ -365,6 +398,8 @@ def attention_decode(
             APPLY_SKIP=apply_skip,
             SKIP_THRESHOLD_LOG2=skip_threshold_log2,
             MEASURE_SPARSITY=do_measure,
+            P_QDQ=p_qdq_mode,
+            p_qdq_scale=p_qdq_scale,
             num_warps=4,
             num_stages=2,
         )

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ruff: noqa: N803, N806 — Triton kernels use uppercase for constexpr and tensor args by convention
 
 """Triton decode attention with optional fused skip-softmax over a paged KV cache.
 
@@ -52,12 +51,13 @@ import triton
 import triton.language as tl
 
 from modelopt.torch.kernels.common.attention.triton_fa import (
-    _P_QDQ_MODES,
+    _QDQ_MODES,
     LOG2E,
     _load_paged_k_tile,
     _load_paged_v_tile,
 )
-from modelopt.torch.kernels.quantization.attention.p_qdq import _p_qdq_nvfp4, _v_qdq_nvfp4
+from modelopt.torch.kernels.quantization.attention.p_qdq import _p_qdq_nvfp4
+from modelopt.torch.kernels.quantization.attention.v_qdq import _v_qdq_nvfp4
 from modelopt.torch.kernels.quantization.common.fp8_quant import fp8_scalar_qdq as _qdq_fp8
 
 # Cap on the auto-chosen split count. Decode KV reads dominate, so a handful of
@@ -469,11 +469,11 @@ def attention_decode(
     BLOCK_D = triton.next_power_of_2(head_dim)
     BLOCK_N = 128  # match attention_calibrate's KV tile granularity
 
-    if p_qdq not in _P_QDQ_MODES:
+    if p_qdq not in _QDQ_MODES:
         raise ValueError(
-            f"p_qdq must be one of {sorted(k for k in _P_QDQ_MODES if k)} or None, got {p_qdq!r}"
+            f"p_qdq must be one of {sorted(k for k in _QDQ_MODES if k)} or None, got {p_qdq!r}"
         )
-    p_qdq_mode = _P_QDQ_MODES[p_qdq]
+    p_qdq_mode = _QDQ_MODES[p_qdq]
     # Per-tensor amax -> kernel scale (q = cast(p / scale) * scale): FP8 uses amax/448,
     # NVFP4 the global scale amax/(6*448). amax=1 (P lies in [0, 1]) = full-range scale.
     p_qdq_scale = 1.0
@@ -482,11 +482,11 @@ def attention_decode(
             raise ValueError(f"p_qdq_amax must be finite and positive, got {p_qdq_amax}")
         p_qdq_scale = p_qdq_amax / 448.0 if p_qdq == "fp8" else p_qdq_amax / (6.0 * 448.0)
 
-    if v_qdq not in _P_QDQ_MODES:
+    if v_qdq not in _QDQ_MODES:
         raise ValueError(
-            f"v_qdq must be one of {sorted(k for k in _P_QDQ_MODES if k)} or None, got {v_qdq!r}"
+            f"v_qdq must be one of {sorted(k for k in _QDQ_MODES if k)} or None, got {v_qdq!r}"
         )
-    v_qdq_mode = _P_QDQ_MODES[v_qdq]
+    v_qdq_mode = _QDQ_MODES[v_qdq]
     # V has no natural amax bound; v_qdq_amax=None -> constant 1.0 global scale (the
     # per-16 block amax carries the range, and V does not saturate E4M3).
     v_qdq_scale = 1.0

--- a/modelopt/torch/kernels/common/attention/decode_attention.py
+++ b/modelopt/torch/kernels/common/attention/decode_attention.py
@@ -105,7 +105,7 @@ def _attn_decode_split_fwd(
     p_qdq_scale=1.0,  # per-tensor P-qdq scale (runtime scalar; amax/448 or amax/(6*448))
     V_QDQ: tl.constexpr = 0,  # value quant-dequant: 0=off, 1=FP8 E4M3, 2=NVFP4 (block-16 along keys)
     v_qdq_scale=1.0,  # per-tensor V-qdq scale (runtime scalar; amax/448 or amax/(6*448))
-    V_CACHE_QUANTIZED: tl.constexpr = False,  # V baked on write -> read complete tiles as-is, FQ only the tail
+    V_CACHE_QUANTIZED: tl.constexpr = False,  # complete block-16 groups are already QDQ
 ):
     """One (request, head, KV split): partial GEMV attention with skip."""
     batch_idx = tl.program_id(0)
@@ -114,10 +114,7 @@ def _attn_decode_split_fwd(
     kv_head_idx = head_idx // kv_group_num
 
     seq_len_kv = tl.load(B_seq_len_k + batch_idx)
-    # Last complete BLOCK_N tile boundary: with V baked on write, tiles below this are on the NVFP4
-    # grid (read as-is); the trailing partial tile is still raw and re-fake-quantized on read.
-    v_dense_boundary = (seq_len_kv // BLOCK_N) * BLOCK_N
-
+    v_dense_boundary = (seq_len_kv // 16) * 16
     # Partition whole BLOCK_N tiles (calibration-aligned) evenly across splits.
     num_tiles = (seq_len_kv + BLOCK_N - 1) // BLOCK_N
     tiles_per_split = (num_tiles + NUM_KV_SPLITS - 1) // NUM_KV_SPLITS
@@ -211,20 +208,22 @@ def _attn_decode_split_fwd(
                 max_blocks_per_seq,
             )
             vt = vt.to(tl.float32)
-            # V is the B-side of BMM2; its NVFP4 blocks of 16 run along the key axis
-            # (axis 0 of [BLOCK_N, BLOCK_D]). _load_paged_v_tile masks out-of-range keys
-            # to 0, so a partial trailing tile cannot poison a block amax. When V is baked
-            # on write (V_CACHE_QUANTIZED), complete tiles are already on the grid -> skip
-            # the redundant re-quant and FQ only the trailing partial tile.
+            # Quantize from pristine cache values. With block-16 on-write baking, completed
+            # groups are already QDQ; select the fresh QDQ result only for the raw partial group.
             if V_QDQ != 0 and ((not V_CACHE_QUANTIZED) or (kv_start + BLOCK_N > v_dense_boundary)):
                 if V_QDQ == 1:
-                    vt = _qdq_fp8(vt, v_qdq_scale)
+                    vq = _qdq_fp8(vt, v_qdq_scale)
                 else:  # V_QDQ == 2 (NVFP4)
-                    vt = _v_qdq_nvfp4(vt, v_qdq_scale, BLOCK_N, BLOCK_D)
+                    vq = _v_qdq_nvfp4(vt, v_qdq_scale, BLOCK_N, BLOCK_D)
                 # Round the dequantized V to the cache (bf16) dtype so an on-read tile matches a
                 # baked-on-write tile bit-for-bit: on-write stores bf16(FQ) in the cache, so the
                 # on-read path must dequant at the same bf16 precision. Makes on-read == on-write.
-                vt = vt.to(V_cache.dtype.element_ty).to(tl.float32)
+                vq = vq.to(V_cache.dtype.element_ty).to(tl.float32)
+                if V_CACHE_QUANTIZED:
+                    tail = (kv_start + kv_pos) >= v_dense_boundary
+                    vt = tl.where(tail[:, None], vq, vt)
+                else:
+                    vt = vq
             acc += tl.sum(p[:, None] * vt, axis=0)  # [BLOCK_D], fp32 accum
             m_i = m_new
 
@@ -289,9 +288,9 @@ def _auto_num_kv_splits(device: torch.device, num_programs: int) -> int:
     return max(1, min(MAX_KV_SPLITS, -(-num_sms // max(num_programs, 1))))
 
 
-# BLOCK_N tile size for the V cache bake — matches the decode/prefill kernels' tile so a baked
-# tile and the kernels' read tile coincide (each tile is fake-quantized exactly once).
-_ONWRITE_BLOCK_N = 128
+# NVFP4 V uses block-16 scaling along the key axis. Complete groups stay QDQ in the cache;
+# the attention kernel QDQs the incomplete pristine group on read.
+_ONWRITE_BLOCK_N = 16
 
 
 @triton.jit
@@ -445,15 +444,12 @@ def attention_decode(
             unnormalized P). Converted to amax/448 (FP8) or amax/(6*448) (NVFP4).
         v_qdq: fake quant-dequant of the value operand V before P @ V — ``"fp8"`` or
             ``"nvfp4"`` (E2M1, block-16 along keys, the BMM2 contraction axis), or
-            ``None``. V is quantized on read here because its keys-axis blocks cannot
-            be formed by a per-token cache write.
+            ``None``. Unless ``v_cache_quantized`` is set, V is quantized on read.
         v_qdq_amax: per-tensor amax for the V qdq. ``None`` uses the constant 1.0
             global scale (V's dynamic per-16 block amax carries the range and does not
             saturate E4M3); a calibrated amax is converted as for ``p_qdq_amax``.
-        v_cache_quantized: when True, V was already NVFP4-baked on write
-            (``fake_quant_v_onwrite``), so complete BLOCK_N tiles are on the grid — the
-            kernel reads them as-is and re-fake-quantizes only the trailing partial tile,
-            avoiding the O(S²) on-read re-quant during decode.
+        v_cache_quantized: when True, complete block-16 groups are already NVFP4 QDQ in
+            the paged cache. The kernel QDQs only the pristine partial group on read.
 
     Returns:
         ``[batch, num_q_heads, head_dim]`` attention output.

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -41,7 +41,7 @@ import triton.language as tl
 _apply_sparse_nm_to_qk_tile: Any = None
 _is_dense_region: Any = None
 _skip_softmax_decision: Any = None
-_p_qdq_fp8: Any = None
+_qdq_fp8: Any = None
 _p_qdq_nvfp4: Any = None
 _v_qdq_nvfp4: Any = None
 
@@ -64,20 +64,20 @@ def _load_sparsity_helpers() -> None:
         _skip_softmax_decision = _skip
 
 
-def _load_p_qdq_helpers() -> None:
-    global _p_qdq_fp8, _p_qdq_nvfp4, _v_qdq_nvfp4
-    if _p_qdq_fp8 is None:
-        from modelopt.torch.kernels.quantization.attention.p_qdq import _p_qdq_nvfp4 as _nvfp4
-        from modelopt.torch.kernels.quantization.attention.p_qdq import _v_qdq_nvfp4 as _vnvfp4
+def _load_qdq_helpers() -> None:
+    global _qdq_fp8, _p_qdq_nvfp4, _v_qdq_nvfp4
+    if _qdq_fp8 is None:
+        from modelopt.torch.kernels.quantization.attention.p_qdq import _p_qdq_nvfp4 as _pnvfp4
+        from modelopt.torch.kernels.quantization.attention.v_qdq import _v_qdq_nvfp4 as _vnvfp4
         from modelopt.torch.kernels.quantization.common.fp8_quant import fp8_scalar_qdq as _fp8
 
-        _p_qdq_fp8 = _fp8
-        _p_qdq_nvfp4 = _nvfp4
+        _qdq_fp8 = _fp8
+        _p_qdq_nvfp4 = _pnvfp4
         _v_qdq_nvfp4 = _vnvfp4
 
 
-# Maps the public p_qdq option to the kernel's P_QDQ constexpr.
-_P_QDQ_MODES = {None: 0, "fp8": 1, "nvfp4": 2}
+# Maps a public p_qdq / v_qdq option ("fp8"/"nvfp4"/None) to the kernel's P_QDQ / V_QDQ constexpr.
+_QDQ_MODES = {None: 0, "fp8": 1, "nvfp4": 2}
 
 
 LOG2E: float = 1.44269504088896
@@ -409,7 +409,7 @@ def _attn_fwd(
             # row_sum keeps the unquantized p: the softmax denominator stays in
             # fp32 and only the quantized P is fed to BMM2.
             if P_QDQ == 1:
-                p = _p_qdq_fp8(p, p_qdq_scale)
+                p = _qdq_fp8(p, p_qdq_scale)
             elif P_QDQ == 2:
                 p = _p_qdq_nvfp4(p, p_qdq_scale, BLOCK_M, BLOCK_N)
 
@@ -444,7 +444,7 @@ def _attn_fwd(
             # key axis (axis 0 of [BLOCK_N, BLOCK_D]); the masked-to-0 loads keep a partial
             # tile from poisoning a block amax. FQ in fp32, then back to v.dtype for the dot.
             if V_QDQ == 1:
-                v = _p_qdq_fp8(v.to(tl.float32), v_qdq_scale).to(v.dtype)
+                v = _qdq_fp8(v.to(tl.float32), v_qdq_scale).to(v.dtype)
             elif V_QDQ == 2:
                 v = _v_qdq_nvfp4(v.to(tl.float32), v_qdq_scale, BLOCK_N, BLOCK_D).to(v.dtype)
             acc = tl.dot(p.to(v.dtype), v, acc)
@@ -1274,12 +1274,12 @@ def attention(
     # permanently excluded from the cache key and later edits to them would
     # silently reuse stale compiled kernels from the on-disk cache.
     _load_sparsity_helpers()
-    _load_p_qdq_helpers()
-    if p_qdq not in _P_QDQ_MODES:
+    _load_qdq_helpers()
+    if p_qdq not in _QDQ_MODES:
         raise ValueError(
-            f"p_qdq must be one of {sorted(k for k in _P_QDQ_MODES if k)} or None, got {p_qdq!r}"
+            f"p_qdq must be one of {sorted(k for k in _QDQ_MODES if k)} or None, got {p_qdq!r}"
         )
-    p_qdq_mode = _P_QDQ_MODES[p_qdq]
+    p_qdq_mode = _QDQ_MODES[p_qdq]
     # Convert the per-tensor amax to the kernel's scale convention
     # (``q = cast(p / scale) * scale``): FP8 uses ``amax / 448``; NVFP4 uses the
     # global scale ``amax / (6 * 448)``. amax=1 (the default, the theoretical
@@ -1289,11 +1289,11 @@ def attention(
         if not (math.isfinite(p_qdq_amax) and p_qdq_amax > 0):
             raise ValueError(f"p_qdq_amax must be a finite positive value, got {p_qdq_amax}")
         p_qdq_scale = p_qdq_amax / 448.0 if p_qdq == "fp8" else p_qdq_amax / (6.0 * 448.0)
-    if v_qdq not in _P_QDQ_MODES:
+    if v_qdq not in _QDQ_MODES:
         raise ValueError(
-            f"v_qdq must be one of {sorted(k for k in _P_QDQ_MODES if k)} or None, got {v_qdq!r}"
+            f"v_qdq must be one of {sorted(k for k in _QDQ_MODES if k)} or None, got {v_qdq!r}"
         )
-    v_qdq_mode = _P_QDQ_MODES[v_qdq]
+    v_qdq_mode = _QDQ_MODES[v_qdq]
     # V has no natural amax bound; ``v_qdq_amax=None`` uses the constant 1.0 global
     # scale (the dynamic per-16 block amax carries the range, and V does not saturate
     # E4M3). A calibrated amax converts as for ``p_qdq_amax``.

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -43,6 +43,7 @@ _is_dense_region: Any = None
 _skip_softmax_decision: Any = None
 _p_qdq_fp8: Any = None
 _p_qdq_nvfp4: Any = None
+_v_qdq_nvfp4: Any = None
 
 
 def _load_sparsity_helpers() -> None:
@@ -64,13 +65,15 @@ def _load_sparsity_helpers() -> None:
 
 
 def _load_p_qdq_helpers() -> None:
-    global _p_qdq_fp8, _p_qdq_nvfp4
+    global _p_qdq_fp8, _p_qdq_nvfp4, _v_qdq_nvfp4
     if _p_qdq_fp8 is None:
         from modelopt.torch.kernels.quantization.attention.p_qdq import _p_qdq_nvfp4 as _nvfp4
+        from modelopt.torch.kernels.quantization.attention.p_qdq import _v_qdq_nvfp4 as _vnvfp4
         from modelopt.torch.kernels.quantization.common.fp8_quant import fp8_scalar_qdq as _fp8
 
         _p_qdq_fp8 = _fp8
         _p_qdq_nvfp4 = _nvfp4
+        _v_qdq_nvfp4 = _vnvfp4
 
 
 # Maps the public p_qdq option to the kernel's P_QDQ constexpr.
@@ -263,6 +266,8 @@ def _attn_fwd(
     SKIP_THRESHOLD_LOG2: tl.constexpr = 0.0,  # log2(lambda) in the kernel's scaled log2 score space
     P_QDQ: tl.constexpr = 0,  # Fake quant-dequant of softmax P: 0=off, 1=FP8 E4M3, 2=NVFP4
     p_qdq_scale=1.0,  # Per-tensor scale for softmax qdq (runtime scalar; amax/448 or amax/(6*448))
+    V_QDQ: tl.constexpr = 0,  # Fake quant-dequant of value V: 0=off, 1=FP8 E4M3, 2=NVFP4 (block-16 keys)
+    v_qdq_scale=1.0,  # Per-tensor scale for V qdq (runtime scalar; amax/448 or amax/(6*448))
     Sparsity_total=None,  # Optional int64 scalar for counting total tiles (atomic)
     Sparsity_skipped=None,  # Optional int64 scalar for counting skipped tiles (atomic)
     MEASURE_SPARSITY: tl.constexpr = False,  # When True, count total/skipped tiles via atomic adds
@@ -435,6 +440,13 @@ def _attn_fwd(
                     mask=((kv_start + kv_pos[:, None]) < seq_len_kv) & d_mask[None, :],
                     other=0.0,
                 )
+            # Optional V quant-dequant (BMM2 B-side). NVFP4 blocks of 16 run along the
+            # key axis (axis 0 of [BLOCK_N, BLOCK_D]); the masked-to-0 loads keep a partial
+            # tile from poisoning a block amax. FQ in fp32, then back to v.dtype for the dot.
+            if V_QDQ == 1:
+                v = _p_qdq_fp8(v.to(tl.float32), v_qdq_scale).to(v.dtype)
+            elif V_QDQ == 2:
+                v = _v_qdq_nvfp4(v.to(tl.float32), v_qdq_scale, BLOCK_N, BLOCK_D).to(v.dtype)
             acc = tl.dot(p.to(v.dtype), v, acc)
             row_max = m_new
         # else: tile skipped — no softmax, no V load, no BMM2 for this tile
@@ -833,6 +845,8 @@ class _Attention(torch.autograd.Function):
         measure_sparsity,
         p_qdq_mode,
         p_qdq_scale,
+        v_qdq_mode,
+        v_qdq_scale,
         k_cache,
         v_cache,
         block_table,
@@ -932,6 +946,8 @@ class _Attention(torch.autograd.Function):
             "SKIP_THRESHOLD_LOG2": skip_threshold_log2,
             "P_QDQ": p_qdq_mode,
             "p_qdq_scale": p_qdq_scale,
+            "V_QDQ": v_qdq_mode,
+            "v_qdq_scale": v_qdq_scale,
             "Sparsity_total": sparsity_total,
             "Sparsity_skipped": sparsity_skipped,
             "MEASURE_SPARSITY": do_measure,
@@ -1137,6 +1153,8 @@ class _Attention(torch.autograd.Function):
             None,  # measure_sparsity
             None,  # p_qdq_mode
             None,  # p_qdq_scale
+            None,  # v_qdq_mode
+            None,  # v_qdq_scale
             None,  # k_cache
             None,  # v_cache
             None,  # block_table
@@ -1165,6 +1183,8 @@ def attention(
     measure_sparsity: bool = False,
     p_qdq: str | None = None,
     p_qdq_amax: float = 1.0,
+    v_qdq: str | None = None,
+    v_qdq_amax: float | None = None,
     k_cache: torch.Tensor | None = None,
     v_cache: torch.Tensor | None = None,
     block_table: torch.Tensor | None = None,
@@ -1221,6 +1241,16 @@ def attention(
             and the global scale ``amax / (6 * 448)`` for NVFP4. A runtime
             scalar — user-set or calibrated values do not recompile the
             kernel. Values above amax saturate.
+        v_qdq: Fake quant-dequant of the value operand ``V`` before ``P @ V``,
+            the other BMM2 operand. ``"fp8"`` or ``"nvfp4"`` (E2M1, one E4M3
+            scale per 16 elements along the *key* axis — the contraction axis,
+            which is axis 0 of the loaded V tile). V is quantized in-kernel on
+            read because its keys-axis blocks cannot be formed by a per-token
+            cache write. ``None`` disables.
+        v_qdq_amax: Per-tensor amax for the V quant-dequant. ``None`` (default)
+            uses the constant 1.0 global scale — V's dynamic per-16 block amax
+            carries the range and V does not saturate E4M3 — while a calibrated
+            amax converts as for ``p_qdq_amax``.
         k_cache: Paged K cache [num_blocks, page_size, num_kv_heads, head_dim].
             When provided, K/V are read from paged cache via block_table
             instead of from contiguous k/v tensors.
@@ -1259,6 +1289,19 @@ def attention(
         if not (math.isfinite(p_qdq_amax) and p_qdq_amax > 0):
             raise ValueError(f"p_qdq_amax must be a finite positive value, got {p_qdq_amax}")
         p_qdq_scale = p_qdq_amax / 448.0 if p_qdq == "fp8" else p_qdq_amax / (6.0 * 448.0)
+    if v_qdq not in _P_QDQ_MODES:
+        raise ValueError(
+            f"v_qdq must be one of {sorted(k for k in _P_QDQ_MODES if k)} or None, got {v_qdq!r}"
+        )
+    v_qdq_mode = _P_QDQ_MODES[v_qdq]
+    # V has no natural amax bound; ``v_qdq_amax=None`` uses the constant 1.0 global
+    # scale (the dynamic per-16 block amax carries the range, and V does not saturate
+    # E4M3). A calibrated amax converts as for ``p_qdq_amax``.
+    v_qdq_scale = 1.0
+    if v_qdq_mode and v_qdq_amax is not None:
+        if not (math.isfinite(v_qdq_amax) and v_qdq_amax > 0):
+            raise ValueError(f"v_qdq_amax must be a finite positive value, got {v_qdq_amax}")
+        v_qdq_scale = v_qdq_amax / 448.0 if v_qdq == "fp8" else v_qdq_amax / (6.0 * 448.0)
     sm_scale = 1.0 / (q.shape[2] ** 0.5) if softmax_scale is None else softmax_scale
     return _Attention.apply(
         q,
@@ -1280,6 +1323,8 @@ def attention(
         measure_sparsity,
         p_qdq_mode,
         p_qdq_scale,
+        v_qdq_mode,
+        v_qdq_scale,
         k_cache,
         v_cache,
         block_table,

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -82,6 +82,12 @@ _QDQ_MODES = {None: 0, "fp8": 1, "nvfp4": 2}
 
 LOG2E: float = 1.44269504088896
 
+# V-bake tile granularity for the on-write NVFP4 cache. Must match
+# ``decode_attention._ONWRITE_BLOCK_N`` (defined there, not imported here, to avoid a
+# circular import — decode_attention imports this module). The prefill ``V_CACHE_QUANTIZED``
+# dense boundary aligns to this bake tile, not the (autotuned) kernel ``BLOCK_N``.
+_V_BAKE_BLOCK_N = 128
+
 # ---------------------------------------------------------------------------
 # Autotune configs for forward kernel
 # ---------------------------------------------------------------------------
@@ -268,6 +274,8 @@ def _attn_fwd(
     p_qdq_scale=1.0,  # Per-tensor scale for softmax qdq (runtime scalar; amax/448 or amax/(6*448))
     V_QDQ: tl.constexpr = 0,  # Fake quant-dequant of value V: 0=off, 1=FP8 E4M3, 2=NVFP4 (block-16 keys)
     v_qdq_scale=1.0,  # Per-tensor scale for V qdq (runtime scalar; amax/448 or amax/(6*448))
+    V_CACHE_QUANTIZED: tl.constexpr = False,  # baked V: read complete tiles as-is; re-FQ only the trailing partial
+    V_BAKE_BLOCK: tl.constexpr = 128,  # bake tile granularity; dense boundary aligns to this, not BLOCK_N
     Sparsity_total=None,  # Optional int64 scalar for counting total tiles (atomic)
     Sparsity_skipped=None,  # Optional int64 scalar for counting skipped tiles (atomic)
     MEASURE_SPARSITY: tl.constexpr = False,  # When True, count total/skipped tiles via atomic adds
@@ -328,6 +336,12 @@ def _attn_fwd(
         if not IS_CAUSAL
         else tl.minimum(causal_offset + (tile_q + 1) * BLOCK_M, seq_len_kv)
     )
+
+    # V baked on write (V_CACHE_QUANTIZED): complete V_BAKE_BLOCK-aligned tiles below this
+    # boundary are already on the NVFP4 grid (read as-is); the trailing partial — or a tile
+    # not yet baked by this chunked-prefill step — is re-FQ'd on read. Aligns to the bake tile
+    # (V_BAKE_BLOCK), NOT the autotuned BLOCK_N, which can differ.
+    v_dense_boundary = (seq_len_kv // V_BAKE_BLOCK) * V_BAKE_BLOCK
 
     # --- Main loop: iterate over KV tiles ---
     for kv_start in range(0, kv_bound, BLOCK_N):
@@ -443,10 +457,14 @@ def _attn_fwd(
             # Optional V quant-dequant (BMM2 B-side). NVFP4 blocks of 16 run along the
             # key axis (axis 0 of [BLOCK_N, BLOCK_D]); the masked-to-0 loads keep a partial
             # tile from poisoning a block amax. FQ in fp32, then back to v.dtype for the dot.
-            if V_QDQ == 1:
-                v = _qdq_fp8(v.to(tl.float32), v_qdq_scale).to(v.dtype)
-            elif V_QDQ == 2:
-                v = _v_qdq_nvfp4(v.to(tl.float32), v_qdq_scale, BLOCK_N, BLOCK_D).to(v.dtype)
+            # When V is baked on write (V_CACHE_QUANTIZED), complete tiles below v_dense_boundary
+            # are already on the grid -> read as-is; only the trailing partial (or a tile not yet
+            # baked by this chunk) is re-FQ'd, avoiding a double-quant of earlier-chunk baked tiles.
+            if V_QDQ != 0 and ((not V_CACHE_QUANTIZED) or (kv_start + BLOCK_N > v_dense_boundary)):
+                if V_QDQ == 1:
+                    v = _qdq_fp8(v.to(tl.float32), v_qdq_scale).to(v.dtype)
+                else:  # V_QDQ == 2 (NVFP4)
+                    v = _v_qdq_nvfp4(v.to(tl.float32), v_qdq_scale, BLOCK_N, BLOCK_D).to(v.dtype)
             acc = tl.dot(p.to(v.dtype), v, acc)
             row_max = m_new
         # else: tile skipped — no softmax, no V load, no BMM2 for this tile
@@ -847,6 +865,7 @@ class _Attention(torch.autograd.Function):
         p_qdq_scale,
         v_qdq_mode,
         v_qdq_scale,
+        v_cache_quantized,
         k_cache,
         v_cache,
         block_table,
@@ -948,6 +967,8 @@ class _Attention(torch.autograd.Function):
             "p_qdq_scale": p_qdq_scale,
             "V_QDQ": v_qdq_mode,
             "v_qdq_scale": v_qdq_scale,
+            "V_CACHE_QUANTIZED": v_cache_quantized,
+            "V_BAKE_BLOCK": _V_BAKE_BLOCK_N,
             "Sparsity_total": sparsity_total,
             "Sparsity_skipped": sparsity_skipped,
             "MEASURE_SPARSITY": do_measure,
@@ -1155,6 +1176,7 @@ class _Attention(torch.autograd.Function):
             None,  # p_qdq_scale
             None,  # v_qdq_mode
             None,  # v_qdq_scale
+            None,  # v_cache_quantized
             None,  # k_cache
             None,  # v_cache
             None,  # block_table
@@ -1185,6 +1207,7 @@ def attention(
     p_qdq_amax: float = 1.0,
     v_qdq: str | None = None,
     v_qdq_amax: float | None = None,
+    v_cache_quantized: bool = False,
     k_cache: torch.Tensor | None = None,
     v_cache: torch.Tensor | None = None,
     block_table: torch.Tensor | None = None,
@@ -1325,6 +1348,7 @@ def attention(
         p_qdq_scale,
         v_qdq_mode,
         v_qdq_scale,
+        v_cache_quantized,
         k_cache,
         v_cache,
         block_table,

--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -82,12 +82,6 @@ _QDQ_MODES = {None: 0, "fp8": 1, "nvfp4": 2}
 
 LOG2E: float = 1.44269504088896
 
-# V-bake tile granularity for the on-write NVFP4 cache. Must match
-# ``decode_attention._ONWRITE_BLOCK_N`` (defined there, not imported here, to avoid a
-# circular import — decode_attention imports this module). The prefill ``V_CACHE_QUANTIZED``
-# dense boundary aligns to this bake tile, not the (autotuned) kernel ``BLOCK_N``.
-_V_BAKE_BLOCK_N = 128
-
 # ---------------------------------------------------------------------------
 # Autotune configs for forward kernel
 # ---------------------------------------------------------------------------
@@ -274,8 +268,7 @@ def _attn_fwd(
     p_qdq_scale=1.0,  # Per-tensor scale for softmax qdq (runtime scalar; amax/448 or amax/(6*448))
     V_QDQ: tl.constexpr = 0,  # Fake quant-dequant of value V: 0=off, 1=FP8 E4M3, 2=NVFP4 (block-16 keys)
     v_qdq_scale=1.0,  # Per-tensor scale for V qdq (runtime scalar; amax/448 or amax/(6*448))
-    V_CACHE_QUANTIZED: tl.constexpr = False,  # baked V: read complete tiles as-is; re-FQ only the trailing partial
-    V_BAKE_BLOCK: tl.constexpr = 128,  # bake tile granularity; dense boundary aligns to this, not BLOCK_N
+    V_CACHE_QUANTIZED: tl.constexpr = False,  # complete block-16 groups are already QDQ
     Sparsity_total=None,  # Optional int64 scalar for counting total tiles (atomic)
     Sparsity_skipped=None,  # Optional int64 scalar for counting skipped tiles (atomic)
     MEASURE_SPARSITY: tl.constexpr = False,  # When True, count total/skipped tiles via atomic adds
@@ -336,12 +329,7 @@ def _attn_fwd(
         if not IS_CAUSAL
         else tl.minimum(causal_offset + (tile_q + 1) * BLOCK_M, seq_len_kv)
     )
-
-    # V baked on write (V_CACHE_QUANTIZED): complete V_BAKE_BLOCK-aligned tiles below this
-    # boundary are already on the NVFP4 grid (read as-is); the trailing partial — or a tile
-    # not yet baked by this chunked-prefill step — is re-FQ'd on read. Aligns to the bake tile
-    # (V_BAKE_BLOCK), NOT the autotuned BLOCK_N, which can differ.
-    v_dense_boundary = (seq_len_kv // V_BAKE_BLOCK) * V_BAKE_BLOCK
+    v_dense_boundary = (seq_len_kv // 16) * 16
 
     # --- Main loop: iterate over KV tiles ---
     for kv_start in range(0, kv_bound, BLOCK_N):
@@ -454,17 +442,18 @@ def _attn_fwd(
                     mask=((kv_start + kv_pos[:, None]) < seq_len_kv) & d_mask[None, :],
                     other=0.0,
                 )
-            # Optional V quant-dequant (BMM2 B-side). NVFP4 blocks of 16 run along the
-            # key axis (axis 0 of [BLOCK_N, BLOCK_D]); the masked-to-0 loads keep a partial
-            # tile from poisoning a block amax. FQ in fp32, then back to v.dtype for the dot.
-            # When V is baked on write (V_CACHE_QUANTIZED), complete tiles below v_dense_boundary
-            # are already on the grid -> read as-is; only the trailing partial (or a tile not yet
-            # baked by this chunk) is re-FQ'd, avoiding a double-quant of earlier-chunk baked tiles.
+            # Quantize from pristine cache values. With block-16 on-write baking, completed
+            # groups are already QDQ; select the fresh QDQ result only for the raw partial group.
             if V_QDQ != 0 and ((not V_CACHE_QUANTIZED) or (kv_start + BLOCK_N > v_dense_boundary)):
                 if V_QDQ == 1:
-                    v = _qdq_fp8(v.to(tl.float32), v_qdq_scale).to(v.dtype)
+                    vq = _qdq_fp8(v.to(tl.float32), v_qdq_scale).to(v.dtype)
                 else:  # V_QDQ == 2 (NVFP4)
-                    v = _v_qdq_nvfp4(v.to(tl.float32), v_qdq_scale, BLOCK_N, BLOCK_D).to(v.dtype)
+                    vq = _v_qdq_nvfp4(v.to(tl.float32), v_qdq_scale, BLOCK_N, BLOCK_D).to(v.dtype)
+                if V_CACHE_QUANTIZED:
+                    tail = (kv_start + kv_pos) >= v_dense_boundary
+                    v = tl.where(tail[:, None], vq, v)
+                else:
+                    v = vq
             acc = tl.dot(p.to(v.dtype), v, acc)
             row_max = m_new
         # else: tile skipped — no softmax, no V load, no BMM2 for this tile
@@ -968,7 +957,6 @@ class _Attention(torch.autograd.Function):
             "V_QDQ": v_qdq_mode,
             "v_qdq_scale": v_qdq_scale,
             "V_CACHE_QUANTIZED": v_cache_quantized,
-            "V_BAKE_BLOCK": _V_BAKE_BLOCK_N,
             "Sparsity_total": sparsity_total,
             "Sparsity_skipped": sparsity_skipped,
             "MEASURE_SPARSITY": do_measure,
@@ -1267,13 +1255,14 @@ def attention(
         v_qdq: Fake quant-dequant of the value operand ``V`` before ``P @ V``,
             the other BMM2 operand. ``"fp8"`` or ``"nvfp4"`` (E2M1, one E4M3
             scale per 16 elements along the *key* axis — the contraction axis,
-            which is axis 0 of the loaded V tile). V is quantized in-kernel on
-            read because its keys-axis blocks cannot be formed by a per-token
-            cache write. ``None`` disables.
+            which is axis 0 of the loaded V tile). V is quantized in-kernel unless
+            ``v_cache_quantized`` is set. ``None`` disables.
         v_qdq_amax: Per-tensor amax for the V quant-dequant. ``None`` (default)
             uses the constant 1.0 global scale — V's dynamic per-16 block amax
             carries the range and V does not saturate E4M3 — while a calibrated
             amax converts as for ``p_qdq_amax``.
+        v_cache_quantized: Complete block-16 groups in the paged V cache are already
+            QDQ. The kernel QDQs only the pristine partial group on read.
         k_cache: Paged K cache [num_blocks, page_size, num_kv_heads, head_dim].
             When provided, K/V are read from paged cache via block_table
             instead of from contiguous k/v tensors.

--- a/modelopt/torch/kernels/quantization/attention/p_qdq.py
+++ b/modelopt/torch/kernels/quantization/attention/p_qdq.py
@@ -13,18 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""BMM2-operand (softmax-P and value) quant-dequant helpers for flash attention.
+"""Softmax-P quant-dequant helper for flash attention.
 
-These ``@triton.jit`` helpers fake-quantize the two operands of the ``P @ V``
-matmul (BMM2) in-kernel — ``P`` (:func:`_p_qdq_nvfp4`, the counterpart of
-``p_bmm_quantizer``) and ``V`` (:func:`_v_qdq_nvfp4`, the counterpart of
-``v_bmm_quantizer``). They are called conditionally from the baseline
-flash-attention kernel in ``common/attention/triton_fa.py`` (and the paged
-decode kernel) under the ``P_QDQ`` / ``V_QDQ`` constexpr guards, following the
-same composition pattern as the sparsity helpers in
-``sparsity/attention/skip_softmax_helpers.py``. Both block 16 along the key
-dimension — the contraction axis of ``P @ V`` — which a per-token cache write
-cannot produce, so V is fake-quantized here on read rather than on write.
+The in-kernel counterpart of ``p_bmm_quantizer``: :func:`_p_qdq_nvfp4` fake-quantizes
+the softmax probabilities ``P`` before the ``P @ V`` matmul (BMM2). Its sibling for the
+value operand of the same matmul is ``attention/v_qdq._v_qdq_nvfp4``; both block 16
+along the key dimension (the contraction axis of ``P @ V``). Called conditionally from
+the baseline flash-attention kernel in ``common/attention/triton_fa.py`` (and the paged
+decode kernel) under the ``P_QDQ`` constexpr guard, following the same composition
+pattern as the sparsity helpers in ``sparsity/attention/skip_softmax_helpers.py``.
 
 Only NVFP4 needs a P-specific helper (tiling policy and block amaxes); the
 per-tensor FP8 mode uses ``quantization/common/fp8_quant.fp8_scalar_qdq``
@@ -67,33 +64,3 @@ def _p_qdq_nvfp4(
     block_amax = tl.expand_dims(tl.max(grouped, axis=2), 2)  # p >= 0, so max == amax
     q = nvfp4_scalar_qdq(grouped, block_amax, global_scale, 16)
     return tl.reshape(q, (BLOCK_M, BLOCK_N))
-
-
-@triton.jit
-def _v_qdq_nvfp4(
-    v,
-    global_scale,
-    BLOCK_N: tl.constexpr,
-    BLOCK_D: tl.constexpr,
-):
-    """NVFP4 fake quant-dequant of the value operand ``V`` of ``P @ V`` (BMM2).
-
-    Same two-level NVFP4 scaling as :func:`_p_qdq_nvfp4`, but ``V``'s blocks of
-    16 run along the *key* dimension — which for the loaded tile
-    ``v [BLOCK_N keys, BLOCK_D head_dim]`` is axis 0 — so 16 contiguous keys
-    share a scale, per head-dim channel (the contraction axis of ``P @ V``).
-    Unlike ``P``, ``V`` is signed, so the block amax uses ``abs``.
-
-    Relies on the caller masking out-of-range keys to 0 (``_load_paged_v_tile``
-    loads with ``other=0.0``): a partial trailing tile then cannot poison a
-    block amax — zeros never raise it — and ``nvfp4_scalar_qdq`` guards the
-    resulting all-zero blocks. The per-tensor ``global_scale`` (``amax/(6*448)``)
-    barely affects V — the dynamic per-16 block amax carries the range and V
-    does not saturate E4M3 — so callers may pass the constant ``1.0``.
-    """
-    tl.static_assert(BLOCK_N % 16 == 0, "BLOCK_N must be divisible by 16 for NVFP4")
-
-    grouped = tl.reshape(v, (BLOCK_N // 16, 16, BLOCK_D))  # 16-key blocks along axis 1 (keys)
-    block_amax = tl.expand_dims(tl.max(tl.abs(grouped), axis=1), 1)  # V is signed -> abs
-    q = nvfp4_scalar_qdq(grouped, block_amax, global_scale, 16)
-    return tl.reshape(q, (BLOCK_N, BLOCK_D))

--- a/modelopt/torch/kernels/quantization/attention/p_qdq.py
+++ b/modelopt/torch/kernels/quantization/attention/p_qdq.py
@@ -13,14 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Softmax-P quant-dequant helpers for the unified flash attention kernel.
+"""BMM2-operand (softmax-P and value) quant-dequant helpers for flash attention.
 
-These ``@triton.jit`` helpers fake-quantize the softmax probabilities ``P``
-before the ``P @ V`` matmul (BMM2) — the in-kernel counterpart of the
-``p_bmm_quantizer`` config. They are called conditionally from the baseline
-flash-attention kernel in ``common/attention/triton_fa.py`` under the
-``P_QDQ`` constexpr guard, following the same composition pattern as
-the sparsity helpers in ``sparsity/attention/skip_softmax_helpers.py``.
+These ``@triton.jit`` helpers fake-quantize the two operands of the ``P @ V``
+matmul (BMM2) in-kernel — ``P`` (:func:`_p_qdq_nvfp4`, the counterpart of
+``p_bmm_quantizer``) and ``V`` (:func:`_v_qdq_nvfp4`, the counterpart of
+``v_bmm_quantizer``). They are called conditionally from the baseline
+flash-attention kernel in ``common/attention/triton_fa.py`` (and the paged
+decode kernel) under the ``P_QDQ`` / ``V_QDQ`` constexpr guards, following the
+same composition pattern as the sparsity helpers in
+``sparsity/attention/skip_softmax_helpers.py``. Both block 16 along the key
+dimension — the contraction axis of ``P @ V`` — which a per-token cache write
+cannot produce, so V is fake-quantized here on read rather than on write.
 
 Only NVFP4 needs a P-specific helper (tiling policy and block amaxes); the
 per-tensor FP8 mode uses ``quantization/common/fp8_quant.fp8_scalar_qdq``
@@ -63,3 +67,33 @@ def _p_qdq_nvfp4(
     block_amax = tl.expand_dims(tl.max(grouped, axis=2), 2)  # p >= 0, so max == amax
     q = nvfp4_scalar_qdq(grouped, block_amax, global_scale, 16)
     return tl.reshape(q, (BLOCK_M, BLOCK_N))
+
+
+@triton.jit
+def _v_qdq_nvfp4(
+    v,
+    global_scale,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    """NVFP4 fake quant-dequant of the value operand ``V`` of ``P @ V`` (BMM2).
+
+    Same two-level NVFP4 scaling as :func:`_p_qdq_nvfp4`, but ``V``'s blocks of
+    16 run along the *key* dimension — which for the loaded tile
+    ``v [BLOCK_N keys, BLOCK_D head_dim]`` is axis 0 — so 16 contiguous keys
+    share a scale, per head-dim channel (the contraction axis of ``P @ V``).
+    Unlike ``P``, ``V`` is signed, so the block amax uses ``abs``.
+
+    Relies on the caller masking out-of-range keys to 0 (``_load_paged_v_tile``
+    loads with ``other=0.0``): a partial trailing tile then cannot poison a
+    block amax — zeros never raise it — and ``nvfp4_scalar_qdq`` guards the
+    resulting all-zero blocks. The per-tensor ``global_scale`` (``amax/(6*448)``)
+    barely affects V — the dynamic per-16 block amax carries the range and V
+    does not saturate E4M3 — so callers may pass the constant ``1.0``.
+    """
+    tl.static_assert(BLOCK_N % 16 == 0, "BLOCK_N must be divisible by 16 for NVFP4")
+
+    grouped = tl.reshape(v, (BLOCK_N // 16, 16, BLOCK_D))  # 16-key blocks along axis 1 (keys)
+    block_amax = tl.expand_dims(tl.max(tl.abs(grouped), axis=1), 1)  # V is signed -> abs
+    q = nvfp4_scalar_qdq(grouped, block_amax, global_scale, 16)
+    return tl.reshape(q, (BLOCK_N, BLOCK_D))

--- a/modelopt/torch/kernels/quantization/attention/v_qdq.py
+++ b/modelopt/torch/kernels/quantization/attention/v_qdq.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Value-operand (V) quant-dequant helper for flash attention.
+
+The in-kernel counterpart of ``v_bmm_quantizer``: :func:`_v_qdq_nvfp4` fake-quantizes
+the ``V`` operand of the ``P @ V`` matmul (BMM2). It is the sibling of
+``attention/p_qdq._p_qdq_nvfp4`` (the ``P`` operand) — both block 16 along the key
+dimension, the contraction axis of ``P @ V``, which a per-token cache write cannot
+produce. V's keys axis is axis 0 of the loaded tile and V is signed, so unlike P its
+block amax uses ``abs``. Called under the ``V_QDQ`` constexpr guard from the baseline
+flash-attention kernel (``common/attention/triton_fa.py``) and the paged decode kernel
+(``common/attention/decode_attention.py``); per-tensor FP8 uses
+``quantization/common/fp8_quant.fp8_scalar_qdq`` directly.
+"""
+
+import triton
+import triton.language as tl
+
+from modelopt.torch.kernels.quantization.common.nvfp4_quant import nvfp4_scalar_qdq
+
+
+@triton.jit
+def _v_qdq_nvfp4(
+    v,
+    global_scale,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    """NVFP4 fake quant-dequant of the value operand ``V`` of ``P @ V`` (BMM2).
+
+    Two-level NVFP4 scaling like ``p_qdq._p_qdq_nvfp4``, but ``V``'s blocks of 16 run
+    along the *key* dimension — which for the loaded tile ``v [BLOCK_N keys, BLOCK_D
+    head_dim]`` is axis 0 — so 16 contiguous keys share a scale, per head-dim channel
+    (the contraction axis of ``P @ V``). Unlike ``P``, ``V`` is signed, so the block
+    amax uses ``abs``.
+
+    Relies on the caller masking out-of-range keys to 0 (``_load_paged_v_tile`` loads
+    with ``other=0.0``): a partial trailing tile then cannot poison a block amax — zeros
+    never raise it — and ``nvfp4_scalar_qdq`` guards the resulting all-zero blocks. The
+    per-tensor ``global_scale`` (``amax/(6*448)``) barely affects V — the dynamic per-16
+    block amax carries the range and V does not saturate E4M3 — so callers may pass the
+    constant ``1.0``.
+    """
+    tl.static_assert(BLOCK_N % 16 == 0, "BLOCK_N must be divisible by 16 for NVFP4")
+
+    grouped = tl.reshape(v, (BLOCK_N // 16, 16, BLOCK_D))  # 16-key blocks along axis 1 (keys)
+    block_amax = tl.expand_dims(tl.max(tl.abs(grouped), axis=1), 1)  # V is signed -> abs
+    q = nvfp4_scalar_qdq(grouped, block_amax, global_scale, 16)
+    return tl.reshape(q, (BLOCK_N, BLOCK_D))

--- a/modelopt/torch/kernels/quantization/common/nvfp4_quant.py
+++ b/modelopt/torch/kernels/quantization/common/nvfp4_quant.py
@@ -105,7 +105,9 @@ def fp8_quantize_scale(block_amax, global_scale):
     """FP8 E4M3 fake-quantize the per-block NVFP4 scale.
 
     Computes ``scale = block_amax / 6.0``, then round-trips it through
-    FP8 E4M3 using ``global_scale`` for the second-level scaling.
+    FP8 E4M3 using ``global_scale`` for the second-level scaling. The scale is
+    clamped to the E4M3 range ``[2**-9, 448]`` before the cast, matching the
+    canonical NVFP4 path (``qtensor/nvfp4_tensor.py``).
 
     Works with any tensor shape (scalar, 1-D, or higher) since all ops
     are element-wise.
@@ -118,8 +120,12 @@ def fp8_quantize_scale(block_amax, global_scale):
         FP8-quantized per-block scale(s), same shape as ``block_amax``.
     """
     FP8_E4M3_MAX: tl.constexpr = 448.0
+    FP8_E4M3_MIN: tl.constexpr = 2**-9  # smallest E4M3 subnormal
     scale_in_fp8_range = block_amax / (6.0 * global_scale)
-    scale_clamped = tl.minimum(scale_in_fp8_range, FP8_E4M3_MAX)
+    # Clamp to [2**-9, 448] before the cast (matches qtensor/nvfp4_tensor.py): the lower
+    # bound floors an underflowed block at the min subnormal instead of letting the scale
+    # round to 0, which would zero the whole block.
+    scale_clamped = tl.minimum(tl.maximum(scale_in_fp8_range, FP8_E4M3_MIN), FP8_E4M3_MAX)
     return scale_clamped.to(tl.float8e4nv).to(tl.float32) * global_scale
 
 

--- a/modelopt/torch/kernels/quantization/gemm/fp4_kernel_hopper.py
+++ b/modelopt/torch/kernels/quantization/gemm/fp4_kernel_hopper.py
@@ -80,8 +80,10 @@ def fp4_fake_quant_kernel(
 
     block_max = tl.max(x_abs, axis=2, keep_dims=True)
 
+    # fp8_quantize_scale clamps the scale to [2**-9, 448] (matches qtensor/nvfp4_tensor.py),
+    # so it is bounded away from 0 and the old ``>= 1e-5 -> 1.0`` underflow guard (which would
+    # otherwise override the clamp for small global scales) is redundant.
     block_max_quant = fp8_quantize_scale(block_max, global_scale_safe)
-    block_max_quant = tl.where(block_max_quant >= 1e-5, block_max_quant, 1.0)
 
     block_max_quant_broadcast = tl.broadcast_to(
         block_max_quant, (TILE_M, NUM_FP4_BLOCKS, BLOCK_SIZE)

--- a/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
+++ b/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
@@ -359,6 +359,27 @@ class TensorQuantizer(nn.Module):
                 raise RuntimeError("Changing shape when setting amax is not allowed.")
             self._amax.data.copy_(value.clone().detach().to(self._amax.device))
 
+    def _set_runtime_default_amax(self, value: torch.Tensor | None) -> None:
+        """Set a nonpersistent fallback amax used only when _amax is absent."""
+        if value is None:
+            if hasattr(self, "_runtime_default_amax"):
+                delattr(self, "_runtime_default_amax")
+            return
+        if value.numel() != 1:
+            raise ValueError(
+                f"Runtime default amax must be scalar, got shape {tuple(value.shape)}."
+            )
+        value = value.detach()
+        if hasattr(self, "_runtime_default_amax"):
+            self._runtime_default_amax.data.copy_(
+                value.to(
+                    device=self._runtime_default_amax.device,
+                    dtype=self._runtime_default_amax.dtype,
+                )
+            )
+        else:
+            self.register_buffer("_runtime_default_amax", value.clone(), persistent=False)
+
     def reset_amax(self):
         """Reset amax to None."""
         if hasattr(self, "_amax"):
@@ -685,10 +706,12 @@ class TensorQuantizer(nn.Module):
             self._bias_value.data.copy_(calib_bias.clone().detach())
 
     def _get_amax(self, inputs):
-        """Get amax from buffer or compute it dynamically."""
-        if self._use_constant_amax:
+        """Get amax from configured state, runtime fallback, or inputs."""
+        if hasattr(self, "_runtime_default_amax"):
+            amax = self._amax if hasattr(self, "_amax") else self._runtime_default_amax
+        elif self._use_constant_amax:
             return torch.tensor(torch.finfo(torch.float8_e4m3fn).max, device=inputs.device)
-        if hasattr(self, "_amax"):
+        elif hasattr(self, "_amax"):
             amax = self._amax
         else:
             reduce_axis = quant_utils.convert_quantization_axis_to_reduce_axis(inputs, self._axis)

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -501,12 +501,20 @@ class _QuantVLLMAttention(QuantModule):
         self.q_bmm_quantizer = TensorQuantizer()
         self.k_bmm_quantizer = TensorQuantizer()
         self.v_bmm_quantizer = TensorQuantizer()
+        # P (softmax) quantizer: a config carrier restored from the checkpoint but NOT applied here
+        # (P only exists inside the attention kernel). The sparse Triton impl reads it to apply
+        # P_QDQ in-kernel. When ``_value_quant_in_kernel`` is set (sparse path), V is likewise
+        # quantized along the key axis in-kernel by that impl, so the V pre-step below is skipped to
+        # avoid double-quantizing V on the wrong (head_dim) axis. Default off keeps native behavior.
+        self.p_bmm_quantizer = TensorQuantizer()
+        self._value_quant_in_kernel = False
         self.parallel_state = create_parallel_state()
 
     def forward(self, query, key, value, *args, **kwargs):
         query = self.q_bmm_quantizer(query)
         key = self.k_bmm_quantizer(key)
-        value = self.v_bmm_quantizer(value)
+        if not self._value_quant_in_kernel:
+            value = self.v_bmm_quantizer(value)
         return super().forward(query, key, value, *args, **kwargs)
 
     def modelopt_post_restore(self, prefix: str = "") -> None:

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -501,11 +501,9 @@ class _QuantVLLMAttention(QuantModule):
         self.q_bmm_quantizer = TensorQuantizer()
         self.k_bmm_quantizer = TensorQuantizer()
         self.v_bmm_quantizer = TensorQuantizer()
-        # P (softmax) quantizer: a config carrier restored from the checkpoint but NOT applied here
-        # (P only exists inside the attention kernel). The sparse Triton impl reads it to apply
-        # P_QDQ in-kernel. When ``_value_quant_in_kernel`` is set (sparse path), V is likewise
-        # quantized along the key axis in-kernel by that impl, so the V pre-step below is skipped to
-        # avoid double-quantizing V on the wrong (head_dim) axis. Default off keeps native behavior.
+        # When ``_value_quant_in_kernel`` is set (sparse path), V is quantized along the key axis
+        # in-kernel by that impl, so the V pre-step below is skipped to avoid double-quantizing V on
+        # the wrong (head_dim) axis. Default off keeps native behavior.
         self.p_bmm_quantizer = TensorQuantizer()
         self._value_quant_in_kernel = False
         self.parallel_state = create_parallel_state()

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -188,8 +188,34 @@ def vllm_replace_quant_module_hook(model: torch.nn.Module) -> None:
 CUSTOM_MODEL_PLUGINS.add(vllm_replace_quant_module_hook)
 
 
+_NVFP4_GLOBAL_SCALE_ONE_AMAX = 6.0 * 448.0
+
+
+def _set_vllm_attention_kv_runtime_amax(module, device: torch.device) -> None:
+    """Set global-scale-one fallback state on supported NVFP4 K/V quantizers."""
+    for attr in ("k_bmm_quantizer", "v_bmm_quantizer"):
+        quantizer = getattr(module, attr, None)
+        if not isinstance(quantizer, TensorQuantizer):
+            continue
+        supported = (
+            quantizer.is_enabled
+            and quantizer.is_nvfp4_dynamic
+            and (quantizer.block_sizes or {}).get(-1) == 16
+        )
+        runtime_amax = (
+            torch.tensor(
+                _NVFP4_GLOBAL_SCALE_ONE_AMAX,
+                device=device,
+                dtype=torch.float32,
+            )
+            if supported
+            else None
+        )
+        quantizer._set_runtime_default_amax(runtime_amax)
+
+
 def _vllm_attention_modelopt_post_restore(self) -> None:
-    """Move Attention module to its correct device after ModelOpt state restore."""
+    """Restore Attention placement and supported NVFP4 K/V runtime defaults."""
     device, dtype = _get_device_dtype(self)
     if device is None or dtype is None:
         raise RuntimeError(
@@ -197,6 +223,7 @@ def _vllm_attention_modelopt_post_restore(self) -> None:
             "Ensure vllm_replace_quant_module_hook runs before replace_quant_module."
         )
     self.to(device=device)
+    _set_vllm_attention_kv_runtime_amax(self, device)
 
 
 class FakeQuantMethod:
@@ -310,6 +337,16 @@ def post_restore_vllm_parallel_linears(model: torch.nn.Module) -> None:
     for module in model.modules():
         if isinstance(module, _VLLMParallelLinear):
             module.modelopt_post_restore("")
+
+
+def post_restore_vllm_attentions(model: torch.nn.Module) -> None:
+    """Re-run vLLM attention post-restore hooks after final quantizer state loading."""
+    for module in model.modules():
+        if not isinstance(module, _ATTENTION_TYPES):
+            continue
+        post_restore = getattr(module, "modelopt_post_restore", None)
+        if callable(post_restore):
+            post_restore("")
 
 
 @QuantModuleRegistry.register({vllm_linear.RowParallelLinear: "vllm_RowParallelLinear"})

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -65,28 +65,42 @@ for module_path in [
     except ImportError:
         continue
 
-try:
-    _has_attention_layers = importlib.util.find_spec("vllm.attention.layers") is not None
-except (ModuleNotFoundError, ValueError):
-    _has_attention_layers = False
 
-if _has_attention_layers:  # vllm < 0.15.0
-    from vllm.attention.layers.cross_attention import CrossAttention
-    from vllm.attention.layers.encoder_only_attention import EncoderOnlyAttention
-else:
-    try:
-        from vllm.model_executor.layers.attention.cross_attention import CrossAttention
-    except ImportError:
-        CrossAttention = None
-    try:
-        from vllm.model_executor.layers.attention.encoder_only_attention import EncoderOnlyAttention
-    except ImportError:
-        EncoderOnlyAttention = None
+# Optional attention classes (cross / encoder-only / MLA) live in different modules across vLLM
+# versions. Try each candidate path independently and guard every import, so a transitional layout
+# (namespace present but a submodule missing) cannot break the base plugin import or silently omit
+# a class from discovery.
+def _optional_attention_cls(class_name, module_paths):
+    for module_path in module_paths:
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError:
+            continue
+        cls = getattr(module, class_name, None)
+        if cls is not None:
+            return cls
+    return None
 
-try:
-    VllmMLAAttention = vllm_attention.MLAAttention
-except (AttributeError, ImportError):
-    VllmMLAAttention = None
+
+CrossAttention = _optional_attention_cls(
+    "CrossAttention",
+    (
+        "vllm.attention.layers.cross_attention",  # vllm < 0.15.0
+        "vllm.model_executor.layers.attention.cross_attention",
+    ),
+)
+EncoderOnlyAttention = _optional_attention_cls(
+    "EncoderOnlyAttention",
+    (
+        "vllm.attention.layers.encoder_only_attention",  # vllm < 0.15.0
+        "vllm.model_executor.layers.attention.encoder_only_attention",
+    ),
+)
+# MLA may live on the resolved base module or a separate path; search both rather than only the base.
+VllmMLAAttention = getattr(vllm_attention, "MLAAttention", None) or _optional_attention_cls(
+    "MLAAttention",
+    ("vllm.attention.layer", "vllm.model_executor.layers.attention", "vllm.attention"),
+)
 
 _ATTENTION_TYPES = tuple(
     t

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -23,13 +23,6 @@ from functools import partial
 from itertools import chain
 
 import torch
-
-# Try multiple import paths for vLLM compatibility across versions
-if importlib.util.find_spec("vllm.attention"):
-    import vllm.attention as vllm_attention  # vllm < 0.16.0
-else:
-    import vllm.model_executor.layers.attention as vllm_attention  # vllm >= 0.16.0
-
 import vllm.model_executor.layers.fused_moe.layer as vllm_fused_moe_layer
 import vllm.model_executor.layers.linear as vllm_linear
 from vllm.distributed.parallel_state import get_dp_group, get_ep_group, get_tp_group
@@ -37,6 +30,28 @@ from vllm.distributed.parallel_state import get_dp_group, get_ep_group, get_tp_g
 from ...utils.distributed import ParallelState
 from ..nn import QuantLinearConvBase, QuantModule, QuantModuleRegistry, TensorQuantizer
 from .custom import CUSTOM_MODEL_PLUGINS
+
+
+# Try multiple import paths for vLLM compatibility across versions. Select a module only if it
+# actually exports ``Attention``: some installed layouts expose ``vllm.attention`` as a namespace
+# package that ``find_spec`` locates but that does not define ``Attention`` (selecting it by
+# namespace existence alone fails later at ``vllm_attention.Attention``).
+def _import_attention_module():
+    for module_name in (
+        "vllm.attention.layer",  # concrete Attention lives here on modern vLLM
+        "vllm.model_executor.layers.attention",  # relocation on some versions
+        "vllm.attention",  # older layouts that export Attention at the package root
+    ):
+        try:
+            module = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        if hasattr(module, "Attention"):
+            return module
+    raise ImportError("No supported vLLM Attention module was found")
+
+
+vllm_attention = _import_attention_module()
 
 # Try multiple import paths for vLLM compatibility across versions
 vllm_shared_fused_moe_layer = None
@@ -67,14 +82,6 @@ else:
         from vllm.model_executor.layers.attention.encoder_only_attention import EncoderOnlyAttention
     except ImportError:
         EncoderOnlyAttention = None
-
-try:
-    _has_attention_layer = importlib.util.find_spec("vllm.attention.layer") is not None
-except (ModuleNotFoundError, ValueError):
-    _has_attention_layer = False
-
-if _has_attention_layer:
-    import vllm.attention.layer as vllm_attention
 
 try:
     VllmMLAAttention = vllm_attention.MLAAttention

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -114,32 +114,46 @@ def _build_sparse_kw(layer_cfg: dict) -> dict:
     return sparse_kw
 
 
-def _p_qdq_from_layer(layer) -> tuple[str | None, float]:
-    """Map a layer's ``p_bmm_quantizer`` to ``(p_qdq mode, p_qdq_amax)`` for the kernels.
+def _bmm_qdq_from_layer(layer, attr: str, default_amax: float | None):
+    """Map a layer's ``attr`` BMM2 quantizer to ``(qdq mode, amax)`` for the kernels.
 
     Mirrors ``_QuantAttention._p_qdq_mode``: per-tensor FP8 -> ``"fp8"``; dynamic NVFP4
     at block size 16 -> ``"nvfp4"``; otherwise (missing/disabled quantizer or an
-    unsupported format) -> ``None`` (no P quant). A calibrated per-tensor ``_amax``, if
-    present, is forwarded so the kernel uses it instead of the default 1.0.
+    unsupported format) -> ``(None, default_amax)``. A calibrated per-tensor ``_amax``,
+    if present, is forwarded so the kernel uses it instead of ``default_amax``.
     """
-    pq = getattr(layer, "p_bmm_quantizer", None)
-    if pq is None or not getattr(pq, "is_enabled", False):
-        return None, 1.0
-    if pq.is_fp8:
+    q = getattr(layer, attr, None)
+    if q is None or not getattr(q, "is_enabled", False):
+        return None, default_amax
+    if q.is_fp8:
         mode = "fp8"
-    elif pq.is_nvfp4_dynamic and (pq.block_sizes or {}).get(-1, None) == 16:
+    elif q.is_nvfp4_dynamic and (q.block_sizes or {}).get(-1, None) == 16:
         mode = "nvfp4"
     else:
-        return None, 1.0
-    amax = getattr(pq, "_amax", None)
+        return None, default_amax
+    amax = getattr(q, "_amax", None)
     if amax is not None:
         if amax.numel() != 1:
             raise NotImplementedError(
-                "p_bmm_quantizer via the sparse Triton kernel supports only a per-tensor "
+                f"{attr} via the sparse Triton kernel supports only a per-tensor "
                 f"(scalar) amax, got shape {tuple(amax.shape)}."
             )
         return mode, float(amax)
-    return mode, 1.0
+    return mode, default_amax
+
+
+def _p_qdq_from_layer(layer) -> tuple[str | None, float]:
+    """P (softmax) BMM2 operand from ``p_bmm_quantizer``; default amax 1.0 (P in [0, 1])."""
+    return _bmm_qdq_from_layer(layer, "p_bmm_quantizer", 1.0)
+
+
+def _v_qdq_from_layer(layer) -> tuple[str | None, float | None]:
+    """V (value) BMM2 operand from ``v_bmm_quantizer``.
+
+    Default amax ``None`` -> the constant 1.0 global scale (V's dynamic per-16
+    block amax carries the range).
+    """
+    return _bmm_qdq_from_layer(layer, "v_bmm_quantizer", None)
 
 
 class ModelOptSparseAttentionImpl(FlashAttentionImpl):
@@ -227,10 +241,13 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         key_cache, value_cache = kv_cache.unbind(0)
         page_size = key_cache.shape[1]
 
-        # Softmax-P quant from the layer's p_bmm_quantizer (config-driven, exported);
-        # None when no/disabled/unsupported quantizer. P quant alone (no sparsity) still
-        # engages the kernel below.
+        # BMM2-operand quant from the layer's p/v_bmm_quantizer (config-driven, exported);
+        # None when no/disabled/unsupported quantizer. P or V quant alone (no sparsity)
+        # still engages the kernel below. K/Q quant is applied upstream by the
+        # _QuantVLLMAttention pre-step (head_dim axis); only the keys-axis BMM2 operands
+        # (P, V) are quantized in-kernel here.
         p_qdq, p_qdq_amax = _p_qdq_from_layer(layer)
+        v_qdq, v_qdq_amax = _v_qdq_from_layer(layer)
 
         # Per-layer sparse kwargs (set by _replace_attention_impl in the worker)
         sparse_kw = dict(getattr(self, "sparse_kw", {}))
@@ -244,8 +261,8 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             for name in ("sparsity_n", "sparsity_m", "dense_sink_tokens", "dense_recent_tokens"):
                 sparse_kw.pop(name, None)
             threshold = sparse_kw.get("skip_softmax_threshold")
-            if threshold is None and p_qdq is None:
-                # No decode sparsity and no P quant for this launch; use vLLM FlashAttention.
+            if threshold is None and p_qdq is None and v_qdq is None:
+                # No decode sparsity and no BMM2 quant for this launch; use vLLM FlashAttention.
                 return self._forward_vllm_flash_attn(
                     layer,
                     query,
@@ -270,10 +287,12 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
                 skip_softmax_threshold=threshold,
                 p_qdq=p_qdq,
                 p_qdq_amax=p_qdq_amax,
+                v_qdq=v_qdq,
+                v_qdq_amax=v_qdq_amax,
                 output=output,
             )
-        if not sparse_kw and p_qdq is None:
-            # No sparse feature and no P quant active (e.g. dynamic calibration
+        if not sparse_kw and p_qdq is None and v_qdq is None:
+            # No sparse feature and no BMM2 quant active (e.g. dynamic calibration
             # disabled the threshold); avoid swapping in the ModelOpt kernel.
             return self._forward_vllm_flash_attn(
                 layer,
@@ -319,6 +338,8 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             page_size=page_size,  # tokens per page in the KV cache
             p_qdq=p_qdq,
             p_qdq_amax=p_qdq_amax,
+            v_qdq=v_qdq,
+            v_qdq_amax=v_qdq_amax,
             **sparse_kw,
         )
 
@@ -338,9 +359,11 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         skip_softmax_threshold: float | None = None,
         p_qdq: str | None = None,
         p_qdq_amax: float = 1.0,
+        v_qdq: str | None = None,
+        v_qdq_amax: float | None = None,
         output: torch.Tensor,
     ) -> torch.Tensor:
-        """Decode via the dedicated paged decode kernel (skip-softmax and/or P quant).
+        """Decode via the dedicated paged decode kernel (skip-softmax and/or P/V quant).
 
         Standard decode schedules exactly one query token per request, so the
         ``num_actual_tokens`` query rows are the per-request decode queries. The
@@ -362,6 +385,8 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             page_size=page_size,
             p_qdq=p_qdq,
             p_qdq_amax=p_qdq_amax,
+            v_qdq=v_qdq,
+            v_qdq_amax=v_qdq_amax,
         )
         output[:num_actual_tokens] = decode_out
         return output

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -114,6 +114,34 @@ def _build_sparse_kw(layer_cfg: dict) -> dict:
     return sparse_kw
 
 
+def _p_qdq_from_layer(layer) -> tuple[str | None, float]:
+    """Map a layer's ``p_bmm_quantizer`` to ``(p_qdq mode, p_qdq_amax)`` for the kernels.
+
+    Mirrors ``_QuantAttention._p_qdq_mode``: per-tensor FP8 -> ``"fp8"``; dynamic NVFP4
+    at block size 16 -> ``"nvfp4"``; otherwise (missing/disabled quantizer or an
+    unsupported format) -> ``None`` (no P quant). A calibrated per-tensor ``_amax``, if
+    present, is forwarded so the kernel uses it instead of the default 1.0.
+    """
+    pq = getattr(layer, "p_bmm_quantizer", None)
+    if pq is None or not getattr(pq, "is_enabled", False):
+        return None, 1.0
+    if pq.is_fp8:
+        mode = "fp8"
+    elif pq.is_nvfp4_dynamic and (pq.block_sizes or {}).get(-1, None) == 16:
+        mode = "nvfp4"
+    else:
+        return None, 1.0
+    amax = getattr(pq, "_amax", None)
+    if amax is not None:
+        if amax.numel() != 1:
+            raise NotImplementedError(
+                "p_bmm_quantizer via the sparse Triton kernel supports only a per-tensor "
+                f"(scalar) amax, got shape {tuple(amax.shape)}."
+            )
+        return mode, float(amax)
+    return mode, 1.0
+
+
 class ModelOptSparseAttentionImpl(FlashAttentionImpl):
     """Attention implementation that uses the ModelOpt Triton kernel.
 
@@ -199,6 +227,11 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         key_cache, value_cache = kv_cache.unbind(0)
         page_size = key_cache.shape[1]
 
+        # Softmax-P quant from the layer's p_bmm_quantizer (config-driven, exported);
+        # None when no/disabled/unsupported quantizer. P quant alone (no sparsity) still
+        # engages the kernel below.
+        p_qdq, p_qdq_amax = _p_qdq_from_layer(layer)
+
         # Per-layer sparse kwargs (set by _replace_attention_impl in the worker)
         sparse_kw = dict(getattr(self, "sparse_kw", {}))
         _resolve_skip_softmax_calibration(
@@ -211,8 +244,8 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             for name in ("sparsity_n", "sparsity_m", "dense_sink_tokens", "dense_recent_tokens"):
                 sparse_kw.pop(name, None)
             threshold = sparse_kw.get("skip_softmax_threshold")
-            if threshold is None:
-                # No decode sparsity active for this launch; use vLLM FlashAttention.
+            if threshold is None and p_qdq is None:
+                # No decode sparsity and no P quant for this launch; use vLLM FlashAttention.
                 return self._forward_vllm_flash_attn(
                     layer,
                     query,
@@ -224,8 +257,8 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
                     output_scale,
                     output_block_scale,
                 )
-            # Decode-only skip-softmax runs on the dedicated paged decode kernel
-            # (one query vector per request, split-K), not the prefill kernel.
+            # Decode runs on the dedicated paged decode kernel (one query vector per
+            # request, split-K): skip-softmax and/or P quant, not the prefill kernel.
             return self._forward_sparse_decode(
                 query=query,
                 key_cache=key_cache,
@@ -235,12 +268,13 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
                 block_table=attn_metadata.block_table,
                 num_actual_tokens=num_actual_tokens,
                 skip_softmax_threshold=threshold,
+                p_qdq=p_qdq,
+                p_qdq_amax=p_qdq_amax,
                 output=output,
             )
-        if not sparse_kw:
-            # Dynamic calibration can disable sparse work for a launch, e.g.
-            # short-prefill thresholds outside the valid lambda range. Avoid
-            # swapping in the ModelOpt dense kernel when no sparse feature is active.
+        if not sparse_kw and p_qdq is None:
+            # No sparse feature and no P quant active (e.g. dynamic calibration
+            # disabled the threshold); avoid swapping in the ModelOpt kernel.
             return self._forward_vllm_flash_attn(
                 layer,
                 query,
@@ -283,6 +317,8 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             v_cache=value_cache,  # [num_blocks, page_size, num_kv_heads, head_dim]
             block_table=attn_metadata.block_table,  # [batch, max_blocks]
             page_size=page_size,  # tokens per page in the KV cache
+            p_qdq=p_qdq,
+            p_qdq_amax=p_qdq_amax,
             **sparse_kw,
         )
 
@@ -299,10 +335,12 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         seq_lens: torch.Tensor,
         block_table: torch.Tensor,
         num_actual_tokens: int,
-        skip_softmax_threshold: float,
+        skip_softmax_threshold: float | None = None,
+        p_qdq: str | None = None,
+        p_qdq_amax: float = 1.0,
         output: torch.Tensor,
     ) -> torch.Tensor:
-        """Decode-only skip-softmax via the dedicated paged decode kernel.
+        """Decode via the dedicated paged decode kernel (skip-softmax and/or P quant).
 
         Standard decode schedules exactly one query token per request, so the
         ``num_actual_tokens`` query rows are the per-request decode queries. The
@@ -322,6 +360,8 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             softmax_scale=self.scale,
             skip_softmax_threshold=skip_softmax_threshold,
             page_size=page_size,
+            p_qdq=p_qdq,
+            p_qdq_amax=p_qdq_amax,
         )
         output[:num_actual_tokens] = decode_out
         return output

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -160,6 +160,29 @@ def _v_qdq_from_layer(layer) -> tuple[str | None, float | None]:
     return _bmm_qdq_from_layer(layer, "v_bmm_quantizer", None)
 
 
+def _assert_bmm_quant_supported(layer, name: str = "") -> None:
+    """Raise if a BMM2 quantizer is enabled but in a format the kernel cannot map.
+
+    ``_bmm_qdq_from_layer`` returns ``None`` for both a disabled quantizer and an
+    enabled one in an unsupported format (only per-tensor FP8 or block-16 dynamic
+    NVFP4 map). The latter must not be served silently: the kernel would skip it and,
+    for V, ``_value_quant_in_kernel`` would also skip the pre-step quantizer, leaving
+    the operand unquantized. Detect that case (enabled, yet unmapped) and fail loud.
+    """
+    for attr, (qdq, _) in (
+        ("p_bmm_quantizer", _p_qdq_from_layer(layer)),
+        ("v_bmm_quantizer", _v_qdq_from_layer(layer)),
+    ):
+        q = getattr(layer, attr, None)
+        if qdq is None and q is not None and getattr(q, "is_enabled", False):
+            where = f"{name}." if name else ""
+            raise NotImplementedError(
+                f"{where}{attr} is enabled but its quant format is unsupported by the "
+                f"sparse attention kernel (supported: per-tensor FP8, block-16 dynamic "
+                f"NVFP4). Re-export with a supported format or disable this quantizer."
+            )
+
+
 def _bake_v_onwrite(value_cache, block_table, seq_lens, query_lens, page_size, v_qdq_amax, decode):
     """Quantize-on-write the newly-complete BLOCK_N V tiles so decode reads them as-is.
 
@@ -239,9 +262,20 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             return output.fill_(0)
 
         if getattr(attn_metadata, "use_cascade", False):
-            # vLLM cascade metadata splits the request into shared-prefix and
-            # suffix pieces. The ModelOpt paged kernel consumes plain per-request
-            # KV lengths, so delegate cascade launches back to vLLM's impl.
+            # Cascade metadata splits a shared-prefix batch into prefix + suffix; the
+            # ModelOpt paged kernel consumes plain per-request KV lengths and cannot.
+            # For a sparse-only layer the native fallback is harmless (dense output, no
+            # skip-softmax). But when attention QUANT is active, native attention serves
+            # the model UN-quantized (wrong numerics, silently), so fail loud instead.
+            # The quant worker also disables cascade up front, so this should not be hit.
+            p_qdq, _ = _p_qdq_from_layer(layer)
+            v_qdq, _ = _v_qdq_from_layer(layer)
+            if p_qdq is not None or v_qdq is not None:
+                raise NotImplementedError(
+                    "vLLM cascade attention is incompatible with ModelOpt attention "
+                    "quant (the native fallback would serve P/V un-quantized). Disable "
+                    "cascade (model_config.disable_cascade_attn=True) or the quantizers."
+                )
             return self._forward_vllm_flash_attn(
                 layer,
                 query,

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -391,6 +391,23 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         # so the kernel computes the correct GQA ratio (num_q_heads // num_kv_heads).
         k_dummy = torch.empty(0, self.num_kv_heads, self.head_size, device=q.device, dtype=q.dtype)
 
+        # NVFP4 V: bake the prompt's complete tiles on write BEFORE the kernel, so the kernel
+        # reads them as-is (V_CACHE_QUANTIZED) and re-fake-quantizes only the trailing partial.
+        # This quantizes each V tile exactly once — no double-quant of tiles a prior chunked-
+        # prefill step already baked — and still leaves decode a pre-quantized cache. FP8 V and
+        # no-quant stay fully on-read (v_cache_quantized False).
+        v_cache_quantized = v_qdq == "nvfp4"
+        if v_cache_quantized:
+            _bake_v_onwrite(
+                value_cache,
+                attn_metadata.block_table,
+                seq_lens,
+                b_seq_len,
+                page_size,
+                v_qdq_amax,
+                decode=False,
+            )
+
         # Call ModelOpt Triton kernel with paged KV.
         # b_seq_len is the query length (e.g., 6 for prefill, 1 for decode).
         # b_seq_len_k is the total KV length including cache (e.g., 6 for first
@@ -418,24 +435,11 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             p_qdq_amax=p_qdq_amax,
             v_qdq=v_qdq,
             v_qdq_amax=v_qdq_amax,
+            v_cache_quantized=v_cache_quantized,
             **sparse_kw,
         )
 
         output[:num_actual_tokens] = triton_out
-        # NVFP4 V: prefill attention read raw V on-read above (O(S), single pass); now bake the
-        # prompt's complete tiles on write so the following decode steps inherit a pre-quantized
-        # cache and stay O(S). (Chunked prefill re-reads earlier baked tiles on-read with a small
-        # idempotency drift; a prefill-side V_CACHE_QUANTIZED gate would remove it — follow-up.)
-        if v_qdq == "nvfp4":
-            _bake_v_onwrite(
-                value_cache,
-                attn_metadata.block_table,
-                seq_lens,
-                b_seq_len,
-                page_size,
-                v_qdq_amax,
-                decode=False,
-            )
         return output
 
     def _forward_sparse_decode(

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -37,6 +37,7 @@ from vllm.v1.attention.backends.flash_attn import (
     FlashAttentionMetadata,
 )
 
+from modelopt.torch.kernels.common.attention.decode_attention import attention_decode
 from modelopt.torch.kernels.common.attention.triton_fa import attention as triton_attention
 
 
@@ -209,11 +210,9 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             # N:M sparse softmax is prefill-only.
             for name in ("sparsity_n", "sparsity_m", "dense_sink_tokens", "dense_recent_tokens"):
                 sparse_kw.pop(name, None)
-            if set(sparse_kw) <= {"skip_softmax_threshold"}:
-                # The current ModelOpt paged kernel is only validated for
-                # sparse prefill in vLLM. Decode-only skip-softmax would route
-                # through the dense Triton path for every non-skipped tile, so
-                # keep decode on vLLM FlashAttention until that path is covered.
+            threshold = sparse_kw.get("skip_softmax_threshold")
+            if threshold is None:
+                # No decode sparsity active for this launch; use vLLM FlashAttention.
                 return self._forward_vllm_flash_attn(
                     layer,
                     query,
@@ -225,6 +224,19 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
                     output_scale,
                     output_block_scale,
                 )
+            # Decode-only skip-softmax runs on the dedicated paged decode kernel
+            # (one query vector per request, split-K), not the prefill kernel.
+            return self._forward_sparse_decode(
+                query=query,
+                key_cache=key_cache,
+                value_cache=value_cache,
+                page_size=page_size,
+                seq_lens=seq_lens,
+                block_table=attn_metadata.block_table,
+                num_actual_tokens=num_actual_tokens,
+                skip_softmax_threshold=threshold,
+                output=output,
+            )
         if not sparse_kw:
             # Dynamic calibration can disable sparse work for a launch, e.g.
             # short-prefill thresholds outside the valid lambda range. Avoid
@@ -275,6 +287,43 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         )
 
         output[:num_actual_tokens] = triton_out
+        return output
+
+    def _forward_sparse_decode(
+        self,
+        *,
+        query: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        page_size: int,
+        seq_lens: torch.Tensor,
+        block_table: torch.Tensor,
+        num_actual_tokens: int,
+        skip_softmax_threshold: float,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        """Decode-only skip-softmax via the dedicated paged decode kernel.
+
+        Standard decode schedules exactly one query token per request, so the
+        ``num_actual_tokens`` query rows are the per-request decode queries. The
+        decode kernel computes one query vector per ``(request, head)`` over the
+        paged cache (split-K over the KV sequence) and applies the same prefix-max
+        skip criterion as the prefill kernel, so realized decode sparsity matches
+        the calibrated ``(a, b)``. The prefill kernel would tile this single query
+        token into ``BLOCK_M`` rows, wasting ~127/128 of the work.
+        """
+        q = query[:num_actual_tokens].contiguous()  # [batch, num_q_heads, head_dim]
+        decode_out = attention_decode(
+            q,
+            key_cache,
+            value_cache,
+            block_table[:num_actual_tokens],
+            seq_lens[:num_actual_tokens],
+            softmax_scale=self.scale,
+            skip_softmax_threshold=skip_softmax_threshold,
+            page_size=page_size,
+        )
+        output[:num_actual_tokens] = decode_out
         return output
 
 

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -37,7 +37,11 @@ from vllm.v1.attention.backends.flash_attn import (
     FlashAttentionMetadata,
 )
 
-from modelopt.torch.kernels.common.attention.decode_attention import attention_decode
+from modelopt.torch.kernels.common.attention.decode_attention import (
+    _ONWRITE_BLOCK_N,
+    attention_decode,
+    fake_quant_v_onwrite,
+)
 from modelopt.torch.kernels.common.attention.triton_fa import attention as triton_attention
 
 
@@ -154,6 +158,31 @@ def _v_qdq_from_layer(layer) -> tuple[str | None, float | None]:
     block amax carries the range).
     """
     return _bmm_qdq_from_layer(layer, "v_bmm_quantizer", None)
+
+
+def _bake_v_onwrite(value_cache, block_table, seq_lens, query_lens, page_size, v_qdq_amax, decode):
+    """Quantize-on-write the newly-complete BLOCK_N V tiles so decode reads them as-is.
+
+    Bakes the tiles that completed since the previous step (``[prev, seq)`` clipped to whole
+    ``_ONWRITE_BLOCK_N`` tiles) into the paged cache, NVFP4, with the same scale the kernel applies
+    on read — turning decode V quant from ``O(S²)`` on-read into ``O(S)`` quantize-once. NVFP4-only;
+    the caller skips it for FP8 V.
+    """
+    bn = _ONWRITE_BLOCK_N
+    prev = (seq_lens - query_lens).to(torch.int32)
+    seqk = seq_lens.to(torch.int32)
+    v_lo = (prev // bn) * bn
+    v_hi = (seqk // bn) * bn
+    v_scale = 1.0 if v_qdq_amax is None else v_qdq_amax / (6.0 * 448.0)
+    fake_quant_v_onwrite(
+        value_cache,
+        block_table,
+        v_lo,
+        v_hi,
+        page_size=page_size,
+        v_qdq_scale=v_scale,
+        decode=decode,
+    )
 
 
 class ModelOptSparseAttentionImpl(FlashAttentionImpl):
@@ -274,6 +303,20 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
                     output_scale,
                     output_block_scale,
                 )
+            # NVFP4 V: bake the newly-complete tiles on write so the decode kernel reads them
+            # as-is (O(S)) instead of re-fake-quantizing the whole cache every step (O(S²)).
+            # FP8 V stays on-read. Bake BEFORE the attention so it reads the baked cache.
+            v_cache_quantized = v_qdq == "nvfp4"
+            if v_cache_quantized:
+                _bake_v_onwrite(
+                    value_cache,
+                    attn_metadata.block_table,
+                    seq_lens,
+                    b_seq_len,
+                    page_size,
+                    v_qdq_amax,
+                    decode=True,
+                )
             # Decode runs on the dedicated paged decode kernel (one query vector per
             # request, split-K): skip-softmax and/or P quant, not the prefill kernel.
             return self._forward_sparse_decode(
@@ -289,6 +332,7 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
                 p_qdq_amax=p_qdq_amax,
                 v_qdq=v_qdq,
                 v_qdq_amax=v_qdq_amax,
+                v_cache_quantized=v_cache_quantized,
                 output=output,
             )
         if not sparse_kw and p_qdq is None and v_qdq is None:
@@ -344,6 +388,20 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         )
 
         output[:num_actual_tokens] = triton_out
+        # NVFP4 V: prefill attention read raw V on-read above (O(S), single pass); now bake the
+        # prompt's complete tiles on write so the following decode steps inherit a pre-quantized
+        # cache and stay O(S). (Chunked prefill re-reads earlier baked tiles on-read with a small
+        # idempotency drift; a prefill-side V_CACHE_QUANTIZED gate would remove it — follow-up.)
+        if v_qdq == "nvfp4":
+            _bake_v_onwrite(
+                value_cache,
+                attn_metadata.block_table,
+                seq_lens,
+                b_seq_len,
+                page_size,
+                v_qdq_amax,
+                decode=False,
+            )
         return output
 
     def _forward_sparse_decode(
@@ -361,6 +419,7 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         p_qdq_amax: float = 1.0,
         v_qdq: str | None = None,
         v_qdq_amax: float | None = None,
+        v_cache_quantized: bool = False,
         output: torch.Tensor,
     ) -> torch.Tensor:
         """Decode via the dedicated paged decode kernel (skip-softmax and/or P/V quant).
@@ -387,6 +446,7 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
             p_qdq_amax=p_qdq_amax,
             v_qdq=v_qdq,
             v_qdq_amax=v_qdq_amax,
+            v_cache_quantized=v_cache_quantized,
         )
         output[:num_actual_tokens] = decode_out
         return output

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -291,7 +291,7 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
                 sparse_kw.pop(name, None)
             threshold = sparse_kw.get("skip_softmax_threshold")
             if threshold is None and p_qdq is None and v_qdq is None:
-                # No decode sparsity and no BMM2 quant for this launch; use vLLM FlashAttention.
+                # No decode sparsity and no BMM quant for this launch; use vLLM FlashAttention.
                 return self._forward_vllm_flash_attn(
                     layer,
                     query,

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -19,14 +19,18 @@ Registers a custom vLLM attention backend that uses the ModelOpt Triton kernel
 with paged KV cache support. Integration approach:
 
 - No module replacement — the Attention module stays intact with all its state
-- Only ``impl`` is swapped from FlashAttentionImpl to ModelOptSparseAttentionImpl
+- Only ``impl`` is swapped to the ModelOpt sparse impl for the layer's backend
+  (``ModelOptSparseAttentionImpl`` for FlashAttention,
+  ``ModelOptSparseFlashInferImpl`` for FlashInfer)
 - KV cache update is handled by vLLM (inherited ``do_kv_cache_update``)
-- ``forward()`` calls ModelOpt Triton only when a validated sparse path is active
+- ``forward()`` calls ModelOpt Triton only when a validated sparse/quant path is active
 
 Vllm-free config helpers (``match_sparse_config`` / ``load_from_checkpoint_metadata``)
 live in ``plugins/sparse_attn_config.py`` and are unit-testable without vLLM.
 """
 
+import functools
+import inspect
 import math
 import warnings
 
@@ -208,13 +212,235 @@ def _bake_v_onwrite(value_cache, block_table, seq_lens, query_lens, page_size, v
     )
 
 
-class ModelOptSparseAttentionImpl(FlashAttentionImpl):
-    """Attention implementation that uses the ModelOpt Triton kernel.
+class _SparseAttentionMixin:
+    """Backend-agnostic sparse + attention-quant forward shared by the sparse impls.
+
+    A backend-specific impl (``ModelOptSparseAttentionImpl`` for FlashAttention,
+    ``ModelOptSparseFlashInferImpl`` for FlashInfer) extracts the dense paged
+    metadata (per-request query offsets/lengths, KV lengths, block table) and the
+    K/V caches from its own attention-metadata and cache layout, then calls
+    :meth:`_forward_common`. The decode/prefill dispatch, the config-driven P/V
+    BMM2 quant (from the layer's ``p/v_bmm_quantizer``), the on-write V bake, and
+    the skip-softmax handling are identical across backends, so only the
+    metadata/cache extraction differs. ``select_sparse_impl_cls`` recognizes any
+    impl that mixes this in.
+
+    Runtime attributes (``scale``, ``num_kv_heads``, ``head_size``) come from the
+    vLLM AttentionImpl base class; ``sparse_kw`` is set by the worker.
+    """
+
+    # Provided at runtime by the vLLM AttentionImpl base class.
+    scale: float
+    num_kv_heads: int
+    head_size: int
+    # Per-layer sparse kwargs set by the worker (empty when quant-only).
+    sparse_kw: dict
+
+    def _forward_common(
+        self,
+        *,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        page_size: int,
+        block_table: torch.Tensor,
+        b_start_loc: torch.Tensor,
+        b_seq_len: torch.Tensor,
+        seq_lens: torch.Tensor,
+        num_actual_tokens: int,
+        max_query_len: int,
+        max_seq_len: int,
+        is_decode_only: bool,
+        is_causal: bool,
+        output: torch.Tensor,
+        dense_fallback,
+    ) -> torch.Tensor:
+        """Run the ModelOpt sparse/quant Triton kernel over the paged cache, or delegate.
+
+        Shared inference path across backends. The backend impl extracts the
+        per-request query offsets/lengths, KV lengths, and block table from its
+        own metadata and the K/V caches from its own layout, then calls this.
+        ``dense_fallback`` is a zero-arg callable that runs the backend's native
+        (dense) attention; it is used when no sparse feature and no BMM2 quant
+        applies to the launch (decode-only skip-softmax, or a launch where dynamic
+        calibration disabled sparsity).
+        """
+        # BMM2-operand quant from the layer's p/v_bmm_quantizer (config-driven, exported);
+        # None when no/disabled/unsupported quantizer. P or V quant alone (no sparsity)
+        # still engages the kernel below. K/Q quant is applied upstream by the
+        # _QuantVLLMAttention pre-step (head_dim axis); only the keys-axis BMM2 operands
+        # (P, V) are quantized in-kernel here.
+        p_qdq, p_qdq_amax = _p_qdq_from_layer(layer)
+        v_qdq, v_qdq_amax = _v_qdq_from_layer(layer)
+
+        # Per-layer sparse kwargs (set by the worker install step).
+        sparse_kw = dict(getattr(self, "sparse_kw", {}))
+        _resolve_skip_softmax_calibration(
+            sparse_kw,
+            is_prefill=not is_decode_only,
+            max_seq_len=max_seq_len,
+        )
+        if is_decode_only:
+            # N:M sparse softmax is prefill-only.
+            for name in ("sparsity_n", "sparsity_m", "dense_sink_tokens", "dense_recent_tokens"):
+                sparse_kw.pop(name, None)
+            threshold = sparse_kw.get("skip_softmax_threshold")
+            if threshold is None and p_qdq is None and v_qdq is None:
+                # No decode sparsity and no BMM quant for this launch; native fallback.
+                return dense_fallback()
+            # NVFP4 V: bake the newly-complete tiles on write so the decode kernel reads them
+            # as-is (O(S)) instead of re-fake-quantizing the whole cache every step (O(S²)).
+            # FP8 V stays on-read. Bake BEFORE the attention so it reads the baked cache.
+            v_cache_quantized = v_qdq == "nvfp4"
+            if v_cache_quantized:
+                _bake_v_onwrite(
+                    value_cache,
+                    block_table,
+                    seq_lens,
+                    b_seq_len,
+                    page_size,
+                    v_qdq_amax,
+                    decode=True,
+                )
+            # Decode runs on the dedicated paged decode kernel (one query vector per
+            # request, split-K): skip-softmax and/or P quant, not the prefill kernel.
+            return self._forward_sparse_decode(
+                query=query,
+                key_cache=key_cache,
+                value_cache=value_cache,
+                page_size=page_size,
+                seq_lens=seq_lens,
+                block_table=block_table,
+                num_actual_tokens=num_actual_tokens,
+                skip_softmax_threshold=threshold,
+                p_qdq=p_qdq,
+                p_qdq_amax=p_qdq_amax,
+                v_qdq=v_qdq,
+                v_qdq_amax=v_qdq_amax,
+                v_cache_quantized=v_cache_quantized,
+                output=output,
+            )
+        if not sparse_kw and p_qdq is None and v_qdq is None:
+            # No sparse feature and no BMM2 quant active (e.g. dynamic calibration
+            # disabled the threshold); avoid swapping in the ModelOpt kernel.
+            return dense_fallback()
+
+        # Prepare metadata for our kernel
+        q = query[:num_actual_tokens].contiguous()
+        # Dummy K/V for paged mode: not used by the kernel (KV are read from
+        # k_cache/v_cache via block_table), but shape[1] must be num_kv_heads
+        # so the kernel computes the correct GQA ratio (num_q_heads // num_kv_heads).
+        k_dummy = torch.empty(0, self.num_kv_heads, self.head_size, device=q.device, dtype=q.dtype)
+
+        # NVFP4 V: bake the prompt's complete tiles on write BEFORE the kernel, so the kernel
+        # reads them as-is (V_CACHE_QUANTIZED) and re-fake-quantizes only the trailing partial.
+        # This quantizes each V tile exactly once — no double-quant of tiles a prior chunked-
+        # prefill step already baked — and still leaves decode a pre-quantized cache. FP8 V and
+        # no-quant stay fully on-read (v_cache_quantized False).
+        v_cache_quantized = v_qdq == "nvfp4"
+        if v_cache_quantized:
+            _bake_v_onwrite(
+                value_cache,
+                block_table,
+                seq_lens,
+                b_seq_len,
+                page_size,
+                v_qdq_amax,
+                decode=False,
+            )
+
+        # Call ModelOpt Triton kernel with paged KV.
+        # b_seq_len is the query length (e.g., 6 for prefill, 1 for decode).
+        # b_seq_len_k is the total KV length including cache (e.g., 6 for first
+        # prefill, 7/8/... for subsequent decode steps).
+        triton_out = triton_attention(
+            q,
+            k=k_dummy,
+            v=k_dummy,
+            # Query metadata
+            b_start_loc=b_start_loc,
+            b_seq_len=b_seq_len,
+            max_input_len=max_query_len,
+            is_causal=is_causal,
+            softmax_scale=self.scale,
+            # KV metadata
+            b_start_loc_k=None,  # paged mode: KV offsets not needed
+            b_seq_len_k=seq_lens,  # total KV length per sequence
+            max_input_len_k=max_seq_len,
+            # Paged KV cache
+            k_cache=key_cache,  # [num_blocks, page_size, num_kv_heads, head_dim]
+            v_cache=value_cache,  # [num_blocks, page_size, num_kv_heads, head_dim]
+            block_table=block_table,  # [batch, max_blocks]
+            page_size=page_size,  # tokens per page in the KV cache
+            p_qdq=p_qdq,
+            p_qdq_amax=p_qdq_amax,
+            v_qdq=v_qdq,
+            v_qdq_amax=v_qdq_amax,
+            v_cache_quantized=v_cache_quantized,
+            **sparse_kw,
+        )
+
+        output[:num_actual_tokens] = triton_out
+        return output
+
+    def _forward_sparse_decode(
+        self,
+        *,
+        query: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        page_size: int,
+        seq_lens: torch.Tensor,
+        block_table: torch.Tensor,
+        num_actual_tokens: int,
+        skip_softmax_threshold: float | None = None,
+        p_qdq: str | None = None,
+        p_qdq_amax: float = 1.0,
+        v_qdq: str | None = None,
+        v_qdq_amax: float | None = None,
+        v_cache_quantized: bool = False,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        """Decode via the dedicated paged decode kernel (skip-softmax and/or P/V quant).
+
+        Standard decode schedules exactly one query token per request, so the
+        ``num_actual_tokens`` query rows are the per-request decode queries. The
+        decode kernel computes one query vector per ``(request, head)`` over the
+        paged cache (split-K over the KV sequence) and applies the same prefix-max
+        skip criterion as the prefill kernel, so realized decode sparsity matches
+        the calibrated ``(a, b)``. The prefill kernel would tile this single query
+        token into ``BLOCK_M`` rows, wasting ~127/128 of the work.
+        """
+        q = query[:num_actual_tokens].contiguous()  # [batch, num_q_heads, head_dim]
+        decode_out = attention_decode(
+            q,
+            key_cache,
+            value_cache,
+            block_table[:num_actual_tokens],
+            seq_lens[:num_actual_tokens],
+            softmax_scale=self.scale,
+            skip_softmax_threshold=skip_softmax_threshold,
+            page_size=page_size,
+            p_qdq=p_qdq,
+            p_qdq_amax=p_qdq_amax,
+            v_qdq=v_qdq,
+            v_qdq_amax=v_qdq_amax,
+            v_cache_quantized=v_cache_quantized,
+        )
+        output[:num_actual_tokens] = decode_out
+        return output
+
+
+class ModelOptSparseAttentionImpl(_SparseAttentionMixin, FlashAttentionImpl):
+    """FlashAttention-backed attention impl that uses the ModelOpt Triton kernel.
 
     Inherits from FlashAttentionImpl to reuse:
     - __init__ (all configuration)
     - do_kv_cache_update (KV cache writing)
-    Only overrides forward() to replace sparse prefill attention computation.
+    Only overrides forward() to replace sparse prefill attention computation. The
+    sparse + attention-quant logic itself lives on ``_SparseAttentionMixin`` so
+    the FlashInfer variant can reuse it.
     """
 
     def _forward_vllm_flash_attn(
@@ -230,7 +456,8 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         output_block_scale: torch.Tensor | None,
     ) -> torch.Tensor:
         """Delegate a launch back to vLLM's native FlashAttention impl."""
-        return super().forward(
+        return FlashAttentionImpl.forward(
+            self,
             layer,
             query,
             key,
@@ -304,75 +531,23 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
         key_cache, value_cache = kv_cache.unbind(0)
         page_size = key_cache.shape[1]
 
-        # BMM2-operand quant from the layer's p/v_bmm_quantizer (config-driven, exported);
-        # None when no/disabled/unsupported quantizer. P or V quant alone (no sparsity)
-        # still engages the kernel below. K/Q quant is applied upstream by the
-        # _QuantVLLMAttention pre-step (head_dim axis); only the keys-axis BMM2 operands
-        # (P, V) are quantized in-kernel here.
-        p_qdq, p_qdq_amax = _p_qdq_from_layer(layer)
-        v_qdq, v_qdq_amax = _v_qdq_from_layer(layer)
-
-        # Per-layer sparse kwargs (set by _replace_attention_impl in the worker)
-        sparse_kw = dict(getattr(self, "sparse_kw", {}))
-        _resolve_skip_softmax_calibration(
-            sparse_kw,
-            is_prefill=not is_decode_only,
+        return self._forward_common(
+            layer=layer,
+            query=query,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            page_size=page_size,
+            block_table=attn_metadata.block_table,
+            b_start_loc=b_start_loc,
+            b_seq_len=b_seq_len,
+            seq_lens=seq_lens,
+            num_actual_tokens=num_actual_tokens,
+            max_query_len=attn_metadata.max_query_len,
             max_seq_len=attn_metadata.max_seq_len,
-        )
-        if is_decode_only:
-            # N:M sparse softmax is prefill-only.
-            for name in ("sparsity_n", "sparsity_m", "dense_sink_tokens", "dense_recent_tokens"):
-                sparse_kw.pop(name, None)
-            threshold = sparse_kw.get("skip_softmax_threshold")
-            if threshold is None and p_qdq is None and v_qdq is None:
-                # No decode sparsity and no BMM quant for this launch; use vLLM FlashAttention.
-                return self._forward_vllm_flash_attn(
-                    layer,
-                    query,
-                    key,
-                    value,
-                    kv_cache,
-                    attn_metadata,
-                    output,
-                    output_scale,
-                    output_block_scale,
-                )
-            # NVFP4 V: bake the newly-complete tiles on write so the decode kernel reads them
-            # as-is (O(S)) instead of re-fake-quantizing the whole cache every step (O(S²)).
-            # FP8 V stays on-read. Bake BEFORE the attention so it reads the baked cache.
-            v_cache_quantized = v_qdq == "nvfp4"
-            if v_cache_quantized:
-                _bake_v_onwrite(
-                    value_cache,
-                    attn_metadata.block_table,
-                    seq_lens,
-                    b_seq_len,
-                    page_size,
-                    v_qdq_amax,
-                    decode=True,
-                )
-            # Decode runs on the dedicated paged decode kernel (one query vector per
-            # request, split-K): skip-softmax and/or P quant, not the prefill kernel.
-            return self._forward_sparse_decode(
-                query=query,
-                key_cache=key_cache,
-                value_cache=value_cache,
-                page_size=page_size,
-                seq_lens=seq_lens,
-                block_table=attn_metadata.block_table,
-                num_actual_tokens=num_actual_tokens,
-                skip_softmax_threshold=threshold,
-                p_qdq=p_qdq,
-                p_qdq_amax=p_qdq_amax,
-                v_qdq=v_qdq,
-                v_qdq_amax=v_qdq_amax,
-                v_cache_quantized=v_cache_quantized,
-                output=output,
-            )
-        if not sparse_kw and p_qdq is None and v_qdq is None:
-            # No sparse feature and no BMM2 quant active (e.g. dynamic calibration
-            # disabled the threshold); avoid swapping in the ModelOpt kernel.
-            return self._forward_vllm_flash_attn(
+            is_decode_only=is_decode_only,
+            is_causal=is_causal,
+            output=output,
+            dense_fallback=lambda: self._forward_vllm_flash_attn(
                 layer,
                 query,
                 key,
@@ -382,112 +557,8 @@ class ModelOptSparseAttentionImpl(FlashAttentionImpl):
                 output,
                 output_scale,
                 output_block_scale,
-            )
-
-        # Prepare metadata for our kernel
-        q = query[:num_actual_tokens].contiguous()
-        # Dummy K/V for paged mode: not used by the kernel (KV are read from
-        # k_cache/v_cache via block_table), but shape[1] must be num_kv_heads
-        # so the kernel computes the correct GQA ratio (num_q_heads // num_kv_heads).
-        k_dummy = torch.empty(0, self.num_kv_heads, self.head_size, device=q.device, dtype=q.dtype)
-
-        # NVFP4 V: bake the prompt's complete tiles on write BEFORE the kernel, so the kernel
-        # reads them as-is (V_CACHE_QUANTIZED) and re-fake-quantizes only the trailing partial.
-        # This quantizes each V tile exactly once — no double-quant of tiles a prior chunked-
-        # prefill step already baked — and still leaves decode a pre-quantized cache. FP8 V and
-        # no-quant stay fully on-read (v_cache_quantized False).
-        v_cache_quantized = v_qdq == "nvfp4"
-        if v_cache_quantized:
-            _bake_v_onwrite(
-                value_cache,
-                attn_metadata.block_table,
-                seq_lens,
-                b_seq_len,
-                page_size,
-                v_qdq_amax,
-                decode=False,
-            )
-
-        # Call ModelOpt Triton kernel with paged KV.
-        # b_seq_len is the query length (e.g., 6 for prefill, 1 for decode).
-        # b_seq_len_k is the total KV length including cache (e.g., 6 for first
-        # prefill, 7/8/... for subsequent decode steps).
-        triton_out = triton_attention(
-            q,
-            k=k_dummy,
-            v=k_dummy,
-            # Query metadata
-            b_start_loc=b_start_loc,
-            b_seq_len=b_seq_len,
-            max_input_len=attn_metadata.max_query_len,
-            is_causal=is_causal,
-            softmax_scale=self.scale,
-            # KV metadata
-            b_start_loc_k=None,  # paged mode: KV offsets not needed
-            b_seq_len_k=seq_lens,  # total KV length per sequence
-            max_input_len_k=attn_metadata.max_seq_len,
-            # Paged KV cache
-            k_cache=key_cache,  # [num_blocks, page_size, num_kv_heads, head_dim]
-            v_cache=value_cache,  # [num_blocks, page_size, num_kv_heads, head_dim]
-            block_table=attn_metadata.block_table,  # [batch, max_blocks]
-            page_size=page_size,  # tokens per page in the KV cache
-            p_qdq=p_qdq,
-            p_qdq_amax=p_qdq_amax,
-            v_qdq=v_qdq,
-            v_qdq_amax=v_qdq_amax,
-            v_cache_quantized=v_cache_quantized,
-            **sparse_kw,
+            ),
         )
-
-        output[:num_actual_tokens] = triton_out
-        return output
-
-    def _forward_sparse_decode(
-        self,
-        *,
-        query: torch.Tensor,
-        key_cache: torch.Tensor,
-        value_cache: torch.Tensor,
-        page_size: int,
-        seq_lens: torch.Tensor,
-        block_table: torch.Tensor,
-        num_actual_tokens: int,
-        skip_softmax_threshold: float | None = None,
-        p_qdq: str | None = None,
-        p_qdq_amax: float = 1.0,
-        v_qdq: str | None = None,
-        v_qdq_amax: float | None = None,
-        v_cache_quantized: bool = False,
-        output: torch.Tensor,
-    ) -> torch.Tensor:
-        """Decode via the dedicated paged decode kernel (skip-softmax and/or P/V quant).
-
-        Standard decode schedules exactly one query token per request, so the
-        ``num_actual_tokens`` query rows are the per-request decode queries. The
-        decode kernel computes one query vector per ``(request, head)`` over the
-        paged cache (split-K over the KV sequence) and applies the same prefix-max
-        skip criterion as the prefill kernel, so realized decode sparsity matches
-        the calibrated ``(a, b)``. The prefill kernel would tile this single query
-        token into ``BLOCK_M`` rows, wasting ~127/128 of the work.
-        """
-        q = query[:num_actual_tokens].contiguous()  # [batch, num_q_heads, head_dim]
-        decode_out = attention_decode(
-            q,
-            key_cache,
-            value_cache,
-            block_table[:num_actual_tokens],
-            seq_lens[:num_actual_tokens],
-            softmax_scale=self.scale,
-            skip_softmax_threshold=skip_softmax_threshold,
-            page_size=page_size,
-            p_qdq=p_qdq,
-            p_qdq_amax=p_qdq_amax,
-            v_qdq=v_qdq,
-            v_qdq_amax=v_qdq_amax,
-            v_cache_quantized=v_cache_quantized,
-        )
-        output[:num_actual_tokens] = decode_out
-        return output
 
 
 class ModelOptSparseAttentionBackend(FlashAttentionBackend):
@@ -507,12 +578,18 @@ class ModelOptSparseAttentionBackend(FlashAttentionBackend):
         return ModelOptSparseAttentionImpl
 
 
-def _clone_sparse_impl(old_impl):
-    """Create a sparse impl while preserving vLLM's initialized runtime state."""
+def _clone_sparse_impl(old_impl, new_cls: type = ModelOptSparseAttentionImpl):
+    """Re-class a vLLM attention impl into ``new_cls``, preserving its state.
+
+    The new impl shares the backend impl's initialized runtime state (config,
+    scales, kv-cache dtype) so ``do_kv_cache_update`` and the dense-fallback
+    ``super().forward()`` keep working. ``new_cls`` selects the backend-specific
+    sparse impl (FlashAttention vs FlashInfer).
+    """
     if getattr(old_impl, "sinks", None) is not None:
         # vLLM passes sinks to FlashAttention as s_aux; our Triton path does not support sinks yet.
         raise NotImplementedError(
-            "ModelOptSparseAttentionImpl does not support vLLM FlashAttention sinks yet."
+            f"{new_cls.__name__} does not support vLLM FlashAttention sinks yet."
         )
 
     try:
@@ -522,6 +599,188 @@ def _clone_sparse_impl(old_impl):
             "Cannot clone vLLM attention impl state: old impl does not expose __dict__."
         ) from err
 
-    new_impl = ModelOptSparseAttentionImpl.__new__(ModelOptSparseAttentionImpl)
+    new_impl = object.__new__(new_cls)
     new_impl.__dict__.update(old_state)
     return new_impl
+
+
+# ---------------------------------------------------------------------------
+# FlashInfer backend support
+# ---------------------------------------------------------------------------
+# FlashInfer's per-step metadata only retains planned wrappers, not the dense
+# block_table / seq_lens / query_start_loc the ModelOpt paged kernel needs. Those
+# live on the CommonAttentionMetadata the builder consumes, so we stash them onto
+# the produced FlashInferMetadata (``_modelopt_*``) and read them back in forward.
+# The KV cache is ``[num_blocks, 2, page_size, num_kv_heads, head_dim]``
+# (``[:, 0]`` = K, ``[:, 1]`` = V); strides are passed through, so this is correct
+# for both NHD and HND physical layouts.
+
+_FLASHINFER_PATCHED = False
+_FLASHINFER_IMPL_CLS: type | None = None
+
+
+def patch_flashinfer_metadata_builder() -> bool:
+    """Stash the dense common metadata onto ``FlashInferMetadata`` at build time.
+
+    Idempotent. Returns ``True`` if the FlashInfer builder is now patched,
+    ``False`` if the FlashInfer backend is unavailable.
+    """
+    global _FLASHINFER_PATCHED
+    if _FLASHINFER_PATCHED:
+        return True
+    try:
+        from vllm.v1.attention.backends.flashinfer import FlashInferMetadataBuilder
+    except ImportError:
+        return False
+
+    orig_build = FlashInferMetadataBuilder.build
+    # Locate ``common_attn_metadata`` by parameter name so the wrapper is robust
+    # to the builder's positional signature (this vLLM build is
+    # ``build(self, common_prefix_len, common_attn_metadata, fast_build=False)``).
+    # Pass ``*args``/``**kwargs`` straight through to avoid re-binding positional
+    # args (re-passing common_attn_metadata first collided with common_prefix_len).
+    build_sig = inspect.signature(orig_build)
+
+    @functools.wraps(orig_build)
+    def build(*args, **kwargs):
+        metadata = orig_build(*args, **kwargs)
+        common = build_sig.bind(*args, **kwargs).arguments["common_attn_metadata"]
+        metadata._modelopt_block_table = common.block_table_tensor
+        metadata._modelopt_seq_lens = common.seq_lens
+        metadata._modelopt_query_start_loc = common.query_start_loc
+        metadata._modelopt_num_actual_tokens = common.num_actual_tokens
+        metadata._modelopt_max_query_len = common.max_query_len
+        metadata._modelopt_max_seq_len = common.max_seq_len
+        return metadata
+
+    FlashInferMetadataBuilder.build = build
+    _FLASHINFER_PATCHED = True
+    return True
+
+
+def get_flashinfer_sparse_impl_cls() -> type:
+    """Build (once) and return ``ModelOptSparseFlashInferImpl``.
+
+    Defined lazily so importing this module does not require the FlashInfer
+    backend (and its ``flashinfer`` dependency) to be installed.
+    """
+    global _FLASHINFER_IMPL_CLS
+    if _FLASHINFER_IMPL_CLS is not None:
+        return _FLASHINFER_IMPL_CLS
+
+    from vllm.v1.attention.backends.flashinfer import FlashInferImpl
+
+    class ModelOptSparseFlashInferImpl(_SparseAttentionMixin, FlashInferImpl):
+        """FlashInfer-backed attention impl with ModelOpt sparse + attention quant.
+
+        With the dense paged metadata stashed by
+        ``patch_flashinfer_metadata_builder`` available, it runs the ModelOpt
+        sparse/quant Triton kernel for sparse-or-quant launches, reading
+        FlashInfer's ``[num_blocks, 2, page, ...]`` cache (``[:, 0]`` = K,
+        ``[:, 1]`` = V). ``do_kv_cache_update`` and the dense fallback come from
+        ``FlashInferImpl`` so they match the FlashInfer KV cache.
+
+        Profiling (``attn_metadata is None``), cascade, an unpatched builder, or a
+        launch with no active sparse/quant feature fall back to native FlashInfer
+        (``FlashInferImpl.forward``) — mirroring ``ModelOptSparseAttentionImpl``.
+        """
+
+        def forward(
+            self,
+            layer,
+            query,
+            key,
+            value,
+            kv_cache,
+            attn_metadata,
+            output=None,
+            output_scale=None,
+            output_block_scale=None,
+        ):
+            """Sparse/quant-serve via the Triton kernel; delegate otherwise."""
+
+            def dense():
+                return FlashInferImpl.forward(
+                    self,
+                    layer,
+                    query,
+                    key,
+                    value,
+                    kv_cache,
+                    attn_metadata,
+                    output,
+                    output_scale,
+                    output_block_scale,
+                )
+
+            # Native FlashInfer for profiling, cascade, or an unpatched builder
+            # (the dense paged metadata the Triton kernel needs is unavailable).
+            # Cascade + active attention quant would silently serve P/V un-quantized;
+            # fail loud instead (the quant worker also disables cascade up front).
+            if attn_metadata is not None and getattr(attn_metadata, "use_cascade", False):
+                p_qdq, _ = _p_qdq_from_layer(layer)
+                v_qdq, _ = _v_qdq_from_layer(layer)
+                if p_qdq is not None or v_qdq is not None:
+                    raise NotImplementedError(
+                        "vLLM cascade attention is incompatible with ModelOpt attention "
+                        "quant (the native fallback would serve P/V un-quantized). Disable "
+                        "cascade (model_config.disable_cascade_attn=True) or the quantizers."
+                    )
+            if (
+                attn_metadata is None
+                or getattr(attn_metadata, "use_cascade", False)
+                or not hasattr(attn_metadata, "_modelopt_block_table")
+            ):
+                return dense()
+
+            assert output is not None, "Output tensor must be provided."
+            key_cache = kv_cache[:, 0]
+            value_cache = kv_cache[:, 1]
+            page_size = key_cache.shape[1]
+            seq_lens = attn_metadata._modelopt_seq_lens
+            cu_seqlens_q = attn_metadata._modelopt_query_start_loc
+            batch = seq_lens.shape[0]
+            b_start_loc = cu_seqlens_q[:batch]
+            b_seq_len = cu_seqlens_q[1 : batch + 1] - cu_seqlens_q[:batch]
+            max_query_len = attn_metadata._modelopt_max_query_len
+            is_decode_only = max_query_len <= 1
+
+            return self._forward_common(
+                layer=layer,
+                query=query,
+                key_cache=key_cache,
+                value_cache=value_cache,
+                page_size=page_size,
+                block_table=attn_metadata._modelopt_block_table,
+                b_start_loc=b_start_loc,
+                b_seq_len=b_seq_len,
+                seq_lens=seq_lens,
+                num_actual_tokens=attn_metadata._modelopt_num_actual_tokens,
+                max_query_len=max_query_len,
+                max_seq_len=attn_metadata._modelopt_max_seq_len,
+                is_decode_only=is_decode_only,
+                is_causal=not is_decode_only,
+                output=output,
+                dense_fallback=dense,
+            )
+
+    _FLASHINFER_IMPL_CLS = ModelOptSparseFlashInferImpl
+    return _FLASHINFER_IMPL_CLS
+
+
+def select_sparse_impl_cls(impl) -> type | None:
+    """Return the ModelOpt sparse impl class for a vLLM attention impl's backend.
+
+    ``None`` if ``impl`` is already a ModelOpt sparse impl or its backend is
+    unsupported. For FlashInfer it also installs the metadata-builder patch that
+    exposes the dense paged metadata the Triton kernel needs. Used by the worker
+    install step to swap the right impl per attention layer.
+    """
+    if isinstance(impl, _SparseAttentionMixin):
+        return None  # already swapped (idempotent across reloads)
+    name = type(impl).__name__
+    if name == "FlashAttentionImpl":
+        return ModelOptSparseAttentionImpl
+    if name == "FlashInferImpl":
+        return get_flashinfer_sparse_impl_cls() if patch_flashinfer_metadata_builder() else None
+    return None

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -236,6 +236,19 @@ class _SparseAttentionMixin:
     # Per-layer sparse kwargs set by the worker (empty when quant-only).
     sparse_kw: dict
 
+    def _modelopt_transform_active(self, layer) -> bool:
+        """True if this layer has a requested ModelOpt transform (P/V quant or sparsity).
+
+        A cascade launch or a launch missing the stashed paged metadata cannot run the ModelOpt
+        kernel; if a transform is active it must fail loud rather than silently serve native and
+        drop the requested quant/sparsity.
+        """
+        return (
+            _p_qdq_from_layer(layer)[0] is not None
+            or _v_qdq_from_layer(layer)[0] is not None
+            or bool(getattr(self, "sparse_kw", None))
+        )
+
     def _forward_common(
         self,
         *,
@@ -489,19 +502,16 @@ class ModelOptSparseAttentionImpl(_SparseAttentionMixin, FlashAttentionImpl):
             return output.fill_(0)
 
         if getattr(attn_metadata, "use_cascade", False):
-            # Cascade metadata splits a shared-prefix batch into prefix + suffix; the
-            # ModelOpt paged kernel consumes plain per-request KV lengths and cannot.
-            # For a sparse-only layer the native fallback is harmless (dense output, no
-            # skip-softmax). But when attention QUANT is active, native attention serves
-            # the model UN-quantized (wrong numerics, silently), so fail loud instead.
-            # The quant worker also disables cascade up front, so this should not be hit.
-            p_qdq, _ = _p_qdq_from_layer(layer)
-            v_qdq, _ = _v_qdq_from_layer(layer)
-            if p_qdq is not None or v_qdq is not None:
+            # Cascade metadata splits a shared-prefix batch into prefix + suffix; the ModelOpt paged
+            # kernel consumes plain per-request KV lengths and cannot. Serving native would silently
+            # drop the requested transform — for QUANT that is wrong numerics, and for SPARSITY the
+            # skip-softmax is lost — so fail loud whenever any transform is active (the worker also
+            # disables cascade up front). Nothing requested -> native is correct.
+            if self._modelopt_transform_active(layer):
                 raise NotImplementedError(
-                    "vLLM cascade attention is incompatible with ModelOpt attention "
-                    "quant (the native fallback would serve P/V un-quantized). Disable "
-                    "cascade (model_config.disable_cascade_attn=True) or the quantizers."
+                    "vLLM cascade attention is incompatible with an active ModelOpt attention plan "
+                    "(quant and/or sparsity) — the native fallback would silently drop it. Disable "
+                    "cascade (model_config.disable_cascade_attn=True)."
                 )
             return self._forward_vllm_flash_attn(
                 layer,
@@ -713,24 +723,27 @@ def get_flashinfer_sparse_impl_cls() -> type:
                     output_block_scale,
                 )
 
-            # Native FlashInfer for profiling, cascade, or an unpatched builder
-            # (the dense paged metadata the Triton kernel needs is unavailable).
-            # Cascade + active attention quant would silently serve P/V un-quantized;
-            # fail loud instead (the quant worker also disables cascade up front).
-            if attn_metadata is not None and getattr(attn_metadata, "use_cascade", False):
-                p_qdq, _ = _p_qdq_from_layer(layer)
-                v_qdq, _ = _v_qdq_from_layer(layer)
-                if p_qdq is not None or v_qdq is not None:
+            # Native FlashInfer only when nothing is requested. Profiling (no metadata) always
+            # delegates; but cascade or a missing metadata-builder patch would silently drop an
+            # active transform, so fail loud when one is active (the worker also disables cascade).
+            if attn_metadata is None:
+                return dense()  # profiling run
+            active = self._modelopt_transform_active(layer)
+            if getattr(attn_metadata, "use_cascade", False):
+                if active:
                     raise NotImplementedError(
-                        "vLLM cascade attention is incompatible with ModelOpt attention "
-                        "quant (the native fallback would serve P/V un-quantized). Disable "
-                        "cascade (model_config.disable_cascade_attn=True) or the quantizers."
+                        "vLLM cascade attention is incompatible with an active ModelOpt attention "
+                        "plan (quant and/or sparsity) — the native fallback would silently drop it. "
+                        "Disable cascade (model_config.disable_cascade_attn=True)."
                     )
-            if (
-                attn_metadata is None
-                or getattr(attn_metadata, "use_cascade", False)
-                or not hasattr(attn_metadata, "_modelopt_block_table")
-            ):
+                return dense()
+            if not hasattr(attn_metadata, "_modelopt_block_table"):
+                if active:
+                    raise NotImplementedError(
+                        "FlashInfer attn_metadata lacks the stashed ModelOpt paged fields (the "
+                        "metadata-builder patch did not apply); refusing to silently serve native "
+                        "and drop the requested attention quant/sparsity."
+                    )
                 return dense()
 
             assert output is not None, "Output tensor must be provided."

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -51,7 +51,7 @@ from modelopt.torch.kernels.common.attention.triton_fa import attention as trito
 
 def _target_sparse_ratio_for_phase(target_sparse_ratio, phase: str) -> float:
     """Return target sparsity for a phase, defaulting old checkpoint metadata."""
-    if isinstance(target_sparse_ratio, (float, int)):
+    if isinstance(target_sparse_ratio, float | int):
         return float(target_sparse_ratio)
     if isinstance(target_sparse_ratio, dict):
         return float(target_sparse_ratio.get(phase, 0.5))
@@ -188,13 +188,13 @@ def _assert_bmm_quant_supported(layer, name: str = "") -> None:
 
 
 def _bake_v_onwrite(value_cache, block_table, seq_lens, query_lens, page_size, v_qdq_amax, decode):
-    """Quantize-on-write the newly-complete BLOCK_N V tiles so decode reads them as-is.
+    """Finalize newly completed block-16 V groups from pristine cache values.
 
-    Bakes the tiles that completed since the previous step (``[prev, seq)`` clipped to whole
-    ``_ONWRITE_BLOCK_N`` tiles) into the paged cache, NVFP4, with the same scale the kernel applies
-    on read — turning decode V quant from ``O(S²)`` on-read into ``O(S)`` quantize-once. NVFP4-only;
-    the caller skips it for FP8 V.
+    Complete groups remain QDQ in the paged cache. The partial group stays pristine and is QDQ
+    on read by the attention kernel. NVFP4-only; FP8 V remains fully on-read.
     """
+    if v_qdq_amax is not None and not (math.isfinite(v_qdq_amax) and v_qdq_amax > 0):
+        raise ValueError(f"v_qdq_amax must be finite and positive, got {v_qdq_amax}")
     bn = _ONWRITE_BLOCK_N
     prev = (seq_lens - query_lens).to(torch.int32)
     seqk = seq_lens.to(torch.int32)
@@ -302,9 +302,8 @@ class _SparseAttentionMixin:
             if threshold is None and p_qdq is None and v_qdq is None:
                 # No decode sparsity and no BMM quant for this launch; native fallback.
                 return dense_fallback()
-            # NVFP4 V: bake the newly-complete tiles on write so the decode kernel reads them
-            # as-is (O(S)) instead of re-fake-quantizing the whole cache every step (O(S²)).
-            # FP8 V stays on-read. Bake BEFORE the attention so it reads the baked cache.
+            # NVFP4 V: finalize newly complete block-16 groups. The kernel QDQs the
+            # pristine partial group on read; FP8 V remains fully on-read.
             v_cache_quantized = v_qdq == "nvfp4"
             if v_cache_quantized:
                 _bake_v_onwrite(
@@ -346,11 +345,8 @@ class _SparseAttentionMixin:
         # so the kernel computes the correct GQA ratio (num_q_heads // num_kv_heads).
         k_dummy = torch.empty(0, self.num_kv_heads, self.head_size, device=q.device, dtype=q.dtype)
 
-        # NVFP4 V: bake the prompt's complete tiles on write BEFORE the kernel, so the kernel
-        # reads them as-is (V_CACHE_QUANTIZED) and re-fake-quantizes only the trailing partial.
-        # This quantizes each V tile exactly once — no double-quant of tiles a prior chunked-
-        # prefill step already baked — and still leaves decode a pre-quantized cache. FP8 V and
-        # no-quant stay fully on-read (v_cache_quantized False).
+        # Complete block-16 groups remain QDQ; the kernel QDQs the pristine partial group
+        # on read so P @ V still receives uniform QDQ values.
         v_cache_quantized = v_qdq == "nvfp4"
         if v_cache_quantized:
             _bake_v_onwrite(

--- a/tests/_test_utils/torch/quantization/tensor_quantizer_common.py
+++ b/tests/_test_utils/torch/quantization/tensor_quantizer_common.py
@@ -237,6 +237,48 @@ class TensorQuantizerTester:
         out = tq(x)
         assert out.shape == x.shape
 
+    def test_runtime_default_amax(self):
+        inputs = torch.tensor([-2.0, 4.0], device=self.device)
+        quantizer = TensorQuantizer().to(self.device)
+        runtime_amax = torch.tensor(2688.0, device=self.device)
+
+        quantizer._set_runtime_default_amax(runtime_amax)
+        torch.testing.assert_close(quantizer._get_amax(inputs), runtime_amax)
+        assert "_runtime_default_amax" not in quantizer.state_dict()
+        assert (
+            "_runtime_default_amax"
+            not in quantizer.get_modelopt_state()["_pytorch_state_metadata"]["buffers"]
+        )
+
+        calibrated_amax = torch.tensor(7.25, device=self.device)
+        quantizer.amax = calibrated_amax
+        torch.testing.assert_close(quantizer._get_amax(inputs), calibrated_amax)
+
+        quantizer._set_runtime_default_amax(None)
+        quantizer.reset_amax()
+        torch.testing.assert_close(quantizer._get_amax(inputs), inputs.abs().amax())
+
+    def test_runtime_default_amax_overrides_constant_amax(self):
+        inputs = torch.tensor([-2.0, 4.0], device=self.device)
+        quantizer = TensorQuantizer(QuantizerAttributeConfig(use_constant_amax=True)).to(
+            self.device
+        )
+        calibrated_amax = torch.tensor(7.25, device=self.device)
+        runtime_amax = torch.tensor(2688.0, device=self.device)
+
+        quantizer.amax = calibrated_amax
+        # Preserve legacy behavior before opt-in fallback.
+        assert quantizer._get_amax(inputs).item() == torch.finfo(torch.float8_e4m3fn).max
+
+        quantizer._set_runtime_default_amax(runtime_amax)
+        torch.testing.assert_close(quantizer._get_amax(inputs), calibrated_amax)
+
+        quantizer.reset_amax()
+        torch.testing.assert_close(quantizer._get_amax(inputs), runtime_amax)
+
+        quantizer._set_runtime_default_amax(None)
+        assert quantizer._get_amax(inputs).item() == torch.finfo(torch.float8_e4m3fn).max
+
     def test_use_constant_amax_skips_calibration(self):
         """Test that use_constant_amax quantizers are disabled during calibration and re-enabled after."""
         # Build a small model with one use_constant_amax quantizer and one normal quantizer

--- a/tests/gpu/torch/kernels/common/attention/test_attention_fakequant_conformance.py
+++ b/tests/gpu/torch/kernels/common/attention/test_attention_fakequant_conformance.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Conformance tests: the on-write V bake reproduces an INDEPENDENT canonical NVFP4 oracle.
+
+The prior V tests (test_decode_attention.py) compare the bake against itself (incremental vs
+one-shot) or against attention *outputs*, so a shared scale/rounding bug in the bake would pass.
+Here the reference uses ``NVFP4QTensor.quantize/dequantize`` on transposed V, so its last-axis
+block-16 contract becomes V's key axis. It never calls the attention kernel's V-QDQ helper. The
+tests check that complete groups stay QDQ while the partial group remains pristine for
+in-kernel QDQ on read.
+"""
+
+import pytest
+import torch
+
+from modelopt.torch.kernels.common.attention import IS_AVAILABLE as TRITON_KERNEL_AVAILABLE
+from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
+
+if TRITON_KERNEL_AVAILABLE:
+    from modelopt.torch.kernels.common.attention.decode_attention import fake_quant_v_onwrite
+
+_NVFP4_BLOCK_SIZE = 16
+
+# NVFP4's E4M3 block scale uses ``tl.float8e4nv``, which requires SM89+ (Ada/Hopper/Blackwell).
+_HAS_SM89 = (
+    TRITON_KERNEL_AVAILABLE
+    and torch.cuda.is_available()
+    and torch.cuda.get_device_capability() >= (8, 9)
+)
+pytestmark = pytest.mark.skipif(not _HAS_SM89, reason="NVFP4 V bake uses tl.float8e4nv (sm_89+)")
+
+
+def _nvfp4_v_oracle(v: torch.Tensor, global_scale: float = 1.0) -> torch.Tensor:
+    """Canonical NVFP4 QDQ of ``[keys, head_dim]`` with block-16 along keys."""
+    seq_len = v.shape[0]
+    padded_len = ((seq_len + _NVFP4_BLOCK_SIZE - 1) // _NVFP4_BLOCK_SIZE) * _NVFP4_BLOCK_SIZE
+    padded = torch.zeros(padded_len, v.shape[1], device=v.device, dtype=v.dtype)
+    padded[:seq_len] = v
+    transposed = padded.T.contiguous()
+    q, scale, double_scale = NVFP4QTensor.quantize(
+        transposed,
+        _NVFP4_BLOCK_SIZE,
+        weights_scaling_factor_2=torch.tensor(global_scale, device=v.device),
+        try_tensorrt=False,
+    )
+    dequant = q.dequantize(
+        dtype=v.dtype,
+        scale=scale,
+        double_scale=double_scale,
+        block_sizes={-1: _NVFP4_BLOCK_SIZE},
+    )
+    return dequant.T[:seq_len].contiguous()
+
+
+def _make_paged_v(v: torch.Tensor, page_size: int):
+    """Scatter ``v`` [seq, head_dim] into a single-request paged cache [num_blocks, page, 1, D]."""
+    seq, head_dim = v.shape
+    num_blocks = (seq + page_size - 1) // page_size
+    cache = torch.zeros(num_blocks, page_size, 1, head_dim, device=v.device, dtype=v.dtype)
+    block_table = torch.arange(num_blocks, device=v.device, dtype=torch.int32).view(1, num_blocks)
+    for blk in range(num_blocks):
+        start, end = blk * page_size, min((blk + 1) * page_size, seq)
+        cache[blk, : end - start, 0] = v[start:end]
+    return cache, block_table
+
+
+def _gather_v(cache: torch.Tensor, block_table: torch.Tensor, seq: int) -> torch.Tensor:
+    """Reconstruct ``[seq, head_dim]`` from the paged cache via the block table (reverse of scatter)."""
+    page_size, head_dim = cache.shape[1], cache.shape[3]
+    out = torch.empty(seq, head_dim, device=cache.device, dtype=cache.dtype)
+    for blk in range(block_table.shape[1]):
+        start, end = blk * page_size, min((blk + 1) * page_size, seq)
+        if start >= seq:
+            break
+        out[start:end] = cache[int(block_table[0, blk]), : end - start, 0]
+    return out
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("page_size", [16, 32, 64, 128])
+@pytest.mark.parametrize("seq_len", [15, 16, 17, 127, 128, 129, 255, 256, 257])
+def test_baked_v_matches_independent_oracle(seq_len, page_size, dtype):
+    """Persistent groups match canonical QDQ and the partial group remains pristine."""
+    torch.manual_seed(seq_len * 100 + page_size)
+    head_dim = 128
+    v = torch.randn(seq_len, head_dim, device="cuda", dtype=dtype)
+    v[:, 0] = 0.017578125  # a block where QDQ(QDQ(V)) differs from QDQ(V)
+    cache, block_table = _make_paged_v(v, page_size)
+    raw = cache.clone()
+
+    baked_len = (seq_len // _NVFP4_BLOCK_SIZE) * _NVFP4_BLOCK_SIZE
+    v_lo = torch.zeros(1, device="cuda", dtype=torch.int32)
+    v_hi = torch.tensor([baked_len], device="cuda", dtype=torch.int32)
+    fake_quant_v_onwrite(cache, block_table, v_lo, v_hi, page_size=page_size)  # global scale 1.0
+
+    if baked_len > 0:
+        baked = _gather_v(cache, block_table, baked_len)
+        oracle = _nvfp4_v_oracle(v[:baked_len], global_scale=1.0)
+        torch.testing.assert_close(baked, oracle, rtol=0, atol=0)
+
+    if baked_len < seq_len:
+        trailing_baked = _gather_v(cache, block_table, seq_len)[baked_len:]
+        trailing_raw = _gather_v(raw, block_table, seq_len)[baked_len:]
+        torch.testing.assert_close(trailing_baked, trailing_raw, rtol=0, atol=0)
+
+
+def test_bake_is_non_trivial():
+    """Sanity: the bake actually quantizes (baked != raw), so a no-op bake cannot pass silently."""
+    torch.manual_seed(7)
+    v = torch.randn(_NVFP4_BLOCK_SIZE, 128, device="cuda", dtype=torch.float16)
+    cache, block_table = _make_paged_v(v, page_size=16)
+    raw = cache.clone()
+    fake_quant_v_onwrite(
+        cache,
+        block_table,
+        torch.zeros(1, device="cuda", dtype=torch.int32),
+        torch.tensor([_NVFP4_BLOCK_SIZE], device="cuda", dtype=torch.int32),
+        page_size=16,
+    )
+    assert not torch.equal(cache, raw)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_baked_v_matches_calibrated_global_scale(dtype):
+    """A calibrated per-tensor scale uses the same numerical contract as the oracle."""
+    torch.manual_seed(19)
+    v = torch.randn(16, 128, device="cuda", dtype=dtype)
+    cache, block_table = _make_paged_v(v, page_size=16)
+    global_scale = 0.125
+    fake_quant_v_onwrite(
+        cache,
+        block_table,
+        torch.zeros(1, device="cuda", dtype=torch.int32),
+        torch.tensor([16], device="cuda", dtype=torch.int32),
+        page_size=16,
+        v_qdq_scale=global_scale,
+    )
+    torch.testing.assert_close(
+        _gather_v(cache, block_table, 16),
+        _nvfp4_v_oracle(v, global_scale=global_scale),
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_oracle_detects_double_qdq(dtype):
+    """The conformance fixture must fail if a completed group is quantized twice."""
+    raw = torch.full((16, 128), 0.017578125, device="cuda", dtype=dtype)
+    once = _nvfp4_v_oracle(raw)
+    twice = _nvfp4_v_oracle(once)
+    assert once[0, 0] == 0.015625
+    assert twice[0, 0] == 0.01171875
+    assert not torch.equal(once, twice)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
+++ b/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
@@ -28,7 +28,10 @@ pytestmark = [
 from modelopt.torch.kernels.common.attention import IS_AVAILABLE as TRITON_KERNEL_AVAILABLE
 
 if TRITON_KERNEL_AVAILABLE:
-    from modelopt.torch.kernels.common.attention.decode_attention import attention_decode
+    from modelopt.torch.kernels.common.attention.decode_attention import (
+        attention_decode,
+        fake_quant_v_onwrite,
+    )
 
 
 def _paged_cache(k, v, seq_lens, page_size):
@@ -247,6 +250,43 @@ class TestDecodeAttention:
         ref = _dense_decode(q, k, v, scale)
         cos = F.cosine_similarity(out.flatten().float(), ref.flatten().float(), dim=0)
         assert cos > 0.99, (p_qdq, v_qdq, float(cos))
+
+    @pytest.mark.skipif(
+        not (torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 9)),
+        reason="NVFP4 qdq uses tl.float8e4nv (sm_89+)",
+    )
+    def test_onwrite_v_matches_onread(self):
+        """On-write V baking is exactly Option 3 (validated on B200).
+
+        (A) The bake reproduces the on-read fake-quant of every complete tile **bit-for-bit**:
+            FQ-all on the baked cache equals FQ-all on the raw cache (quantize-once == re-quant-
+            every-read; re-fake-quantizing already-baked tiles is idempotent).
+        (B) The read-as-is path (``v_cache_quantized=True``) matches on-read within an fp32-reduction
+            tolerance: the V values are identical per (A), but reading baked tiles as-is vs fake-
+            quantizing on read compiles to a slightly different fp32 reduction order (~1e-5).
+        """
+        batch, seq_k, head_dim, page_size = 2, 1000, 128, 16  # 7 complete 128-tiles + 104 trailing
+        scale = 1.0 / (head_dim**0.5)
+        q, k, v, seq_lens = self._inputs(batch, 16, 16, seq_k, head_dim, seed=11)
+        k_cache, v_cache, block_table = _paged_cache(k, v, seq_lens, page_size)
+        kw = {"softmax_scale": scale, "page_size": page_size, "num_kv_splits": 1, "v_qdq": "nvfp4"}
+
+        out_onread = attention_decode(q, k_cache, v_cache, block_table, seq_lens, **kw)
+
+        v_baked = v_cache.clone()
+        v_lo = torch.zeros(batch, device=q.device, dtype=torch.int32)
+        v_hi = ((seq_lens // 128) * 128).to(torch.int32)
+        fake_quant_v_onwrite(v_baked, block_table, v_lo, v_hi, page_size=page_size)
+
+        # (A) bit-identical V values: FQ-all on the baked cache == FQ-all on the raw cache.
+        out_onread_baked = attention_decode(q, k_cache, v_baked, block_table, seq_lens, **kw)
+        torch.testing.assert_close(out_onread_baked, out_onread, rtol=0, atol=0)
+
+        # (B) read-as-is matches within the fp32-reduction ordering of the two compiled paths.
+        out_onwrite = attention_decode(
+            q, k_cache, v_baked, block_table, seq_lens, v_cache_quantized=True, **kw
+        )
+        torch.testing.assert_close(out_onwrite, out_onread, rtol=2e-3, atol=2e-3)
 
 
 if __name__ == "__main__":

--- a/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
+++ b/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
@@ -214,6 +214,40 @@ class TestDecodeAttention:
             ref = _dense_decode(q[b : b + 1], k[b : b + 1, :, :sl], v[b : b + 1, :, :sl], scale)
             torch.testing.assert_close(out[b : b + 1], ref, rtol=5e-3, atol=5e-3)
 
+    @pytest.mark.skipif(
+        not (torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 9)),
+        reason="FP8/NVFP4 qdq uses tl.float8e4nv (sm_89+)",
+    )
+    @pytest.mark.parametrize(
+        ("p_qdq", "v_qdq"), [(None, "nvfp4"), ("nvfp4", "nvfp4"), (None, "fp8")]
+    )
+    def test_bmm2_qdq_close_to_dense(self, p_qdq, v_qdq):
+        """In-kernel P/V quant-dequant of BMM2 stays close to dense decode.
+
+        V is fake-quantized on read with NVFP4 blocks of 16 along the key axis
+        (BMM2 contraction) — the keys-axis blocking a per-token cache write cannot
+        produce. Small block-16 quant error => high cosine vs the dense fp32 result.
+        """
+        batch, seq_k, head_dim, page_size = 2, 1024, 128, 16
+        scale = 1.0 / (head_dim**0.5)
+        q, k, v, seq_lens = self._inputs(batch, 16, 16, seq_k, head_dim, seed=7)
+        k_cache, v_cache, block_table = _paged_cache(k, v, seq_lens, page_size)
+
+        out = attention_decode(
+            q,
+            k_cache,
+            v_cache,
+            block_table,
+            seq_lens,
+            softmax_scale=scale,
+            page_size=page_size,
+            p_qdq=p_qdq,
+            v_qdq=v_qdq,
+        )
+        ref = _dense_decode(q, k, v, scale)
+        cos = F.cosine_similarity(out.flatten().float(), ref.flatten().float(), dim=0)
+        assert cos > 0.99, (p_qdq, v_qdq, float(cos))
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
+++ b/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
@@ -17,6 +17,7 @@
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 pytestmark = [
     pytest.mark.filterwarnings("ignore::UserWarning"),
@@ -82,6 +83,28 @@ class TestDecodeAttention:
             q, k_cache, v_cache, block_table, seq_lens, softmax_scale=scale, page_size=page_size
         )
         torch.testing.assert_close(out, _dense_decode(q, k, v, scale), rtol=5e-3, atol=5e-3)
+
+    @pytest.mark.parametrize(("num_q_heads", "num_kv_heads"), [(32, 8), (16, 16)])
+    def test_matches_pytorch_sdpa(self, num_q_heads, num_kv_heads):
+        """The decode kernel matches PyTorch native scaled_dot_product_attention (fp16)."""
+        batch, seq_k, head_dim, page_size = 2, 1024, 128, 16
+        scale = 1.0 / (head_dim**0.5)
+        q, k, v, seq_lens = self._inputs(batch, num_q_heads, num_kv_heads, seq_k, head_dim, seed=5)
+        k_cache, v_cache, block_table = _paged_cache(k, v, seq_lens, page_size)
+
+        out = attention_decode(
+            q, k_cache, v_cache, block_table, seq_lens, softmax_scale=scale, page_size=page_size
+        )
+        # Native attention: the single decode query [B,H,1,D] attends to all KV.
+        g = num_q_heads // num_kv_heads
+        ref = F.scaled_dot_product_attention(
+            q.unsqueeze(2),
+            k.repeat_interleave(g, dim=1),
+            v.repeat_interleave(g, dim=1),
+            scale=scale,
+            is_causal=False,
+        ).squeeze(2)
+        torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-2)
 
     def test_tiny_threshold_matches_dense(self):
         """A near-zero lambda skips almost nothing, so output stays close to dense."""

--- a/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
+++ b/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU tests for the paged decode attention kernel (with optional skip-softmax)."""
+
+import pytest
+import torch
+
+pytestmark = [
+    pytest.mark.filterwarnings("ignore::UserWarning"),
+    pytest.mark.filterwarnings("ignore::RuntimeWarning"),
+    pytest.mark.filterwarnings("ignore::DeprecationWarning"),
+]
+
+from modelopt.torch.kernels.common.attention import IS_AVAILABLE as TRITON_KERNEL_AVAILABLE
+
+if TRITON_KERNEL_AVAILABLE:
+    from modelopt.torch.kernels.common.attention.decode_attention import attention_decode
+
+
+def _paged_cache(k, v, seq_lens, page_size):
+    """[B, KVH, S, D] K/V -> paged [num_blocks, page_size, KVH, D] + block_table."""
+    batch, num_kv, _seq, head_dim = k.shape
+    blocks = [(int(seq_lens[b].item()) + page_size - 1) // page_size for b in range(batch)]
+    k_cache = torch.zeros(sum(blocks), page_size, num_kv, head_dim, device=k.device, dtype=k.dtype)
+    v_cache = torch.zeros_like(k_cache)
+    block_table = torch.zeros(batch, max(blocks), device=k.device, dtype=torch.int32)
+    g = 0
+    for b in range(batch):
+        sl = int(seq_lens[b].item())
+        kb, vb = k[b].transpose(0, 1), v[b].transpose(0, 1)  # [S, KVH, D]
+        for blk in range(blocks[b]):
+            block_table[b, blk] = g
+            ts, te = blk * page_size, min((blk + 1) * page_size, sl)
+            k_cache[g, : te - ts] = kb[ts:te]
+            v_cache[g, : te - ts] = vb[ts:te]
+            g += 1
+    return k_cache, v_cache, block_table
+
+
+def _dense_decode(q, k, v, scale):
+    """Reference decode attention. q [B,H,D]; k,v [B,KVH,S,D] (GQA)."""
+    num_q, num_kv = q.shape[1], k.shape[1]
+    kk = k.repeat_interleave(num_q // num_kv, dim=1)
+    vv = v.repeat_interleave(num_q // num_kv, dim=1)
+    scores = torch.matmul(q.unsqueeze(2), kk.transpose(-2, -1)).squeeze(2) * scale  # [B,H,S]
+    p = scores.float().softmax(dim=-1).to(v.dtype)
+    return torch.matmul(p.unsqueeze(2), vv).squeeze(2)  # [B,H,D]
+
+
+@pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
+class TestDecodeAttention:
+    def _inputs(self, batch, num_q_heads, num_kv_heads, seq_k, head_dim, seed=0):
+        torch.manual_seed(seed)
+        q = torch.randn(batch, num_q_heads, head_dim, device="cuda", dtype=torch.float16)
+        k = torch.randn(batch, num_kv_heads, seq_k, head_dim, device="cuda", dtype=torch.float16)
+        v = torch.randn(batch, num_kv_heads, seq_k, head_dim, device="cuda", dtype=torch.float16)
+        seq_lens = torch.full((batch,), seq_k, device="cuda", dtype=torch.int32)
+        return q, k, v, seq_lens
+
+    @pytest.mark.parametrize(("num_q_heads", "num_kv_heads"), [(4, 4), (8, 2)])
+    def test_matches_dense_no_skip(self, num_q_heads, num_kv_heads):
+        """Without skipping, the kernel computes exact dense decode attention."""
+        batch, seq_k, head_dim, page_size = 3, 500, 64, 16
+        scale = 1.0 / (head_dim**0.5)
+        q, k, v, seq_lens = self._inputs(batch, num_q_heads, num_kv_heads, seq_k, head_dim)
+        k_cache, v_cache, block_table = _paged_cache(k, v, seq_lens, page_size)
+
+        out = attention_decode(
+            q, k_cache, v_cache, block_table, seq_lens, softmax_scale=scale, page_size=page_size
+        )
+        torch.testing.assert_close(out, _dense_decode(q, k, v, scale), rtol=5e-3, atol=5e-3)
+
+    def test_tiny_threshold_matches_dense(self):
+        """A near-zero lambda skips almost nothing, so output stays close to dense."""
+        batch, seq_k, head_dim, page_size = 2, 384, 64, 16
+        scale = 1.0 / (head_dim**0.5)
+        q, k, v, seq_lens = self._inputs(batch, 4, 2, seq_k, head_dim, seed=1)
+        k_cache, v_cache, block_table = _paged_cache(k, v, seq_lens, page_size)
+
+        out = attention_decode(
+            q,
+            k_cache,
+            v_cache,
+            block_table,
+            seq_lens,
+            softmax_scale=scale,
+            skip_softmax_threshold=2**-20,
+            page_size=page_size,
+        )
+        torch.testing.assert_close(out, _dense_decode(q, k, v, scale), rtol=1e-2, atol=1e-2)
+
+    def test_sink_skips_most_tiles(self):
+        """A dominant sink at position 0 makes distant tiles negligible -> skipped."""
+        batch, seq_k, head_dim, page_size = 1, 2048, 64, 16
+        scale = 1.0 / (head_dim**0.5)
+        q = torch.ones(batch, 4, head_dim, device="cuda", dtype=torch.float16)
+        k = torch.zeros(batch, 4, seq_k, head_dim, device="cuda", dtype=torch.float16)
+        k[:, :, 0] = 20.0  # sink dominates every query
+        v = torch.randn(batch, 4, seq_k, head_dim, device="cuda", dtype=torch.float16)
+        seq_lens = torch.full((batch,), seq_k, device="cuda", dtype=torch.int32)
+        k_cache, v_cache, block_table = _paged_cache(k, v, seq_lens, page_size)
+
+        out = attention_decode(
+            q,
+            k_cache,
+            v_cache,
+            block_table,
+            seq_lens,
+            softmax_scale=scale,
+            skip_softmax_threshold=0.1,
+            page_size=page_size,
+            num_kv_splits=1,  # single split => global prefix max => maximal skipping
+            measure_sparsity=True,
+        )
+        # Sink => the vast majority of the 2048/128 = 16 tiles/head are skippable.
+        total, skipped = out._sparsity_total, out._sparsity_skipped
+        assert total == 4 * (seq_k // 128), (total, skipped)
+        assert skipped / total > 0.8, (skipped, total)
+        # Output still tracks the (sink-dominated) dense result.
+        torch.testing.assert_close(out, _dense_decode(q, k, v, scale), rtol=5e-2, atol=5e-2)
+
+    @pytest.mark.parametrize("num_kv_splits", [1, 2, 4, 8, 16])
+    def test_split_k_matches_dense(self, num_kv_splits):
+        """Split-K combine is numerically exact regardless of the split count."""
+        batch, seq_k, head_dim, page_size = 2, 1000, 64, 16
+        scale = 1.0 / (head_dim**0.5)
+        q, k, v, seq_lens = self._inputs(batch, 8, 2, seq_k, head_dim, seed=3)
+        k_cache, v_cache, block_table = _paged_cache(k, v, seq_lens, page_size)
+
+        out = attention_decode(
+            q,
+            k_cache,
+            v_cache,
+            block_table,
+            seq_lens,
+            softmax_scale=scale,
+            page_size=page_size,
+            num_kv_splits=num_kv_splits,
+        )
+        torch.testing.assert_close(out, _dense_decode(q, k, v, scale), rtol=5e-3, atol=5e-3)
+
+    @pytest.mark.parametrize("num_kv_splits", [2, 4])
+    def test_split_k_with_tiny_threshold_matches_dense(self, num_kv_splits):
+        """Skip + split-K compose: a near-zero lambda still matches dense."""
+        batch, seq_k, head_dim, page_size = 2, 768, 64, 16
+        scale = 1.0 / (head_dim**0.5)
+        q, k, v, seq_lens = self._inputs(batch, 4, 2, seq_k, head_dim, seed=4)
+        k_cache, v_cache, block_table = _paged_cache(k, v, seq_lens, page_size)
+
+        out = attention_decode(
+            q,
+            k_cache,
+            v_cache,
+            block_table,
+            seq_lens,
+            softmax_scale=scale,
+            skip_softmax_threshold=2**-20,
+            page_size=page_size,
+            num_kv_splits=num_kv_splits,
+        )
+        torch.testing.assert_close(out, _dense_decode(q, k, v, scale), rtol=1e-2, atol=1e-2)
+
+    def test_varlen_lengths(self):
+        """Per-request KV lengths (non-uniform, non-page-aligned) are handled."""
+        batch, num_q_heads, num_kv_heads, head_dim, page_size = 3, 4, 2, 64, 16
+        scale = 1.0 / (head_dim**0.5)
+        seq_k = 600
+        q, k, v, _ = self._inputs(batch, num_q_heads, num_kv_heads, seq_k, head_dim, seed=2)
+        seq_lens = torch.tensor([130, 511, 600], device="cuda", dtype=torch.int32)
+        k_cache, v_cache, block_table = _paged_cache(k, v, seq_lens, page_size)
+
+        out = attention_decode(
+            q, k_cache, v_cache, block_table, seq_lens, softmax_scale=scale, page_size=page_size
+        )
+        # Reference must honor each request's own KV length.
+        for b in range(batch):
+            sl = int(seq_lens[b].item())
+            ref = _dense_decode(q[b : b + 1], k[b : b + 1, :, :sl], v[b : b + 1, :, :sl], scale)
+            torch.testing.assert_close(out[b : b + 1], ref, rtol=5e-3, atol=5e-3)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
+++ b/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
@@ -288,6 +288,62 @@ class TestDecodeAttention:
         )
         torch.testing.assert_close(out_onwrite, out_onread, rtol=2e-3, atol=2e-3)
 
+    @pytest.mark.skipif(
+        not (torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 9)),
+        reason="NVFP4 qdq uses tl.float8e4nv (sm_89+)",
+    )
+    def test_quant_plus_skip_softmax_compose(self):
+        """Attention quant (P/V NVFP4) and skip-softmax compose in a single launch.
+
+        Two checks that the two features stack without interfering:
+        (1) near-off skip (tiny lambda) + quant == quant-only — skip never fires, so the
+            output is unchanged from quant alone (the features are independent).
+        (2) aggressive skip on a dominant sink + quant still drops most tiles AND tracks the
+            (sink-dominated) dense result — skip selects tiles on the quantized scores while
+            P/V are fake-quantized on the surviving tiles.
+        """
+        qkw = {"p_qdq": "nvfp4", "v_qdq": "nvfp4", "num_kv_splits": 1, "page_size": 16}
+
+        # (1) quant-only vs quant + near-off skip (tiny lambda skips ~nothing).
+        b, s, d = 2, 1024, 128
+        scale = 1.0 / (d**0.5)
+        q, k, v, seq_lens = self._inputs(b, 16, 16, s, d, seed=9)
+        kc, vc, bt = _paged_cache(k, v, seq_lens, 16)
+        out_q = attention_decode(q, kc, vc, bt, seq_lens, softmax_scale=scale, **qkw)
+        out_qs = attention_decode(
+            q, kc, vc, bt, seq_lens, softmax_scale=scale, skip_softmax_threshold=2**-20, **qkw
+        )
+        torch.testing.assert_close(out_qs, out_q, rtol=1e-2, atol=1e-2)
+
+        # (2) quant + aggressive skip on a dominant sink: most tiles drop, output tracks dense.
+        bs, ss, ds = 1, 2048, 128
+        scale_s = 1.0 / (ds**0.5)
+        qs = torch.ones(bs, 16, ds, device="cuda", dtype=torch.float16)
+        ks = torch.zeros(bs, 16, ss, ds, device="cuda", dtype=torch.float16)
+        ks[:, :, 0] = 20.0  # sink dominates every query
+        vs = torch.randn(bs, 16, ss, ds, device="cuda", dtype=torch.float16)
+        sl = torch.full((bs,), ss, device="cuda", dtype=torch.int32)
+        kcs, vcs, bts = _paged_cache(ks, vs, sl, 16)
+        out = attention_decode(
+            qs,
+            kcs,
+            vcs,
+            bts,
+            sl,
+            softmax_scale=scale_s,
+            skip_softmax_threshold=0.1,
+            measure_sparsity=True,
+            **qkw,
+        )
+        assert out._sparsity_skipped / out._sparsity_total > 0.8, (
+            out._sparsity_skipped,
+            out._sparsity_total,
+        )
+        cos = F.cosine_similarity(
+            out.flatten().float(), _dense_decode(qs, ks, vs, scale_s).flatten().float(), dim=0
+        )
+        assert cos > 0.95, float(cos)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
+++ b/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
@@ -256,18 +256,13 @@ class TestDecodeAttention:
         reason="NVFP4 qdq uses tl.float8e4nv (sm_89+)",
     )
     def test_onwrite_v_matches_onread(self):
-        """On-write V baking is exactly Option 3 (validated on B200).
-
-        (A) The bake reproduces the on-read fake-quant of every complete tile **bit-for-bit**:
-            FQ-all on the baked cache equals FQ-all on the raw cache (quantize-once == re-quant-
-            every-read; re-fake-quantizing already-baked tiles is idempotent).
-        (B) The read-as-is path (``v_cache_quantized=True``) matches on-read within an fp32-reduction
-            tolerance: the V values are identical per (A), but reading baked tiles as-is vs fake-
-            quantizing on read compiles to a slightly different fp32 reduction order (~1e-5).
-        """
-        batch, seq_k, head_dim, page_size = 2, 1000, 128, 16  # 7 complete 128-tiles + 104 trailing
+        """Block-16 baking plus tail QDQ matches pristine on-read QDQ in decode."""
+        batch, seq_k, head_dim, page_size = 2, 17, 128, 16
         scale = 1.0 / (head_dim**0.5)
         q, k, v, seq_lens = self._inputs(batch, 16, 16, seq_k, head_dim, seed=11)
+        q.zero_()
+        k.zero_()
+        v.fill_(0.017578125)  # QDQ once -> 0.015625; twice -> 0.01171875
         k_cache, v_cache, block_table = _paged_cache(k, v, seq_lens, page_size)
         kw = {"softmax_scale": scale, "page_size": page_size, "num_kv_splits": 1, "v_qdq": "nvfp4"}
 
@@ -275,18 +270,12 @@ class TestDecodeAttention:
 
         v_baked = v_cache.clone()
         v_lo = torch.zeros(batch, device=q.device, dtype=torch.int32)
-        v_hi = ((seq_lens // 128) * 128).to(torch.int32)
-        fake_quant_v_onwrite(v_baked, block_table, v_lo, v_hi, page_size=page_size)
-
-        # (A) bit-identical V values: FQ-all on the baked cache == FQ-all on the raw cache.
-        out_onread_baked = attention_decode(q, k_cache, v_baked, block_table, seq_lens, **kw)
-        torch.testing.assert_close(out_onread_baked, out_onread, rtol=0, atol=0)
-
-        # (B) read-as-is matches within the fp32-reduction ordering of the two compiled paths.
+        v_hi = ((seq_lens // 16) * 16).to(torch.int32)
+        fake_quant_v_onwrite(v_baked, block_table, v_lo, v_hi, page_size=page_size, decode=True)
         out_onwrite = attention_decode(
             q, k_cache, v_baked, block_table, seq_lens, v_cache_quantized=True, **kw
         )
-        torch.testing.assert_close(out_onwrite, out_onread, rtol=2e-3, atol=2e-3)
+        torch.testing.assert_close(out_onwrite, out_onread, rtol=1e-4, atol=1e-5)
 
     @pytest.mark.skipif(
         not (torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 9)),
@@ -351,9 +340,9 @@ class TestDecodeAttention:
     reason="NVFP4 qdq uses tl.float8e4nv (sm_89+)",
 )
 class TestOnwriteVBakeLifecycle:
-    """The in-place 128-token V bake is schedule-independent and only ever touches new tiles.
+    """Complete block-16 groups are finalized once while the partial group stays pristine.
 
-    ``fake_quant_v_onwrite`` bakes complete ``_ONWRITE_BLOCK_N`` (128) tiles in ``[v_lo, v_hi)``.
+    ``fake_quant_v_onwrite`` bakes complete block-16 groups in ``[v_lo, v_hi)``.
     Correctness requires each tile be baked exactly once from the pristine V: NVFP4 block QDQ is not
     generally idempotent (a re-bake recomputes the E4M3 block scale from the already-quantized amax,
     which can shift), so a double-bake would drift. These tests prove the incremental (chunked-write)
@@ -361,7 +350,7 @@ class TestOnwriteVBakeLifecycle:
     an earlier (already-baked) or trailing (still-partial) tile.
     """
 
-    _BN = 128  # _ONWRITE_BLOCK_N: the on-write bake tile size
+    _BN = 16
 
     def _v_cache(self, batch, seq_k, head_dim, page_size, seed, dtype):
         torch.manual_seed(seed)
@@ -379,16 +368,14 @@ class TestOnwriteVBakeLifecycle:
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
     @pytest.mark.parametrize("page_size", [16, 32, 64])
     def test_incremental_bake_equals_one_shot(self, dtype, page_size):
-        """Baking [0,128) then [128,256) as the sequence grows equals a single [0,256) bake."""
-        batch, seq_k, head_dim = 2, 300, 128  # two complete 128-tiles + a 44-token trailing tile
+        """Baking two completed groups incrementally equals baking both in one launch."""
+        batch, seq_k, head_dim = 2, 44, 128
         v_inc, block_table = self._v_cache(batch, seq_k, head_dim, page_size, seed=3, dtype=dtype)
         raw = v_inc.clone()
         v_one = v_inc.clone()
 
-        # Incremental: bake each 128-tile as it completes.
         self._bake(v_inc, block_table, 0, self._BN, page_size, batch)
         self._bake(v_inc, block_table, self._BN, 2 * self._BN, page_size, batch)
-        # One-shot: bake both complete tiles at once.
         self._bake(v_one, block_table, 0, 2 * self._BN, page_size, batch)
 
         torch.testing.assert_close(v_inc, v_one, rtol=0, atol=0)
@@ -397,25 +384,19 @@ class TestOnwriteVBakeLifecycle:
 
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
     def test_bake_leaves_earlier_and_trailing_tiles_untouched(self, dtype):
-        """Baking a later tile must not rewrite an already-baked tile or a still-partial trailing one.
-
-        With page_size == 128 each 128-token tile is exactly one page, so the invariant reduces to a
-        bit-for-bit page comparison (no double-bake of tile 0; the 44-token trailing tile stays raw).
-        """
-        batch, seq_k, head_dim, page_size = 2, 300, 128, 128
+        """Baking a later group leaves the prior group and partial tail untouched."""
+        batch, seq_k, head_dim, page_size = 2, 44, 128, 64
         v_cache, block_table = self._v_cache(batch, seq_k, head_dim, page_size, seed=5, dtype=dtype)
         raw = v_cache.clone()
 
-        self._bake(v_cache, block_table, 0, self._BN, page_size, batch)  # bake tile 0 (page g0)
+        self._bake(v_cache, block_table, 0, self._BN, page_size, batch)
         after_first = v_cache.clone()
-        self._bake(v_cache, block_table, self._BN, 2 * self._BN, page_size, batch)  # bake tile 1
+        self._bake(v_cache, block_table, self._BN, 2 * self._BN, page_size, batch)
 
         for b in range(batch):
-            g0, g2 = int(block_table[b, 0]), int(block_table[b, 2])
-            # Tile 0's page is unchanged by the second bake (baked once, never re-baked).
-            torch.testing.assert_close(v_cache[g0], after_first[g0], rtol=0, atol=0)
-            # The trailing partial tile ([256,300), < 128 tokens) is never a complete tile: stays raw.
-            torch.testing.assert_close(v_cache[g2], raw[g2], rtol=0, atol=0)
+            page = int(block_table[b, 0])
+            torch.testing.assert_close(v_cache[page, :16], after_first[page, :16], rtol=0, atol=0)
+            torch.testing.assert_close(v_cache[page, 32:44], raw[page, 32:44], rtol=0, atol=0)
 
 
 if __name__ == "__main__":

--- a/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
+++ b/tests/gpu/torch/kernels/common/attention/test_decode_attention.py
@@ -345,5 +345,78 @@ class TestDecodeAttention:
         assert cos > 0.95, float(cos)
 
 
+@pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 9)),
+    reason="NVFP4 qdq uses tl.float8e4nv (sm_89+)",
+)
+class TestOnwriteVBakeLifecycle:
+    """The in-place 128-token V bake is schedule-independent and only ever touches new tiles.
+
+    ``fake_quant_v_onwrite`` bakes complete ``_ONWRITE_BLOCK_N`` (128) tiles in ``[v_lo, v_hi)``.
+    Correctness requires each tile be baked exactly once from the pristine V: NVFP4 block QDQ is not
+    generally idempotent (a re-bake recomputes the E4M3 block scale from the already-quantized amax,
+    which can shift), so a double-bake would drift. These tests prove the incremental (chunked-write)
+    schedule produces the same cache as one one-shot bake, and that baking a later tile never rewrites
+    an earlier (already-baked) or trailing (still-partial) tile.
+    """
+
+    _BN = 128  # _ONWRITE_BLOCK_N: the on-write bake tile size
+
+    def _v_cache(self, batch, seq_k, head_dim, page_size, seed, dtype):
+        torch.manual_seed(seed)
+        k = torch.randn(batch, 1, seq_k, head_dim, device="cuda", dtype=dtype)
+        v = torch.randn(batch, 1, seq_k, head_dim, device="cuda", dtype=dtype)
+        seq_lens = torch.full((batch,), seq_k, device="cuda", dtype=torch.int32)
+        _, v_cache, block_table = _paged_cache(k, v, seq_lens, page_size)
+        return v_cache, block_table
+
+    def _bake(self, v_cache, block_table, lo, hi, page_size, batch):
+        v_lo = torch.full((batch,), lo, device="cuda", dtype=torch.int32)
+        v_hi = torch.full((batch,), hi, device="cuda", dtype=torch.int32)
+        fake_quant_v_onwrite(v_cache, block_table, v_lo, v_hi, page_size=page_size)
+
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    @pytest.mark.parametrize("page_size", [16, 32, 64])
+    def test_incremental_bake_equals_one_shot(self, dtype, page_size):
+        """Baking [0,128) then [128,256) as the sequence grows equals a single [0,256) bake."""
+        batch, seq_k, head_dim = 2, 300, 128  # two complete 128-tiles + a 44-token trailing tile
+        v_inc, block_table = self._v_cache(batch, seq_k, head_dim, page_size, seed=3, dtype=dtype)
+        raw = v_inc.clone()
+        v_one = v_inc.clone()
+
+        # Incremental: bake each 128-tile as it completes.
+        self._bake(v_inc, block_table, 0, self._BN, page_size, batch)
+        self._bake(v_inc, block_table, self._BN, 2 * self._BN, page_size, batch)
+        # One-shot: bake both complete tiles at once.
+        self._bake(v_one, block_table, 0, 2 * self._BN, page_size, batch)
+
+        torch.testing.assert_close(v_inc, v_one, rtol=0, atol=0)
+        # Non-vacuous: the bake actually quantized the completed tiles.
+        assert not torch.equal(v_inc, raw)
+
+    @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+    def test_bake_leaves_earlier_and_trailing_tiles_untouched(self, dtype):
+        """Baking a later tile must not rewrite an already-baked tile or a still-partial trailing one.
+
+        With page_size == 128 each 128-token tile is exactly one page, so the invariant reduces to a
+        bit-for-bit page comparison (no double-bake of tile 0; the 44-token trailing tile stays raw).
+        """
+        batch, seq_k, head_dim, page_size = 2, 300, 128, 128
+        v_cache, block_table = self._v_cache(batch, seq_k, head_dim, page_size, seed=5, dtype=dtype)
+        raw = v_cache.clone()
+
+        self._bake(v_cache, block_table, 0, self._BN, page_size, batch)  # bake tile 0 (page g0)
+        after_first = v_cache.clone()
+        self._bake(v_cache, block_table, self._BN, 2 * self._BN, page_size, batch)  # bake tile 1
+
+        for b in range(batch):
+            g0, g2 = int(block_table[b, 0]), int(block_table[b, 2])
+            # Tile 0's page is unchanged by the second bake (baked once, never re-baked).
+            torch.testing.assert_close(v_cache[g0], after_first[g0], rtol=0, atol=0)
+            # The trailing partial tile ([256,300), < 128 tokens) is never a complete tile: stays raw.
+            torch.testing.assert_close(v_cache[g2], raw[g2], rtol=0, atol=0)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/gpu/torch/kernels/common/attention/test_triton_fa_p_qdq.py
+++ b/tests/gpu/torch/kernels/common/attention/test_triton_fa_p_qdq.py
@@ -348,17 +348,20 @@ class TestSoftmaxQdqBackward:
 
 @pytest.mark.skipif(not _HAS_SM89, reason="NVFP4 E4M3 block scale (tl.float8e4nv) requires SM89+")
 class TestNvfp4ScaleUnderflow:
-    """Boundary behavior of the NVFP4 block-scale underflow guard (P/V path).
+    """Boundary behavior of the NVFP4 block-scale clamp (P/V path).
 
-    A block whose amax is small enough that the E4M3 block scale underflows to
-    zero must not yield NaN/inf: ``nvfp4_scalar_quant``'s ``scale_safe`` maps a
-    ``0``/NaN/inf scale to ``1.0``, and the tiny entries then round to 0 on the E2M1
-    grid. Tiny softmax-P blocks occur naturally in long context (keys many
-    log2-units below the row max), so this guard is hit in real workloads.
+    ``fp8_quantize_scale`` clamps the per-block scale to the E4M3 range
+    ``[2**-9, 448]`` (matching ``qtensor/nvfp4_tensor.py``) before the cast, so an
+    underflowed block is floored at the min subnormal instead of letting the scale
+    round to a 0 (which would zero the whole block). Two regimes result, both finite:
+    a block far below the floor still rounds to 0 on the E2M1 grid (its entries over
+    the floored scale fall under 0.25), while a block in the reconstruction band
+    ``[~1.8e-7, 2.2e-6]`` comes back nonzero. Tiny softmax-P blocks occur naturally in
+    long context (keys many log2-units below the row max).
 
     With P's fixed global scale ``1/(6*448)``, ``fp8_quantize_scale`` forms the
-    in-range value ``block_amax * 448``; it underflows E4M3 (rounds to 0) once
-    ``block_amax`` drops below ~2.2e-6.
+    in-range value ``block_amax * 448``; below ``block_amax ~= 2.2e-6`` it clamps to
+    the ``2**-9`` floor (dequant scale ``2**-9 / 2688 ~= 7.27e-7``).
     """
 
     P_GLOBAL_SCALE = 1.0 / (6.0 * 448.0)
@@ -370,22 +373,35 @@ class TestNvfp4ScaleUnderflow:
         return out
 
     def test_tiny_block_underflow_is_finite_and_zeroed(self):
-        # amax * 448 far below the E4M3 min subnormal (2^-9) -> scale rounds to 0
-        # -> scale_safe guard -> 1.0 -> tiny values (< 0.25) round to 0. No NaN/inf.
+        # Far below the reconstruction band: the scale clamps to 2^-9, but the entries
+        # (1e-7 / 7.27e-7 = 0.14 < 0.25) still round to 0 on the E2M1 grid. No NaN/inf.
         x = torch.full((16,), 1e-7, device="cuda", dtype=torch.float32)
         out = self._run(x)
         assert torch.isfinite(out).all()
         assert torch.all(out == 0.0)
 
+    def test_underflow_band_reconstructs_nonzero(self):
+        # In the reconstruction band (amax 2e-6, below the E4M3 min but above the E2M1
+        # round-to-0 threshold): the scale clamps to the 2^-9 floor and the block comes
+        # back nonzero instead of zeroing, matching canonical NVFP4 (nvfp4_tensor.py).
+        x = torch.full((16,), 2e-6, device="cuda", dtype=torch.float32)
+        out = self._run(x)
+        assert torch.isfinite(out).all()
+        assert torch.all(out != 0.0)
+        expected = 3.0 * (2**-9) * self.P_GLOBAL_SCALE  # E2M1 value 3 * floored dequant scale
+        assert torch.allclose(out, torch.full_like(out, expected), rtol=1e-3, atol=1e-9), (
+            f"{out[0].item():.6e} vs {expected:.6e}"
+        )
+
     def test_zero_block_is_finite(self):
-        # An all-zero block (amax 0 -> scale 0) must stay finite via the guard.
+        # An all-zero block (amax 0) clamps the scale to 2^-9 (> 0), so 0/scale = 0, finite.
         x = torch.zeros(16, device="cuda", dtype=torch.float32)
         out = self._run(x)
         assert torch.isfinite(out).all()
         assert torch.all(out == 0.0)
 
     def test_in_range_block_is_finite_and_nonzero(self):
-        # A normal block (amax 0.5) keeps its scale inside E4M3 range -> no guard,
+        # A normal block (amax 0.5) keeps its scale inside E4M3 range -> no clamp,
         # round-trips to a nonzero, finite result.
         x = torch.full((16,), 0.5, device="cuda", dtype=torch.float32)
         out = self._run(x)

--- a/tests/gpu/torch/kernels/common/attention/test_triton_fa_p_qdq.py
+++ b/tests/gpu/torch/kernels/common/attention/test_triton_fa_p_qdq.py
@@ -15,6 +15,8 @@
 
 """GPU tests for the softmax quant-dequant (P_QDQ) feature of the Triton FA kernel."""
 
+# ruff: noqa: N803 — Triton JIT wrapper uses uppercase for constexpr and tensor args
+
 import pytest
 import torch
 from conftest import make_qkv, make_varlen_meta, sdpa_reference
@@ -24,13 +26,33 @@ from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor, e2m1_
 from modelopt.torch.quantization.tensor_quant import fp8_eager
 
 if TRITON_KERNEL_AVAILABLE:
+    import triton
+    import triton.language as tl
+
     from modelopt.torch.kernels.common.attention import attention
     from modelopt.torch.kernels.common.attention.triton_fa import LOG2E
+    from modelopt.torch.kernels.quantization.common.nvfp4_quant import nvfp4_scalar_qdq
+
+    @triton.jit
+    def _nvfp4_qdq_block_kernel(X, OUT, GS, N: tl.constexpr):
+        """Run the P/V in-kernel quant primitive ``nvfp4_scalar_qdq`` on one N-block."""
+        i = tl.arange(0, N)
+        xv = tl.load(X + i)
+        block_amax = tl.max(tl.abs(xv))
+        tl.store(OUT + i, nvfp4_scalar_qdq(xv, block_amax, tl.load(GS), N))
+
 
 # The kernel runs with a single pinned config under pytest (see _FWD_CONFIGS):
 # BLOCK_M=128, BLOCK_N=64. The tile-looped reference below relies on it.
 BLOCK_N = 64
 FP8_E4M3_MAX = 448.0
+
+# NVFP4's E4M3 block scale uses ``tl.float8e4nv``, which requires SM89+ (Ada/Hopper/Blackwell).
+_HAS_SM89 = (
+    TRITON_KERNEL_AVAILABLE
+    and torch.cuda.is_available()
+    and torch.cuda.get_device_capability() >= (8, 9)
+)
 
 
 def _qdq_fp8(p, scale=1.0):
@@ -322,3 +344,50 @@ class TestSoftmaxQdqBackward:
             assert torch.isfinite(g_qdq).all()
             rel_err = (g_qdq - g_dense).norm() / g_dense.norm()
             assert rel_err < 5e-2, f"relative gradient error too large: {rel_err:.4f}"
+
+
+@pytest.mark.skipif(not _HAS_SM89, reason="NVFP4 E4M3 block scale (tl.float8e4nv) requires SM89+")
+class TestNvfp4ScaleUnderflow:
+    """Boundary behavior of the NVFP4 block-scale underflow guard (P/V path).
+
+    A block whose amax is small enough that the E4M3 block scale underflows to
+    zero must not yield NaN/inf: ``nvfp4_scalar_quant``'s ``scale_safe`` maps a
+    ``0``/NaN/inf scale to ``1.0``, and the tiny entries then round to 0 on the E2M1
+    grid. Tiny softmax-P blocks occur naturally in long context (keys many
+    log2-units below the row max), so this guard is hit in real workloads.
+
+    With P's fixed global scale ``1/(6*448)``, ``fp8_quantize_scale`` forms the
+    in-range value ``block_amax * 448``; it underflows E4M3 (rounds to 0) once
+    ``block_amax`` drops below ~2.2e-6.
+    """
+
+    P_GLOBAL_SCALE = 1.0 / (6.0 * 448.0)
+
+    def _run(self, x):
+        gs = torch.tensor(self.P_GLOBAL_SCALE, device="cuda", dtype=torch.float32)
+        out = torch.empty_like(x)
+        _nvfp4_qdq_block_kernel[(1,)](x, out, gs, N=x.shape[0])
+        return out
+
+    def test_tiny_block_underflow_is_finite_and_zeroed(self):
+        # amax * 448 far below the E4M3 min subnormal (2^-9) -> scale rounds to 0
+        # -> scale_safe guard -> 1.0 -> tiny values (< 0.25) round to 0. No NaN/inf.
+        x = torch.full((16,), 1e-7, device="cuda", dtype=torch.float32)
+        out = self._run(x)
+        assert torch.isfinite(out).all()
+        assert torch.all(out == 0.0)
+
+    def test_zero_block_is_finite(self):
+        # An all-zero block (amax 0 -> scale 0) must stay finite via the guard.
+        x = torch.zeros(16, device="cuda", dtype=torch.float32)
+        out = self._run(x)
+        assert torch.isfinite(out).all()
+        assert torch.all(out == 0.0)
+
+    def test_in_range_block_is_finite_and_nonzero(self):
+        # A normal block (amax 0.5) keeps its scale inside E4M3 range -> no guard,
+        # round-trips to a nonzero, finite result.
+        x = torch.full((16,), 0.5, device="cuda", dtype=torch.float32)
+        out = self._run(x)
+        assert torch.isfinite(out).all()
+        assert torch.any(out != 0.0)

--- a/tests/gpu/torch/kernels/common/attention/test_triton_fa_p_qdq.py
+++ b/tests/gpu/torch/kernels/common/attention/test_triton_fa_p_qdq.py
@@ -83,14 +83,19 @@ def _qdq_nvfp4(p, global_scale=1.0):
 
     p: [..., n] with n % 16 == 0 and p >= 0. The per-block E4M3 scale is the
     kernel's ``fp8_quantize_scale(block_amax, global_scale)``, which equals
-    ``fp8_eager(block_amax / 6, amax=448 * global_scale)`` — so the FP8 scale
+    ``fp8_eager(block_amax / 6, amax=448 * global_scale)`` with the per-block scale clamped to the
+    E4M3 range ``[2**-9, 448]`` (in units of the global scale) BEFORE the cast — so the FP8 scale
     quantization is reused from modelopt rather than re-spelled here.
     """
     shape = p.shape
     g = p.reshape(*shape[:-1], shape[-1] // 16, 16)
     block_amax = g.amax(dim=-1, keepdim=True)  # p >= 0, so max == amax
-    scale = fp8_eager(block_amax / 6.0, torch.tensor(FP8_E4M3_MAX * global_scale, device=p.device))
-    scale = torch.where(scale == 0.0, torch.ones_like(scale), scale)
+    # Match the kernel's fp8_quantize_scale clamp: floor an underflowed block scale at the smallest
+    # E4M3 subnormal (2**-9) instead of letting it round to 0 (the canonical clamp; replaces the old
+    # ``scale == 0 -> 1.0`` guard). A no-op for non-underflow blocks, so existing conformance is
+    # unchanged; it only makes the reference match the kernel in the underflow band.
+    raw_scale = (block_amax / 6.0).clamp(2**-9 * global_scale, FP8_E4M3_MAX * global_scale)
+    scale = fp8_eager(raw_scale, torch.tensor(FP8_E4M3_MAX * global_scale, device=p.device))
     q = _fp4_round(g / scale) * scale
     return q.reshape(shape)
 

--- a/tests/gpu/torch/quantization/test_tensor_quantizer_cuda.py
+++ b/tests/gpu/torch/quantization/test_tensor_quantizer_cuda.py
@@ -81,6 +81,21 @@ class TestTensorQuantizerfp4:
 
         assert fp4_quantizer._get_amax(x) == x.abs().amax()
 
+    def test_runtime_default_amax(self):
+        quantizer = tensor_quantizer.TensorQuantizer(
+            QuantizerAttributeConfig(
+                num_bits=(2, 1),
+                block_sizes={-1: 16, "type": "dynamic", "scale_bits": (4, 3)},
+            )
+        ).cuda()
+        inputs = torch.randn(2, 4, 16, device="cuda")
+        runtime_amax = torch.tensor(2688.0, device="cuda")
+
+        quantizer._set_runtime_default_amax(runtime_amax)
+        actual = quantizer(inputs)
+        expected = tensor_quant.dynamic_block_quant(inputs, 16, runtime_amax, None, (2, 1), (4, 3))
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
     @pytest.mark.parametrize("pass_through_bwd", [True, False])
     def test_fp4_backward(self, pass_through_bwd):
         fp4_quantizer = tensor_quantizer.TensorQuantizer(

--- a/tests/gpu_vllm/torch/quantization/test_fakequant_worker.py
+++ b/tests/gpu_vllm/torch/quantization/test_fakequant_worker.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for the ``fakequant_worker`` config-driven calibration gate.
+
+The removed ``QUANT_SKIP_CALIB`` env flag is replaced by ``need_calibration(quant_cfg)`` (config,
+not env): the calibration dataset is built only when the recipe has an enabled quantizer that is
+not marked ``type: "dynamic"``. A static recipe can therefore never silently skip its required
+calibration, and a fully dynamic recipe skips the dataset (and the HF ``datasets`` stack).
+"""
+
+import os
+import sys
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch.nn as nn
+
+# The worker module lives under examples/vllm_serve and is imported as a top-level module there.
+_VLLM_SERVE_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "..", "examples", "vllm_serve"
+)
+sys.path.insert(0, os.path.abspath(_VLLM_SERVE_DIR))
+
+import fakequant_worker as fqw
+
+_STATIC_CFG = {
+    "quant_cfg": {
+        "*input_quantizer": {"num_bits": 8, "enable": True},
+        "default": {"enable": False},
+    },
+    "algorithm": "max",
+}
+_DYNAMIC_CFG = {
+    "quant_cfg": {
+        "*input_quantizer": {"num_bits": 8, "type": "dynamic", "enable": True},
+        "default": {"enable": False},
+    },
+    "algorithm": "max",
+}
+
+
+def _fake_self():
+    model_runner = SimpleNamespace(
+        model=nn.Module(),  # no quantizers -> the post-fold weight-quantizer check is a no-op
+        model_config=SimpleNamespace(tokenizer="dummy-tokenizer"),
+    )
+    return SimpleNamespace(model_runner=model_runner, device="cpu")
+
+
+@pytest.fixture
+def calibration_calls(monkeypatch):
+    """Stub every heavy dependency and record whether the dataset/forward_loop was built."""
+    calls = {"datasets_built": 0, "forward_loops": []}
+
+    monkeypatch.setattr(
+        fqw,
+        "AutoTokenizer",
+        SimpleNamespace(from_pretrained=lambda *a, **k: SimpleNamespace(pad_token="<unk>")),
+    )
+
+    def _fake_loader(**kwargs):
+        calls["datasets_built"] += 1
+        return object()
+
+    monkeypatch.setattr(fqw, "get_dataset_dataloader", _fake_loader)
+    monkeypatch.setattr(fqw, "calibrate_fun", lambda dataloader, worker: lambda model: None)
+
+    def _fake_quantize(model, cfg, forward_loop=None):
+        calls["forward_loops"].append(forward_loop)
+        return model
+
+    monkeypatch.setattr(fqw.mtq, "quantize", _fake_quantize)
+    monkeypatch.setattr(fqw.mtq, "print_quant_summary", lambda model: None)
+    monkeypatch.setattr(fqw.mtq, "fold_weight", lambda model: None)
+    monkeypatch.setattr(fqw, "post_restore_vllm_attentions", lambda model: None)
+    monkeypatch.setattr(fqw, "disable_compilation", lambda model: nullcontext())
+    monkeypatch.setitem(fqw.quant_config, "modelopt_state_path", None)
+    monkeypatch.setitem(fqw.quant_config, "quant_file_path", None)
+    return calls
+
+
+def test_static_recipe_builds_calibration_dataset(monkeypatch, calibration_calls):
+    monkeypatch.setattr(fqw, "get_quant_config", lambda quant_config, model: _STATIC_CFG)
+
+    fqw._fakequant_run_prolog_worker(_fake_self())
+
+    # A static recipe must calibrate: dataset built, forward_loop is a real calibration callable.
+    assert calibration_calls["datasets_built"] == 1
+    assert len(calibration_calls["forward_loops"]) == 1
+    assert callable(calibration_calls["forward_loops"][0])
+
+
+def test_dynamic_recipe_skips_calibration_dataset(monkeypatch, calibration_calls):
+    monkeypatch.setattr(fqw, "get_quant_config", lambda quant_config, model: _DYNAMIC_CFG)
+
+    fqw._fakequant_run_prolog_worker(_fake_self())
+
+    # A fully dynamic recipe needs no calibration: no dataset built, forward_loop is None.
+    assert calibration_calls["datasets_built"] == 0
+    assert calibration_calls["forward_loops"] == [None]

--- a/tests/gpu_vllm/torch/quantization/test_impl_swap_attention_quant.py
+++ b/tests/gpu_vllm/torch/quantization/test_impl_swap_attention_quant.py
@@ -128,6 +128,8 @@ def _make_worker(
     model,
     *,
     dcp=1,
+    dbo=False,
+    ubatching=False,
     prefix_caching=False,
     kv_transfer=None,
     speculative=None,
@@ -139,7 +141,9 @@ def _make_worker(
     # In real vLLM ``vllm_config.model_config`` and ``model_runner.model_config`` are the same object.
     model_config = SimpleNamespace(hf_config=hf_config, enforce_eager=enforce_eager, dtype=dtype)
     vllm_config = SimpleNamespace(
-        parallel_config=SimpleNamespace(decode_context_parallel_size=dcp),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=dcp, enable_dbo=dbo, use_ubatching=ubatching
+        ),
         cache_config=SimpleNamespace(enable_prefix_caching=prefix_caching, block_size=block_size),
         kv_transfer_config=kv_transfer,
         speculative_config=speculative,
@@ -299,6 +303,8 @@ def test_unsupported_reasons_for_unrecognized_backend():
     ("kwargs", "needle"),
     [
         ({"dcp": 2}, "decode_context_parallel_size"),
+        ({"dbo": True}, "dual batch overlap"),
+        ({"ubatching": True}, "dual batch overlap"),
         ({"prefix_caching": True}, "prefix caching"),
         ({"kv_transfer": object()}, "connector"),
         ({"speculative": object()}, "speculative"),

--- a/tests/gpu_vllm/torch/quantization/test_impl_swap_attention_quant.py
+++ b/tests/gpu_vllm/torch/quantization/test_impl_swap_attention_quant.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for the attention-only impl-swap attach in ``quant_sparse_attn_worker``.
+
+The attach must (1) convert only vLLM ``Attention`` modules to ``_QuantVLLMAttention`` and configure
+their ``q/k/v/p_bmm_quantizer`` as dynamic block-16 NVFP4 (K/V getting the global-scale-1.0 default),
+and (2) leave a realquant-style Linear untouched -- converting that Linear (as ``mtq.quantize`` would)
+raises ``AssertionError`` in ``_VLLMParallelLinear._setup``, which is exactly what this path avoids.
+
+Only ``create_parallel_state`` is patched away (it needs a live vLLM distributed group); everything
+else -- the registry, the real ``_setup``, ``set_quantizer_by_cfg``, ``post_restore_vllm_attentions``
+-- runs for real on CPU.
+"""
+
+import os
+import sys
+
+import pytest
+import torch
+import torch.nn as nn
+import vllm.model_executor.layers.linear as vllm_linear
+
+import modelopt.torch.quantization.plugins.vllm as vllm_plugin
+from modelopt.torch.quantization.nn import QuantModuleRegistry
+from modelopt.torch.utils.distributed import ParallelState
+
+# The worker module lives under examples/vllm_serve and is imported as a top-level module there.
+_VLLM_SERVE_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "..", "examples", "vllm_serve"
+)
+sys.path.insert(0, os.path.abspath(_VLLM_SERVE_DIR))
+
+from quant_sparse_attn_worker import _attach_attention_quant_impl_swap
+
+
+@pytest.fixture
+def _no_distributed_parallel_state(monkeypatch):
+    """Convert attention on CPU without a live vLLM distributed group.
+
+    ``_QuantVLLMAttention._setup`` calls ``create_parallel_state()`` (needs ``get_dp_group()`` /
+    ``get_tp_group()``); on CPU we swap it for the same default ``_initialize_parallel_state`` uses.
+    """
+    monkeypatch.setattr(
+        vllm_plugin, "create_parallel_state", lambda: ParallelState(data_parallel_group=None)
+    )
+
+
+class _RealAttention(vllm_plugin.vllm_attention.Attention):
+    """Real vLLM ``Attention`` subclass with ``__init__`` bypassed (no engine needed on CPU)."""
+
+    def __init__(self):
+        nn.Module.__init__(self)
+        # A trivial param so post-restore device/dtype detection succeeds.
+        self.dummy = nn.Parameter(torch.zeros(1))
+
+
+class _RealQuantMethod:
+    """Stand-in for a realquant Linear method (e.g. ModelOptFp8LinearMethod) -- NOT unquantized."""
+
+
+class _RealQuantLinear(vllm_linear.RowParallelLinear):
+    """Real vLLM Linear subclass carrying a non-``UnquantizedLinearMethod`` quant method."""
+
+    def __init__(self):
+        nn.Module.__init__(self)
+        self.quant_method = _RealQuantMethod()
+
+
+@pytest.mark.usefixtures("_no_distributed_parallel_state")
+def test_impl_swap_converts_attention_and_configures_nvfp4():
+    attention = _RealAttention()
+    model = nn.ModuleDict({"attn": attention})
+
+    _attach_attention_quant_impl_swap(model)
+
+    converted = model.attn
+    assert isinstance(converted, vllm_plugin._QuantVLLMAttention)
+
+    # All four BMM quantizers enabled and configured as dynamic block-16 NVFP4.
+    for name in ("q_bmm_quantizer", "k_bmm_quantizer", "v_bmm_quantizer", "p_bmm_quantizer"):
+        quantizer = getattr(converted, name)
+        assert quantizer.is_enabled
+        assert quantizer.is_nvfp4_dynamic
+        assert quantizer.num_bits == (2, 1)
+        assert (quantizer.block_sizes or {}).get(-1) == 16
+
+    # K/V pick up the global-scale-1.0 runtime default (amax == 6 * 448 == 2688), matching
+    # test_vllm_kv_default_scale.py; the dynamic Q/P quantizers get no runtime default.
+    inputs = torch.tensor([-3.0, 5.0])
+    for name in ("k_bmm_quantizer", "v_bmm_quantizer"):
+        assert getattr(converted, name)._get_amax(inputs).item() == 2688.0
+    assert not hasattr(converted.q_bmm_quantizer, "_runtime_default_amax")
+    assert not hasattr(converted.p_bmm_quantizer, "_runtime_default_amax")
+
+
+@pytest.mark.usefixtures("_no_distributed_parallel_state")
+def test_impl_swap_leaves_realquant_linear_untouched():
+    linear = _RealQuantLinear()
+    model = nn.ModuleDict({"proj": linear})
+
+    # Sanity: this Linear IS a registered QuantModule but is NOT an attention type; converting it
+    # (as mtq.quantize / replace_quant_module would) trips the _VLLMParallelLinear quant_method
+    # assert -- the exact failure the attention-only attach exists to avoid.
+    assert type(linear) in QuantModuleRegistry
+    assert not isinstance(linear, vllm_plugin._ATTENTION_TYPES)
+    with pytest.raises(AssertionError):
+        QuantModuleRegistry.convert(_RealQuantLinear())
+
+    # The attach must neither convert the Linear nor raise.
+    _attach_attention_quant_impl_swap(model)
+
+    assert model.proj is linear
+    assert type(model.proj) is _RealQuantLinear
+    assert not isinstance(model.proj, vllm_plugin._QuantVLLMAttention)

--- a/tests/gpu_vllm/torch/quantization/test_impl_swap_attention_quant.py
+++ b/tests/gpu_vllm/torch/quantization/test_impl_swap_attention_quant.py
@@ -111,6 +111,7 @@ class _FakeAttention(vllm_plugin.vllm_attention.Attention):
         sliding_window=None,
         kv_sharing_target_layer_name=None,
         kv_cache_dtype="auto",
+        head_size=128,
     ):
         nn.Module.__init__(self)
         # A trivial param so post-restore device/dtype detection succeeds.
@@ -120,6 +121,7 @@ class _FakeAttention(vllm_plugin.vllm_attention.Attention):
         self.sliding_window = sliding_window
         self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
         self.kv_cache_dtype = kv_cache_dtype
+        self.head_size = head_size
 
 
 def _make_worker(
@@ -131,17 +133,21 @@ def _make_worker(
     speculative=None,
     block_size=16,
     hf_config=None,
+    enforce_eager=True,
 ):
+    # In real vLLM ``vllm_config.model_config`` and ``model_runner.model_config`` are the same object.
+    model_config = SimpleNamespace(hf_config=hf_config, enforce_eager=enforce_eager)
     vllm_config = SimpleNamespace(
         parallel_config=SimpleNamespace(decode_context_parallel_size=dcp),
         cache_config=SimpleNamespace(enable_prefix_caching=prefix_caching, block_size=block_size),
         kv_transfer_config=kv_transfer,
         speculative_config=speculative,
+        model_config=model_config,
     )
     model_runner = SimpleNamespace(
         model=model,
         vllm_config=vllm_config,
-        model_config=SimpleNamespace(hf_config=hf_config),
+        model_config=model_config,
         cascade_attn_enabled=False,
     )
     return SimpleNamespace(model_runner=model_runner)
@@ -236,11 +242,34 @@ def test_unsupported_reasons_empty_for_supported_decoder():
         ({"kv_sharing_target_layer_name": "model.layers.0.self_attn"}, "kv_sharing"),
         ({"kv_cache_dtype": "fp8"}, "kv_cache_dtype"),
         ({"kv_cache_dtype": "fp8_e4m3"}, "kv_cache_dtype"),
+        ({"head_size": 72}, "head_size"),  # not a multiple of 16 -> blocks span heads
+        ({"head_size": 40}, "head_size"),
     ],
 )
 def test_unsupported_reasons_for_module_attrs(kwargs, needle):
     reasons = _unsupported_attention_reasons(_FakeAttention(**kwargs))
     assert any(needle in reason for reason in reasons), reasons
+
+
+def test_unsupported_reasons_accepts_head_size_multiple_of_16():
+    assert _unsupported_attention_reasons(_FakeAttention(head_size=128)) == []
+
+
+@pytest.mark.skipif(vllm_plugin.VllmMLAAttention is None, reason="MLA attention not available")
+def test_unsupported_reasons_rejects_mla_layout():
+    """MLA is a distinct class (attn_type==DECODER) — must be rejected by layout, not silently run."""
+
+    class _FakeMLA(vllm_plugin.VllmMLAAttention):
+        def __init__(self):
+            nn.Module.__init__(self)
+            self.attn_type = AttentionType.DECODER
+            self.impl = _make_flash_impl()
+            self.head_size = 128
+
+    module = _FakeMLA()
+    assert not isinstance(module, vllm_plugin.vllm_attention.Attention)
+    reasons = _unsupported_attention_reasons(module)
+    assert any("MLA" in reason or "layout" in reason for reason in reasons), reasons
 
 
 @pytest.mark.parametrize(
@@ -274,6 +303,7 @@ def test_unsupported_reasons_for_unrecognized_backend():
         ({"speculative": object()}, "speculative"),
         ({"block_size": 24}, "multiple"),
         ({"block_size": 0}, "multiple"),
+        ({"enforce_eager": False}, "enforce_eager"),
     ],
 )
 def test_validate_global_runtime_flags_unsupported(kwargs, needle):
@@ -285,6 +315,34 @@ def test_validate_global_runtime_flags_unsupported(kwargs, needle):
 def test_validate_global_runtime_ok():
     worker_obj = _make_worker(nn.ModuleDict({"attn": _FakeAttention()}))
     assert _validate_global_runtime(worker_obj) == []
+
+
+# --- ATTN_QUANT_MODE validation (no silent fall-through to un-quantized) ------------------------
+
+
+def test_resolve_attn_quant_mode_default_is_impl_swap(monkeypatch):
+    monkeypatch.delenv("ATTN_QUANT_MODE", raising=False)
+    assert worker._resolve_attn_quant_mode() == "impl_swap"
+
+
+def test_resolve_attn_quant_mode_rejects_typo(monkeypatch):
+    monkeypatch.setenv("ATTN_QUANT_MODE", "impl_swp")
+    with pytest.raises(ValueError, match="invalid"):
+        worker._resolve_attn_quant_mode()
+
+
+def test_resolve_attn_quant_mode_mtq_requires_source(monkeypatch):
+    monkeypatch.setenv("ATTN_QUANT_MODE", "mtq")
+    for key in ("quant_cfg", "kv_quant_cfg", "modelopt_state_path", "recipe_path"):
+        monkeypatch.setitem(worker.quant_config, key, None)
+    with pytest.raises(ValueError, match="requires a quant source"):
+        worker._resolve_attn_quant_mode()
+
+
+def test_resolve_attn_quant_mode_mtq_with_source(monkeypatch):
+    monkeypatch.setenv("ATTN_QUANT_MODE", "mtq")
+    monkeypatch.setitem(worker.quant_config, "quant_cfg", "NVFP4_DEFAULT_CFG")
+    assert worker._resolve_attn_quant_mode() == "mtq"
 
 
 @pytest.mark.usefixtures("_no_sparse_config")

--- a/tests/gpu_vllm/torch/quantization/test_impl_swap_attention_quant.py
+++ b/tests/gpu_vllm/torch/quantization/test_impl_swap_attention_quant.py
@@ -134,9 +134,10 @@ def _make_worker(
     block_size=16,
     hf_config=None,
     enforce_eager=True,
+    dtype=torch.bfloat16,
 ):
     # In real vLLM ``vllm_config.model_config`` and ``model_runner.model_config`` are the same object.
-    model_config = SimpleNamespace(hf_config=hf_config, enforce_eager=enforce_eager)
+    model_config = SimpleNamespace(hf_config=hf_config, enforce_eager=enforce_eager, dtype=dtype)
     vllm_config = SimpleNamespace(
         parallel_config=SimpleNamespace(decode_context_parallel_size=dcp),
         cache_config=SimpleNamespace(enable_prefix_caching=prefix_caching, block_size=block_size),
@@ -304,6 +305,10 @@ def test_unsupported_reasons_for_unrecognized_backend():
         ({"block_size": 24}, "multiple"),
         ({"block_size": 0}, "multiple"),
         ({"enforce_eager": False}, "enforce_eager"),
+        (
+            {"dtype": torch.float32},
+            "dtype",
+        ),  # resolved fp32 KV cache (e.g. via kv_cache_dtype=auto)
     ],
 )
 def test_validate_global_runtime_flags_unsupported(kwargs, needle):

--- a/tests/gpu_vllm/torch/quantization/test_impl_swap_attention_quant.py
+++ b/tests/gpu_vllm/torch/quantization/test_impl_swap_attention_quant.py
@@ -13,28 +13,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""CPU tests for the attention-only impl-swap attach in ``quant_sparse_attn_worker``.
+"""CPU tests for the ``quant_sparse_attn_worker`` install path.
 
-The attach must (1) convert only vLLM ``Attention`` modules to ``_QuantVLLMAttention`` and configure
-their ``q/k/v/p_bmm_quantizer`` as dynamic block-16 NVFP4 (K/V getting the global-scale-1.0 default),
-and (2) leave a realquant-style Linear untouched -- converting that Linear (as ``mtq.quantize`` would)
-raises ``AssertionError`` in ``_VLLMParallelLinear._setup``, which is exactly what this path avoids.
+Three layers of coverage, all on CPU (no vLLM engine boot):
 
-Only ``create_parallel_state`` is patched away (it needs a live vLLM distributed group); everything
-else -- the registry, the real ``_setup``, ``set_quantizer_by_cfg``, ``post_restore_vllm_attentions``
--- runs for real on CPU.
+- ``_attach_attention_quant_impl_swap`` converts only the approved vLLM ``Attention`` modules to
+  ``_QuantVLLMAttention`` (dynamic block-16 NVFP4, K/V global-scale-1.0) and leaves a realquant
+  Linear untouched.
+- ``_preflight_quant_sparse_attn`` / ``_validate_global_runtime`` / ``_unsupported_attention_reasons``
+  reject every unsupported configuration in the support matrix with a single, layer-qualified
+  ``NotImplementedError`` and never mutate the model (pure resolver).
+- ``_prepare_quant_sparse_attn`` / ``_commit_quant_sparse_attn`` install atomically: a clone failure
+  on any layer leaves every original ``module.impl`` and ``_value_quant_in_kernel`` gate unchanged.
+
+Only ``create_parallel_state`` is patched away (it needs a live vLLM distributed group); the
+registry, the real ``_setup``, ``set_quantizer_by_cfg``, ``post_restore_vllm_attentions``, the real
+``FlashAttentionImpl`` state, ``_clone_sparse_impl``, and ``select_sparse_impl_cls`` all run for real.
 """
 
 import os
 import sys
+from types import SimpleNamespace
 
 import pytest
 import torch
 import torch.nn as nn
 import vllm.model_executor.layers.linear as vllm_linear
+from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
 
 import modelopt.torch.quantization.plugins.vllm as vllm_plugin
 from modelopt.torch.quantization.nn import QuantModuleRegistry
+from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import ModelOptSparseAttentionImpl
 from modelopt.torch.utils.distributed import ParallelState
 
 # The worker module lives under examples/vllm_serve and is imported as a top-level module there.
@@ -43,7 +52,18 @@ _VLLM_SERVE_DIR = os.path.join(
 )
 sys.path.insert(0, os.path.abspath(_VLLM_SERVE_DIR))
 
-from quant_sparse_attn_worker import _attach_attention_quant_impl_swap
+import quant_sparse_attn_worker as worker
+from quant_sparse_attn_worker import (
+    AttentionType,
+    _attach_attention_quant_impl_swap,
+    _AttentionInstallRecord,
+    _commit_quant_sparse_attn,
+    _install_quant_sparse_attn,
+    _preflight_quant_sparse_attn,
+    _prepare_quant_sparse_attn,
+    _unsupported_attention_reasons,
+    _validate_global_runtime,
+)
 
 
 @pytest.fixture
@@ -58,13 +78,73 @@ def _no_distributed_parallel_state(monkeypatch):
     )
 
 
-class _RealAttention(vllm_plugin.vllm_attention.Attention):
+@pytest.fixture
+def _no_sparse_config(monkeypatch):
+    """No checkpoint sparse-attention config, so candidacy is driven purely by quant."""
+    monkeypatch.setattr(worker, "load_from_checkpoint_metadata", lambda hf_config: None)
+
+
+def _make_flash_impl(**overrides):
+    """A real vLLM ``FlashAttentionImpl`` with initialized runtime state (clone/select work on it)."""
+    impl = FlashAttentionImpl(
+        num_heads=2,
+        head_size=64,
+        scale=0.125,
+        num_kv_heads=2,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="auto",
+    )
+    for key, value in overrides.items():
+        setattr(impl, key, value)
+    return impl
+
+
+class _FakeAttention(vllm_plugin.vllm_attention.Attention):
     """Real vLLM ``Attention`` subclass with ``__init__`` bypassed (no engine needed on CPU)."""
 
-    def __init__(self):
+    def __init__(
+        self,
+        *,
+        impl=None,
+        attn_type=AttentionType.DECODER,
+        sliding_window=None,
+        kv_sharing_target_layer_name=None,
+        kv_cache_dtype="auto",
+    ):
         nn.Module.__init__(self)
         # A trivial param so post-restore device/dtype detection succeeds.
         self.dummy = nn.Parameter(torch.zeros(1))
+        self.impl = impl if impl is not None else _make_flash_impl()
+        self.attn_type = attn_type
+        self.sliding_window = sliding_window
+        self.kv_sharing_target_layer_name = kv_sharing_target_layer_name
+        self.kv_cache_dtype = kv_cache_dtype
+
+
+def _make_worker(
+    model,
+    *,
+    dcp=1,
+    prefix_caching=False,
+    kv_transfer=None,
+    speculative=None,
+    block_size=16,
+    hf_config=None,
+):
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(decode_context_parallel_size=dcp),
+        cache_config=SimpleNamespace(enable_prefix_caching=prefix_caching, block_size=block_size),
+        kv_transfer_config=kv_transfer,
+        speculative_config=speculative,
+    )
+    model_runner = SimpleNamespace(
+        model=model,
+        vllm_config=vllm_config,
+        model_config=SimpleNamespace(hf_config=hf_config),
+        cascade_attn_enabled=False,
+    )
+    return SimpleNamespace(model_runner=model_runner)
 
 
 class _RealQuantMethod:
@@ -79,12 +159,15 @@ class _RealQuantLinear(vllm_linear.RowParallelLinear):
         self.quant_method = _RealQuantMethod()
 
 
+# --- Attach: convert only approved attention modules -------------------------------------------
+
+
 @pytest.mark.usefixtures("_no_distributed_parallel_state")
 def test_impl_swap_converts_attention_and_configures_nvfp4():
-    attention = _RealAttention()
+    attention = _FakeAttention()
     model = nn.ModuleDict({"attn": attention})
 
-    _attach_attention_quant_impl_swap(model)
+    _attach_attention_quant_impl_swap(model, {"attn"})
 
     converted = model.attn
     assert isinstance(converted, vllm_plugin._QuantVLLMAttention)
@@ -97,8 +180,7 @@ def test_impl_swap_converts_attention_and_configures_nvfp4():
         assert quantizer.num_bits == (2, 1)
         assert (quantizer.block_sizes or {}).get(-1) == 16
 
-    # K/V pick up the global-scale-1.0 runtime default (amax == 6 * 448 == 2688), matching
-    # test_vllm_kv_default_scale.py; the dynamic Q/P quantizers get no runtime default.
+    # K/V pick up the global-scale-1.0 runtime default (amax == 6 * 448 == 2688); dynamic Q/P do not.
     inputs = torch.tensor([-3.0, 5.0])
     for name in ("k_bmm_quantizer", "v_bmm_quantizer"):
         assert getattr(converted, name)._get_amax(inputs).item() == 2688.0
@@ -107,7 +189,7 @@ def test_impl_swap_converts_attention_and_configures_nvfp4():
 
 
 @pytest.mark.usefixtures("_no_distributed_parallel_state")
-def test_impl_swap_leaves_realquant_linear_untouched():
+def test_impl_swap_leaves_non_attention_untouched():
     linear = _RealQuantLinear()
     model = nn.ModuleDict({"proj": linear})
 
@@ -119,9 +201,188 @@ def test_impl_swap_leaves_realquant_linear_untouched():
     with pytest.raises(AssertionError):
         QuantModuleRegistry.convert(_RealQuantLinear())
 
-    # The attach must neither convert the Linear nor raise.
-    _attach_attention_quant_impl_swap(model)
+    # Even with the Linear's name approved, the isinstance guard skips it (not an attention type).
+    _attach_attention_quant_impl_swap(model, {"proj"})
 
     assert model.proj is linear
     assert type(model.proj) is _RealQuantLinear
     assert not isinstance(model.proj, vllm_plugin._QuantVLLMAttention)
+
+
+@pytest.mark.usefixtures("_no_distributed_parallel_state")
+def test_impl_swap_converts_only_allowed_names():
+    keep = _FakeAttention()
+    skip = _FakeAttention()
+    model = nn.ModuleDict({"keep": keep, "skip": skip})
+
+    _attach_attention_quant_impl_swap(model, {"keep"})
+
+    assert isinstance(model.keep, vllm_plugin._QuantVLLMAttention)
+    assert not isinstance(model.skip, vllm_plugin._QuantVLLMAttention)
+
+
+# --- Preflight support matrix (pure resolver) --------------------------------------------------
+
+
+def test_unsupported_reasons_empty_for_supported_decoder():
+    assert _unsupported_attention_reasons(_FakeAttention()) == []
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "needle"),
+    [
+        ({"attn_type": "encoder"}, "DECODER"),
+        ({"sliding_window": 128}, "sliding_window"),
+        ({"kv_sharing_target_layer_name": "model.layers.0.self_attn"}, "kv_sharing"),
+        ({"kv_cache_dtype": "fp8"}, "kv_cache_dtype"),
+        ({"kv_cache_dtype": "fp8_e4m3"}, "kv_cache_dtype"),
+    ],
+)
+def test_unsupported_reasons_for_module_attrs(kwargs, needle):
+    reasons = _unsupported_attention_reasons(_FakeAttention(**kwargs))
+    assert any(needle in reason for reason in reasons), reasons
+
+
+@pytest.mark.parametrize(
+    ("impl_overrides", "needle"),
+    [
+        ({"alibi_slopes": [0.1, 0.2]}, "alibi"),
+        ({"logits_soft_cap": 30.0}, "logits_soft_cap"),
+        ({"sinks": object()}, "sinks"),
+    ],
+)
+def test_unsupported_reasons_for_impl_attrs(impl_overrides, needle):
+    module = _FakeAttention(impl=_make_flash_impl(**impl_overrides))
+    reasons = _unsupported_attention_reasons(module)
+    assert any(needle in reason for reason in reasons), reasons
+
+
+def test_unsupported_reasons_for_unrecognized_backend():
+    class _WeirdImpl:
+        pass
+
+    reasons = _unsupported_attention_reasons(_FakeAttention(impl=_WeirdImpl()))
+    assert any("backend" in reason for reason in reasons), reasons
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "needle"),
+    [
+        ({"dcp": 2}, "decode_context_parallel_size"),
+        ({"prefix_caching": True}, "prefix caching"),
+        ({"kv_transfer": object()}, "connector"),
+        ({"speculative": object()}, "speculative"),
+        ({"block_size": 24}, "multiple"),
+        ({"block_size": 0}, "multiple"),
+    ],
+)
+def test_validate_global_runtime_flags_unsupported(kwargs, needle):
+    worker_obj = _make_worker(nn.ModuleDict({"attn": _FakeAttention()}), **kwargs)
+    reasons = _validate_global_runtime(worker_obj)
+    assert any(needle in reason for reason in reasons), reasons
+
+
+def test_validate_global_runtime_ok():
+    worker_obj = _make_worker(nn.ModuleDict({"attn": _FakeAttention()}))
+    assert _validate_global_runtime(worker_obj) == []
+
+
+@pytest.mark.usefixtures("_no_sparse_config")
+def test_preflight_happy_path_returns_records():
+    model = nn.ModuleDict({"a": _FakeAttention(), "b": _FakeAttention()})
+    records = _preflight_quant_sparse_attn(_make_worker(model), quant_will_be_configured=True)
+    assert {record.name for record in records} == {"a", "b"}
+
+
+@pytest.mark.usefixtures("_no_sparse_config")
+def test_preflight_raises_with_layer_name_and_reason():
+    model = nn.ModuleDict({"good": _FakeAttention(), "bad": _FakeAttention(sliding_window=256)})
+    with pytest.raises(NotImplementedError) as exc:
+        _preflight_quant_sparse_attn(_make_worker(model), quant_will_be_configured=True)
+    message = str(exc.value)
+    assert "bad" in message
+    assert "sliding_window" in message
+
+
+@pytest.mark.usefixtures("_no_sparse_config")
+def test_preflight_aggregates_global_and_per_layer_reasons():
+    model = nn.ModuleDict({"bad": _FakeAttention(kv_cache_dtype="fp8")})
+    worker_obj = _make_worker(model, prefix_caching=True)
+    with pytest.raises(NotImplementedError) as exc:
+        _preflight_quant_sparse_attn(worker_obj, quant_will_be_configured=True)
+    message = str(exc.value)
+    assert "prefix caching" in message
+    assert "kv_cache_dtype" in message
+
+
+@pytest.mark.usefixtures("_no_sparse_config")
+def test_preflight_is_pure_and_leaves_model_unmutated():
+    bad = _FakeAttention(sliding_window=256)
+    model = nn.ModuleDict({"bad": bad})
+    impl_before = bad.impl
+    with pytest.raises(NotImplementedError):
+        _preflight_quant_sparse_attn(_make_worker(model), quant_will_be_configured=True)
+    assert bad.impl is impl_before
+    assert not isinstance(bad, vllm_plugin._QuantVLLMAttention)
+
+
+# --- Two-pass atomic install -------------------------------------------------------------------
+
+
+@pytest.fixture
+def converted_two_layer_worker(_no_distributed_parallel_state):
+    """A worker whose model has two NVFP4-quantized decoder attention layers (post-attach)."""
+    model = nn.ModuleDict({"a": _FakeAttention(), "b": _FakeAttention()})
+    _attach_attention_quant_impl_swap(model, {"a", "b"})
+    # Conversion must preserve the backend impl the sparse clone re-classes.
+    assert all(isinstance(model[name].impl, FlashAttentionImpl) for name in ("a", "b"))
+    return _make_worker(model)
+
+
+def _records_for(worker_obj):
+    model = worker_obj.model_runner.model
+    return tuple(_AttentionInstallRecord(name=name, sparse_kw={}) for name in model)
+
+
+def test_prepare_constructs_all_without_assigning(converted_two_layer_worker):
+    worker_obj = converted_two_layer_worker
+    model = worker_obj.model_runner.model
+    impls_before = {name: model[name].impl for name in model}
+
+    prepared = _prepare_quant_sparse_attn(worker_obj, _records_for(worker_obj))
+
+    assert len(prepared) == 2
+    assert all(isinstance(item.new_impl, ModelOptSparseAttentionImpl) for item in prepared)
+    # Prepare must not touch the live modules.
+    for name in model:
+        assert model[name].impl is impls_before[name]
+        assert model[name]._value_quant_in_kernel is False
+
+
+def test_commit_assigns_impls_then_flips_value_gate(converted_two_layer_worker):
+    worker_obj = converted_two_layer_worker
+    model = worker_obj.model_runner.model
+
+    prepared = _prepare_quant_sparse_attn(worker_obj, _records_for(worker_obj))
+    _commit_quant_sparse_attn(prepared)
+
+    for name in model:
+        assert isinstance(model[name].impl, ModelOptSparseAttentionImpl)
+        # V is NVFP4 -> in-kernel V ownership, so the head_dim V pre-step is skipped.
+        assert model[name]._value_quant_in_kernel is True
+
+
+def test_install_failure_on_last_layer_leaves_model_unchanged(converted_two_layer_worker):
+    worker_obj = converted_two_layer_worker
+    model = worker_obj.model_runner.model
+    # Make the second layer unclonable (sinks are unsupported) so prepare raises after the first
+    # layer already prepared -- commit must never run.
+    model["b"].impl.sinks = object()
+    impls_before = {name: model[name].impl for name in model}
+
+    with pytest.raises(NotImplementedError, match="sinks"):
+        _install_quant_sparse_attn(worker_obj, _records_for(worker_obj))
+
+    for name in model:
+        assert model[name].impl is impls_before[name]
+        assert model[name]._value_quant_in_kernel is False

--- a/tests/gpu_vllm/torch/quantization/test_vllm_dynamic_modules.py
+++ b/tests/gpu_vllm/torch/quantization/test_vllm_dynamic_modules.py
@@ -29,6 +29,7 @@ TinyDeepseekV3 (+ MLAAttention).
 from __future__ import annotations
 
 import gc
+import types
 
 import pytest
 from _test_utils.torch.transformers_models import (
@@ -41,13 +42,68 @@ from vllm.distributed import cleanup_dist_env_and_memory
 
 import modelopt.torch.quantization as mtq
 from modelopt.torch.quantization.nn import TensorQuantizer
+from modelopt.torch.quantization.plugins import vllm as vllm_plugin
 from modelopt.torch.quantization.plugins.vllm import (
     _ATTENTION_TYPES,
     VllmMLAAttention,
+    _import_attention_module,
     _QuantFusedMoEBase,
     _VLLMParallelLinear,
     disable_compilation,
 )
+
+# --- Attention import-path selection (no engine boot) ------------------------------------------
+# Some installed layouts expose ``vllm.attention`` as a namespace package that ``find_spec``
+# locates but that does not define ``Attention``. Selecting a module by namespace existence alone
+# then fails at ``vllm_attention.Attention``. ``_import_attention_module`` must instead accept a
+# module only when it actually exports ``Attention``.
+
+
+def test_import_attention_module_registers_concrete_attention():
+    """The plugin's resolved module must export a concrete ``Attention`` class (regression:
+    on layouts where only ``vllm.model_executor.layers.attention`` has it, importing the plugin
+    used to raise ``AttributeError`` on the namespace ``vllm.attention``)."""
+    module = _import_attention_module()
+    assert isinstance(getattr(module, "Attention", None), type)
+    # The module-level ``vllm_attention`` bound at import time is the same resolved module.
+    assert vllm_plugin.vllm_attention.Attention is module.Attention
+    assert vllm_plugin.vllm_attention.Attention in _ATTENTION_TYPES
+
+
+def test_import_attention_module_skips_namespace_without_attention(monkeypatch):
+    """A module that imports but lacks ``Attention`` is skipped in favor of one that has it."""
+
+    class _Attention:
+        pass
+
+    namespace = types.ModuleType("vllm.attention")  # imports fine, but no ``Attention``
+    concrete = types.ModuleType("vllm.model_executor.layers.attention")
+    concrete.Attention = _Attention
+    available = {"vllm.attention": namespace, "vllm.model_executor.layers.attention": concrete}
+
+    def fake_import(name):
+        if name in available:
+            return available[name]
+        raise ImportError(name)
+
+    monkeypatch.setattr(vllm_plugin.importlib, "import_module", fake_import)
+    selected = _import_attention_module()
+    assert selected is concrete
+    assert selected is not namespace
+
+
+def test_import_attention_module_raises_when_no_module_exports_attention(monkeypatch):
+    """Refuse to select a namespace solely because ``find_spec``/import succeeds."""
+    namespace = types.ModuleType("vllm.attention")  # imports, but never exports ``Attention``
+
+    def fake_import(name):
+        if name == "vllm.attention":
+            return namespace
+        raise ImportError(name)
+
+    monkeypatch.setattr(vllm_plugin.importlib, "import_module", fake_import)
+    with pytest.raises(ImportError):
+        _import_attention_module()
 
 
 def _quantize_and_summarize(self):

--- a/tests/gpu_vllm/torch/quantization/test_vllm_kv_default_scale.py
+++ b/tests/gpu_vllm/torch/quantization/test_vllm_kv_default_scale.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from modelopt.torch.quantization.config import QuantizerAttributeConfig
+from modelopt.torch.quantization.nn import SequentialQuantizer, TensorQuantizer
+from modelopt.torch.quantization.plugins import vllm as vllm_plugin
+from modelopt.torch.quantization.plugins.vllm import _set_vllm_attention_kv_runtime_amax
+
+
+def _nvfp4_quantizer(*, block_size=16, enabled=True, amax=None, use_constant_amax=False):
+    quantizer = TensorQuantizer(
+        QuantizerAttributeConfig(
+            num_bits=(2, 1),
+            block_sizes={-1: block_size, "type": "dynamic", "scale_bits": (4, 3)},
+            enable=enabled,
+            use_constant_amax=use_constant_amax,
+        )
+    )
+    if amax is not None:
+        quantizer.amax = torch.tensor(amax)
+    return quantizer
+
+
+def test_uncalibrated_nvfp4_kv_use_global_scale_one():
+    layer = SimpleNamespace(
+        q_bmm_quantizer=_nvfp4_quantizer(),
+        k_bmm_quantizer=_nvfp4_quantizer(use_constant_amax=True),
+        v_bmm_quantizer=_nvfp4_quantizer(use_constant_amax=True),
+        p_bmm_quantizer=_nvfp4_quantizer(),
+    )
+    _set_vllm_attention_kv_runtime_amax(layer, torch.device("cpu"))
+    inputs = torch.tensor([-3.0, 5.0])
+    for name in ("k_bmm_quantizer", "v_bmm_quantizer"):
+        quantizer = getattr(layer, name)
+        assert quantizer._get_amax(inputs).item() == 2688.0
+        assert quantizer._get_amax(inputs).item() / (6.0 * 448.0) == 1.0
+        assert "_runtime_default_amax" not in quantizer.state_dict()
+    assert not hasattr(layer.q_bmm_quantizer, "_runtime_default_amax")
+    assert not hasattr(layer.p_bmm_quantizer, "_runtime_default_amax")
+
+
+def test_calibrated_kv_amax_overrides_runtime_default():
+    layer = SimpleNamespace(
+        k_bmm_quantizer=_nvfp4_quantizer(amax=7.25, use_constant_amax=True),
+        v_bmm_quantizer=_nvfp4_quantizer(use_constant_amax=True),
+    )
+    _set_vllm_attention_kv_runtime_amax(layer, torch.device("cpu"))
+    # Simulate optional modelopt_state_weights loading after metadata restore.
+    layer.v_bmm_quantizer.amax = torch.tensor(9.5)
+    _set_vllm_attention_kv_runtime_amax(layer, torch.device("cpu"))
+    inputs = torch.tensor([-3.0, 5.0])
+    assert layer.k_bmm_quantizer._get_amax(inputs).item() == 7.25
+    assert layer.v_bmm_quantizer._get_amax(inputs).item() == 9.5
+
+
+def test_sequential_kv_quantizers_are_left_unchanged():
+    sequential = SequentialQuantizer(_nvfp4_quantizer(), _nvfp4_quantizer())
+    layer = SimpleNamespace(k_bmm_quantizer=sequential, v_bmm_quantizer=sequential)
+    _set_vllm_attention_kv_runtime_amax(layer, torch.device("cpu"))
+    assert all(not hasattr(q, "_runtime_default_amax") for q in sequential)
+
+
+def test_unsupported_kv_quantizers_do_not_get_runtime_default():
+    fp8 = TensorQuantizer(QuantizerAttributeConfig(num_bits=(4, 3)))
+    block32 = _nvfp4_quantizer(block_size=32)
+    disabled = _nvfp4_quantizer(enabled=False)
+    for quantizer in (fp8, block32, disabled):
+        layer = SimpleNamespace(k_bmm_quantizer=quantizer, v_bmm_quantizer=quantizer)
+        _set_vllm_attention_kv_runtime_amax(layer, torch.device("cpu"))
+        assert not hasattr(quantizer, "_runtime_default_amax")
+
+
+def test_post_restore_vllm_attentions_visits_only_attention_modules(monkeypatch):
+    class BaseAttention(nn.Module):
+        pass
+
+    class QuantAttention(BaseAttention):
+        def __init__(self):
+            super().__init__()
+            self.post_restore_calls = []
+
+        def modelopt_post_restore(self, prefix=""):
+            self.post_restore_calls.append(prefix)
+
+    class NativeAttention(BaseAttention):
+        pass
+
+    class UnrelatedModule(nn.Module):
+        @property
+        def modelopt_post_restore(self):
+            raise AssertionError("non-attention hook lookup")
+
+    attention = QuantAttention()
+    native_attention = NativeAttention()
+    model = nn.ModuleList([attention, native_attention, UnrelatedModule(), nn.Linear(2, 2)])
+    monkeypatch.setattr(vllm_plugin, "_ATTENTION_TYPES", (BaseAttention,))
+
+    vllm_plugin.post_restore_vllm_attentions(model)
+
+    assert attention.post_restore_calls == [""]

--- a/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_sparse_attn_worker.py
+++ b/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_sparse_attn_worker.py
@@ -117,7 +117,10 @@ def test_forward_delegates_cascade_metadata_to_vllm(monkeypatch):
 @pytest.mark.parametrize(
     ("sparse_kw", "max_query_len", "max_seq_len"),
     [
-        ({"skip_softmax_threshold": 0.001}, 1, 128),
+        # A prefill launch whose calibrated threshold resolves out of the valid lambda range → the
+        # skip is disabled → no effective sparse work → delegate. (A *decode* launch with a direct
+        # skip_softmax_threshold is effective work and routes to the kernel; see the decode-route
+        # test below.)
         (
             {
                 "threshold_scale_factor": {
@@ -197,6 +200,72 @@ def test_forward_delegates_launches_without_effective_sparse_work(
     assert called["attn_metadata"] is attn_metadata
     assert result is output
     assert torch.all(result == 5)
+
+
+def test_forward_decode_skip_softmax_routes_to_kernel(monkeypatch):
+    """A decode launch with a direct skip_softmax_threshold IS effective work: it must route to the
+    paged decode kernel (``attention_decode``), not delegate to native FlashAttention."""
+    impl = _clone_sparse_impl(_make_old_impl())
+    impl.sparse_kw = {"skip_softmax_threshold": 0.001}
+    seq_len, head_dim = 128, impl.head_size
+    q = torch.zeros(1, impl.num_heads, head_dim, dtype=torch.float16)
+    kv_cache = torch.zeros(2, 1, seq_len, impl.num_kv_heads, head_dim, dtype=torch.float16)
+    output = torch.empty_like(q)
+    attn_metadata = type(
+        "AttnMetadata",
+        (),
+        {
+            "num_actual_tokens": 1,
+            "max_query_len": 1,  # decode
+            "max_seq_len": seq_len,
+            "query_start_loc": torch.tensor([0, 1], dtype=torch.int32),
+            "seq_lens": torch.tensor([seq_len], dtype=torch.int32),
+            "block_table": torch.zeros(1, 1, dtype=torch.int32),
+        },
+    )()
+    called = {}
+
+    def fake_decode(*args, **kwargs):
+        called["decode"] = True
+        return output.fill_(7)
+
+    def fake_flash_forward(self, *args, **kwargs):
+        raise AssertionError("decode skip-softmax must route to attention_decode, not delegate")
+
+    monkeypatch.setattr(vllm_plugin, "attention_decode", fake_decode)
+    monkeypatch.setattr(FlashAttentionImpl, "forward", fake_flash_forward)
+
+    impl.forward(
+        layer=None,
+        query=q,
+        key=q,
+        value=q,
+        kv_cache=kv_cache,
+        attn_metadata=attn_metadata,
+        output=output,
+    )
+    assert called.get("decode") is True
+
+
+def test_forward_cascade_with_active_plan_raises():
+    """Cascade + an active ModelOpt plan (here sparse-only) must fail loud, not silently delegate to
+    native attention (which would drop the requested skip-softmax / quant)."""
+    impl = _clone_sparse_impl(_make_old_impl())
+    impl.sparse_kw = {"skip_softmax_threshold": 0.001}  # active transform, no P/V quant
+    q = torch.zeros(1, impl.num_heads, impl.head_size, dtype=torch.float16)
+    kv_cache = torch.zeros(2, 1, 16, impl.num_kv_heads, impl.head_size, dtype=torch.float16)
+    output = torch.empty_like(q)
+    attn_metadata = type("AttnMetadata", (), {"use_cascade": True})()
+    with pytest.raises(NotImplementedError, match="cascade"):
+        impl.forward(
+            layer=None,
+            query=q,
+            key=q,
+            value=q,
+            kv_cache=kv_cache,
+            attn_metadata=attn_metadata,
+            output=output,
+        )
 
 
 def test_forward_resolves_calibrated_skip_softmax_threshold(monkeypatch):

--- a/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_plugin.py
+++ b/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_plugin.py
@@ -36,6 +36,7 @@ from modelopt.torch.kernels.common.attention import IS_AVAILABLE as TRITON_KERNE
 from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
     ModelOptSparseAttentionImpl,
     _p_qdq_from_layer,
+    _v_qdq_from_layer,
 )
 
 if TRITON_KERNEL_AVAILABLE:
@@ -69,6 +70,32 @@ def test_p_qdq_from_layer():
     nvfp4 = {"is_fp8": False, "is_nvfp4_dynamic": True, "_amax": None}
     assert _p_qdq_from_layer(_layer(**nvfp4, block_sizes={-1: 16})) == ("nvfp4", 1.0)
     assert _p_qdq_from_layer(_layer(**nvfp4, block_sizes={-1: 32})) == (None, 1.0)
+
+
+def test_v_qdq_from_layer():
+    """_v_qdq_from_layer maps a layer's v_bmm_quantizer to (v_qdq mode, amax).
+
+    Same FP8/NVFP4 mapping as P, but V has no natural amax bound, so the default
+    (no calibrated _amax) is ``None`` -> the kernel's constant 1.0 global scale.
+    """
+    # Missing / disabled quantizer -> no V quant, default amax None.
+    assert _v_qdq_from_layer(None) == (None, None)
+    assert _v_qdq_from_layer(SimpleNamespace()) == (None, None)
+    disabled = SimpleNamespace(v_bmm_quantizer=SimpleNamespace(is_enabled=False))
+    assert _v_qdq_from_layer(disabled) == (None, None)
+
+    def _layer(**kw):
+        return SimpleNamespace(v_bmm_quantizer=SimpleNamespace(is_enabled=True, **kw))
+
+    # Per-tensor FP8 -> "fp8"; calibrated scalar _amax forwarded, else default None.
+    fp8 = {"is_fp8": True, "is_nvfp4_dynamic": False, "block_sizes": None}
+    assert _v_qdq_from_layer(_layer(**fp8, _amax=None)) == ("fp8", None)
+    assert _v_qdq_from_layer(_layer(**fp8, _amax=torch.tensor(0.5))) == ("fp8", 0.5)
+
+    # Dynamic NVFP4 at block size 16 -> "nvfp4"; any other block size -> None.
+    nvfp4 = {"is_fp8": False, "is_nvfp4_dynamic": True, "_amax": None}
+    assert _v_qdq_from_layer(_layer(**nvfp4, block_sizes={-1: 16})) == ("nvfp4", None)
+    assert _v_qdq_from_layer(_layer(**nvfp4, block_sizes={-1: 32})) == (None, None)
 
 
 def _make_paged_cache(k, v, b_start_loc, b_seq_len, num_kv_heads, head_dim, page_size):

--- a/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_plugin.py
+++ b/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_plugin.py
@@ -33,7 +33,10 @@ import torch
 from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
 
 from modelopt.torch.kernels.common.attention import IS_AVAILABLE as TRITON_KERNEL_AVAILABLE
-from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import ModelOptSparseAttentionImpl
+from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
+    ModelOptSparseAttentionImpl,
+    _p_qdq_from_layer,
+)
 
 if TRITON_KERNEL_AVAILABLE:
     from modelopt.torch.kernels.common.attention import attention as triton_attention
@@ -44,6 +47,28 @@ _ACTIVE_PREFILL_SPARSE_KW = {
     "dense_sink_tokens": 0,
     "dense_recent_tokens": 0,
 }
+
+
+def test_p_qdq_from_layer():
+    """_p_qdq_from_layer maps a layer's p_bmm_quantizer to (p_qdq mode, amax)."""
+    # Missing / disabled quantizer -> no P quant.
+    assert _p_qdq_from_layer(None) == (None, 1.0)
+    assert _p_qdq_from_layer(SimpleNamespace()) == (None, 1.0)
+    disabled = SimpleNamespace(p_bmm_quantizer=SimpleNamespace(is_enabled=False))
+    assert _p_qdq_from_layer(disabled) == (None, 1.0)
+
+    def _layer(**kw):
+        return SimpleNamespace(p_bmm_quantizer=SimpleNamespace(is_enabled=True, **kw))
+
+    # Per-tensor FP8 -> "fp8"; a calibrated scalar _amax is forwarded, else default 1.0.
+    fp8 = {"is_fp8": True, "is_nvfp4_dynamic": False, "block_sizes": None}
+    assert _p_qdq_from_layer(_layer(**fp8, _amax=None)) == ("fp8", 1.0)
+    assert _p_qdq_from_layer(_layer(**fp8, _amax=torch.tensor(0.5))) == ("fp8", 0.5)
+
+    # Dynamic NVFP4 at block size 16 -> "nvfp4"; any other block size -> None.
+    nvfp4 = {"is_fp8": False, "is_nvfp4_dynamic": True, "_amax": None}
+    assert _p_qdq_from_layer(_layer(**nvfp4, block_sizes={-1: 16})) == ("nvfp4", 1.0)
+    assert _p_qdq_from_layer(_layer(**nvfp4, block_sizes={-1: 32})) == (None, 1.0)
 
 
 def _make_paged_cache(k, v, b_start_loc, b_seq_len, num_kv_heads, head_dim, page_size):

--- a/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_plugin.py
+++ b/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_plugin.py
@@ -35,6 +35,7 @@ from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
 from modelopt.torch.kernels.common.attention import IS_AVAILABLE as TRITON_KERNEL_AVAILABLE
 from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
     ModelOptSparseAttentionImpl,
+    _assert_bmm_quant_supported,
     _p_qdq_from_layer,
     _v_qdq_from_layer,
 )
@@ -96,6 +97,49 @@ def test_v_qdq_from_layer():
     nvfp4 = {"is_fp8": False, "is_nvfp4_dynamic": True, "_amax": None}
     assert _v_qdq_from_layer(_layer(**nvfp4, block_sizes={-1: 16})) == ("nvfp4", None)
     assert _v_qdq_from_layer(_layer(**nvfp4, block_sizes={-1: 32})) == (None, None)
+
+
+def test_assert_bmm_quant_supported():
+    """An enabled BMM2 quantizer in an unmapped format must raise -- never serve unquantized.
+
+    Regression for the silent V-quant skip: when P maps but ``v_bmm_quantizer`` is enabled
+    in a format the kernel cannot map (e.g. block size != 16), the layer would otherwise be
+    served with V unquantized (kernel skips it and ``_value_quant_in_kernel`` skips the
+    pre-step). Install must fail loud instead.
+    """
+    # Disabled / missing / sparse-only -> no raise.
+    _assert_bmm_quant_supported(SimpleNamespace())
+    _assert_bmm_quant_supported(SimpleNamespace(v_bmm_quantizer=SimpleNamespace(is_enabled=False)))
+
+    def _layer(attr, **kw):
+        return SimpleNamespace(**{attr: SimpleNamespace(is_enabled=True, **kw)})
+
+    mapped_fp8 = {"is_fp8": True, "is_nvfp4_dynamic": False, "block_sizes": None, "_amax": None}
+    mapped_nvfp4 = {
+        "is_fp8": False,
+        "is_nvfp4_dynamic": True,
+        "block_sizes": {-1: 16},
+        "_amax": None,
+    }
+    unmapped = {"is_fp8": False, "is_nvfp4_dynamic": True, "block_sizes": {-1: 32}, "_amax": None}
+
+    # Mapped formats (per-tensor FP8, block-16 NVFP4) on either operand -> no raise.
+    _assert_bmm_quant_supported(_layer("p_bmm_quantizer", **mapped_fp8))
+    _assert_bmm_quant_supported(_layer("v_bmm_quantizer", **mapped_nvfp4))
+
+    # Enabled but unmapped (block 32) -> raise, for P and for V.
+    with pytest.raises(NotImplementedError, match="unsupported"):
+        _assert_bmm_quant_supported(_layer("p_bmm_quantizer", **unmapped))
+    with pytest.raises(NotImplementedError, match="unsupported"):
+        _assert_bmm_quant_supported(_layer("v_bmm_quantizer", **unmapped))
+
+    # The motivating case: P maps, V enabled-but-unmapped -> must raise (not silently skip V).
+    p_ok_v_bad = SimpleNamespace(
+        p_bmm_quantizer=SimpleNamespace(is_enabled=True, **mapped_fp8),
+        v_bmm_quantizer=SimpleNamespace(is_enabled=True, **unmapped),
+    )
+    with pytest.raises(NotImplementedError, match="v_bmm_quantizer"):
+        _assert_bmm_quant_supported(p_ok_v_bad)
 
 
 def _make_paged_cache(k, v, b_start_loc, b_seq_len, num_kv_heads, head_dim, page_size):

--- a/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_plugin.py
+++ b/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_plugin.py
@@ -95,6 +95,20 @@ def _make_impl(num_heads, head_dim, num_kv_heads):
     )
 
 
+def _dense_decode_ref(q, k, v, kv_start, kv_lens, num_heads, num_kv_heads, scale):
+    """Reference decode attention per request. q [batch, H, D]; k/v [total_kv, KVH, D]."""
+    g = num_heads // num_kv_heads
+    outs = []
+    for b in range(q.shape[0]):
+        s, length = int(kv_start[b].item()), int(kv_lens[b].item())
+        kb = k[s : s + length].transpose(0, 1).repeat_interleave(g, dim=0)  # [H, L, D]
+        vb = v[s : s + length].transpose(0, 1).repeat_interleave(g, dim=0)
+        scores = (q[b].unsqueeze(1) @ kb.transpose(-1, -2)).squeeze(1) * scale  # [H, L]
+        p = scores.float().softmax(dim=-1).to(v.dtype)
+        outs.append((p.unsqueeze(1) @ vb).squeeze(1))  # [H, D]
+    return torch.stack(outs, dim=0)
+
+
 @pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
 class TestModelOptSparseAttentionImpl:
     """Verify forward() metadata translation matches a contiguous reference."""
@@ -300,6 +314,58 @@ class TestModelOptSparseAttentionImpl:
         assert called["attn_metadata"] is attn_metadata
         assert result is output
         assert torch.all(result == 9)
+
+    def test_decode_skip_softmax_uses_decode_kernel(self, monkeypatch):
+        """Decode-only skip-softmax routes through the ModelOpt decode kernel.
+
+        With a near-zero threshold (skips almost nothing) the paged decode kernel
+        must reproduce dense decode attention, and must NOT fall back to vLLM's
+        native attention.
+        """
+        batch = 2
+        kv_lens = torch.tensor([130, 200], device="cuda", dtype=torch.int32)  # multi-tile
+        num_heads, num_kv_heads, head_dim = 4, 2, 64
+        page_size = 16
+        dtype = torch.float16
+        scale = 1.0 / (head_dim**0.5)
+
+        torch.manual_seed(3)
+        q = torch.randn(batch, num_heads, head_dim, device="cuda", dtype=dtype)
+        k = torch.randn(int(kv_lens.sum()), num_kv_heads, head_dim, device="cuda", dtype=dtype)
+        v = torch.randn_like(k)
+        kv_start = torch.tensor([0, int(kv_lens[0].item())], device="cuda", dtype=torch.int32)
+        kv_cache, block_table = _make_paged_cache(
+            k, v, kv_start, kv_lens, num_kv_heads, head_dim, page_size
+        )
+        attn_metadata = SimpleNamespace(
+            num_actual_tokens=batch,
+            max_query_len=1,
+            max_seq_len=int(kv_lens.max().item()),
+            query_start_loc=torch.tensor([0, 1, 2], device="cuda", dtype=torch.int32),
+            seq_lens=kv_lens,
+            block_table=block_table,
+        )
+
+        # Native attention must NOT be reached for a skip-softmax decode launch.
+        def _fail_fallback(*args, **kwargs):
+            raise AssertionError("decode skip-softmax should not delegate to vLLM")
+
+        monkeypatch.setattr(FlashAttentionImpl, "forward", _fail_fallback)
+
+        impl = _make_impl(num_heads, head_dim, num_kv_heads)
+        impl.sparse_kw = {"skip_softmax_threshold": 2**-20}  # ~dense
+        out = impl.forward(
+            layer=None,
+            query=q,
+            key=q,
+            value=q,
+            kv_cache=kv_cache,
+            attn_metadata=attn_metadata,
+            output=torch.empty_like(q),
+        )
+
+        ref = _dense_decode_ref(q, k, v, kv_start, kv_lens, num_heads, num_kv_heads, scale)
+        torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-2)
 
     def test_profiling_run_returns_zeros(self):
         """attn_metadata=None (vLLM profiling pass) must zero-fill output and return."""

--- a/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_plugin.py
+++ b/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_plugin.py
@@ -33,6 +33,7 @@ import torch
 from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
 
 from modelopt.torch.kernels.common.attention import IS_AVAILABLE as TRITON_KERNEL_AVAILABLE
+from modelopt.torch.sparsity.attention_sparsity.plugins import vllm as vllm_plugin
 from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import (
     ModelOptSparseAttentionImpl,
     _assert_bmm_quant_supported,
@@ -49,6 +50,93 @@ _ACTIVE_PREFILL_SPARSE_KW = {
     "dense_sink_tokens": 0,
     "dense_recent_tokens": 0,
 }
+
+
+def test_bake_v_onwrite_finalizes_completed_blocks_only(monkeypatch):
+    """The V-cache preparation leaves the raw partial block for in-kernel QDQ."""
+    calls = {}
+
+    def _fake_bake(value_cache, block_table, v_lo, v_hi, **kwargs):
+        calls["bake"] = (v_lo.clone(), v_hi.clone(), kwargs)
+
+    monkeypatch.setattr(vllm_plugin, "fake_quant_v_onwrite", _fake_bake)
+
+    seq_lens = torch.tensor([15, 16, 17], dtype=torch.int32)
+    query_lens = torch.ones(3, dtype=torch.int32)
+    result = vllm_plugin._bake_v_onwrite(
+        object(),
+        object(),
+        seq_lens,
+        query_lens,
+        page_size=16,
+        v_qdq_amax=None,
+        decode=True,
+    )
+
+    v_lo, v_hi, bake_kwargs = calls["bake"]
+    torch.testing.assert_close(v_lo, torch.tensor([0, 0, 16], dtype=torch.int32))
+    torch.testing.assert_close(v_hi, torch.tensor([0, 16, 16], dtype=torch.int32))
+    assert bake_kwargs["decode"] is True
+    assert bake_kwargs["v_qdq_scale"] == 1.0
+    assert result is None
+
+
+@pytest.mark.parametrize("amax", [0.0, -1.0, float("nan"), float("inf")])
+def test_bake_v_onwrite_rejects_invalid_scale_before_mutation(monkeypatch, amax):
+    """An invalid calibrated scale must fail before any permanent cache write."""
+
+    def _unexpected_mutation(*args, **kwargs):
+        raise AssertionError("V cache mutated before scale validation")
+
+    monkeypatch.setattr(vllm_plugin, "fake_quant_v_onwrite", _unexpected_mutation)
+    with pytest.raises(ValueError, match="finite and positive"):
+        vllm_plugin._bake_v_onwrite(
+            object(),
+            object(),
+            torch.tensor([16], dtype=torch.int32),
+            torch.tensor([1], dtype=torch.int32),
+            page_size=16,
+            v_qdq_amax=amax,
+            decode=True,
+        )
+
+
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 9)),
+    reason="NVFP4 V cache preparation uses tl.float8e4nv (sm_89+)",
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_v_cache_chunk_lifecycle_never_requantizes_completed_groups(dtype):
+    """The plugin range logic finalizes each block once across chunked writes."""
+    value = 0.017578125  # QDQ once -> 0.015625; twice -> 0.01171875
+    value_cache = torch.full((3, 16, 1, 128), value, device="cuda", dtype=dtype)
+    block_table = torch.arange(3, device="cuda", dtype=torch.int32).view(1, 3)
+
+    def _step(seq_len, query_len):
+        seq_lens = torch.tensor([seq_len], device="cuda", dtype=torch.int32)
+        query_lens = torch.tensor([query_len], device="cuda", dtype=torch.int32)
+        vllm_plugin._bake_v_onwrite(
+            value_cache,
+            block_table,
+            seq_lens,
+            query_lens,
+            page_size=16,
+            v_qdq_amax=None,
+            decode=False,
+        )
+
+    _step(15, 15)
+    torch.testing.assert_close(value_cache[0, :15], torch.full_like(value_cache[0, :15], value))
+
+    _step(17, 2)
+    first_group = value_cache[0].clone()
+    torch.testing.assert_close(first_group, torch.full_like(first_group, 0.015625))
+    assert value_cache[1, 0, 0, 0] == value
+
+    _step(33, 16)
+    torch.testing.assert_close(value_cache[0], first_group, rtol=0, atol=0)
+    torch.testing.assert_close(value_cache[1], torch.full_like(value_cache[1], 0.015625))
+    assert value_cache[2, 0, 0, 0] == value
 
 
 def test_p_qdq_from_layer():
@@ -270,6 +358,58 @@ class TestModelOptSparseAttentionImpl:
         )
 
         torch.testing.assert_close(out_paged, out_ref, rtol=1e-2, atol=1e-2)
+
+    @pytest.mark.skipif(
+        not (torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 9)),
+        reason="NVFP4 V cache preparation uses tl.float8e4nv (sm_89+)",
+    )
+    def test_prefill_baked_v_plus_tail_matches_pristine_onread(self):
+        """Completed V groups plus raw-tail QDQ match full on-read QDQ in prefill."""
+        seq_len = 17
+        num_heads, num_kv_heads, head_dim = 2, 1, 64
+        page_size = 16
+        dtype = torch.float16
+        q = torch.zeros(seq_len, num_heads, head_dim, device="cuda", dtype=dtype)
+        k = torch.zeros(seq_len, num_kv_heads, head_dim, device="cuda", dtype=dtype)
+        v = torch.full_like(k, 0.017578125)  # QDQ once -> 0.015625; twice -> 0.01171875
+        starts = torch.zeros(1, device="cuda", dtype=torch.int32)
+        seq_lens = torch.tensor([seq_len], device="cuda", dtype=torch.int32)
+        kv_cache, block_table = _make_paged_cache(
+            k, v, starts, seq_lens, num_kv_heads, head_dim, page_size
+        )
+        k_cache, raw_v_cache = kv_cache.unbind(0)
+        common = {
+            "b_seq_len_k": seq_lens,
+            "max_input_len_k": seq_len,
+            "k_cache": k_cache,
+            "block_table": block_table,
+            "page_size": page_size,
+            "v_qdq": "nvfp4",
+        }
+        out_onread = triton_attention(
+            q, k, v, starts, seq_lens, seq_len, v_cache=raw_v_cache, **common
+        )
+
+        baked_v_cache = raw_v_cache.clone()
+        vllm_plugin.fake_quant_v_onwrite(
+            baked_v_cache,
+            block_table,
+            starts,
+            torch.tensor([16], device="cuda", dtype=torch.int32),
+            page_size=page_size,
+        )
+        out_baked = triton_attention(
+            q,
+            k,
+            v,
+            starts,
+            seq_lens,
+            seq_len,
+            v_cache=baked_v_cache,
+            v_cache_quantized=True,
+            **common,
+        )
+        torch.testing.assert_close(out_baked, out_onread, rtol=1e-4, atol=1e-5)
 
     def test_chunked_prefill_is_forwarded_to_kernel(self):
         """Chunked prefill metadata is handled by the suffix-aware causal mask."""


### PR DESCRIPTION
### What does this PR do?

Type of change: ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

<!-- Details about the change. -->
NVFP4 fake‑quantized attention with skip‑softmax/2:4 sparsity for vLLM serving.

### Usage

```python
# Serve a ModelOpt-exported checkpoint (quantized + a sparse_attention_config block)
# with combined attention quant + skip-softmax sparsity:
MODELOPT_STATE_PATH=<ckpt>/vllm_fq_modelopt_state.pth \
    python examples/vllm_serve/vllm_serve_quant_sparse_attn.py <ckpt> \
        -tp 8 --host 0.0.0.0 --port 8000

# Low-level kernel API (used internally by the vLLM plugin):
from modelopt.torch.kernels.common.attention import attention  # prefill (Triton)

out = attention(
    q, k, v, b_start_loc, b_seq_len, max_input_len,
    is_causal=True, softmax_scale=scale,
    p_qdq="nvfp4", v_qdq="nvfp4",      # in-kernel NVFP4 fake-quant of P and V
    sparsity_n=2, sparsity_m=4,        # optional 2:4 prefill sparsity
)

```

### Testing

| model | aa-lcr  | 
| -----: | ------: | 
|  baseline |    64.69±0.53 |
|  nvfp4 attn |   63.88±0.72 | 

| kv_len | prefill |   s=1 |   s=2 |   s=4 |   s=8 |  auto |  best |   speedup |
| -----: | ------: | ----: | ----: | ----: | ----: | ----: | ----: | --------: |
|  2,048 |   0.084 | 0.115 | 0.064 | 0.043 | 0.034 | 0.054 | 0.034 | **2.47×** |
|  8,192 |   0.289 | 0.424 | 0.221 | 0.132 | 0.087 | 0.171 | 0.087 | **3.31×** |
| 32,768 |   1.109 | 1.659 | 0.849 | 0.488 | 0.295 | 0.641 | 0.295 | **3.76×** |

| kv_len | prefill |   s=1 |   s=2 |   s=4 |   s=8 |  auto |  best |   speedup |
| -----: | ------: | ----: | ----: | ----: | ----: | ----: | ----: | --------: |
|  2,048 |   0.101 | 0.136 | 0.075 | 0.067 | 0.058 | 0.063 | 0.058 | **1.75×** |
|  8,192 |   0.155 | 0.502 | 0.260 | 0.139 | 0.080 | 0.118 | 0.080 | **1.94×** |
| 32,768 |   0.567 | 1.976 | 1.003 | 0.519 | 0.277 | 0.427 | 0.277 | **2.05×** |

- s = num_kv_splits — how many GPU programs cooperate to compute one (request, head) output. The kernel splits that request's KV sequence into s contiguous chunks; each program does a partial softmax (running max + denominator + weighted‑V) over its chunk, and a small combine kernel merges the s partials.
  - s=1, no split: one program does the whole KV reduction per head (like an ordinary flash decode).
  - s=8, 8 programs split the KV reduction, so with only batch=1 × 32 heads = 32 base programs you get 256 programs in flight — much better SM occupancy. That's why bigger s is faster at batch=1.
- auto: the timing when you pass num_kv_splits=None, i.e. the kernel's built‑in _auto_num_kv_splits heuristic chooses s from the SM count and batch×heads. I timed it as its own column to see how the default pick compares to the explicit sweep.
- best: just the minimum latency across all the split settings I timed (s=1/2/4/8 and auto) for that row — i.e. the fastest decode config. The speedup column is prefill ÷ best.


Kernel vs PyTorch native SDPA — A6000, fp16, batch=2, head_dim=128:

| Config (B, Hq, Hkv, D) | KV Length | Max Abs Error | Max Rel Error | Cosine Similarity |
|-------------------------|----------:|--------------:|--------------:|------------------:|
| 2, 32, 8, 128 (GQA 4:1) |     1,024 |       1.2e-4  |       1.7e-2  |          1.000000 |
| 2, 32, 8, 128 (GQA 4:1) |     8,192 |       3.1e-5  |       8.2e-3  |          1.000000 |
| 2, 32, 8, 128 (GQA 4:1) |    32,768 |       1.5e-5  |       4.7e-3  |          1.000000 |
| 2, 16, 16, 128 (MHA)    |     1,024 |       1.2e-4  |       1.7e-2  |          1.000000 |
| 2, 16, 16, 128 (MHA)    |     8,192 |       3.1e-5  |       7.2e-3  |          1.000000 |
| 2, 16, 16, 128 (MHA)    |    32,768 |       1.5e-5  |       4.4e-3  |          1.000000 |


### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->
