### PR TITLE
fix(recipes): sync INT4 blockwise recipe defaults

### DIFF
--- a/modelopt_recipes/general/ptq/int4_blockwise_weight_only.yaml
+++ b/modelopt_recipes/general/ptq/int4_blockwise_weight_only.yaml
@@ -16,47 +16,19 @@
 metadata:
   recipe_type: ptq
   description: INT4 blockwise weight-only (W4A16, block size 128), max calibration.
+
+imports:
+  base_disable_all: configs/ptq/units/base_disable_all
+  default_disabled_quantizers: configs/ptq/units/default_disabled_quantizers
+  int4_per_block: configs/numerics/int4_per_block
+
 quantize:
   algorithm: max
   quant_cfg:
-    - quantizer_name: '*'
-      enable: false
+    - $import: base_disable_all
     - quantizer_name: '*weight_quantizer'
       cfg:
-        num_bits: 4
-        block_sizes:
-          -1: 128
+        $import: int4_per_block
     - quantizer_name: '*input_quantizer'
       enable: false
-    - quantizer_name: '*block_sparse_moe.gate*'
-      enable: false
-    - quantizer_name: '*linear_attn.conv1d*'
-      enable: false
-    - quantizer_name: '*lm_head*'
-      enable: false
-    - quantizer_name: '*mixer.conv1d*'
-      enable: false
-    - quantizer_name: '*mlp.gate.*'
-      enable: false
-    - quantizer_name: '*mlp.shared_expert_gate.*'
-      enable: false
-    - quantizer_name: '*output_layer*'
-      enable: false
-    - quantizer_name: '*proj_out.*'
-      enable: false
-    - quantizer_name: '*router*'
-      enable: false
-    - quantizer_name: 'output.*'
-      enable: false
-    - parent_class: 'nn.BatchNorm1d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm2d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.BatchNorm3d'
-      quantizer_name: '*'
-      enable: false
-    - parent_class: 'nn.LeakyReLU'
-      quantizer_name: '*'
-      enable: false
+    - $import: default_disabled_quantizers

--- a/tests/unit/recipe/test_loader.py
+++ b/tests/unit/recipe/test_loader.py
@@ -156,6 +156,7 @@ def test_load_recipe_builtin_description():
 _BUILTIN_PTQ_RECIPES = [
     "general/ptq/fp8_default-kv_fp8",
     "general/ptq/fp8_default-kv_fp8_cast",
+    "general/ptq/int4_blockwise_weight_only",
     "general/ptq/nvfp4_default-kv_fp8",
     "general/ptq/nvfp4_default-kv_fp8_cast",
     "general/ptq/nvfp4_default-kv_nvfp4_cast",
@@ -509,6 +510,7 @@ def test_load_recipe_dflash_field_validation_raises(tmp_path):
     ("yaml_path", "model_cfg_name", "kv_cfg_name"),
     [
         ("general/ptq/fp8_default-kv_fp8.yaml", "FP8_DEFAULT_CFG", "FP8_KV_CFG"),
+        ("general/ptq/int4_blockwise_weight_only.yaml", "INT4_BLOCKWISE_WEIGHT_ONLY_CFG", None),
         ("general/ptq/nvfp4_default-kv_fp8.yaml", "NVFP4_DEFAULT_CFG", "FP8_KV_CFG"),
         ("general/ptq/nvfp4_mlp_only-kv_fp8.yaml", "NVFP4_MLP_ONLY_CFG", "FP8_KV_CFG"),
         ("general/ptq/nvfp4_omlp_only-kv_fp8.yaml", "NVFP4_OMLP_ONLY_CFG", "FP8_KV_CFG"),
@@ -517,7 +519,7 @@ def test_load_recipe_dflash_field_validation_raises(tmp_path):
 def test_general_ptq_yaml_matches_config_dicts(yaml_path, model_cfg_name, kv_cfg_name):
     """Each general/ptq YAML's quant_cfg list matches the merged Python config dicts."""
     model_cfg = getattr(qcfg, model_cfg_name)
-    kv_cfg = getattr(qcfg, kv_cfg_name)
+    kv_cfg = getattr(qcfg, kv_cfg_name) if kv_cfg_name is not None else None
     recipe = load_recipe(yaml_path)
     yaml_data = {"quantize": recipe.quantize}
 
@@ -552,7 +554,10 @@ def test_general_ptq_yaml_matches_config_dicts(yaml_path, model_cfg_name, kv_cfg
     def _sort_key(entry):
         return json.dumps(entry, sort_keys=True, default=str)
 
-    python_entries = _normalize_entries(model_cfg["quant_cfg"] + kv_cfg["quant_cfg"])
+    python_quant_cfg = model_cfg["quant_cfg"]
+    if kv_cfg is not None:
+        python_quant_cfg = python_quant_cfg + kv_cfg["quant_cfg"]
+    python_entries = _normalize_entries(python_quant_cfg)
     yaml_entries = _normalize_entries(yaml_data["quantize"]["quant_cfg"])
 
     assert sorted(python_entries, key=_sort_key) == sorted(yaml_entries, key=_sort_key)


### PR DESCRIPTION
### What does this PR do?

Fixes the public `general/ptq/int4_blockwise_weight_only` recipe added in PR #1172 by composing it from the shared recipe units instead of carrying a manually duplicated quantizer exclusion list.

The duplicated list had drifted from `configs/ptq/units/default_disabled_quantizers`, so the public INT4 recipe missed newer standard exclusions such as linear-attention projections, VLM vision/projector modules, and `nn.Embedding`. Recipe mode can apply directly to the broader model path, so those missing exclusions can quantize modules that the shared preset/qformat path avoids.

NVBug: 6311597

### Testing

- [x] `python_pwd tools/precommit/check_modelopt_recipes.py modelopt_recipes/general/ptq/int4_blockwise_weight_only.yaml`
- [x] `pytest_pwd tests/unit/recipe/test_loader.py::test_load_recipe_all_builtins tests/unit/recipe/test_loader.py::test_general_ptq_yaml_matches_config_dicts -q`
- [x] `pytest_pwd tests/unit/recipe/test_presets.py -q`
- [x] Direct assertion that `general/ptq/int4_blockwise_weight_only` includes current standard exclusions for `*linear_attn.in_proj_a*`, `*linear_attn.in_proj_b*`, VLM modules, and `nn.Embedding`.

### Notes

The NVBug page redirects to Microsoft sign-in from my shell, so this fix is based on the Slack-linked PR diff anchor resolving to `modelopt_recipes/general/ptq/int4_blockwise_weight_only.yaml` and local recipe/preset drift analysis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new INT4 blockwise weight-only PTQ recipe for easier low-bit quantization setup.
  * Streamlined recipe configuration so shared defaults are reused automatically.

* **Bug Fixes**
  * Improved recipe loading and validation for cases where some configuration entries are not present.
  * Updated consistency checks to handle these configurations more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->