### PR TITLE
[Feat]: Add Final Norm for vLLM Hidden Extractor

### DIFF
--- a/examples/speculative_decoding/eagle_utils.py
+++ b/examples/speculative_decoding/eagle_utils.py
@@ -91,7 +91,19 @@ def make_speculative_data_module(
             EagleVllmStreamingDataset,
         )
 
-        ds = load_dataset("json", data_files=data_args.data_path, split="train")
+        # data_path may be a single jsonl, a glob string, or a directory of shards.
+        # HF load_dataset's data_files takes a file/glob/list but NOT a bare directory,
+        # so expand a directory into its sorted *.jsonl files (avoids physically
+        # concatenating large multi-shard corpora and shell-glob fragility).
+        _dp = data_args.data_path
+        if Path(_dp).is_dir():
+            _data_files = sorted(str(p) for p in Path(_dp).glob("*.jsonl"))
+            if not _data_files:
+                raise ValueError(f"No .jsonl files found in directory {_dp}")
+            print_rank_0(f"Loading {len(_data_files)} jsonl shards from directory {_dp}")
+        else:
+            _data_files = _dp
+        ds = load_dataset("json", data_files=_data_files, split="train")
         if data_args.sample_size > 0:
             ds = ds.select(range(data_args.sample_size))
         # Map-style dataset: each rank fetches its own DistributedSampler shard.

--- a/modelopt/torch/speculative/eagle/utils.py
+++ b/modelopt/torch/speculative/eagle/utils.py
@@ -156,6 +156,9 @@ class OfflineSupervisedDataset(Dataset):
             "attention_mask": torch.ones_like(offline_data["input_ids"]),
             "loss_mask": loss_mask,
             "labels": labels,
+            # Whether the dumped hidden is pre-(final-)norm (the consumer re-applies the base
+            # norm if so). Read from the dump; default False = post-norm, the prior behavior.
+            "base_hidden_prenorm": bool(offline_data.get("hidden_states_prenorm", False)),
         }
         return ret
 
@@ -195,6 +198,19 @@ class EagleOfflineDataCollator:
             k: torch.stack([self._pad_or_truncate(item[k], self.train_len) for item in features])
             for k in ["base_model_hidden_states", "aux_hidden_states"]
         }
