### PR TITLE
[Fix]: honor NIXL_BACKENDS env for streaming RDMA 

### DIFF
--- a/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
+++ b/modelopt/torch/speculative/plugins/hf_streaming_dataset.py
@@ -370,7 +370,12 @@ class EagleVllmStreamingDataset(StreamingDataset):
         if getattr(self, "_nixl_pid", None) != pid:
             from nixl._api import nixl_agent, nixl_agent_config
 
-            self._nixl = nixl_agent(f"hs-trainer-{pid}", nixl_agent_config(backends=["UCX"]))
+            # Backend(s) overridable via NIXL_BACKENDS (comma-separated). Default UCX
+            # (InfiniBand). On AWS EFA set NIXL_BACKENDS=LIBFABRIC: UCX needs the EFA verbs
+            # driver (libefa-rdmav34.so), which many containers lack, so UCX RDMA fails with
+            # nixlRemoteDisconnectError on the first transfer.
+            _backends = os.environ.get("NIXL_BACKENDS", "UCX").split(",")
+            self._nixl = nixl_agent(f"hs-trainer-{pid}", nixl_agent_config(backends=_backends))
             self._nixl_pid = pid
             self._remote_by_host: dict = {}
             self._recv = None

--- a/modelopt/torch/speculative/plugins/rdma_hidden_states_connector.py
+++ b/modelopt/torch/speculative/plugins/rdma_hidden_states_connector.py
@@ -37,6 +37,7 @@ trusted cluster fabric -- any reachable peer can read descriptors / free slots.
 
 import base64
 import json
+import os
 import socket
 import threading
 import time
@@ -249,7 +250,14 @@ class RdmaHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
                 max_num_seqs,
             )
 
-        self._nixl = nixl_agent(f"hs-producer-{uuid.uuid4()}", nixl_agent_config(backends=["UCX"]))
+        # Backend(s) overridable via NIXL_BACKENDS (comma-separated). Default UCX
+        # (InfiniBand). On AWS EFA set NIXL_BACKENDS=LIBFABRIC: UCX needs the EFA verbs
+        # driver (libefa-rdmav34.so), which many containers lack, so UCX RDMA fails with
+        # nixlRemoteDisconnectError on the first transfer.
+        _backends = os.environ.get("NIXL_BACKENDS", "UCX").split(",")
+        self._nixl = nixl_agent(
+            f"hs-producer-{uuid.uuid4()}", nixl_agent_config(backends=_backends)
+        )
         # ONE-TIME pool registration (the only ibv_reg_mr).
         t0 = time.time()
         self._pool = torch.empty(


### PR DESCRIPTION
### What does this PR do?

Type of change: ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

<!-- Details about the change. -->

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->
