### PR TITLE
Improve lm_eval readme to clarify how accelerate launch works

### DIFF
--- a/examples/llm_eval/README.md
+++ b/examples/llm_eval/README.md
@@ -26,7 +26,7 @@ python lm_eval_hf.py --model hf --model_args pretrained=<HF model folder or mode
 
 For a quick smoke test, add `--limit 10` to any of the above commands to evaluate on only 10 samples.
 
-- To fit one model across multiple GPUs (model sharding; this does not speed up evaluation):
+- To fit one model across multiple GPUs (model sharding) and enable larger batches that may speed up evaluation:
 
 ```sh
 python lm_eval_hf.py --model hf --model_args pretrained=<HF model folder or model card>,parallelize=True --tasks <comma separated tasks> --batch_size 4

--- a/examples/llm_eval/README.md
+++ b/examples/llm_eval/README.md
@@ -26,7 +26,7 @@ python lm_eval_hf.py --model hf --model_args pretrained=<HF model folder or mode
 
 For a quick smoke test, add `--limit 10` to any of the above commands to evaluate on only 10 samples.
 
-- With model-sharding (for models which require multiple GPUs):
+- To fit one model across multiple GPUs (model sharding; this does not speed up evaluation):
 
 ```sh
 python lm_eval_hf.py --model hf --model_args pretrained=<HF model folder or model card>,parallelize=True --tasks <comma separated tasks> --batch_size 4
@@ -36,7 +36,11 @@ python lm_eval_hf.py --model hf --model_args pretrained=<HF model folder or mode
 
 - For data-parallel evaluation with model-sharding:
 
-With the following command, the model will be sharded across `total_num_of_available_gpus/num_copies_of_your_model` with a data-parallelism of `num_copies_of_your_model`
+`--num_processes` controls how many model copies evaluate samples concurrently. More
+copies usually make evaluation faster but leave fewer GPUs for each copy. With `N`
+GPUs, each copy uses approximately `N / num_processes` GPUs. For example, on 8 GPUs,
+8 processes run eight single-GPU copies. Choose the largest number of processes for
+which each model copy fits.
 
 ```sh
 accelerate launch --multi_gpu --num_processes <num_copies_of_your_model> \


### PR DESCRIPTION
### What does this PR do?

Improve lm_eval readme to clarify how accelerate launch works for lm_eval.

### Usage

see examples/llm_eval/README.md

### Testing
- Manually reviewed changed documentation.
- No impact on the commands used in the tutorial, only language-based clarification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified LM-Eval-Harness baseline instructions for multi-GPU evaluation.
  * Updated model-sharding guidance to emphasize fitting a single model across multiple GPUs and enabling larger batches (which may speed up evaluation).
  * Expanded data-parallel details to explain how `--num_processes` controls concurrent model copies and GPU allocation, including an 8-GPU example.
  * Removed outdated shorthand wording and replaced it with clearer, step-by-step guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->