### PR TITLE
Fix Nemotron-H PTQ failure on Transformers 5.x with --trust_remote_code (moe_latent_size AttributeError)

### DIFF
--- a/examples/hf_ptq/example_utils.py
+++ b/examples/hf_ptq/example_utils.py
@@ -731,16 +731,27 @@ def get_model(
             auto_model_module = getattr(transformers, architecture)
             from_config = auto_model_module._from_config
 
+        # Keep the config from the same version as the model definition: re-derive a
+        # remote-code config with the built-in class to avoid attribute mismatches.
+        config_for_init = hf_config
+        if auto_model_module not in [AutoModelForCausalLM, AutoModel] and type(
+            hf_config
+        ).__module__.startswith("transformers_modules"):
+            builtin_config_kwargs = {
+                k: v for k, v in config_kwargs.items() if k != "trust_remote_code"
+            }
+            config_for_init = AutoConfig.from_pretrained(ckpt_path, **builtin_config_kwargs)
+
         with init_empty_weights(include_buffers=True):
             # When computing the device_map, assuming bfloat16 precision by default,
             # unless specified by the hf_config.
-            torch_dtype = getattr(hf_config, "torch_dtype", torch.bfloat16)
+            torch_dtype = getattr(config_for_init, "torch_dtype", torch.bfloat16)
             model_kwargs2 = model_kwargs.copy()
             if auto_model_module not in [AutoModelForCausalLM, AutoModel]:
                 model_kwargs2.pop("trust_remote_code", None)
             model_kwargs2["dtype"] = torch_dtype
             model_kwargs2.pop("max_memory", None)
-            model = from_config(hf_config, **model_kwargs2)
+            model = from_config(config_for_init, **model_kwargs2)
 
         max_memory = get_max_memory()
         inferred_device_map = infer_auto_device_map(model, max_memory=max_memory)

--- a/examples/hf_ptq/example_utils.py
+++ b/examples/hf_ptq/example_utils.py
@@ -598,6 +598,25 @@ def get_original_hf_quant_method(config) -> str | None:
     return None
 
 
+def _resolve_init_config(hf_config, auto_model_module, ckpt_path, config_kwargs):
+    """Re-derive a built-in config when a remote-code config is used with a built-in model
+    class, so it matches the model definition's version; fall back to hf_config otherwise.
+    """
+    if auto_model_module in [AutoModelForCausalLM, AutoModel]:
+        return hf_config
+    if not type(hf_config).__module__.startswith("transformers_modules"):
+        return hf_config
+    builtin_config_kwargs = {k: v for k, v in config_kwargs.items() if k != "trust_remote_code"}
+    try:
+        return AutoConfig.from_pretrained(ckpt_path, **builtin_config_kwargs)
+    except Exception as e:
+        warnings.warn(
+            f"Could not re-derive a built-in config for {ckpt_path} ({e}); using the "
+            "remote-code config for device-map inference."
+        )
+        return hf_config
+
+
 def get_model(
     ckpt_path,
     device="cuda",
@@ -731,16 +750,9 @@ def get_model(
             auto_model_module = getattr(transformers, architecture)
             from_config = auto_model_module._from_config
 
-        # Keep the config from the same version as the model definition: re-derive a
-        # remote-code config with the built-in class to avoid attribute mismatches.
-        config_for_init = hf_config
-        if auto_model_module not in [AutoModelForCausalLM, AutoModel] and type(
-            hf_config
-        ).__module__.startswith("transformers_modules"):
-            builtin_config_kwargs = {
-                k: v for k, v in config_kwargs.items() if k != "trust_remote_code"
-            }
-            config_for_init = AutoConfig.from_pretrained(ckpt_path, **builtin_config_kwargs)
+        config_for_init = _resolve_init_config(
+            hf_config, auto_model_module, ckpt_path, config_kwargs
+        )
 
         with init_empty_weights(include_buffers=True):
             # When computing the device_map, assuming bfloat16 precision by default,

--- a/tests/examples/hf_ptq/test_example_utils.py
+++ b/tests/examples/hf_ptq/test_example_utils.py
@@ -20,6 +20,7 @@ separate-file-standalone, separate-file-indexed) plus a negative case.
 
 import json
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 from _test_utils.examples.hf_ptq_example_utils import example_utils
@@ -194,3 +195,37 @@ def test_get_original_hf_quant_method_none_for_unquantized():
         example_utils.get_original_hf_quant_method(SimpleNamespace(quantization_config=None))
         is None
     )
+
+
+# ---------- _resolve_init_config ---------------------------------------------
+
+
+def _remote_config():
+    # Config whose class module lives under "transformers_modules" (remote code).
+    cls = type("_RemoteConfig", (), {"__module__": "transformers_modules.ckpt.config"})
+    return cls()
+
+
+def test_resolve_init_config_rederives_for_remote_config():
+    builtin_cfg = SimpleNamespace()
+    with patch.object(
+        example_utils.AutoConfig, "from_pretrained", return_value=builtin_cfg
+    ) as mock:
+        out = example_utils._resolve_init_config(
+            _remote_config(), object, "/ckpt", {"trust_remote_code": True}
+        )
+    assert out is builtin_cfg
+    mock.assert_called_once_with("/ckpt")  # trust_remote_code stripped
+
+
+def test_resolve_init_config_keeps_non_remote_config():
+    cfg = SimpleNamespace()  # module is "types", not remote
+    with patch.object(example_utils.AutoConfig, "from_pretrained") as mock:
+        assert example_utils._resolve_init_config(cfg, object, "/ckpt", {}) is cfg
+    mock.assert_not_called()
+
+
+def test_resolve_init_config_falls_back_when_rederive_raises():
+    cfg = _remote_config()
+    with patch.object(example_utils.AutoConfig, "from_pretrained", side_effect=ValueError()):
+        assert example_utils._resolve_init_config(cfg, object, "/ckpt", {}) is cfg


### PR DESCRIPTION

### What does this PR do?

Type of change: Bug fix

Quantizing remote-code checkpoints such as `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` with `--trust_remote_code` fails on Transformers 5.x during model loading:

```
AttributeError: 'NemotronHConfig' object has no attribute 'moe_latent_size'
```

(It works on Transformers 4.57.x.)

**Root cause:** In `examples/llm_ptq/example_utils.py::get_model`, `AutoConfig.from_pretrained(..., trust_remote_code=True)` loads the checkpoint's bundled **remote** `NemotronHConfig` (authored for Transformers 4.55.4, which has no `moe_latent_size`). But because `NemotronHForCausalLM` is a **built-in** class in Transformers 5.x, the empty-weights device-map build instantiates the built-in model class, whose modeling code reads `config.moe_latent_size`. The remote (old) config and the built-in (new) model are a mismatched pair. Transformers 4.57.x only worked by luck — its built-in model never accessed that field.

**Fix:** When instantiating the built-in model class, feed it a config from the **same version as the model definition**. If the loaded config came from remote code (its class module lives under `transformers_modules`), re-derive it with the built-in class (`AutoConfig` without `trust_remote_code`) so required fields get their defaults. Non-remote configs are untouched. The subsequent real model load already resolves the config via the built-in `config_class`, so only the device-map build needed aligning.

### Usage

No API change. The previously-failing command now works:

```python
python examples/llm_ptq/hf_ptq.py \
    --pyt_ckpt_path nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 \
    --qformat fp8,nvfp4_mse --calib_size 64 \
    --export_path ./output/nemotron-nano-fp8-nvfp4_mse \
    --trust_remote_code --dataset cnn_dailymail --auto_quantize_bits 4.75
```

### Testing

- Reproduced the original `AttributeError` on Transformers 5.7.0, then confirmed the fix resolves it.
- End-to-end: `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` nvfp4 PTQ + export completes successfully on Transformers 5.7.0.
- `tests/examples/llm_ptq/` unit tests (`test_example_utils.py`, `test_hf_ptq_args.py`, `test_cast_mxfp4_to_nvfp4.py`) all pass.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ <!-- Only changes the config used for the device-map build when a remote-code config is paired with a built-in model class; non-remote configs and all other code paths are unchanged. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A <!-- Example-script bug fix; a regression test would require a remote-code checkpoint to load. Existing llm_ptq unit tests pass and the fix was validated end-to-end. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌ <!-- Run `/claude review`. -->

### Additional Information

The fix is general: re-deriving the config with the built-in class handles any field the built-in model adds in future Transformers releases, not just `moe_latent_size`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model initialization when using remote-code configurations by re-deriving the initialization config for built-in model classes when possible.
  * Added a safe fallback to keep using the original configuration if re-derivation fails.
* **Tests**
  * Added unit tests covering remote-code config re-derivation, ensuring unchanged configs are not re-derived, and verifying fallback behavior on errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->