+        # Propagate the producer's pre-norm declaration. DFlash honors it to decide whether to
+        # re-apply the base final norm; other heads ignore it. It must be constant across the
+        # batch: a batch is normed as a whole, so mixing pre-norm (True) and post-norm (False)
+        # dumps — e.g. a directory blending pre-PR and pre-norm dumps — would silently feed
+        # un-normed hiddens to lm_head for the minority. Fail loud rather than corrupt the target.
+        if "base_hidden_prenorm" in features[0]:
+            prenorm_flags = {bool(f["base_hidden_prenorm"]) for f in features}
+            if len(prenorm_flags) > 1:
+                raise ValueError(
+                    "base_hidden_prenorm is not constant across the batch "
+                    f"(got {prenorm_flags}); do not mix pre-norm and post-norm dumps."
+                )
+            base_model_outputs["base_hidden_prenorm"] = prenorm_flags.pop()
 
         batch = {
             **base_batch,

--- a/modelopt/torch/speculative/plugins/hf_dflash.py
+++ b/modelopt/torch/speculative/plugins/hf_dflash.py
@@ -88,7 +88,12 @@ from .modeling_dflash import (  # noqa: F401
     DFlashModule,
     build_target_layer_ids,
 )
-from .modeling_fakebase import _BASE_MODEL_PATHS, _EMBED_TOKENS_PATHS, _LM_HEAD_PATHS
+from .modeling_fakebase import (
+    _BASE_MODEL_PATHS,
+    _EMBED_TOKENS_PATHS,
+    _FINAL_NORM_PATHS,
+    _LM_HEAD_PATHS,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +166,16 @@ class HFDFlashModel(DFlashModel):
         return self.get_submodule(self.base_model_lm_head_path)
 
     @property
+    def _base_model_norm(self):
+        """Base model's final pre-lm_head RMSNorm, or None if none was located.
+
+        Applied before lm_head in the offline/streaming distillation path only when the
+        producer captured a pre-norm hidden (base_hidden_prenorm), to reconstruct true logits.
+        """
+        path = getattr(self, "base_model_norm_path", None)
+        return self.get_submodule(path) if path else None
+
+    @property
     def _base_llm_config(self):
         return (
             getattr(self.config, "text_config", None)
@@ -188,6 +203,16 @@ class HFDFlashModel(DFlashModel):
                     continue
             else:
                 raise ValueError(f"Part {name} not found in model")
+        # Final pre-lm_head norm is OPTIONAL (set None if absent): used to re-normalize the
+        # un-normed final hidden collect by vllm.
+        self.base_model_norm_path = None
+        for path in _FINAL_NORM_PATHS:
+            try:
+                assert isinstance(self.get_submodule(path), torch.nn.Module)
+                self.base_model_norm_path = path
+                break
+            except Exception:
+                continue
 
     def modify(self, config):
         """Initialize DFlash draft module."""
@@ -566,13 +591,15 @@ class HFDFlashModel(DFlashModel):
         # 1. Run base model → extract target hidden states
         if self.dflash_offline:
             assert "base_model_outputs" in kwargs
-            base_outputs = DFlashBaseModelOutput.from_offline_dict(kwargs["base_model_outputs"])
-            if base_outputs.logits is None and self.dflash_self_logit_distillation:
-                # Compute logits from last-layer hidden states for KD loss.
-                # base_model_hidden_states is required on this path — fail fast
-                # with KeyError rather than lm_head(None).
-                out_hiddens = kwargs["base_model_outputs"]["base_model_hidden_states"]
-                base_outputs.logits = self._base_model_lm_head(out_hiddens)
+            # For self-logit-distillation, from_offline_dict reconstructs base logits from the
+            # captured hidden (final norm re-applied as needed) when the producer didn't supply
+            # them, and raises if anything needed for that is missing.
+            base_outputs = DFlashBaseModelOutput.from_offline_dict(
+                kwargs["base_model_outputs"],
+                self._base_model_norm,
+                self._base_model_lm_head,
+                need_logits=self.dflash_self_logit_distillation,
+            )
             target_hidden = base_outputs.target_hidden
         else:
             # TODO: For co-training the base model, remove no_grad and eval() switch.

--- a/modelopt/torch/speculative/plugins/hf_eagle.py
+++ b/modelopt/torch/speculative/plugins/hf_eagle.py
@@ -40,7 +40,13 @@ from ..utils import (
     temporary_set_config_value,
 )
 from .modeling_eagle import EagleBaseModelOutput, EagleModule
-from .modeling_fakebase import _BASE_MODEL_PATHS, _EMBED_TOKENS_PATHS, _LM_HEAD_PATHS
+from .modeling_fakebase import (
+    _BASE_MODEL_PATHS,
+    _EMBED_TOKENS_PATHS,
+    _FINAL_NORM_PATHS,
+    _LM_HEAD_PATHS,
+)
+from .modeling_final_norm import _maybe_apply_base_final_norm
 
 __all__ = ["HFARValidation", "HFEagleModel", "default_eagle_aux_layer_ids"]
 
@@ -72,6 +78,16 @@ class HFEagleModel(EagleModel):
     @property
     def _base_model_lm_head(self):
         return self.get_submodule(self.base_model_lm_head_path)
+
+    @property
+    def _base_model_norm(self):
+        """Base model's final pre-lm_head norm, or None if none was located.
+
+        Applied before lm_head in the offline/streaming distillation path only when the
+        producer captured a pre-norm hidden (base_hidden_prenorm), to reconstruct true logits.
+        """
+        path = getattr(self, "base_model_norm_path", None)
+        return self.get_submodule(path) if path else None
 
     @property
     def _base_llm_config(self):
@@ -116,6 +132,17 @@ class HFEagleModel(EagleModel):
                     continue
             if not found_submodule:
                 raise ValueError(f"Part {name} not found in model")
+
+        # Final pre-lm_head norm is OPTIONAL (set None if absent): used to re-normalize the
+        # un-normed final hidden captured by vLLM in the offline/streaming path.
+        self.base_model_norm_path = None
+        for path in _FINAL_NORM_PATHS:
+            try:
+                assert isinstance(self.get_submodule(path), torch.nn.Module)
+                self.base_model_norm_path = path
+                break
+            except Exception:
+                continue
 
     def _activate_torch_compile(self):
         import torch._dynamo
@@ -683,7 +710,12 @@ class HFEagleModel(EagleModel):
             assert "base_model_outputs" in kwargs
             base_outputs = EagleBaseModelOutput.from_offline_dict(kwargs["base_model_outputs"])
             if base_outputs.logits is None:
-                base_outputs.logits = self._base_model_lm_head(base_outputs.out_hiddens)
+                # Re-apply the base final norm when the producer captured a pre-norm hidden
+                # (vLLM streaming); fails loud if pre-norm is declared but no norm was located.
+                out_hiddens = _maybe_apply_base_final_norm(
+                    base_outputs.out_hiddens, kwargs["base_model_outputs"], self._base_model_norm
+                )
+                base_outputs.logits = self._base_model_lm_head(out_hiddens)
             past_key_values = None
         else:
             with self._nvtx_range("base_model_forward"):

--- a/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
+++ b/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
@@ -63,6 +63,19 @@ __all__ = [
 
 IGNORE_TOKEN_ID = LabelSmoother.ignore_index
 
+
+def nixl_backends_from_env() -> list[str]:
+    """NIXL backend list from ``NIXL_BACKENDS`` (comma-separated), defaulting to ``["UCX"]``.
+
+    Shared by the trainer-side agent (here) and the producer-side connector
+    (rdma_hidden_states_connector.py) so the two ALWAYS agree — they must use the same
+    backend to hand off over RDMA. Default UCX (InfiniBand clusters like HSG/nrt); on AWS EFA
+    set ``NIXL_BACKENDS=LIBFABRIC`` — UCX needs the EFA verbs driver (libefa-rdmav34.so) which
+    the container lacks, so UCX RDMA dies there.
+    """
+    return os.environ.get("NIXL_BACKENDS", "UCX").split(",")
+
+
 # Errors from ``_fetch`` that are genuinely transient (server overloaded / connection
 # reset / timeout) and so count against the circuit breaker and trigger a resample.
 # Anything else -- notably the ``RuntimeError`` raised on server token drift, or a
@@ -242,12 +255,17 @@ class StreamingDataset(Dataset):
     def _tokenize_entry(self, entry: dict) -> dict | None:
         """Tokenize a single entry.
 
-        Returns ``None`` for entries missing ``cid`` / ``messages``, or when
+        Returns ``None`` for entries missing ``cid`` / ``conversations``-or-``messages``, or when
         right-truncation to ``max_seq_len`` drops the entire supervised span
         (``answer_only_loss`` mode with the assistant turn at the tail).
         """
         cid = entry.get("conversation_id") or entry.get("uuid")
-        convs = entry.get("messages") or entry.get("conversations")
+        # Prefer ``conversations``, fall back to ``messages`` (the documented default format;
+        # see examples README). The order matters: some corpora (e.g. Spec-Decoding-Dataset-v2)
+        # carry a degenerate user-only ``messages`` stub (no assistant turn) alongside the real
+        # dialogue in ``conversations`` — preferring ``conversations`` picks the real dialogue
+        # there, while a ``messages``-only corpus still works via the fallback.
+        convs = entry.get("conversations") or entry.get("messages")
         if cid is None or not convs or not isinstance(convs, list):
             return None
         input_ids, loss_mask = _tokenize_with_loss_mask(
@@ -321,6 +339,9 @@ class EagleVllmStreamingConfig(StreamingConfig):
     # Required here (the base field is optional): the RDMA recv buffer is pre-sized and
     # registered once from max_seq_len, so it must be known before the first fetch.
     max_seq_len: int = Field(gt=0)
+    # vLLM captures the residual stream BEFORE the final norm, so the trainer must re-apply it
+    # before lm_head (see HFDFlashModel.forward). Set False for a post-norm producer.
+    base_hidden_prenorm: bool = True
 
     @field_validator("server_urls", mode="before")
     @classmethod
@@ -370,7 +391,8 @@ class EagleVllmStreamingDataset(StreamingDataset):
         if getattr(self, "_nixl_pid", None) != pid:
             from nixl._api import nixl_agent, nixl_agent_config
 
-            self._nixl = nixl_agent(f"hs-trainer-{pid}", nixl_agent_config(backends=["UCX"]))
+            _backends = nixl_backends_from_env()
+            self._nixl = nixl_agent(f"hs-trainer-{pid}", nixl_agent_config(backends=_backends))
             self._nixl_pid = pid
             self._remote_by_host: dict = {}
             self._recv = None
@@ -413,6 +435,17 @@ class EagleVllmStreamingDataset(StreamingDataset):
         )
         r.raise_for_status()
         kv = r.json().get("kv_transfer_params") or {}
+        # Fail loud on undersized pool slots: if the serve connector's max_tokens is below our
+        # max_seq_len, long prompts overflow the slot and the producer silently skips capture,
+        # so /desc never readies and the fetch would hang. Surface it as a clear error instead.
+        conn_max_tokens = kv.get("hs_max_tokens")
+        if conn_max_tokens is not None and conn_max_tokens < self.config.max_seq_len:
+            raise RuntimeError(
+                f"serve connector max_tokens={conn_max_tokens} < trainer max_seq_len="
+                f"{self.config.max_seq_len}: prompts longer than {conn_max_tokens} tokens would "
+                "be silently dropped (capture skipped) and the fetch would hang. Raise "
+                "HS_MAX_TOKENS to >= max_seq_len, or unset it to auto-size from max_model_len."
+            )
         rid = kv.get("hs_req_id")
         if rid is None:
             warn_rank_0(f"[streaming] no hs_req_id for {sample['cid']}")
@@ -532,4 +565,5 @@ class EagleVllmStreamingDataset(StreamingDataset):
             "attention_mask": torch.ones_like(input_ids),
             "loss_mask": loss_mask,
             "labels": labels,
+            "base_hidden_prenorm": self.config.base_hidden_prenorm,
         }

--- a/modelopt/torch/speculative/plugins/modeling_dflash.py
+++ b/modelopt/torch/speculative/plugins/modeling_dflash.py
@@ -53,6 +53,8 @@ from transformers.models.qwen3.modeling_qwen3 import (
 )
 from transformers.models.qwen3.modeling_qwen3 import rotate_half as _rotate_half
 
+from .modeling_final_norm import _maybe_apply_base_final_norm
+
 __all__ = ["DFlashBaseModelOutput", "DFlashModule", "build_target_layer_ids"]
 
 
@@ -64,15 +66,37 @@ class DFlashBaseModelOutput:
     logits: torch.Tensor | None = None  # base model logits [B, seq, vocab]
 
     @classmethod
-    def from_offline_dict(cls, d: dict):
+    def from_offline_dict(
+        cls, d: dict, base_model_norm=None, base_model_lm_head=None, need_logits=False
+    ):
         """Construct from a dict of pre-computed base model outputs (offline training).
 
         ``aux_hidden_states`` is required — missing it raises KeyError at the entry point
         rather than producing a cryptic failure deeper in the forward.
+
+        When ``need_logits`` (self-logit-distillation) and the producer didn't supply
+        ``base_model_logits``, logits are reconstructed from the captured final hidden via
+        ``base_model_lm_head`` — first re-applying the base final norm when the producer captured
+        a pre-(final-)norm hidden (``base_hidden_prenorm``), so the reconstruction is correct
+        regardless of capture format. Anything missing on that path raises rather than silently
+        yielding None logits: no ``base_model_lm_head`` (ValueError), no captured hidden
+        (KeyError), or a pre-norm hidden with no ``base_model_norm`` (feeding an un-normed hidden
+        to lm_head would be a corrupt distillation target).
         """
+        logits = d.get("base_model_logits")
+        if need_logits and logits is None:
+            if base_model_lm_head is None:
+                raise ValueError(
+                    "need_logits=True but base_model_lm_head is None; cannot reconstruct logits."
+                )
+            out_hiddens = d.get("base_model_hidden_states")
+            if out_hiddens is None:
+                raise KeyError("base_model_hidden_states")
+            out_hiddens = _maybe_apply_base_final_norm(out_hiddens, d, base_model_norm)
+            logits = base_model_lm_head(out_hiddens)
         return cls(
             target_hidden=d["aux_hidden_states"],
-            logits=d.get("base_model_logits"),
+            logits=logits,
         )
 
 

--- a/modelopt/torch/speculative/plugins/modeling_fakebase.py
+++ b/modelopt/torch/speculative/plugins/modeling_fakebase.py
@@ -32,6 +32,8 @@ from transformers import (
     PreTrainedModel,
 )
 
+from .modeling_final_norm import _FINAL_NORM_CLASSES, _select_final_norm_type
+
 # Candidate module paths searched in order — shared with HFEagleModel._find_base_model_parts
 _EMBED_TOKENS_PATHS = [
     "embed_tokens",
@@ -46,6 +48,15 @@ _LM_HEAD_PATHS = [
     "lm_head",
     "language_model.lm_head",
     "output",  # Mistral native checkpoints (consolidated.safetensors)
+]
+_FINAL_NORM_PATHS = [
+    "model.norm",
+    "language_model.model.norm",
+    "norm",
+    "backbone.norm_f",
+    "backbone.norm",
+    "language_model.backbone.norm",
+    "model.language_model.norm",
 ]
 _BASE_MODEL_PATHS = [
     "language_model.model",
@@ -78,16 +89,25 @@ class FakeBaseConfig(PretrainedConfig):
         num_attention_heads=None,
         num_key_value_heads=None,
         intermediate_size=None,
+        rms_norm_eps=1e-6,
+        rope_theta=None,
+        final_norm_type=None,
         **kwargs,
     ):
         """Initialize FakeBaseConfig with minimal model configuration parameters."""
         super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
+        self.rms_norm_eps = rms_norm_eps
+        # Which self-implemented final-norm class FakeBaseModel builds, or None to build no norm
+        # (model whose final-norm type we don't know). See _FINAL_NORM_CLASSES /
+        # _FINAL_NORM_TYPE_BY_MODEL_TYPE. Persisted so a reloaded config rebuilds the same norm.
+        self.final_norm_type = final_norm_type
         self.num_hidden_layers = num_hidden_layers
         # Mirror the original base layer count. The non-fake offline path loads with
         # num_hidden_layers=0 and stashes the real count here (see utils.load_vlm_or_llm);
         # the fake base keeps num_hidden_layers as the real count, so default to it. DFlash's
         # offline modify() reads num_orig_hidden_layers directly (hf_dflash.py), so it must
         # always be present on the base config.
+        # TODO: Deprecate the old offline path.
         self.num_orig_hidden_layers = (
             num_orig_hidden_layers if num_orig_hidden_layers is not None else num_hidden_layers
         )
@@ -103,6 +123,8 @@ class FakeBaseConfig(PretrainedConfig):
             num_key_value_heads if num_key_value_heads is not None else num_attention_heads
         )
         self.intermediate_size = intermediate_size
+        # For some drafter algo (e.g. DFlash) rope theta must match target model. Extract here.
+        self.rope_theta = rope_theta
         if isinstance(dtype, str):
             dtype = getattr(torch, dtype)
         self.dtype = dtype
@@ -135,6 +157,14 @@ class FakeBaseModel(PreTrainedModel):
         self.lm_head = nn.Linear(
             config.hidden_size, config.vocab_size, bias=False, dtype=config.dtype
         )
+        # Final pre-lm_head norm, applied before lm_head when reconstructing base logits for
+        # self-logit-distillation (vLLM-captured final hidden states are un-normed). Built ONLY
+        # when the base model's final-norm type is known (config.final_norm_type set); otherwise
+        # no ``norm`` attribute exists and downstream skips re-norming. The concrete class comes
+        # from config.final_norm_type (see _FINAL_NORM_CLASSES); weight loaded in from_source.
+        if config.final_norm_type is not None:
+            norm_cls = _FINAL_NORM_CLASSES[config.final_norm_type]
+            self.norm = norm_cls(config.hidden_size, eps=config.rms_norm_eps, dtype=config.dtype)
         # Initialize weights and apply final processing
         self.post_init()
 
@@ -172,14 +202,13 @@ class FakeBaseModel(PreTrainedModel):
             num_attention_heads=getattr(base_cfg, "num_attention_heads", None),
             num_key_value_heads=getattr(base_cfg, "num_key_value_heads", None),
             intermediate_size=getattr(base_cfg, "intermediate_size", None),
+            rms_norm_eps=getattr(base_cfg, "rms_norm_eps", 1e-6),
+            rope_theta=getattr(base_cfg, "rope_theta", None),
+            final_norm_type=_select_final_norm_type(getattr(base_cfg, "model_type", None)),
         )
         model = cls(config)
-        # Load lm_head and embed_tokens only from checkpoint
-        lm_head_w, embed_tokens_w = model._load_weights(source)
-        assert lm_head_w.shape == (config.vocab_size, config.hidden_size)
-        assert embed_tokens_w.shape == (config.vocab_size, config.hidden_size)
-        model.lm_head.weight.data.copy_(lm_head_w)
-        model.embed_tokens.weight.data.copy_(embed_tokens_w)
+        # Load lm_head, embed_tokens, and (for known models) the final norm into the model.
+        model._load_weights(source)
         return model
 
     @staticmethod
@@ -234,8 +263,13 @@ class FakeBaseModel(PreTrainedModel):
             return [os.path.join(source, name) for name in shard_filenames]
         return [hf_hub_download(repo_id=source, filename=name) for name in shard_filenames]
 
-    def _load_weights(self, source: str):
-        """Load lm_head and embed_tokens weights from a local directory or HuggingFace Hub repo."""
+    def _load_weights(self, source: str) -> None:
+        """Load lm_head, embed_tokens, and (for known models) the final norm into this model.
+
+        Reads only the tensors needed (never materializes a whole shard) and copies them into
+        the already-constructed submodules. For unknown models (``final_norm_type`` unset) the
+        norm is neither loaded nor present (``self.norm`` does not exist; see :meth:`__init__`).
+        """
         weight_map = self._load_index(source)
 
         embed_tokens_key = self._find_weight_key(weight_map, _EMBED_TOKENS_PATHS, "embed_tokens")
@@ -247,16 +281,35 @@ class FakeBaseModel(PreTrainedModel):
                 raise
             lm_head_key = embed_tokens_key
 
-        lm_head_path, embed_tokens_path = self._resolve_shard_paths(
-            source, [weight_map[lm_head_key], weight_map[embed_tokens_key]]
-        )
-
-        # Pull only the two tensors we need; avoids materializing the whole file.
-        def _read(path: str, key: str) -> torch.Tensor:
+        # Pull only the tensor we need; avoids materializing the whole file.
+        def _read(key: str) -> torch.Tensor:
+            (path,) = self._resolve_shard_paths(source, [weight_map[key]])
             with safe_open(path, framework="pt", device="cpu") as h:
                 return h.get_tensor(key)
 
-        return _read(lm_head_path, lm_head_key), _read(embed_tokens_path, embed_tokens_key)
+        # Explicit shape checks: copy_ would broadcast a wrong-but-compatible shape silently.
+        # Use raises (not asserts) so the guard survives python -O / PYTHONOPTIMIZE.
+        hidden, vocab = self.config.hidden_size, self.config.vocab_size
+        embed_tokens_w = _read(embed_tokens_key)
+        lm_head_w = _read(lm_head_key)
+        if embed_tokens_w.shape != (vocab, hidden):
+            raise ValueError(
+                f"embed_tokens weight shape {tuple(embed_tokens_w.shape)} != ({vocab}, {hidden})"
+            )
+        if lm_head_w.shape != (vocab, hidden):
+            raise ValueError(
+                f"lm_head weight shape {tuple(lm_head_w.shape)} != ({vocab}, {hidden})"
+            )
+        self.embed_tokens.weight.data.copy_(embed_tokens_w)
+        self.lm_head.weight.data.copy_(lm_head_w)
+
+        # Final norm only for models whose norm type we know (final_norm_type set); when known it
+        # MUST be present — a missing key is a hard error, never a silent skip. Unknown: no norm.
+        if self.config.final_norm_type is not None:
+            norm_w = _read(self._find_weight_key(weight_map, _FINAL_NORM_PATHS, "final_norm"))
+            if norm_w.shape != (hidden,):
+                raise ValueError(f"final-norm weight shape {tuple(norm_w.shape)} != ({hidden},)")
+            self.norm.weight.data.copy_(norm_w)
 
     def forward(self, *args, **kwargs):
         """Not implemented: FakeBaseModel omits full model weights and cannot run inference."""

--- a/modelopt/torch/speculative/plugins/modeling_final_norm.py
+++ b/modelopt/torch/speculative/plugins/modeling_final_norm.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Self-implemented final (pre-lm_head) norms for the offline/streaming fake base model.
+
+FakeBaseModel reconstructs base logits from vLLM-captured final hidden states, which are
+*un-normed* — so it must re-apply the base model's final norm before lm_head. We reimplement a
+small, explicit set of norm variants here (rather than importing each base model's real module)
+to keep the fake base lightweight, and map base ``model_type`` → norm type so a norm is applied
+only when we know which one the model uses.
+"""
+
+import torch
+from transformers.models.llama.modeling_llama import LlamaRMSNorm
+
+
+class _FinalRMSNorm(LlamaRMSNorm):
+    """Canonical transformers RMSNorm with an added ``dtype`` to build the weight in that dtype.
+
+    Llama/Qwen/Mistral/Kimi all share this exact module. The forward is inherited unchanged —
+    float32 reduction, ``x * rsqrt(mean(x^2) + eps) * weight``. We only add the dtype convenience
+    because FakeBaseModel constructs its submodules without a model-wide ``.to(dtype)``; a float32
+    weight here would promote the output to float32 and mismatch the bf16 lm_head. ``weight`` is
+    loaded from the base checkpoint.
+    """
+
+    def __init__(self, hidden_size, eps=1e-6, dtype=torch.bfloat16):
+        super().__init__(hidden_size, eps)
+        self.to(dtype)
+
+
+# Registry of self-implemented final-norm variants. We deliberately reimplement these
+# (rather than importing the base model's actual module) to keep FakeBaseModel lightweight.
+# Only a small, explicit set is supported; add a class here when a new type is needed.
+_FINAL_NORM_CLASSES = {
+    "rmsnorm": _FinalRMSNorm,
+}
+
+# Base ``model_type`` → final-norm type. ONLY listed models get a norm — applying the wrong or
+# un-loaded norm to the un-normed vLLM hidden would silently corrupt the distillation target.
+# Hardcoded, not auto-detected: add an entry (plus a class in ``_FINAL_NORM_CLASSES`` for a new
+# flavor, e.g. Gemma's ``(1 + weight)`` RMSNorm) to enable a model; unlisted → no norm.
+_FINAL_NORM_TYPE_BY_MODEL_TYPE: dict[str, str] = {
+    "llama": "rmsnorm",
+    "mistral": "rmsnorm",
+    "mixtral": "rmsnorm",
+    "qwen2": "rmsnorm",
+    "qwen3": "rmsnorm",
+    "qwen3_moe": "rmsnorm",
+    "deepseek_v3": "rmsnorm",
+    "kimi_k2": "rmsnorm",  # Kimi-K2 / K2-Thinking (DeepSeek-V3 arch) report model_type "kimi_k2"
+    "kimi_k25": "rmsnorm",  # Kimi-K2.5 / K2.6 / K2.7 all report model_type "kimi_k25"
+    # gpt_oss intentionally DISABLED: GptOssRMSNorm uses an fp32 weight + multiply-then-cast,
+    # unlike _FinalRMSNorm's bf16 weight, so reusing it would silently bias reconstructed logits.
+    # Re-enable once a gpt_oss-style class (fp32 weight, multiply-then-cast) is in _FINAL_NORM_CLASSES.
+}
+
+
+def _select_final_norm_type(model_type: str | None) -> str | None:
+    """Return the final-norm type for a base ``model_type``, or ``None`` if unknown.
+
+    ``None`` means we don't know the model's final norm, so FakeBaseModel builds no norm.
+    """
+    return _FINAL_NORM_TYPE_BY_MODEL_TYPE.get(model_type or "")
+
+
+def _maybe_apply_base_final_norm(hidden, base_model_outputs, base_model_norm):
+    """Re-apply the base model's final norm to ``hidden`` before lm_head, per the producer.
+
+    When the offline/streaming producer captured a *pre-final-norm* hidden it sets
+    ``base_hidden_prenorm=True`` in ``base_model_outputs``; the consumer must re-apply the base
+    final norm to reconstruct correct logits. Shared by the DFlash and EAGLE offline forwards.
+
+    - ``base_hidden_prenorm`` falsy (post-norm capture, e.g. HF/TRT-LLM): return ``hidden`` as-is.
+    - ``base_hidden_prenorm`` true and a norm is available: return the normed hidden.
+    - ``base_hidden_prenorm`` true but ``base_model_norm is None``: raise — we cannot reconstruct
+      correct logits, and silently feeding an un-normed hidden into lm_head would corrupt the
+      distillation target. The base ``model_type`` is not enabled in
+      ``_FINAL_NORM_TYPE_BY_MODEL_TYPE``.
+    """
+    if not base_model_outputs.get("base_hidden_prenorm", False):
+        return hidden
+    if base_model_norm is None:
+        raise RuntimeError(
+            "base_model_outputs declares base_hidden_prenorm=True (the producer captured a "
+            "pre-final-norm hidden) but no base final norm was located for this model. "
+            "Reconstructing logits without re-applying the final norm would corrupt the "
+            "distillation target. This base model_type is not enabled in "
+            "_FINAL_NORM_TYPE_BY_MODEL_TYPE (see modeling_final_norm.py) — add it, and a "
+            "matching norm class in _FINAL_NORM_CLASSES if it needs a new norm flavor."
+        )
+    return base_model_norm(hidden)

--- a/modelopt/torch/speculative/plugins/rdma_hidden_states_connector.py
+++ b/modelopt/torch/speculative/plugins/rdma_hidden_states_connector.py
@@ -58,6 +58,8 @@ from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
 
+from .hf_streaming_dataset import nixl_backends_from_env
+
 logger = init_logger(__name__)
 
 
@@ -249,7 +251,10 @@ class RdmaHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
                 max_num_seqs,
             )
 
-        self._nixl = nixl_agent(f"hs-producer-{uuid.uuid4()}", nixl_agent_config(backends=["UCX"]))
+        _backends = nixl_backends_from_env()
+        self._nixl = nixl_agent(
+            f"hs-producer-{uuid.uuid4()}", nixl_agent_config(backends=_backends)
+        )
         # ONE-TIME pool registration (the only ibv_reg_mr).
         t0 = time.time()
         self._pool = torch.empty(
@@ -389,8 +394,16 @@ class RdmaHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         return meta
 
     def request_finished(self, request, block_ids):
-        """Return the request id + sidecar port for the trainer to fetch over RDMA."""
-        return True, {"hs_req_id": request.request_id, "hs_sidecar_port": self._sidecar_port}
+        """Return the request id + sidecar port for the trainer to fetch over RDMA.
+
+        ``hs_max_tokens`` lets the trainer fail loud if its ``max_seq_len`` exceeds our pool
+        slot capacity (which would otherwise silently drop long prompts and hang the fetch).
+        """
+        return True, {
+            "hs_req_id": request.request_id,
+            "hs_sidecar_port": self._sidecar_port,
+            "hs_max_tokens": self._max_tokens,
+        }
 
     def request_finished_all_groups(self, request, block_ids):
         """Multi-group variant of :meth:`request_finished` (first group's blocks)."""

--- a/tests/unit/torch/speculative/plugins/test_fakebase.py
+++ b/tests/unit/torch/speculative/plugins/test_fakebase.py
@@ -51,6 +51,8 @@ def fake_checkpoint(tmp_path, fake_config):
     tensors = {
         "lm_head.weight": torch.zeros(_VOCAB_SIZE, _HIDDEN_SIZE),
         "embed_tokens.weight": torch.zeros(_VOCAB_SIZE, _HIDDEN_SIZE),
+        # model_type "llama" is in the final-norm whitelist, so FakeBaseModel requires the norm.
+        "norm.weight": torch.ones(_HIDDEN_SIZE),
     }
     shard = tmp_path / "model-00001-of-00001.safetensors"
     safetensors.torch.save_file(tensors, shard)
@@ -75,6 +77,7 @@ def test_fakebase_single_file_no_index(tmp_path, fake_config):
     tensors = {
         "lm_head.weight": torch.zeros(_VOCAB_SIZE, _HIDDEN_SIZE),
         "embed_tokens.weight": torch.zeros(_VOCAB_SIZE, _HIDDEN_SIZE),
+        "norm.weight": torch.ones(_HIDDEN_SIZE),
     }
     safetensors.torch.save_file(tensors, tmp_path / "model.safetensors")
     model = FakeBaseModel.from_source(str(tmp_path))
@@ -87,7 +90,10 @@ def test_fakebase_tied_embeddings_falls_back_to_embed(tmp_path, fake_config):
     FakeBaseModel must reuse ``embed_tokens`` for both."""
     fake_config.tie_word_embeddings = True
     weight = torch.randn(_VOCAB_SIZE, _HIDDEN_SIZE)
-    safetensors.torch.save_file({"embed_tokens.weight": weight}, tmp_path / "model.safetensors")
+    safetensors.torch.save_file(
+        {"embed_tokens.weight": weight, "norm.weight": torch.ones(_HIDDEN_SIZE)},
+        tmp_path / "model.safetensors",
+    )
     model = FakeBaseModel.from_source(str(tmp_path))
     torch.testing.assert_close(model.lm_head.weight, weight)
     torch.testing.assert_close(model.embed_tokens.weight, weight)

--- a/tests/unit/torch/speculative/plugins/test_hf_speculative_offline.py
+++ b/tests/unit/torch/speculative/plugins/test_hf_speculative_offline.py
@@ -209,6 +209,7 @@ def test_offline_dataset_len_and_getitem(tmp_path):
         "attention_mask",
         "loss_mask",
         "labels",
+        "base_hidden_prenorm",
     }
     assert item["input_ids"].shape == (SEQ_LEN,)
     assert item["attention_mask"].shape == (SEQ_LEN,)

--- a/tests/unit/torch/speculative/plugins/test_hf_streaming_dataset.py
+++ b/tests/unit/torch/speculative/plugins/test_hf_streaming_dataset.py
@@ -359,6 +359,7 @@ def test_eagle_vllm_dataset_end_to_end(monkeypatch):
         "attention_mask",
         "loss_mask",
         "labels",
+        "base_hidden_prenorm",
     }
     for b in batches:
         assert set(b) == expected_keys

--- a/tests/unit/torch/speculative/plugins/test_modeling_final_norm.py
+++ b/tests/unit/torch/speculative/plugins/test_modeling_final_norm.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the self-implemented final norm and the pre-norm re-application helper."""
+
+import pytest
+import torch
+
+pytest.importorskip("transformers")
+
+from modelopt.torch.speculative.plugins.modeling_final_norm import (
+    _FinalRMSNorm,
+    _maybe_apply_base_final_norm,
+    _select_final_norm_type,
+)
+
+_HIDDEN_SIZE = 16
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected"),
+    [
+        ("llama", "rmsnorm"),
+        ("qwen3", "rmsnorm"),
+        ("deepseek_v3", "rmsnorm"),
+        ("kimi_k2", "rmsnorm"),
+        ("kimi_k25", "rmsnorm"),
+        # gpt_oss is intentionally DISABLED: its RMSNorm forward/weight dtype differs from the
+        # Llama variant we reuse, so it must not resolve to a norm type until a matching class
+        # is added.
+        ("gpt_oss", None),
+        ("gemma", None),  # unlisted model
+        ("", None),
+        (None, None),
+    ],
+)
+def test_select_final_norm_type(model_type, expected):
+    assert _select_final_norm_type(model_type) == expected
+
+
+def test_final_rmsnorm_dtype_and_shape():
+    """_FinalRMSNorm builds its weight in the requested dtype and preserves input dtype/shape."""
+    norm = _FinalRMSNorm(_HIDDEN_SIZE, eps=1e-6, dtype=torch.bfloat16)
+    assert norm.weight.dtype == torch.bfloat16
+    x = torch.randn(2, 4, _HIDDEN_SIZE, dtype=torch.bfloat16)
+    out = norm(x)
+    assert out.dtype == torch.bfloat16
+    assert out.shape == x.shape
+
+
+def test_maybe_apply_norm_postnorm_is_noop():
+    """base_hidden_prenorm falsy or absent -> hidden returned unchanged, norm never touched."""
+    hidden = torch.randn(2, 4, _HIDDEN_SIZE)
+    # Missing key.
+    assert _maybe_apply_base_final_norm(hidden, {}, None) is hidden
+    # Explicit False, even when a norm is available.
+    norm = _FinalRMSNorm(_HIDDEN_SIZE, dtype=torch.float32)
+    assert _maybe_apply_base_final_norm(hidden, {"base_hidden_prenorm": False}, norm) is hidden
+
+
+def test_maybe_apply_norm_prenorm_applies():
+    """base_hidden_prenorm=True with a norm available -> the norm is applied."""
+    norm = _FinalRMSNorm(_HIDDEN_SIZE, dtype=torch.float32)
+    hidden = torch.randn(2, 4, _HIDDEN_SIZE)
+    out = _maybe_apply_base_final_norm(hidden, {"base_hidden_prenorm": True}, norm)
+    assert out.shape == hidden.shape
+    torch.testing.assert_close(out, norm(hidden))
+
+
+def test_maybe_apply_norm_prenorm_without_norm_raises():
+    """base_hidden_prenorm=True but no norm located -> fail loud, never silently skip."""
+    hidden = torch.randn(2, 4, _HIDDEN_SIZE)
+    with pytest.raises(RuntimeError, match="_FINAL_NORM_TYPE_BY_MODEL_TYPE"):
+        _maybe_apply_base_final_norm(hidden, {"base_hidden_prenorm": True}, None)

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_dflash.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_dflash.yaml
@@ -6,8 +6,10 @@
 #
 # data.mode=streaming sets dflash_offline so the DFlash module consumes streamed
 # hidden states instead of running the fake base.
-# Capture ids = [2,16,31,45,59,60] (kimi_k25/deepseek_v3, 61 layers): 5 DFlash
-# target layers + base 60. n_captured = num_target_layers + 1.
+# Capture ids = [2,16,31,45,59,61] (kimi_k25/deepseek_v3, 61 layers): 5 DFlash
+# target layers + true final layer 61. n_captured = num_target_layers + 1.
+# (61 = true final hidden; requires a vLLM with the aux-capture fix vllm#46788.
+#  Without it use 60 — the 2nd-to-last layer — which caps acceptance length.)
 #
 # answer_only_loss=true: Kimi ships only a slow tokenizer, so it can't derive the
 # assistant mask the standard way (return_assistant_tokens_mask needs a fast
@@ -72,7 +74,7 @@ pipeline:
     environment:
       - HF_MODEL_CKPT: <<global_vars.hf_model>>
       # No spaces in values: nemo_run emits `export FOO=value` unquoted.
-      - EAGLE_CAPTURE_IDS: "[2,16,31,45,59,60]"
+      - EAGLE_CAPTURE_IDS: "[2,16,31,45,59,61]"
       - SERVE_TP: "4"
       # Per-rank in-flight fetches; keep low so the cold NVFP4-MoE serve isn't flooded past its execute-model timeout (kills EngineCore).
       - STREAMING_NUM_WORKERS: "1"

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_dflash_multi_node.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_dflash_multi_node.yaml
@@ -7,8 +7,10 @@
 # on one 4-GPU node, so each serve replica owns a whole node.
 #
 # Capture ids: build_target_layer_ids(num_orig=61, num_draft=5)=[1,15,30,44,58]
-# -> +1 for embedding = [2,16,31,45,59], append base 60 (final layer uncapturable).
+# -> +1 for embedding = [2,16,31,45,59], append true final layer 61.
 # 6 captured = 5 aux layers, matching the 5-layer DFlash draft block.
+# (61 = true final hidden; requires a vLLM with the aux-capture fix vllm#46788.
+#  Without it use 60 — the 2nd-to-last layer — which caps acceptance length.)
 #
 # Run ON the cluster login node (paramiko can't reach the cluster through its login proxy):
 #   export SLURM_HOST=localhost SLURM_ACCOUNT=<your_account> \
@@ -72,7 +74,7 @@ pipeline:
     environment:
       - HF_MODEL_CKPT: <<global_vars.hf_model>>
       # See header for derivation.
-      - EAGLE_CAPTURE_IDS: "[2,16,31,45,59,60]"
+      - EAGLE_CAPTURE_IDS: "[2,16,31,45,59,61]"
       - SERVE_NODES: "2"
       - SERVE_TP: "4"
       # Per-rank in-flight fetches; keep low so the cold NVFP4-MoE serve isn't flooded past its execute-model timeout (kills EngineCore).

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_eagle3.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_eagle3.yaml
@@ -3,8 +3,9 @@
 # Requires GB200: native NVFP4 + 192 GB/GPU fits the ~551 GB model at TP=4 on one node.
 # node 0 = vllm serve (TP=4), node 1 = EAGLE3 trainer (fake base); 4 GPUs each.
 #
-# Capture ids: deepseek_v3 arch, 61 layers, indexed by layer input (0..60);
-# [2,30,58] aux + [60] base (final layer not capturable).
+# Capture ids: deepseek_v3 arch, 61 layers; [2,30,58] aux + [61] true final layer.
+# (61 = true final hidden; requires a vLLM with the aux-capture fix vllm#46788.
+#  Without it use 60 — the 2nd-to-last layer — which caps acceptance length.)
 #
 # Run ON the cluster login node (paramiko can't reach the cluster through its login proxy):
 #   export SLURM_HOST=localhost SLURM_ACCOUNT=<your_account> \
@@ -58,7 +59,7 @@ pipeline:
     environment:
       - HF_MODEL_CKPT: <<global_vars.hf_model>>
       # No spaces: nemo_run emits `export FOO=value` unquoted.
-      - EAGLE_CAPTURE_IDS: "[2,30,58,60]"
+      - EAGLE_CAPTURE_IDS: "[2,30,58,61]"
       - SERVE_TP: "4"
       # Per-rank in-flight fetches; keep low so the cold NVFP4-MoE serve isn't flooded past its execute-model timeout (kills EngineCore).
       - STREAMING_NUM_WORKERS: "1"

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_eagle3_multi_node.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_eagle3_multi_node.yaml
@@ -4,8 +4,9 @@
 # common/eagle3/train_eagle_streaming.sh header.
 #
 # Requires GB200: native NVFP4 + 192 GB/GPU fits ~551 GB Kimi at TP=4 on one node.
-# Capture ids = [2,30,58] aux + [60] base = 4 (kimi_k25/deepseek_v3, 61 layers;
-# layer 60 is the last capturable, used as base).
+# Capture ids = [2,30,58] aux + [61] true final = 4 (kimi_k25/deepseek_v3, 61 layers;
+# layer 61 is the true final hidden, used as base). 61 requires a vLLM with the
+# aux-capture fix vllm#46788; without it use 60 — the 2nd-to-last layer (caps AL).
 #
 # Run ON the cluster login node (paramiko can't reach the cluster through its login proxy):
 #   export SLURM_HOST=localhost SLURM_ACCOUNT=<your_account> \
@@ -57,7 +58,7 @@ pipeline:
     environment:
       - HF_MODEL_CKPT: <<global_vars.hf_model>>
       # No spaces in values: nemo_run emits `export FOO=value` unquoted.
-      - EAGLE_CAPTURE_IDS: "[2,30,58,60]"
+      - EAGLE_CAPTURE_IDS: "[2,30,58,61]"
       - SERVE_NODES: "2"
       - SERVE_TP: "4"
       # Per-rank in-flight fetches; keep low so the cold NVFP4-MoE serve isn't flooded past its execute-model timeout (kills EngineCore).


### PR DESCRIPTION
### What does this PR do?

**Type of change:** Bug fix

vLLM captures the final-layer hidden state *before* the model's final norm, but the
offline/streaming distillation path fed it straight into `lm_head`, so the reconstructed
base logits (the KD target) were computed from un-normed hidden states.

This PR re-applies the base model's final norm before `lm_head` when the producer declares
a pre-norm capture (`base_hidden_prenorm`), for both DFlash and EAGLE:

- Producer sets `base_hidden_prenorm` (streaming: `True`; offline: from the dump).
- Consumer (`_maybe_apply_base_final_norm`) re-applies the base final norm, and **fails loud**
  if pre-norm is declared but the model's norm type isn't supported (no silent corruption).
- `FakeBaseModel` now loads the base final norm (+ `rope_theta`/`rms_norm_eps`); norm type is
  gated by an explicit `model_type` allowlist (gpt_oss excluded pending a matching norm class).

### Testing

`tests/unit/torch/speculative/plugins/test_modeling_final_norm.py`; DFlash/EAGLE streaming
training verified end-to-end.

- Backward compatible?: ✅ (post-norm captures declare `base_hidden_prenorm=False` → unchanged)
- New tests: ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded speculative decoding/distillation to reconstruct missing base-model logits by optionally applying a base model’s final pre–LM-head normalization when pre-norm hidden states are provided.
  * Streaming dataset now emits `base_hidden_prenorm` and can configure RDMA backends from environment settings.
* **Bug Fixes**
  * Rejects mixed `base_hidden_prenorm` values within a batch.
  * Fails fast on streaming token-length mismatches.
  * Streaming dataset loading supports directory inputs by expanding sorted JSONL shards (and errors if none are found).
* **Tests**
  * Added/updated unit and dataset tests for final-norm behavior and the new batch field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->