### PR TITLE
docs(deployment): add AIPerf throughput/latency benchmarking reference

### DIFF
--- a/.agents/skills/deployment/SKILL.md
+++ b/.agents/skills/deployment/SKILL.md
@@ -194,6 +194,14 @@ curl -s http://localhost:8000/v1/completions \
 
 All checks must pass before reporting success to the user.
 
+### 5b. Benchmark throughput/latency (optional)
+
+If the user asks to benchmark, measure throughput/latency, or compare precisions,
+use **AIPerf** (Apache-2.0, OpenAI-compatible client benchmark). See
+`references/benchmarking.md` for install, the pre-benchmark coherence gate, the
+`aiperf profile` flags (notably `--extra-inputs ignore_eos:true`), suggested
+token shapes, and how to read `profile_export_aiperf.json`.
+
 ### 6. Remote deployment (SSH/SLURM)
 
 If a cluster config exists (`~/.config/modelopt/clusters.yaml`, `.agents/clusters.yaml`, or `.claude/clusters.yaml`), or the user mentions running on a remote machine:

--- a/.agents/skills/deployment/references/benchmarking.md
+++ b/.agents/skills/deployment/references/benchmarking.md
@@ -1,0 +1,110 @@
+# Benchmarking a Deployment with AIPerf
+
+[AIPerf](https://github.com/ai-dynamo/aiperf) (Apache-2.0, NVIDIA; the successor
+to GenAI-Perf) is a client-side benchmark for any OpenAI-compatible endpoint. It
+reports the latency/throughput metrics that matter for serving — TTFT, ITL,
+output token throughput, and per-user throughput — under controlled concurrency
+and token shapes.
+
+Use this once you have a healthy endpoint (see the main `SKILL.md` "Verify the
+deployment" step). Benchmarking gibberish is meaningless, so always run the
+**coherence gate** below first.
+
+## 1. Install
+
+Install into a **clean venv**. Installing `aiperf` directly into some inference
+images fails on a `blinker` distutils conflict (`Cannot uninstall blinker ...`):
+
+```bash
+python3 -m venv aiperf-venv
+aiperf-venv/bin/pip install -q aiperf
+AIPERF=aiperf-venv/bin/aiperf
+```
+
+## 2. Coherence gate (run before benchmarking)
+
+AIPerf measures throughput on incoherent output just as happily as on correct
+output. A wrong KV-cache dtype, a missing serving patch, or a mis-wired
+activation can produce *fluent nonsense* that only a real generation check (or an
+accuracy eval) catches — the perf numbers will look fine. Assert sane output
+first:
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"<model>","messages":[{"role":"user",
+       "content":"What is the capital of France? Then compute 17*23."}],
+       "max_tokens":128}' \
+  | python3 -c "import json,sys; t=json.load(sys.stdin)['choices'][0]['message']['content']; \
+print('COHERENCE:',repr(t[:200])); sys.exit(0 if 'Paris' in t else 1)" \
+  || { echo 'INCOHERENT OUTPUT — wrong KV dtype / missing serving patch?'; exit 1; }
+```
+
+## 3. Run a sweep
+
+```bash
+$AIPERF profile -m <model> --endpoint-type chat --streaming -u localhost:8000 \
+    --synthetic-input-tokens-mean $ISL --output-tokens-mean $OSL \
+    --concurrency $C --request-count $RC \
+    --tokenizer <model> --tokenizer-trust-remote-code \
+    --extra-inputs ignore_eos:true \
+    --random-seed 42 --artifact-dir $ARTIFACT_DIR
+```
+
+Critical flags:
+
+- **`--extra-inputs ignore_eos:true`** — forces generation to run to
+  `output-tokens-mean` so the realized output length equals the target. Without
+  it, models that stop early give throughput computed over truncated outputs, and
+  results aren't comparable across precisions. **Do not omit.**
+- **`--streaming`** — required for a meaningful TTFT / inter-token-latency split.
+- **`--tokenizer ... --tokenizer-trust-remote-code`** — point the tokenizer at
+  the same repo so synthetic token counts match the model's tokenizer.
+- **`--random-seed 42`** — reproducible synthetic prompts across runs.
+
+Sweep `--concurrency` over a range (e.g. `1 4 16 64 128 256 512`) to trace the
+latency-vs-throughput curve; set `--request-count` to a few × concurrency so each
+point reaches steady state.
+
+### Suggested token shapes
+
+Run more than one shape so the deployment is characterized under different
+prefill/decode and prefix-cache conditions:
+
+| Shape       | Input (ISL) | Output (OSL) | Notes                                  |
+|-------------|-------------|--------------|----------------------------------------|
+| chat        | ~8000       | ~1000        | typical chat turn                      |
+| agentic     | ~64000      | ~400         | long-context, short completion         |
+
+To exercise prefix caching, AIPerf's prefix-prompt options (e.g.
+`--prefix-prompt-length` with a small pool) reuse a shared prefix across requests
+so a known fraction hits the KV cache — useful when the server has
+`--enable-prefix-caching`.
+
+## 4. Compare the results
+
+Each run writes `profile_export_aiperf.json` to `--artifact-dir`. Key fields:
+
+- `time_to_first_token`
+- `inter_token_latency`
+- `output_token_throughput`
+- `output_token_throughput_per_user`
+- `output_sequence_length`
+
+First **sanity-check `output_sequence_length` == target OSL** — this confirms
+`ignore_eos` took effect. Then compare per concurrency point (e.g. quantized vs
+baseline precision of the same model) at matched ISL/OSL.
+
+## 5. Gotchas
+
+- **KV-cache dtype is per-model.** Some attention kernels are fp8-capable, others
+  are bf16-only — passing `--kv-cache-dtype fp8` to a bf16-only kernel can break
+  generation (caught by the coherence gate). When unsure, omit the flag (defaults
+  to the model dtype) and confirm coherence. This is a *serving* flag, not an
+  AIPerf flag — set it on `vllm serve` / the launch command.
+- **`ignore_eos` is mandatory for fair comparison** — see §3.
+- **Match the serving config across compared runs** — image, tensor/expert
+  parallelism, KV dtype, and token shapes must be identical, or the comparison
+  isn't apples-to-apples.
+- **NVFP4 on Blackwell sm_103 needs a cu130 image** — see the vLLM note in the
+  main `SKILL.md`; a wrong image serves nothing (or the coherence gate fails).

--- a/.agents/skills/deployment/references/benchmarking.md
+++ b/.agents/skills/deployment/references/benchmarking.md
@@ -36,19 +36,33 @@ curl -s http://localhost:8000/v1/chat/completions \
        "content":"What is the capital of France? Then compute 17*23."}],
        "max_tokens":128}' \
   | python3 -c "import json,sys; t=json.load(sys.stdin)['choices'][0]['message']['content']; \
-print('COHERENCE:',repr(t[:200])); sys.exit(0 if 'Paris' in t else 1)" \
+ok = 'Paris' in t and '391' in t; print('COHERENCE:',repr(t[:200])); sys.exit(0 if ok else 1)" \
   || { echo 'INCOHERENT OUTPUT — wrong KV dtype / missing serving patch?'; exit 1; }
 ```
 
