### PR TITLE
Refine DeciLM dtype handling in HF PTQ

### DIFF
--- a/examples/hf_ptq/example_utils.py
+++ b/examples/hf_ptq/example_utils.py
@@ -626,11 +626,13 @@ def _get_config_dtype(config):
     return config_dtype
 
 
-def _apply_dtype_to_config(model_kwargs, config_dtype, is_decilm):
+def _apply_dtype_to_config(model_kwargs, config_dtype, is_decilm, apply_config_dtype=False):
     model_kwargs = model_kwargs.copy()
     if is_decilm:
         model_kwargs["torch_dtype"] = config_dtype
         model_kwargs.pop("dtype", None)
+    elif apply_config_dtype:
+        model_kwargs["dtype"] = config_dtype
     return model_kwargs
 
 
@@ -776,11 +778,11 @@ def get_model(
             # When computing the device_map, assuming bfloat16 precision by default,
             # unless specified by the hf_config.
             config_dtype = _get_config_dtype(config_for_init)
-            model_kwargs2 = _apply_dtype_to_config(model_kwargs, config_dtype, is_decilm)
+            model_kwargs2 = _apply_dtype_to_config(
+                model_kwargs, config_dtype, is_decilm, apply_config_dtype=True
+            )
             if auto_model_module not in [AutoModelForCausalLM, AutoModel]:
                 model_kwargs2.pop("trust_remote_code", None)
-            if not is_decilm:
-                model_kwargs2["dtype"] = config_dtype
             model_kwargs2.pop("max_memory", None)
             model = from_config(config_for_init, **model_kwargs2)
 

--- a/examples/hf_ptq/example_utils.py
+++ b/examples/hf_ptq/example_utils.py
@@ -626,7 +626,7 @@ def _get_config_dtype(config):
     return config_dtype
 
 
-def _apply_decilm_config_dtype(model_kwargs, config_dtype, is_decilm):
+def _apply_dtype_to_config(model_kwargs, config_dtype, is_decilm):
     model_kwargs = model_kwargs.copy()
     if is_decilm:
         model_kwargs["torch_dtype"] = config_dtype
@@ -776,7 +776,7 @@ def get_model(
             # When computing the device_map, assuming bfloat16 precision by default,
             # unless specified by the hf_config.
             config_dtype = _get_config_dtype(config_for_init)
-            model_kwargs2 = _apply_decilm_config_dtype(model_kwargs, config_dtype, is_decilm)
+            model_kwargs2 = _apply_dtype_to_config(model_kwargs, config_dtype, is_decilm)
             if auto_model_module not in [AutoModelForCausalLM, AutoModel]:
                 model_kwargs2.pop("trust_remote_code", None)
             if not is_decilm:
@@ -802,7 +802,7 @@ def get_model(
             )
             model_kwargs["max_memory"] = max_memory
 
-        model_kwargs2 = _apply_decilm_config_dtype(model_kwargs, config_dtype, is_decilm)
+        model_kwargs2 = _apply_dtype_to_config(model_kwargs, config_dtype, is_decilm)
         model = auto_model_module.from_pretrained(
             ckpt_path,
             device_map=device_map,

--- a/examples/hf_ptq/example_utils.py
+++ b/examples/hf_ptq/example_utils.py
@@ -626,9 +626,9 @@ def _get_config_dtype(config):
     return config_dtype
 
 
-def _apply_dtype_to_config(model_kwargs, config_dtype, is_decilm, apply_config_dtype=False):
+def _apply_dtype_to_config(model_kwargs, config_dtype, architecture, apply_config_dtype=False):
     model_kwargs = model_kwargs.copy()
-    if is_decilm:
+    if "DeciLM" in architecture:
         model_kwargs["torch_dtype"] = config_dtype
         model_kwargs.pop("dtype", None)
     elif apply_config_dtype:
@@ -769,7 +769,6 @@ def get_model(
             auto_model_module = getattr(transformers, architecture)
             from_config = auto_model_module._from_config
 
-        is_decilm = "DeciLM" in architecture
         config_for_init = _resolve_init_config(
             hf_config, auto_model_module, ckpt_path, config_kwargs
         )
@@ -779,7 +778,7 @@ def get_model(
             # unless specified by the hf_config.
             config_dtype = _get_config_dtype(config_for_init)
             model_kwargs2 = _apply_dtype_to_config(
-                model_kwargs, config_dtype, is_decilm, apply_config_dtype=True
+                model_kwargs, config_dtype, architecture, apply_config_dtype=True
             )
             if auto_model_module not in [AutoModelForCausalLM, AutoModel]:
                 model_kwargs2.pop("trust_remote_code", None)
@@ -804,7 +803,7 @@ def get_model(
             )
             model_kwargs["max_memory"] = max_memory
 
-        model_kwargs2 = _apply_dtype_to_config(model_kwargs, config_dtype, is_decilm)
+        model_kwargs2 = _apply_dtype_to_config(model_kwargs, config_dtype, architecture)
         model = auto_model_module.from_pretrained(
             ckpt_path,
             device_map=device_map,

--- a/examples/hf_ptq/example_utils.py
+++ b/examples/hf_ptq/example_utils.py
@@ -617,6 +617,23 @@ def _resolve_init_config(hf_config, auto_model_module, ckpt_path, config_kwargs)
         return hf_config
 
 
+def _get_config_dtype(config):
+    config_dtype = (
+        getattr(config, "dtype", None) or getattr(config, "torch_dtype", None) or torch.bfloat16
+    )
+    if isinstance(config_dtype, str):
+        config_dtype = getattr(torch, config_dtype)
+    return config_dtype
+
+
+def _apply_decilm_config_dtype(model_kwargs, config_dtype, is_decilm):
+    model_kwargs = model_kwargs.copy()
+    if is_decilm:
+        model_kwargs["torch_dtype"] = config_dtype
+        model_kwargs.pop("dtype", None)
+    return model_kwargs
+
+
 def get_model(
     ckpt_path,
     device="cuda",
@@ -758,20 +775,11 @@ def get_model(
         with init_empty_weights(include_buffers=True):
             # When computing the device_map, assuming bfloat16 precision by default,
             # unless specified by the hf_config.
-            config_dtype = (
-                getattr(config_for_init, "dtype", None)
-                or getattr(config_for_init, "torch_dtype", None)
-                or torch.bfloat16
-            )
-            if isinstance(config_dtype, str):
-                config_dtype = getattr(torch, config_dtype)
-            model_kwargs2 = model_kwargs.copy()
+            config_dtype = _get_config_dtype(config_for_init)
+            model_kwargs2 = _apply_decilm_config_dtype(model_kwargs, config_dtype, is_decilm)
             if auto_model_module not in [AutoModelForCausalLM, AutoModel]:
                 model_kwargs2.pop("trust_remote_code", None)
-            if is_decilm:
-                model_kwargs2["torch_dtype"] = config_dtype
-                model_kwargs2.pop("dtype", None)
-            else:
+            if not is_decilm:
                 model_kwargs2["dtype"] = config_dtype
             model_kwargs2.pop("max_memory", None)
             model = from_config(config_for_init, **model_kwargs2)
@@ -794,9 +802,7 @@ def get_model(
             )
             model_kwargs["max_memory"] = max_memory
 
-        model_kwargs2 = model_kwargs.copy()
-        if is_decilm:
-            model_kwargs2.pop("dtype", None)
+        model_kwargs2 = _apply_decilm_config_dtype(model_kwargs, config_dtype, is_decilm)
         model = auto_model_module.from_pretrained(
             ckpt_path,
             device_map=device_map,

--- a/tests/examples/hf_ptq/test_example_utils.py
+++ b/tests/examples/hf_ptq/test_example_utils.py
@@ -278,7 +278,7 @@ def test_get_model_uses_expected_dtype_kwarg(
         def from_pretrained(*args, **kwargs):
             calls["from_pretrained"] = kwargs
             assert "dtype" not in kwargs
-            assert "torch_dtype" not in kwargs
+            assert kwargs["torch_dtype"] is torch.float16
             return FakeModel()
 
     class FakeLlamaForCausalLM(FakeAutoModelForCausalLM):


### PR DESCRIPTION
## Summary
- factor config dtype resolution into helpers for HF PTQ model loading
- keep DeciLM empty-init and final-load kwargs on `torch_dtype` while avoiding unsupported `dtype` forwarding
- update the DeciLM dtype unit assertion for the follow-up behavior

Follow-up to #1857 for NVBug 6359821.

## Validation
- `pytest_pwd tests/examples/hf_ptq/test_example_utils.py -q -x` (`15 passed`)
- `git diff --check`
- `pre-commit run --files examples/hf_ptq/example_utils.py tests/examples/hf_ptq/test_example_utils.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model loading so precision (dtype) is applied more consistently across supported loading paths, including DeciLM models.
  * Updated initialization to derive dtype from model configuration and pass the expected precision into model loading kwargs.

* **Tests**
  * Updated test expectations to reflect the new dtype kwarg behavior during `from_pretrained` for causal language model loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->