### PR TITLE
Fix HF PTQ empty-init dtype kwargs

### DIFF
--- a/examples/hf_ptq/example_utils.py
+++ b/examples/hf_ptq/example_utils.py
@@ -598,6 +598,51 @@ def get_original_hf_quant_method(config) -> str | None:
     return None
 
 
+def _empty_model_init_kwargs(model_kwargs, torch_dtype):
+    init_kwargs = model_kwargs.copy()
+    init_kwargs.pop("max_memory", None)
+    init_kwargs["dtype"] = torch_dtype
+    return init_kwargs
+
+
+def _empty_model_init_dtype(hf_config):
+    torch_dtype = (
+        getattr(hf_config, "dtype", None)
+        or getattr(hf_config, "torch_dtype", None)
+        or torch.bfloat16
+    )
+    if isinstance(torch_dtype, str):
+        torch_dtype = getattr(torch, torch_dtype)
+    return torch_dtype
+
+
+def _is_unexpected_dtype_kwarg_error(error):
+    message = str(error)
+    return "unexpected keyword argument" in message and (
+        "'dtype'" in message or '"dtype"' in message
+    )
+
+
+def _from_config_for_empty_weights(from_config, hf_config, model_kwargs, torch_dtype):
+    try:
+        return from_config(hf_config, **model_kwargs)
+    except TypeError as error:
+        if "dtype" not in model_kwargs or not _is_unexpected_dtype_kwarg_error(error):
+            raise
+
+        model_kwargs_without_dtype = model_kwargs.copy()
+        model_kwargs_without_dtype.pop("dtype", None)
+        orig_dtype = torch.get_default_dtype()
+        torch.set_default_dtype(torch_dtype)
+        try:
+            # Some remote-code constructors, such as DeciLMForCausalLM, reject the
+            # Transformers dtype kwarg even though bf16-sized empty weights are
+            # still needed for device-map inference.
+            return from_config(hf_config, **model_kwargs_without_dtype)
+        finally:
+            torch.set_default_dtype(orig_dtype)
+
+
 def get_model(
     ckpt_path,
     device="cuda",
@@ -734,13 +779,13 @@ def get_model(
         with init_empty_weights(include_buffers=True):
             # When computing the device_map, assuming bfloat16 precision by default,
             # unless specified by the hf_config.
-            torch_dtype = getattr(hf_config, "torch_dtype", torch.bfloat16)
-            model_kwargs2 = model_kwargs.copy()
+            torch_dtype = _empty_model_init_dtype(hf_config)
+            model_kwargs2 = _empty_model_init_kwargs(model_kwargs, torch_dtype)
             if auto_model_module not in [AutoModelForCausalLM, AutoModel]:
                 model_kwargs2.pop("trust_remote_code", None)
-            model_kwargs2["dtype"] = torch_dtype
-            model_kwargs2.pop("max_memory", None)
-            model = from_config(hf_config, **model_kwargs2)
+            model = _from_config_for_empty_weights(
+                from_config, hf_config, model_kwargs2, torch_dtype
+            )
 
         max_memory = get_max_memory()
         inferred_device_map = infer_auto_device_map(model, max_memory=max_memory)

--- a/examples/hf_ptq/example_utils.py
+++ b/examples/hf_ptq/example_utils.py
@@ -598,51 +598,6 @@ def get_original_hf_quant_method(config) -> str | None:
     return None
 
 
-def _empty_model_init_kwargs(model_kwargs, torch_dtype):
-    init_kwargs = model_kwargs.copy()
-    init_kwargs.pop("max_memory", None)
-    init_kwargs["dtype"] = torch_dtype
-    return init_kwargs
-
-
-def _empty_model_init_dtype(hf_config):
-    torch_dtype = (
-        getattr(hf_config, "dtype", None)
-        or getattr(hf_config, "torch_dtype", None)
-        or torch.bfloat16
-    )
-    if isinstance(torch_dtype, str):
-        torch_dtype = getattr(torch, torch_dtype)
-    return torch_dtype
-
-
-def _is_unexpected_dtype_kwarg_error(error):
-    message = str(error)
-    return "unexpected keyword argument" in message and (
-        "'dtype'" in message or '"dtype"' in message
-    )
-
-
-def _from_config_for_empty_weights(from_config, hf_config, model_kwargs, torch_dtype):
-    try:
-        return from_config(hf_config, **model_kwargs)
-    except TypeError as error:
-        if "dtype" not in model_kwargs or not _is_unexpected_dtype_kwarg_error(error):
-            raise
-
-        model_kwargs_without_dtype = model_kwargs.copy()
-        model_kwargs_without_dtype.pop("dtype", None)
-        orig_dtype = torch.get_default_dtype()
-        torch.set_default_dtype(torch_dtype)
-        try:
-            # Some remote-code constructors, such as DeciLMForCausalLM, reject the
-            # Transformers dtype kwarg even though bf16-sized empty weights are
-            # still needed for device-map inference.
-            return from_config(hf_config, **model_kwargs_without_dtype)
-        finally:
-            torch.set_default_dtype(orig_dtype)
-
-
 def get_model(
     ckpt_path,
     device="cuda",
@@ -779,13 +734,20 @@ def get_model(
         with init_empty_weights(include_buffers=True):
             # When computing the device_map, assuming bfloat16 precision by default,
             # unless specified by the hf_config.
-            torch_dtype = _empty_model_init_dtype(hf_config)
-            model_kwargs2 = _empty_model_init_kwargs(model_kwargs, torch_dtype)
+            torch_dtype = (
+                getattr(hf_config, "dtype", None)
+                or getattr(hf_config, "torch_dtype", None)
+                or torch.bfloat16
+            )
+            if isinstance(torch_dtype, str):
+                torch_dtype = getattr(torch, torch_dtype)
+            model_kwargs2 = model_kwargs.copy()
             if auto_model_module not in [AutoModelForCausalLM, AutoModel]:
                 model_kwargs2.pop("trust_remote_code", None)
-            model = _from_config_for_empty_weights(
-                from_config, hf_config, model_kwargs2, torch_dtype
-            )
+            model_kwargs2["torch_dtype"] = torch_dtype
+            model_kwargs2.pop("dtype", None)
+            model_kwargs2.pop("max_memory", None)
+            model = from_config(hf_config, **model_kwargs2)
 
         max_memory = get_max_memory()
         inferred_device_map = infer_auto_device_map(model, max_memory=max_memory)

--- a/tests/examples/hf_ptq/test_example_utils.py
+++ b/tests/examples/hf_ptq/test_example_utils.py
@@ -19,9 +19,9 @@ separate-file-standalone, separate-file-indexed) plus a negative case.
 """
 
 import json
+from contextlib import nullcontext
 from types import SimpleNamespace
 
-import pytest
 import torch
 from _test_utils.examples.hf_ptq_example_utils import example_utils
 from safetensors.torch import save_file
@@ -197,93 +197,48 @@ def test_get_original_hf_quant_method_none_for_unquantized():
     )
 
 
-def test_empty_model_init_kwargs_keeps_dtype_for_general_from_config():
-    kwargs = {
-        "dtype": "auto",
-        "torch_dtype": torch.float16,
-        "max_memory": {0: 1024},
-        "trust_remote_code": True,
-        "attn_implementation": "flash_attention_2",
-    }
-
-    init_kwargs = example_utils._empty_model_init_kwargs(kwargs, torch.bfloat16)
-
-    assert init_kwargs == {
-        "dtype": torch.bfloat16,
-        "torch_dtype": torch.float16,
-        "trust_remote_code": True,
-        "attn_implementation": "flash_attention_2",
-    }
-
-
-def test_empty_model_init_dtype_prefers_config_dtype():
-    assert (
-        example_utils._empty_model_init_dtype(
-            SimpleNamespace(dtype=torch.float16, torch_dtype=torch.bfloat16)
-        )
-        is torch.float16
+def test_get_model_empty_init_uses_torch_dtype_not_dtype(monkeypatch):
+    calls = {}
+    hf_config = SimpleNamespace(
+        architectures=["DeciLMForCausalLM"],
+        dtype=torch.float16,
+        model_type="llama",
+        torch_dtype=torch.bfloat16,
     )
 
+    class FakeModel:
+        def eval(self):
+            calls["eval"] = True
 
-def test_empty_model_init_dtype_defaults_to_bfloat16():
-    assert example_utils._empty_model_init_dtype(SimpleNamespace()) is torch.bfloat16
+    class FakeAutoModelForCausalLM:
+        @staticmethod
+        def from_config(config, **kwargs):
+            calls["from_config"] = kwargs
+            assert config is hf_config
+            assert "dtype" not in kwargs
+            assert kwargs["torch_dtype"] is torch.float16
+            assert "max_memory" not in kwargs
+            return FakeModel()
 
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            calls["from_pretrained"] = kwargs
+            return FakeModel()
 
-def test_from_config_for_empty_weights_calls_with_dtype_first():
-    calls = []
-
-    def from_config(config, **kwargs):
-        calls.append((config, kwargs, torch.get_default_dtype()))
-        return "model"
-
-    hf_config = SimpleNamespace()
-    model_kwargs = {"dtype": torch.bfloat16, "trust_remote_code": True}
-
-    assert (
-        example_utils._from_config_for_empty_weights(
-            from_config, hf_config, model_kwargs, torch.bfloat16
-        )
-        == "model"
+    monkeypatch.setattr(
+        example_utils.AutoConfig,
+        "from_pretrained",
+        lambda *args, **kwargs: hf_config,
     )
+    monkeypatch.setattr(example_utils, "AutoModelForCausalLM", FakeAutoModelForCausalLM)
+    monkeypatch.setattr(example_utils, "is_nemotron_vl", lambda config: False)
+    monkeypatch.setattr(example_utils, "is_speculative", lambda config: False)
+    monkeypatch.setattr(example_utils, "init_empty_weights", lambda include_buffers: nullcontext())
+    monkeypatch.setattr(example_utils, "get_max_memory", lambda: {0: 1024})
+    monkeypatch.setattr(example_utils, "infer_auto_device_map", lambda model, max_memory: {"": 0})
 
-    assert calls == [(hf_config, model_kwargs, torch.get_default_dtype())]
+    model = example_utils.get_model("checkpoint", device="cpu", trust_remote_code=True)
 
-
-def test_from_config_for_empty_weights_retries_without_dtype_with_default_dtype():
-    calls = []
-    original_dtype = torch.get_default_dtype()
-
-    def from_config(config, **kwargs):
-        calls.append((kwargs, torch.get_default_dtype()))
-        if "dtype" in kwargs:
-            raise TypeError("__init__() got an unexpected keyword argument 'dtype'")
-        return config
-
-    try:
-        hf_config = SimpleNamespace()
-        model_kwargs = {"dtype": torch.bfloat16, "trust_remote_code": True}
-
-        assert (
-            example_utils._from_config_for_empty_weights(
-                from_config, hf_config, model_kwargs, torch.bfloat16
-            )
-            is hf_config
-        )
-
-        assert calls == [
-            (model_kwargs, original_dtype),
-            ({"trust_remote_code": True}, torch.bfloat16),
-        ]
-        assert torch.get_default_dtype() is original_dtype
-    finally:
-        torch.set_default_dtype(original_dtype)
-
-
-def test_from_config_for_empty_weights_reraises_other_type_error():
-    def from_config(config, **kwargs):
-        raise TypeError("missing required positional argument: 'hidden_size'")
-
-    with pytest.raises(TypeError, match="hidden_size"):
-        example_utils._from_config_for_empty_weights(
-            from_config, SimpleNamespace(), {"dtype": torch.bfloat16}, torch.bfloat16
-        )
+    assert isinstance(model, FakeModel)
+    assert calls["eval"]
+    assert calls["from_config"]["trust_remote_code"] is True

--- a/tests/examples/hf_ptq/test_example_utils.py
+++ b/tests/examples/hf_ptq/test_example_utils.py
@@ -21,6 +21,7 @@ separate-file-standalone, separate-file-indexed) plus a negative case.
 import json
 from types import SimpleNamespace
 
+import pytest
 import torch
 from _test_utils.examples.hf_ptq_example_utils import example_utils
 from safetensors.torch import save_file
@@ -194,3 +195,95 @@ def test_get_original_hf_quant_method_none_for_unquantized():
         example_utils.get_original_hf_quant_method(SimpleNamespace(quantization_config=None))
         is None
     )
+
+
+def test_empty_model_init_kwargs_keeps_dtype_for_general_from_config():
+    kwargs = {
+        "dtype": "auto",
+        "torch_dtype": torch.float16,
+        "max_memory": {0: 1024},
+        "trust_remote_code": True,
+        "attn_implementation": "flash_attention_2",
+    }
+
+    init_kwargs = example_utils._empty_model_init_kwargs(kwargs, torch.bfloat16)
+
+    assert init_kwargs == {
+        "dtype": torch.bfloat16,
+        "torch_dtype": torch.float16,
+        "trust_remote_code": True,
+        "attn_implementation": "flash_attention_2",
+    }
+
+
+def test_empty_model_init_dtype_prefers_config_dtype():
+    assert (
+        example_utils._empty_model_init_dtype(
+            SimpleNamespace(dtype=torch.float16, torch_dtype=torch.bfloat16)
+        )
+        is torch.float16
+    )
+
+
+def test_empty_model_init_dtype_defaults_to_bfloat16():
+    assert example_utils._empty_model_init_dtype(SimpleNamespace()) is torch.bfloat16
+
+
+def test_from_config_for_empty_weights_calls_with_dtype_first():
+    calls = []
+
+    def from_config(config, **kwargs):
+        calls.append((config, kwargs, torch.get_default_dtype()))
+        return "model"
+
+    hf_config = SimpleNamespace()
+    model_kwargs = {"dtype": torch.bfloat16, "trust_remote_code": True}
+
+    assert (
+        example_utils._from_config_for_empty_weights(
+            from_config, hf_config, model_kwargs, torch.bfloat16
+        )
+        == "model"
+    )
+
+    assert calls == [(hf_config, model_kwargs, torch.get_default_dtype())]
+
+
+def test_from_config_for_empty_weights_retries_without_dtype_with_default_dtype():
+    calls = []
+    original_dtype = torch.get_default_dtype()
+
+    def from_config(config, **kwargs):
+        calls.append((kwargs, torch.get_default_dtype()))
+        if "dtype" in kwargs:
+            raise TypeError("__init__() got an unexpected keyword argument 'dtype'")
+        return config
+
+    try:
+        hf_config = SimpleNamespace()
+        model_kwargs = {"dtype": torch.bfloat16, "trust_remote_code": True}
+
+        assert (
+            example_utils._from_config_for_empty_weights(
+                from_config, hf_config, model_kwargs, torch.bfloat16
+            )
+            is hf_config
+        )
+
+        assert calls == [
+            (model_kwargs, original_dtype),
+            ({"trust_remote_code": True}, torch.bfloat16),
+        ]
+        assert torch.get_default_dtype() is original_dtype
+    finally:
+        torch.set_default_dtype(original_dtype)
+
+
+def test_from_config_for_empty_weights_reraises_other_type_error():
+    def from_config(config, **kwargs):
+        raise TypeError("missing required positional argument: 'hidden_size'")
+
+    with pytest.raises(TypeError, match="hidden_size"):
+        example_utils._from_config_for_empty_weights(
+            from_config, SimpleNamespace(), {"dtype": torch.bfloat16}, torch.bfloat16
+        )


### PR DESCRIPTION
## Summary

Fixes NVBug 6359821: `hf_ptq.py` can fail during the empty-weight device-map probe for remote/custom architectures like `DeciLMForCausalLM` because the probe forwards `dtype` into `from_config()`, and that kwarg can leak to the custom model constructor.

This change removes dtype-related kwargs from the temporary `from_config()` call and instead sets PyTorch's default dtype only around the empty-weight construction used for `infer_auto_device_map`.

NVBug: https://nvbugspro.nvidia.com/bug/6359821

## Validation

- `pre-commit run --files examples/hf_ptq/example_utils.py tests/examples/hf_ptq/test_example_utils.py`
- `pytest_pwd tests/examples/hf_ptq/test_example_utils.py` (13 passed)