+Assert **both** parts (the factual answer *and* `17*23 == 391`) — a model that
+gets the capital right but the arithmetic wrong is still degraded, and a
+single-token match is too easy to pass on garbage.
+
 ## 3. Run a sweep
 
+There is no separate "sweep file" — drive the sweep inline by looping the
+concurrency values and invoking `aiperf profile` once per point. **Give each
+point its own `--artifact-dir`**, or every run overwrites the previous
+`profile_export_aiperf.json` and the comparison is lost:
+
 ```bash
-$AIPERF profile -m <model> --endpoint-type chat --streaming -u localhost:8000 \
-    --synthetic-input-tokens-mean $ISL --output-tokens-mean $OSL \
-    --concurrency $C --request-count $RC \
-    --tokenizer <model> --tokenizer-trust-remote-code \
-    --extra-inputs ignore_eos:true \
-    --random-seed 42 --artifact-dir $ARTIFACT_DIR
+ISL=8000; OSL=1000; OUT=./aiperf_results   # one shape; repeat for others (see below)
+for C in 1 4 16 64 128 256 512; do
+  RC=$(( C * 5 ))                           # a few requests per concurrency for steady state
+  $AIPERF profile -m <model> --endpoint-type chat --streaming -u localhost:8000 \
+      --synthetic-input-tokens-mean $ISL --output-tokens-mean $OSL \
+      --concurrency $C --request-count $RC \
+      --tokenizer <model> --tokenizer-trust-remote-code \
+      --extra-inputs ignore_eos:true \
+      --random-seed 42 \
+      --artifact-dir "$OUT/isl${ISL}_osl${OSL}/c${C}"   # unique per sweep point
+done
 ```
 
 Critical flags:
