### PR TITLE
[Chore]: Add license for Dflash code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -112,6 +112,8 @@ repos:
               modelopt/torch/quantization/plugins/attention.py|
               modelopt/torch/sparsity/attention_sparsity/methods/vsa_utils.py|
               modelopt/torch/speculative/eagle/utils.py|
+              modelopt/torch/speculative/plugins/hf_dflash.py|
+              modelopt/torch/speculative/plugins/modeling_dflash.py|
               modelopt/torch/speculative/plugins/hf_medusa.py|
               modelopt/torch/utils/plugins/megatron_mmlu.py|
               examples/deepseek/deepseek_v3/quantize_to_nvfp4.py|

--- a/LICENSE
+++ b/LICENSE
@@ -246,6 +246,7 @@ the following copyright holders, licensed under the MIT License:
   Copyright (c) 2020 Dan Hendrycks
   Copyright (c) 2023 Deep Cognition and Language Research (DeCLaRe) Lab
   Copyright (c) 2023 DeepSeek
+  Copyright (c) 2025 sgl-project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modelopt/torch/speculative/plugins/hf_dflash.py
+++ b/modelopt/torch/speculative/plugins/hf_dflash.py
@@ -1,5 +1,26 @@
+# Adapted from https://github.com/sgl-project/SpecForge/blob/8ea5ca6/specforge/core/dflash.py
+# Copyright (c) 2025 sgl-project
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 AND MIT
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modelopt/torch/speculative/plugins/modeling_dflash.py
+++ b/modelopt/torch/speculative/plugins/modeling_dflash.py
@@ -1,5 +1,26 @@
+# Adapted from https://github.com/sgl-project/SpecForge/blob/8ea5ca6/specforge/modeling/draft/dflash.py
+# Copyright (c) 2025 sgl-project
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-2.0 AND MIT
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### What does this PR do?

Type of change: Chore / documentation (license compliance)

The DFlash implementation in `modelopt/torch/speculative/plugins/` is adapted from [SpecForge](https://github.com/sgl-project/SpecForge) (MIT licensed). This PR adds the required third-party attribution per the [Copying code from other sources](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md#-copying-code-from-other-sources) guidance:

- **`hf_dflash.py`** ← adapted from `specforge/core/dflash.py`
- **`modeling_dflash.py`** ← adapted from `specforge/modeling/draft/dflash.py`

Changes:
- Add upstream attribution header (source link with commit hash + SpecForge MIT copyright/license notice) above the NVIDIA Apache-2.0 header in both files.
- Update `SPDX-License-Identifier` to `Apache-2.0 AND MIT` in both files.
- Add `Copyright (c) 2025 sgl-project` to the MIT section under *Third-Party Software Notices* in `LICENSE`.
- Exclude both files from the `insert-license` pre-commit hook so the NVIDIA header is not auto-inserted above the upstream header.

### Usage

N/A — no functional/API change (comments and license metadata only).

### Testing

- `pre-commit run insert-license-py --files <both files>` → reports **Skipped** (files correctly excluded).
- Verified `SPDX-License-Identifier: Apache-2.0 AND MIT` is present in both files and the upstream header precedes the NVIDIA header.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌

### Additional Information

Upstream pinned at SpecForge commit `8ea5ca6`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated third-party license notices to include an additional attribution.
  * Added license/header text to two Python modules for clearer provenance.
  * Adjusted the pre-commit configuration so those files are skipped by the license insertion check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->