### PR TITLE
feat(mcp): support MFA Slurm submissions

### DIFF
--- a/tools/launcher/common/smoke/hostname.sh
+++ b/tools/launcher/common/smoke/hostname.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+echo "MODEL_OPT_HOSTNAME_SMOKE_START"
+hostname
+whoami
+pwd
+echo "MODEL_OPT_HOSTNAME_SMOKE_DONE"

--- a/tools/launcher/core.py
+++ b/tools/launcher/core.py
@@ -23,7 +23,10 @@ import getpass
 import json
 import os
 import re
+import shlex
+import subprocess
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 import nemo_run as run
 import yaml
@@ -249,6 +252,140 @@ class SandboxPipeline:
 # ---------------------------------------------------------------------------
 
 
+@dataclass
+class _ControlMasterSession:
+    """Minimal Fabric-like session backed by an OpenSSH ControlMaster socket."""
+
+    user: str
+    host: str
+    port: int
+    sock_path: str
+    pre_command: str | None = None
+    connect_kwargs: dict | None = None
+    is_connected: bool = True
+
+    def _ssh_opts(self) -> list[str]:
+        return [
+            "-o",
+            f"ControlPath={self.sock_path}",
+            "-o",
+            "ControlMaster=no",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+        ]
+
+    def run(self, command: str, hide: bool = True, warn: bool = False, **kwargs):
+        if self.pre_command:
+            command = f"{self.pre_command} && {command}"
+        proc = subprocess.run(
+            [
+                "ssh",
+                "-p",
+                str(self.port or 22),
+                *self._ssh_opts(),
+                f"{self.user}@{self.host}",
+                command,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0 and not warn:
+            raise RuntimeError(
+                f"Remote command failed (exit {proc.returncode}):\n"
+                f"  cmd: {command}\n"
+                f"  stderr: {proc.stderr.strip()}"
+            )
+        return SimpleNamespace(
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            exited=proc.returncode,
+            command=command,
+        )
+
+    def local(self, command: str, hide: bool = True, warn: bool = False, **kwargs):
+        command = self._inject_controlmaster_rsh(command)
+        proc = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0 and not warn:
+            raise RuntimeError(
+                f"Local command failed (exit {proc.returncode}):\n"
+                f"  cmd: {command}\n"
+                f"  stderr: {proc.stderr.strip()}"
+            )
+        return SimpleNamespace(
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            exited=proc.returncode,
+            command=command,
+        )
+
+    def _inject_controlmaster_rsh(self, command: str) -> str:
+        if not command.startswith("rsync ") or "--rsh='ssh " not in command:
+            return command
+        opts = " ".join(map(shlex.quote, self._ssh_opts()))
+        return command.replace("--rsh='ssh ", f"--rsh='ssh {opts} ", 1)
+
+    def close(self) -> None:
+        self.is_connected = False
+
+
+class ControlMasterSSHTunnel(run.SSHTunnel):
+    """SSHTunnel variant that reuses an existing OpenSSH ControlMaster socket."""
+
+    def _control_socket_path(self) -> str | None:
+        value = os.environ.get("MODELOPT_LAUNCHER_SSH_CONTROL_PATH")
+        return os.path.expanduser(value) if value else None
+
+    def _has_live_controlmaster(self) -> bool:
+        sock_path = self._control_socket_path()
+        if not sock_path or not os.path.exists(sock_path):
+            return False
+        proc = subprocess.run(
+            [
+                "ssh",
+                "-O",
+                "check",
+                "-o",
+                f"ControlPath={sock_path}",
+                f"{self.user}@{self.host}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return proc.returncode == 0
+
+    def _raise_reauth_required(self) -> None:
+        reconnect = os.environ.get("MODELOPT_LAUNCHER_SSH_RECONNECT_COMMAND") or "ssh"
+        raise RuntimeError(
+            "mfa_reauth_required: an active OpenSSH ControlMaster socket is "
+            f"required at {self._control_socket_path()}. Run `{reconnect}`, "
+            "keep it connected, then retry this submission."
+        )
+
+    def connect(self):
+        """Attach nemo-run to an already-authenticated OpenSSH ControlMaster session."""
+        if self._has_live_controlmaster():
+            self.session = _ControlMasterSession(
+                user=self.user,
+                host=self.host,
+                port=int(getattr(self, "port", 22) or 22),
+                sock_path=self._control_socket_path() or "",
+                pre_command=self.pre_command,
+                connect_kwargs={},
+            )
+            return
+        self._raise_reauth_required()
+
+
 def build_slurm_executor(
     user,
     identity,
@@ -297,7 +434,12 @@ def build_slurm_executor(
     if slurm_config.host in ("localhost", "127.0.0.1"):
         tunnel = run.LocalTunnel(job_dir=job_dir)
     else:
-        tunnel = run.SSHTunnel(
+        tunnel_cls = (
+            ControlMasterSSHTunnel
+            if os.environ.get("MODELOPT_LAUNCHER_SSH_CONTROL_PATH")
+            else run.SSHTunnel
+        )
+        tunnel = tunnel_cls(
             host=slurm_config.host,
             user=user or getattr(slurm_config, "user", None) or getpass.getuser(),
             port=slurm_config.port,

--- a/tools/launcher/examples/smoke/hostname.yaml
+++ b/tools/launcher/examples/smoke/hostname.yaml
@@ -1,0 +1,22 @@
+# Minimal Slurm smoke test for launcher/MCP integration on CPU-only or
+# no-GRES clusters. It verifies:
+#   MCP submit_job -> launcher YAML parse -> Slurm submit -> container start.
+
+job_name: hostname_smoke
+pipeline:
+  skip: false
+  allow_to_fail: false
+  note: "Slurm container CPU smoke test"
+
+  task_0:
+    script: common/smoke/hostname.sh
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: null
+      time: "00:10:00"
+      mem: "16G"
+      container: ubuntu:24.04
+      container_mounts: []
+      srun_args: []

--- a/tools/launcher/slurm_config.py
+++ b/tools/launcher/slurm_config.py
@@ -48,7 +48,9 @@ class SlurmConfig:
     requeue: bool = False
     nodes: int = 1
     ntasks_per_node: int = 1
-    gpus_per_node: int = 1
+    # None means omit GPU GRES entirely. Some clusters expose GPU nodes without
+    # Slurm GRES, so requesting --gpus-per-node would make valid jobs fail.
+    gpus_per_node: Optional[int] = 1
     time: str = "04:00:00"
     mem: str = "0"
     local: bool = False
@@ -68,7 +70,7 @@ def slurm_factory(
     qos: Optional[str] = os.environ.get("SLURM_QOS"),
     nodes: int = 1,
     ntasks_per_node: int = 1,
-    gpus_per_node: int = 1,
+    gpus_per_node: Optional[int] = 1,
     container: str = "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc8",
     modelopt_install_path: str = "/usr/local/lib/python3.12/dist-packages/modelopt",
     container_mounts: list[str] = [

--- a/tools/launcher/tests/test_slurm_config.py
+++ b/tools/launcher/tests/test_slurm_config.py
@@ -65,6 +65,10 @@ class TestSlurmConfig:
         assert cfg.mem == "128G"
         assert cfg.container_mounts == ["/data:/data"]
 
+    def test_nullable_gpus_per_node(self):
+        cfg = SlurmConfig(gpus_per_node=None)
+        assert cfg.gpus_per_node is None
+
 
 class TestSlurmFactory:
     """Tests for the slurm_factory function."""
@@ -99,6 +103,10 @@ class TestSlurmFactory:
     def test_override_nodes(self):
         cfg = slurm_factory(nodes=8)
         assert cfg.nodes == 8
+
+    def test_override_gpus_per_node_none(self):
+        cfg = slurm_factory(gpus_per_node=None)
+        assert cfg.gpus_per_node is None
 
     def test_override_partition(self):
         cfg = slurm_factory(partition="gpu")

--- a/tools/launcher/tests/test_slurm_executor.py
+++ b/tools/launcher/tests/test_slurm_executor.py
@@ -22,11 +22,93 @@ We mock run.SSHTunnel and run.SlurmExecutor to verify the arguments passed.
 
 from unittest.mock import MagicMock, patch
 
-from core import build_slurm_executor
+import pytest
+from core import ControlMasterSSHTunnel, build_slurm_executor
 
 
 class TestBuildSlurmExecutor:
     """Tests for build_slurm_executor mount construction and executor params."""
+
+    @patch("core.run.SlurmExecutor")
+    @patch("core.ControlMasterSSHTunnel")
+    def test_controlmaster_env_selects_controlmaster_tunnel(
+        self, mock_tunnel, mock_executor, monkeypatch
+    ):
+        """MFA clusters reuse OpenSSH ControlMaster instead of Paramiko SSHTunnel."""
+        monkeypatch.setenv("MODELOPT_LAUNCHER_SSH_CONTROL_PATH", "/tmp/ptyche.sock")
+        mock_tunnel.return_value = MagicMock()
+
+        slurm_config = MagicMock(
+            requeue=False,
+            host="login-ptyche.nvidia.com",
+            port=22,
+            account="test_account",
+            partition="batch",
+            container="ubuntu:24.04",
+            modelopt_install_path="/opt/modelopt",
+            container_mounts=[],
+            srun_args=[],
+            nodes=1,
+            ntasks_per_node=1,
+            gpus_per_node=None,
+            array=None,
+        )
+
+        build_slurm_executor(
+            user="chenhany-mfa",
+            identity=None,
+            slurm_config=slurm_config,
+            experiment_id="exp_001",
+            job_dir="/lustre/experiments",
+            task_name="job_0",
+            packager=MagicMock(),
+        )
+
+        mock_tunnel.assert_called_once()
+        assert mock_tunnel.call_args.kwargs["host"] == "login-ptyche.nvidia.com"
+        assert mock_tunnel.call_args.kwargs["user"] == "chenhany-mfa"
+        mock_executor.assert_called_once()
+
+
+class TestControlMasterSSHTunnel:
+    """Tests for the OpenSSH ControlMaster-backed tunnel shim."""
+
+    def test_connect_reuses_live_controlmaster(self, monkeypatch, tmp_path):
+        sock = tmp_path / "cm.sock"
+        sock.touch()
+        monkeypatch.setenv("MODELOPT_LAUNCHER_SSH_CONTROL_PATH", str(sock))
+
+        def fake_run(argv, **kwargs):
+            assert argv[:3] == ["ssh", "-O", "check"]
+            assert f"ControlPath={sock}" in argv
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("core.subprocess.run", fake_run)
+
+        tunnel = ControlMasterSSHTunnel(
+            host="login-ptyche.nvidia.com",
+            user="chenhany-mfa",
+            job_dir="/tmp/job",
+        )
+        tunnel.connect()
+
+        assert tunnel.session.is_connected is True
+        assert tunnel.session.host == "login-ptyche.nvidia.com"
+
+    def test_connect_requires_reauth_when_controlmaster_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("MODELOPT_LAUNCHER_SSH_CONTROL_PATH", str(tmp_path / "missing.sock"))
+        monkeypatch.setenv("MODELOPT_LAUNCHER_SSH_RECONNECT_COMMAND", "ssh ptyche")
+
+        tunnel = ControlMasterSSHTunnel(
+            host="login-ptyche.nvidia.com",
+            user="chenhany-mfa",
+            job_dir="/tmp/job",
+        )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            tunnel.connect()
+        assert "mfa_reauth_required" in str(exc_info.value)
+        assert "ssh ptyche" in str(exc_info.value)
 
     @patch("core.run.SlurmExecutor")
     @patch("core.run.SSHTunnel")

--- a/tools/mcp/modelopt_mcp/bridge.py
+++ b/tools/mcp/modelopt_mcp/bridge.py
@@ -678,6 +678,8 @@ def verify_slurm_setup_impl(
     cluster_host: str,
     cluster_user: str | None = None,
     identity: str | None = None,
+    control_socket: str | None = None,
+    reconnect_command: str | None = None,
 ) -> dict:
     """Probe passwordless SSH to a Slurm cluster login node.
 
@@ -695,6 +697,44 @@ def verify_slurm_setup_impl(
         "-o",
         "ConnectTimeout=5",
     ]
+    if control_socket:
+        expanded_socket = os.path.expanduser(control_socket)
+        check_target = f"{cluster_user}@{cluster_host}" if cluster_user else cluster_host
+        check = subprocess.run(
+            [
+                "ssh",
+                "-O",
+                "check",
+                "-o",
+                f"ControlPath={expanded_socket}",
+                check_target,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        if check.returncode != 0:
+            return {
+                "ok": False,
+                "executor": "slurm",
+                "cluster_host": cluster_host,
+                "cluster_user": cluster_user,
+                "reason": "mfa_reauth_required",
+                "control_socket": control_socket,
+                "reconnect_command": reconnect_command,
+                "diagnostic": (
+                    "OpenSSH ControlMaster socket is absent or expired. "
+                    f"Run `{reconnect_command or 'ssh <cluster>'}`, keep it "
+                    "connected, then retry."
+                ),
+            }
+        argv += [
+            "-o",
+            f"ControlPath={expanded_socket}",
+            "-o",
+            "ControlMaster=no",
+        ]
     if identity:
         argv += ["-i", identity]
     target = f"{cluster_user}@{cluster_host}" if cluster_user else cluster_host
@@ -751,6 +791,7 @@ def verify_slurm_setup_impl(
         "executor": "slurm",
         "cluster_host": cluster_host,
         "cluster_user": cluster_user,
+        "control_socket": control_socket,
         "whoami": lines[0] if lines else "",
         "remote_hostname": lines[1] if len(lines) > 1 else "",
     }
@@ -797,14 +838,24 @@ def _normalize_yaml_path(yaml_path: str, *, examples_dir: Path | None = None) ->
 def submit_job_impl(
     *,
     yaml_path: str,
-    hf_local: str | None,
-    cluster_host: str | None,
-    cluster_user: str | None,
-    identity: str | None,
-    job_dir: str | None,
-    job_name: str | None,
-    extra_overrides: dict[str, str] | None,
-    skip_verify: bool,
+    hf_local: str | None = None,
+    cluster_host: str | None = None,
+    cluster_user: str | None = None,
+    identity: str | None = None,
+    job_dir: str | None = None,
+    job_name: str | None = None,
+    extra_overrides: dict[str, str] | None = None,
+    skip_verify: bool = False,
+    account: str | None = None,
+    partition: str | None = None,
+    container: str | None = None,
+    gpus_per_node: int | None = None,
+    ntasks_per_node: int | None = None,
+    control_socket: str | None = None,
+    reconnect_command: str | None = None,
+    gpu_type: str | None = None,
+    mfa: bool = False,
+    ssh_alias: str | None = None,
     dry_run: bool = False,
     source_ref: str | None = None,
     source_repo: str | None = None,
@@ -875,6 +926,8 @@ def submit_job_impl(
                 cluster_host=cluster_host or "",
                 cluster_user=cluster_user,
                 identity=identity,
+                control_socket=control_socket,
+                reconnect_command=reconnect_command,
             )
         if not check.get("ok"):
             return {
@@ -941,7 +994,21 @@ def submit_job_impl(
         argv.append(f"job_dir={job_dir}")
     if job_name:
         argv.append(f"job_name={job_name}")
-    for k, v in (extra_overrides or {}).items():
+
+    overrides = dict(extra_overrides or {})
+    if executor == "slurm":
+        slurm_prefix = "pipeline.task_0.slurm_config."
+        if account:
+            overrides.setdefault(f"{slurm_prefix}account", account)
+        if partition:
+            overrides.setdefault(f"{slurm_prefix}partition", partition)
+        if container:
+            overrides.setdefault(f"{slurm_prefix}container", container)
+        if gpus_per_node is not None:
+            overrides.setdefault(f"{slurm_prefix}gpus_per_node", str(gpus_per_node))
+        if ntasks_per_node is not None:
+            overrides.setdefault(f"{slurm_prefix}ntasks_per_node", str(ntasks_per_node))
+    for k, v in overrides.items():
         argv.append(f"{k}={v}")
 
     # Propagate env so submit-side and status-side agree on NEMORUN_HOME.
@@ -960,6 +1027,14 @@ def submit_job_impl(
         # against this same host above (when verify_setup=True), so the
         # value is known good.
         child_env["SLURM_HOST"] = cluster_host or ""
+        if account:
+            child_env["SLURM_ACCOUNT"] = account
+        if partition:
+            child_env["SLURM_PARTITION"] = partition
+        if control_socket:
+            child_env["MODELOPT_LAUNCHER_SSH_CONTROL_PATH"] = os.path.expanduser(control_socket)
+        if reconnect_command:
+            child_env["MODELOPT_LAUNCHER_SSH_RECONNECT_COMMAND"] = reconnect_command
 
     if executor == "docker":
         # Docker mode: spawn detached. Discard stdout/stderr to /dev/null —

--- a/tools/mcp/modelopt_mcp/server.py
+++ b/tools/mcp/modelopt_mcp/server.py
@@ -104,6 +104,21 @@ def _build_server() -> FastMCP:
                 description=("SSH identity file (-i) override. None uses default key / ssh-agent.")
             ),
         ] = None,
+        control_socket: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "OpenSSH ControlMaster socket path for MFA clusters. "
+                    "When set, verify_setup checks the socket and reuses it."
+                )
+            ),
+        ] = None,
+        reconnect_command: Annotated[
+            str | None,
+            Field(
+                description=("Command shown to the user when control_socket is missing or expired.")
+            ),
+        ] = None,
     ) -> dict:
         if executor == "docker":
             return bridge.verify_docker_setup_impl()
@@ -119,6 +134,8 @@ def _build_server() -> FastMCP:
                 cluster_host=cluster_host,
                 cluster_user=cluster_user,
                 identity=identity,
+                control_socket=control_socket,
+                reconnect_command=reconnect_command,
             )
         # Pydantic Literal already constrains; this is a defensive fallback.
         return {"ok": False, "reason": "unknown_executor"}
@@ -174,6 +191,59 @@ def _build_server() -> FastMCP:
         identity: Annotated[
             str | None,
             Field(description=("SSH identity file (-i). None uses ssh-agent / default key.")),
+        ] = None,
+        account: Annotated[
+            str | None,
+            Field(description=("Slurm account override, usually from nmm-sandbox cluster config.")),
+        ] = None,
+        partition: Annotated[
+            str | None,
+            Field(
+                description=("Slurm partition override, usually from nmm-sandbox cluster config.")
+            ),
+        ] = None,
+        container: Annotated[
+            str | None,
+            Field(
+                description=("Container image override for pipeline.task_0.slurm_config.container.")
+            ),
+        ] = None,
+        gpus_per_node: Annotated[
+            int | None,
+            Field(
+                description=(
+                    "Slurm GPUs-per-node override. Omit for CPU-only or nmm-sandbox "
+                    "MFA clusters that intentionally leave GPU GRES unset."
+                )
+            ),
+        ] = None,
+        ntasks_per_node: Annotated[
+            int | None,
+            Field(description=("Slurm ntasks-per-node override.")),
+        ] = None,
+        control_socket: Annotated[
+            str | None,
+            Field(
+                description=("OpenSSH ControlMaster socket path for MFA clusters such as ptyche.")
+            ),
+        ] = None,
+        reconnect_command: Annotated[
+            str | None,
+            Field(
+                description=("Command shown to the user when the ControlMaster socket has expired.")
+            ),
+        ] = None,
+        gpu_type: Annotated[
+            str | None,
+            Field(description=("Informational GPU type from cluster inventory.")),
+        ] = None,
+        mfa: Annotated[
+            bool,
+            Field(description=("Whether this cluster requires MFA-backed SSH.")),
+        ] = False,
+        ssh_alias: Annotated[
+            str | None,
+            Field(description=("Optional SSH alias from cluster inventory.")),
         ] = None,
         job_dir: Annotated[
             str | None,
@@ -256,6 +326,16 @@ def _build_server() -> FastMCP:
             cluster_host=cluster_host,
             cluster_user=cluster_user,
             identity=identity,
+            account=account,
+            partition=partition,
+            container=container,
+            gpus_per_node=gpus_per_node,
+            ntasks_per_node=ntasks_per_node,
+            control_socket=control_socket,
+            reconnect_command=reconnect_command,
+            gpu_type=gpu_type,
+            mfa=mfa,
+            ssh_alias=ssh_alias,
             job_dir=job_dir,
             job_name=job_name,
             extra_overrides=extra_overrides,

--- a/tools/mcp/tests/test_bridge.py
+++ b/tools/mcp/tests/test_bridge.py
@@ -201,6 +201,63 @@ def test_verify_slurm_ssh_success(monkeypatch):
     assert result["remote_hostname"] == "cluster-login-01"
 
 
+def test_verify_slurm_controlmaster_success(monkeypatch):
+    """MFA clusters can verify through an existing OpenSSH ControlMaster socket."""
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        if argv[:3] == ["ssh", "-O", "check"]:
+            return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+        assert "ControlPath=/tmp/ptyche.sock" in argv
+        assert "ControlMaster=no" in argv
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=0,
+            stdout="chenhany\nlogin-ptyche\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = bridge.verify_slurm_setup_impl(
+        cluster_host="login-ptyche.nvidia.com",
+        cluster_user="chenhany-mfa",
+        control_socket="/tmp/ptyche.sock",
+        reconnect_command="ssh ptyche",
+    )
+
+    assert result["ok"] is True
+    assert result["control_socket"] == "/tmp/ptyche.sock"
+    assert len(calls) == 2
+
+
+def test_verify_slurm_controlmaster_missing(monkeypatch):
+    """Missing ControlMaster socket returns a reauth diagnostic before probing SSH."""
+
+    def fake_run(argv, **kwargs):
+        assert argv[:3] == ["ssh", "-O", "check"]
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=255,
+            stdout="",
+            stderr="Control socket connect failed",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = bridge.verify_slurm_setup_impl(
+        cluster_host="login-ptyche.nvidia.com",
+        cluster_user="chenhany-mfa",
+        control_socket="/tmp/missing.sock",
+        reconnect_command="ssh ptyche",
+    )
+
+    assert result["ok"] is False
+    assert result["reason"] == "mfa_reauth_required"
+    assert result["reconnect_command"] == "ssh ptyche"
+
+
 def test_verify_slurm_auth_failed(monkeypatch):
     """Ssh -o BatchMode=yes exit 255 → ssh_auth_failed with diagnostic."""
 
@@ -473,6 +530,64 @@ def test_submit_job_slurm_parses_nemo_job_id(monkeypatch, tmp_path):
     assert result["ok"] is True
     assert result["slurm_job_id"] == "13049989"
     assert result["experiment_id"] == "cicd_1782173197"
+
+
+def test_submit_job_slurm_accepts_nmm_cluster_fields(monkeypatch, tmp_path):
+    """nmm-sandbox resolved cluster config maps to launcher overrides and env."""
+    yaml_dir = tmp_path / "examples"
+    yaml_dir.mkdir()
+    (yaml_dir / "config.yaml").write_text("job_name: t\npipeline: []\n")
+    monkeypatch.setenv("MODELOPT_LAUNCHER_EXAMPLES_DIR", str(yaml_dir))
+
+    verify_seen = {}
+
+    def fake_verify(**kwargs):
+        verify_seen.update(kwargs)
+        return {"ok": True}
+
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        captured["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=0,
+            stdout=(
+                "Experiment Status for cicd_1782173197\n"
+                "- Job id: 13049989\n"
+                'experiment = run.Experiment.from_id("cicd_1782173197")\n'
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(bridge, "verify_slurm_setup_impl", fake_verify)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = bridge.submit_job_impl(
+        yaml_path="config.yaml",
+        cluster_host="login-ptyche.nvidia.com",
+        cluster_user="chenhany-mfa",
+        account="coreai_dlalgo_cw",
+        partition="batch",
+        container="ubuntu:24.04",
+        ntasks_per_node=1,
+        control_socket="~/.ssh/ptyche.sock",
+        reconnect_command="ssh ptyche",
+        skip_verify=False,
+    )
+
+    assert result["ok"] is True
+    assert verify_seen["control_socket"] == "~/.ssh/ptyche.sock"
+    assert verify_seen["reconnect_command"] == "ssh ptyche"
+    assert "pipeline.task_0.slurm_config.account=coreai_dlalgo_cw" in captured["argv"]
+    assert "pipeline.task_0.slurm_config.partition=batch" in captured["argv"]
+    assert "pipeline.task_0.slurm_config.container=ubuntu:24.04" in captured["argv"]
+    assert "pipeline.task_0.slurm_config.ntasks_per_node=1" in captured["argv"]
+    assert captured["env"]["SLURM_ACCOUNT"] == "coreai_dlalgo_cw"
+    assert captured["env"]["SLURM_PARTITION"] == "batch"
+    assert captured["env"]["MODELOPT_LAUNCHER_SSH_CONTROL_PATH"].endswith(".ssh/ptyche.sock")
+    assert captured["env"]["MODELOPT_LAUNCHER_SSH_RECONNECT_COMMAND"] == "ssh ptyche"
 
 
 def test_submit_job_slurm_job_id_without_experiment_id_is_failure(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add OpenSSH ControlMaster-backed Slurm tunnel support for MFA clusters
- expose nmm-sandbox-style cluster fields through modelopt-mcp verify_setup/submit_job
- allow CPU/no-GRES Slurm jobs with nullable gpus_per_node
- add a packaged CPU hostname smoke example for launcher/MCP validation

## Validation
- ruff check on edited files
- uv run --project tools/mcp pytest tools/mcp/tests/test_bridge.py -q
- uv run --project tools/launcher pytest tools/launcher/tests/test_slurm_config.py tools/launcher/tests/test_slurm_executor.py -q
- live ptyche smoke via modelopt-mcp: experiment cicd_1782602659, Slurm job 2299306, completed 0:0 with MODEL_OPT_HOSTNAME_SMOKE_DONE in remote log

## Notes
- Full launcher test directory still has existing local Docker subprocess failures where uv run launch.py cannot import modelopt_launcher; focused launcher tests for this change pass.

Jira: OMNIML-5352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reusing an existing SSH ControlMaster connection during remote job setup.
  * Expanded Slurm job submission options to better handle clusters with different account, partition, container, and GPU settings.
  * Added a new minimal hostname smoke test for CPU-only cluster validation.

* **Bug Fixes**
  * Improved setup checks to clearly report when SSH re-authentication is required before retrying job submission.
  * Allowed GPU settings to be omitted when a cluster does not expose GPU GRES.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->