@@ -62,14 +76,14 @@ Critical flags:
   the same repo so synthetic token counts match the model's tokenizer.
 - **`--random-seed 42`** — reproducible synthetic prompts across runs.
 
-Sweep `--concurrency` over a range (e.g. `1 4 16 64 128 256 512`) to trace the
-latency-vs-throughput curve; set `--request-count` to a few × concurrency so each
-point reaches steady state.
+The concurrency range traces the latency-vs-throughput curve; `--request-count`
+of a few × concurrency lets each point reach steady state.
 
 ### Suggested token shapes
 
 Run more than one shape so the deployment is characterized under different
-prefill/decode and prefix-cache conditions:
+prefill/decode and prefix-cache conditions (rerun the loop above with each
+`ISL`/`OSL` pair, keeping the per-shape, per-concurrency `--artifact-dir`):
 
 | Shape       | Input (ISL) | Output (OSL) | Notes                                  |
 |-------------|-------------|--------------|----------------------------------------|
@@ -83,7 +97,8 @@ so a known fraction hits the KV cache — useful when the server has
 
 ## 4. Compare the results
 
-Each run writes `profile_export_aiperf.json` to `--artifact-dir`. Key fields:
+Each run writes `profile_export_aiperf.json` to its own `--artifact-dir` (one per
+shape × concurrency point, per §3). Key fields:
 
 - `time_to_first_token`
 - `inter_token_latency`


### PR DESCRIPTION
### What does this PR do?

Type of change: documentation

Adds an AIPerf benchmarking reference to the **deployment** agent skill so the
skill can guide throughput/latency benchmarking of a served checkpoint (the skill
description already advertises "benchmark throughput" but had no concrete how-to).

- New `references/benchmarking.md`: install [AIPerf](https://github.com/ai-dynamo/aiperf)
  (Apache-2.0) in a clean venv, run a pre-benchmark **coherence gate**, the
  `aiperf profile` flags (notably `--extra-inputs ignore_eos:true` for
  deterministic output length and fair cross-precision comparison), suggested
  token shapes, and how to read `profile_export_aiperf.json`.
- `SKILL.md`: new optional step "5b. Benchmark throughput/latency" linking the reference.

Content is framework- and model-agnostic; no internal infrastructure, cluster
paths, or unreleased model names.

### Usage

Within the deployment skill, after a healthy endpoint is verified:

```bash
python3 -m venv aiperf-venv && aiperf-venv/bin/pip install -q aiperf
aiperf-venv/bin/aiperf profile -m <model> --endpoint-type chat --streaming \
  -u localhost:8000 --synthetic-input-tokens-mean 8000 --output-tokens-mean 1000 \
  --concurrency 16 --request-count 64 --tokenizer <model> \
  --extra-inputs ignore_eos:true --random-seed 42 --artifact-dir ./aiperf_out
```

### Testing

Docs-only change. `pre-commit run --files` (markdownlint, symlink sync, etc.)
passes on both files.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: N/A (docs only)
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A (docs only)
- Did you update Changelog?: N/A (skill docs, not a library feature/API change)
- Did you get Claude approval on this PR?: ❌ (not yet run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added optional Step 5b to the Deployment Skill guide with benchmarking instructions for throughput/latency using AIPerf.
  * Introduced a dedicated benchmarking reference covering environment setup, a correctness/coherence validation step, AIPerf sweep configuration, and guidance for fair comparisons and interpreting exported results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->