### PR TITLE
Add deployment test cases, fix deployment-related issues, and remove private models

### DIFF
--- a/tests/_test_utils/deploy_utils.py
+++ b/tests/_test_utils/deploy_utils.py
@@ -369,6 +369,7 @@ class ModelDeployer:
                 },
                 tensor_parallel_size=self.tensor_parallel_size,
                 trust_remote_code=True,
+                max_model_len=4096,
             )
         else:
             quantization_method = "modelopt"
@@ -379,6 +380,7 @@ class ModelDeployer:
                 quantization=quantization_method,
                 tensor_parallel_size=self.tensor_parallel_size,
                 trust_remote_code=True,
+                max_model_len=4096,
             )
         sampling_params = SamplingParams(temperature=0.8, top_p=0.9)
         conversations = [[{"role": "user", "content": p}] for p in COMMON_PROMPTS]

--- a/tests/_test_utils/deploy_utils.py
+++ b/tests/_test_utils/deploy_utils.py
@@ -325,6 +325,8 @@ class ModelDeployer:
                 **base_kw,
             )
 
+        from transformers import AutoTokenizer
+
         tokenizer_model = self.base_model if "eagle" in self.model_id.lower() else self.model_id
         tokenizer = AutoTokenizer.from_pretrained(tokenizer_model, trust_remote_code=True)
         prompts = COMMON_PROMPTS

--- a/tests/_test_utils/deploy_utils.py
+++ b/tests/_test_utils/deploy_utils.py
@@ -149,25 +149,57 @@ def _run_deploy_via_subprocess(
     eagle3_one_model: bool,
 ) -> None:
     """Run deploy in a subprocess and print its stdout/stderr so pytest capture=tee-sys captures to DB."""
+    import tempfile
     tests_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     project_root = os.path.dirname(tests_dir)
     env = {
         **os.environ,
         "PYTHONPATH": project_root + os.pathsep + os.environ.get("PYTHONPATH", ""),
     }
-    code = f"""from _test_utils.deploy_utils import _run_{backend}_deploy
-_run_{backend}_deploy(
-    {model_id!r}, {tensor_parallel_size}, {mini_sm}, {attn_backend!r}, {base_model!r}, {eagle3_one_model}
-)
-"""
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        cwd=tests_dir,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
+    code = f"""import sys
+sys.path.insert(0, {tests_dir!r})
+if __name__ == '__main__':
+    from _test_utils.deploy_utils import _run_{backend}_deploy
+    _run_{backend}_deploy(
+        {model_id!r}, {tensor_parallel_size}, {mini_sm}, {attn_backend!r}, {base_model!r}, {eagle3_one_model}
     )
+"""
+    if backend == "trtllm":
+        mpirun = os.environ.get("MPIRUN", "mpirun")
+        cmd = [
+            mpirun,
+            "--allow-run-as-root",
+            "--oversubscribe",
+            "-n", "1",
+            sys.executable,
+        ]
+    else:
+        cmd = [sys.executable, "-c", code]
+
+    if backend == "trtllm":
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write(code)
+            tmp_path = f.name
+        try:
+            result = subprocess.run(
+                cmd + [tmp_path],
+                cwd=tests_dir,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        finally:
+            os.unlink(tmp_path)
+    else:
+        result = subprocess.run(
+            cmd,
+            cwd=tests_dir,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
     if result.stdout:
         print(result.stdout, end="", flush=True)
     result.check_returncode()
@@ -293,12 +325,32 @@ class ModelDeployer:
                 **base_kw,
             )
 
-        outputs = llm.generate(COMMON_PROMPTS, sampling_params)
-        # Print outputs
-        for output in outputs:
-            prompt = output.prompt
+        tokenizer_model = self.base_model if "eagle" in self.model_id.lower() else self.model_id
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_model, trust_remote_code=True)
+        prompts = COMMON_PROMPTS
+        if tokenizer.chat_template is not None:
+            prompts = [
+                tokenizer.apply_chat_template(
+                    [{"role": "user", "content": prompt}],
+                    tokenize=False,
+                    add_generation_prompt=True,
+                )
+                for prompt in COMMON_PROMPTS
+            ]
+
+        outputs = llm.generate(prompts, sampling_params)
+        assert len(outputs) == len(COMMON_PROMPTS), (
+            f"Expected {len(COMMON_PROMPTS)} outputs, got {len(outputs)}"
+        )
+        for i, output in enumerate(outputs):
             generated_text = output.outputs[0].text
-            print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+            assert isinstance(generated_text, str), f"Output {i} text is not a string"
+            assert generated_text.strip(), f"Output {i} generated empty text"
+            print(f"Model: {self.model_id}")
+            print(f"Input prompt: {COMMON_PROMPTS[i]!r}")
+            print(f"Rendered prompt: {output.prompt!r}")
+            print(f"Generated text: {generated_text!r}")
+            print("-" * 50)
         del llm
 
     def _deploy_vllm_impl(self):
@@ -327,23 +379,25 @@ class ModelDeployer:
                 trust_remote_code=True,
             )
         sampling_params = SamplingParams(temperature=0.8, top_p=0.9)
-        outputs = llm.generate(COMMON_PROMPTS, sampling_params)
+        conversations = [[{"role": "user", "content": p}] for p in COMMON_PROMPTS]
+        outputs = llm.chat(conversations, sampling_params)
 
-        # Assertions and output
         assert len(outputs) == len(COMMON_PROMPTS), (
             f"Expected {len(COMMON_PROMPTS)} outputs, got {len(outputs)}"
         )
 
         for i, output in enumerate(outputs):
-            assert output.prompt == COMMON_PROMPTS[i], f"Prompt mismatch at index {i}"
             assert hasattr(output, "outputs"), f"Output {i} missing 'outputs' attribute"
             assert len(output.outputs) > 0, f"Output {i} has no generated text"
             assert hasattr(output.outputs[0], "text"), f"Output {i} missing 'text' attribute"
             assert isinstance(output.outputs[0].text, str), f"Output {i} text is not a string"
-            assert len(output.outputs[0].text) > 0, f"Output {i} generated empty text"
+            generated_text = output.outputs[0].text
+            assert generated_text.strip(), f"Output {i} generated empty text"
 
             print(f"Model: {self.model_id}")
-            print(f"Prompt: {output.prompt!r}, Generated text: {output.outputs[0].text!r}")
+            print(f"Input prompt: {COMMON_PROMPTS[i]!r}")
+            print(f"Rendered prompt: {getattr(output, 'prompt', None)!r}")
+            print(f"Generated text: {generated_text!r}")
             print("-" * 50)
         del llm
 
@@ -393,8 +447,37 @@ class ModelDeployer:
                 quantization=quantization_method,
                 tp_size=self.tensor_parallel_size,
                 trust_remote_code=True,
+                context_length=4096,
             )
-        print(llm.generate(["What's the age of the earth? "]))
+        from transformers import AutoTokenizer
+
+        tokenizer_model = self.base_model if "eagle" in self.model_id.lower() else self.model_id
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_model, trust_remote_code=True)
+        if tokenizer.chat_template is not None:
+            prompts = [
+                tokenizer.apply_chat_template(
+                    [{"role": "user", "content": p}],
+                    tokenize=False,
+                    add_generation_prompt=True,
+                )
+                for p in COMMON_PROMPTS
+            ]
+        else:
+            prompts = COMMON_PROMPTS
+
+        outputs = llm.generate(prompts)
+        assert len(outputs) == len(COMMON_PROMPTS), (
+            f"Expected {len(COMMON_PROMPTS)} outputs, got {len(outputs)}"
+        )
+        for i, output in enumerate(outputs):
+            generated_text = output["text"] if isinstance(output, dict) else str(output)
+            assert isinstance(generated_text, str), f"Output {i} text is not a string"
+            assert generated_text.strip(), f"Output {i} generated empty text"
+            print(f"Model: {self.model_id}")
+            print(f"Input prompt: {COMMON_PROMPTS[i]!r}")
+            print(f"Rendered prompt: {prompts[i]!r}")
+            print(f"Generated text: {generated_text!r}")
+            print("-" * 50)
         llm.shutdown()
         del llm
 

--- a/tests/_test_utils/deploy_utils.py
+++ b/tests/_test_utils/deploy_utils.py
@@ -288,6 +288,7 @@ class ModelDeployer:
         else:
             llm = LLM(
                 model=self.model_id,
+                backend="pytorch",
                 kv_cache_config=kv_cache_config,
                 **base_kw,
             )

--- a/tests/_test_utils/deploy_utils.py
+++ b/tests/_test_utils/deploy_utils.py
@@ -377,6 +377,8 @@ class ModelDeployer:
         elif self.model_id in (
             "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8",
             "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4",
+            "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
+            "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
         ):
             llm = sgl.Engine(
                 model_path=self.model_id,

--- a/tests/_test_utils/deploy_utils.py
+++ b/tests/_test_utils/deploy_utils.py
@@ -183,7 +183,7 @@ if __name__ == '__main__':
             tmp_path = f.name
         try:
             result = subprocess.run(
-                cmd + [tmp_path],
+                [*cmd, tmp_path],
                 cwd=tests_dir,
                 env=env,
                 stdout=subprocess.PIPE,

--- a/tests/_test_utils/deploy_utils.py
+++ b/tests/_test_utils/deploy_utils.py
@@ -170,7 +170,8 @@ if __name__ == '__main__':
             mpirun,
             "--allow-run-as-root",
             "--oversubscribe",
-            "-n", "1",
+            "-n",
+            "1",
             sys.executable,
         ]
     else:

--- a/tests/_test_utils/deploy_utils.py
+++ b/tests/_test_utils/deploy_utils.py
@@ -17,6 +17,7 @@ import itertools
 import os
 import subprocess
 import sys
+import tempfile
 import traceback
 
 import pytest
@@ -149,7 +150,6 @@ def _run_deploy_via_subprocess(
     eagle3_one_model: bool,
 ) -> None:
     """Run deploy in a subprocess and print its stdout/stderr so pytest capture=tee-sys captures to DB."""
-    import tempfile
     tests_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     project_root = os.path.dirname(tests_dir)
     env = {
@@ -325,6 +325,7 @@ class ModelDeployer:
                 **base_kw,
             )
 
+        # Deferred import: transformers is a heavy optional dependency not always present.
         from transformers import AutoTokenizer
 
         tokenizer_model = self.base_model if "eagle" in self.model_id.lower() else self.model_id
@@ -375,12 +376,15 @@ class ModelDeployer:
             quantization_method = "modelopt"
             if "fp4" in self.model_id.lower():
                 quantization_method = "modelopt_fp4"
+            # DeepSeek-V4 FlashMLA requires fp8 kv-cache explicitly
+            kv_cache_dtype = "fp8" if "deepseek-v4" in self.model_id.lower() else "auto"
             llm = LLM(
                 model=self.model_id,
                 quantization=quantization_method,
                 tensor_parallel_size=self.tensor_parallel_size,
                 trust_remote_code=True,
                 max_model_len=4096,
+                kv_cache_dtype=kv_cache_dtype,
             )
         sampling_params = SamplingParams(temperature=0.8, top_p=0.9)
         conversations = [[{"role": "user", "content": p}] for p in COMMON_PROMPTS]
@@ -453,6 +457,7 @@ class ModelDeployer:
                 trust_remote_code=True,
                 context_length=4096,
             )
+        # Deferred import: transformers is a heavy optional dependency not always present.
         from transformers import AutoTokenizer
 
         tokenizer_model = self.base_model if "eagle" in self.model_id.lower() else self.model_id
@@ -474,7 +479,12 @@ class ModelDeployer:
             f"Expected {len(COMMON_PROMPTS)} outputs, got {len(outputs)}"
         )
         for i, output in enumerate(outputs):
-            generated_text = output["text"] if isinstance(output, dict) else str(output)
+            if isinstance(output, dict):
+                generated_text = output["text"]
+            elif isinstance(output, str):
+                generated_text = output
+            else:
+                raise TypeError(f"Output {i} has unexpected type {type(output)}: {output!r}")
             assert isinstance(generated_text, str), f"Output {i} text is not a string"
             assert generated_text.strip(), f"Output {i} generated empty text"
             print(f"Model: {self.model_id}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def pytest_addoption(parser):
 # Every collectible test group must be listed here else collection errors occur
 # A test can override its cap by adding ``@pytest.mark.timeout(...)``
 _DEFAULT_TIMEOUT = {
-    "examples": 300,
+    "examples": 3600,
     "gpu": 120,
     "gpu_megatron": 120,
     "gpu_trtllm": 60,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import platform
 from pathlib import Path
 
@@ -48,7 +49,7 @@ def pytest_addoption(parser):
 # Every collectible test group must be listed here else collection errors occur
 # A test can override its cap by adding ``@pytest.mark.timeout(...)``
 _DEFAULT_TIMEOUT = {
-    "examples": 3600,
+    "examples": int(os.environ.get("MODELOPT_QA_TEST_TIMEOUT", 300)),
     "gpu": 120,
     "gpu_megatron": 120,
     "gpu_trtllm": 60,

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -788,3 +788,19 @@ def test_wan2_2_t2v_a14b_diffusers_fp8(command):
 )
 def test_diffusiongemma_26b_a4b_it_nvfp4(command):
     command.run()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        *ModelDeployerList(
+            model_id="nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
+            backend=("trtllm", "vllm", "sglang"),
+            tensor_parallel_size=2,
+            mini_sm=89,
+        ),
+    ],
+    ids=idfn,
+)
+def test_nemotron(command):
+    command.run()

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -377,6 +377,12 @@ def test_mixtral(command):
             mini_sm=100,
             attn_backend="FLASHINFER",
         ),
+        *ModelDeployerList(
+            model_id="nvidia/Gemma-4-26B-A4B-NVFP4",
+            backend=("vllm",),
+            tensor_parallel_size=2,
+            mini_sm=100,
+        ),
     ],
     ids=idfn,
 )

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -172,12 +172,6 @@ def test_deepseek(command):
             tensor_parallel_size=8,
         ),
         *ModelDeployerList(
-            model_id="nvidia/Llama-4-Maverick-17B-128E-Instruct-NVFP4",
-            backend=("trtllm", "vllm", "sglang"),
-            tensor_parallel_size=8,
-            mini_sm=100,
-        ),
-        *ModelDeployerList(
             model_id="nvidia/Llama-4-Scout-17B-16E-Instruct-FP8",
             backend=("trtllm", "vllm", "sglang"),
             tensor_parallel_size=8,
@@ -234,11 +228,6 @@ def test_llama(command):
             backend=("trtllm", "vllm", "sglang"),
             tensor_parallel_size=4,
             mini_sm=89,
-        ),
-        *ModelDeployerList(
-            model_id="nvidia/QwQ-32B-NVFP4",
-            backend=("trtllm", "vllm", "sglang"),
-            mini_sm=100,
         ),
         *ModelDeployerList(
             model_id="nvidia/Qwen3-32B-NVFP4",
@@ -329,54 +318,6 @@ def test_qwen(command):
     "command",
     [
         *ModelDeployerList(
-            model_id="nvidia/Mixtral-8x7B-Instruct-v0.1-FP8",
-            backend=("trtllm", "vllm", "sglang"),
-            mini_sm=89,
-        ),
-        *ModelDeployerList(
-            model_id="nvidia/Mixtral-8x7B-Instruct-v0.1-NVFP4",
-            backend=("trtllm", "vllm", "sglang"),
-            mini_sm=100,
-        ),
-    ],
-    ids=idfn,
-)
-def test_mixtral(command):
-    command.run()
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
-        *ModelDeployerList(
-            model_id="nvidia/gemma-3-12b-it-NVFP4",
-            backend=("trtllm", "vllm", "sglang"),
-            tensor_parallel_size=1,
-            mini_sm=100,
-            attn_backend="FLASHINFER",
-        ),
-        *ModelDeployerList(
-            model_id="nvidia/gemma-3-12b-it-FP8",
-            backend=("trtllm", "vllm", "sglang"),
-            tensor_parallel_size=1,
-            mini_sm=89,
-            attn_backend="FLASHINFER",
-        ),
-        *ModelDeployerList(
-            model_id="nvidia/gemma-3-27b-it-NVFP4",
-            backend=("trtllm", "vllm", "sglang"),
-            tensor_parallel_size=1,
-            mini_sm=100,
-            attn_backend="FLASHINFER",
-        ),
-        *ModelDeployerList(
-            model_id="nvidia/gemma-3-27b-it-FP8",
-            backend=("trtllm", "vllm", "sglang"),
-            tensor_parallel_size=1,
-            mini_sm=89,
-            attn_backend="FLASHINFER",
-        ),
-        *ModelDeployerList(
             model_id="nvidia/Gemma-4-31B-IT-NVFP4",
             backend=("trtllm", "vllm", "sglang"),
             tensor_parallel_size=1,
@@ -434,12 +375,6 @@ def test_phi(command):
 @pytest.mark.parametrize(
     "command",
     [
-        *ModelDeployerList(
-            model_id="nvidia/Kimi-K2-Instruct-NVFP4",
-            backend=("trtllm", "vllm", "sglang"),
-            tensor_parallel_size=8,
-            mini_sm=100,
-        ),
         *ModelDeployerList(
             model_id="nvidia/Kimi-K2-Thinking-NVFP4",
             backend=("trtllm", "vllm", "sglang"),
@@ -592,18 +527,6 @@ def test_llama_nemotron(command):
             tensor_parallel_size=1,
             mini_sm=89,
         ),
-        *ModelDeployerList(
-            model_id="nvidia/Llama-3.1-70B-Medusa-FP8",
-            backend=("trtllm", "sglang"),
-            tensor_parallel_size=2,
-            mini_sm=100,
-        ),
-        *ModelDeployerList(
-            model_id="nvidia/Llama-3.1-405B-Medusa-FP8",
-            backend=("trtllm", "sglang"),
-            tensor_parallel_size=8,
-            mini_sm=100,
-        ),
     ],
     ids=idfn,
 )
@@ -662,13 +585,6 @@ def test_medusa(command):
             eagle3_one_model=False,
         ),
         *ModelDeployerList(
-            base_model="Qwen/Qwen3-30B-A3B",
-            model_id="nvidia/Qwen3-30B-A3B-Eagle3",
-            backend=("trtllm", "sglang"),
-            tensor_parallel_size=1,
-            mini_sm=89,
-        ),
-        *ModelDeployerList(
             base_model="Qwen/Qwen3-30B-A3B-Thinking-2507",
             model_id="nvidia/Qwen3-30B-A3B-Thinking-2507-Eagle3",
             backend=("trtllm", "sglang"),
@@ -694,16 +610,6 @@ def test_medusa(command):
             base_model="openai/gpt-oss-120b",
             model_id="nvidia/gpt-oss-120b-Eagle3-throughput",
             backend=("trtllm", "sglang"),
-            tensor_parallel_size=8,
-            mini_sm=89,
-        ),
-        *ModelDeployerList(
-            base_model="nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-            model_id="nvidia/EAGLE3-NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
-            # SGLang excluded: Nemotron hybrid (Mamba+attention) doesn't support
-            # speculative decoding in SGLang (NVBugs 6130106)
-            backend=("trtllm", "vllm"),
-            eagle3_one_model=False,
             tensor_parallel_size=8,
             mini_sm=89,
         ),

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -772,3 +772,19 @@ def test_wan2_2_t2v_a14b_diffusers_nvfp4(command):
 )
 def test_wan2_2_t2v_a14b_diffusers_fp8(command):
     command.run()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        *ModelDeployerList(
+            model_id="nvidia/diffusiongemma-26B-A4B-it-NVFP4",
+            backend=("trtllm", "vllm", "sglang"),
+            tensor_parallel_size=2,
+            mini_sm=100,
+        ),
+    ],
+    ids=idfn,
+)
+def test_diffusiongemma_26b_a4b_it_nvfp4(command):
+    command.run()

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -817,3 +817,18 @@ def test_diffusiongemma_26b_a4b_it_nvfp4(command):
 )
 def test_nemotron(command):
     command.run()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        *ModelDeployerList(
+            model_id="nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
+            backend=("trtllm", "vllm", "sglang"),
+            tensor_parallel_size=8,
+        ),
+    ],
+    ids=idfn,
+)
+def test_nvidia_nemotron_3_ultra_550b_a55b_bf16(command):
+    command.run()

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -799,6 +799,12 @@ def test_diffusiongemma_26b_a4b_it_nvfp4(command):
             tensor_parallel_size=2,
             mini_sm=89,
         ),
+        *ModelDeployerList(
+            model_id="nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
+            backend=("trtllm", "vllm", "sglang"),
+            tensor_parallel_size=2,
+            mini_sm=100,
+        ),
     ],
     ids=idfn,
 )

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -107,6 +107,12 @@ def cleanup_after_test():
             tensor_parallel_size=8,
             mini_sm=100,
         ),
+        *ModelDeployerList(
+            model_id="nvidia/DeepSeek-V4-Flash-NVFP4",
+            backend=("trtllm", "vllm", "sglang"),
+            tensor_parallel_size=8,
+            mini_sm=100,
+        ),
     ],
     ids=idfn,
 )

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -671,3 +671,19 @@ def test_eagle(command):
         command.run()
     else:
         pytest.skip(f"Local model not found: {local_path}")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        *ModelDeployerList(
+            model_id="nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4",
+            backend=("trtllm", "vllm", "sglang"),
+            tensor_parallel_size=8,
+            mini_sm=100,
+        ),
+    ],
+    ids=idfn,
+)
+def test_nvidia_nemotron_3_ultra_550b_a55b_nvfp4(command):
+    command.run()

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -502,6 +502,12 @@ def test_glm(command):
             tensor_parallel_size=8,
             mini_sm=100,
         ),
+        *ModelDeployerList(
+            model_id="nvidia/MiniMax-M3-NVFP4",
+            backend=("trtllm", "vllm", "sglang"),
+            tensor_parallel_size=4,
+            mini_sm=100,
+        ),
     ],
     ids=idfn,
 )

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -458,6 +458,11 @@ def test_phi(command):
             tensor_parallel_size=8,
             mini_sm=100,
         ),
+        *ModelDeployerList(
+            model_id="nvidia/Kimi-K2.6-Eagle3",
+            backend=("trtllm", "vllm", "sglang"),
+            tensor_parallel_size=8,
+        ),
     ],
     ids=idfn,
 )

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -651,6 +651,7 @@ def test_eagle(command):
     ],
     ids=idfn,
 )
+@pytest.mark.timeout(14400)
 def test_nvidia_nemotron_3_ultra_550b_a55b_nvfp4(command):
     command.run()
 
@@ -721,6 +722,7 @@ def test_diffusiongemma_26b_a4b_it_nvfp4(command):
     ],
     ids=idfn,
 )
+@pytest.mark.timeout(7200)
 def test_nemotron(command):
     command.run()
 
@@ -736,5 +738,6 @@ def test_nemotron(command):
     ],
     ids=idfn,
 )
+@pytest.mark.timeout(14400)
 def test_nvidia_nemotron_3_ultra_550b_a55b_bf16(command):
     command.run()

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -446,6 +446,12 @@ def test_phi(command):
             tensor_parallel_size=8,
             mini_sm=100,
         ),
+        *ModelDeployerList(
+            model_id="nvidia/Kimi-K2.6-NVFP4",
+            backend=("vllm",),
+            tensor_parallel_size=8,
+            mini_sm=100,
+        ),
     ],
     ids=idfn,
 )

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -723,3 +723,19 @@ def test_eagle(command):
 )
 def test_nvidia_nemotron_3_ultra_550b_a55b_nvfp4(command):
     command.run()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        *ModelDeployerList(
+            model_id="nvidia/Wan2.2-T2V-A14B-Diffusers-NVFP4",
+            backend=("trtllm", "sglang"),
+            tensor_parallel_size=1,
+            mini_sm=100,
+        ),
+    ],
+    ids=idfn,
+)
+def test_wan2_2_t2v_a14b_diffusers_nvfp4(command):
+    command.run()

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -306,6 +306,12 @@ def test_llama(command):
             tensor_parallel_size=4,
             mini_sm=100,
         ),
+        *ModelDeployerList(
+            model_id="nvidia/Qwen3.5-122B-A10B-NVFP4",
+            backend=("vllm",),
+            tensor_parallel_size=4,
+            mini_sm=100,
+        ),
     ],
     ids=idfn,
 )

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -294,6 +294,12 @@ def test_llama(command):
             tensor_parallel_size=8,
             mini_sm=100,
         ),
+        *ModelDeployerList(
+            model_id="nvidia/Qwen3.6-35B-A3B-NVFP4",
+            backend=("vllm",),
+            tensor_parallel_size=4,
+            mini_sm=100,
+        ),
     ],
     ids=idfn,
 )

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -572,6 +572,7 @@ def test_minimax(command):
     ],
     ids=idfn,
 )
+@pytest.mark.timeout(3600)
 def test_llama_nemotron(command):
     command.run()
 

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -468,6 +468,12 @@ def test_kimi(command):
             tensor_parallel_size=8,
             mini_sm=100,
         ),
+        *ModelDeployerList(
+            model_id="nvidia/GLM-5.1-NVFP4",
+            backend=("vllm", "sglang"),
+            tensor_parallel_size=8,
+            mini_sm=100,
+        ),
     ],
     ids=idfn,
 )

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -101,6 +101,12 @@ def cleanup_after_test():
             tensor_parallel_size=8,
             mini_sm=100,
         ),
+        *ModelDeployerList(
+            model_id="nvidia/DeepSeek-V4-Pro-NVFP4",
+            backend=("vllm", "sglang"),
+            tensor_parallel_size=8,
+            mini_sm=100,
+        ),
     ],
     ids=idfn,
 )

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -739,3 +739,19 @@ def test_nvidia_nemotron_3_ultra_550b_a55b_nvfp4(command):
 )
 def test_wan2_2_t2v_a14b_diffusers_nvfp4(command):
     command.run()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        *ModelDeployerList(
+            model_id="nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
+            backend=("trtllm", "sglang"),
+            tensor_parallel_size=1,
+            mini_sm=89,
+        ),
+    ],
+    ids=idfn,
+)
+def test_wan2_2_t2v_a14b_diffusers_fp8(command):
+    command.run()

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -491,6 +491,12 @@ def test_kimi(command):
             tensor_parallel_size=8,
             mini_sm=100,
         ),
+        *ModelDeployerList(
+            model_id="nvidia/GLM-5.2-NVFP4",
+            backend=("trtllm", "vllm", "sglang"),
+            tensor_parallel_size=8,
+            mini_sm=100,
+        ),
     ],
     ids=idfn,
 )

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -530,7 +530,6 @@ def test_llama_nemotron(command):
     ],
     ids=idfn,
 )
-@pytest.mark.skip(reason="Medusa is not supported yet")
 def test_medusa(command):
     command.run()
 
@@ -556,6 +555,14 @@ def test_medusa(command):
         *ModelDeployerList(
             base_model="nvidia/Kimi-K2.5-NVFP4",
             model_id="nvidia/Kimi-K2.5-Thinking-Eagle3",
+            backend=("trtllm", "sglang"),
+            tensor_parallel_size=8,
+            mini_sm=100,
+            eagle3_one_model=False,
+        ),
+        *ModelDeployerList(
+            base_model="nvidia/Kimi-K2.6-NVFP4",
+            model_id="nvidia/Kimi-K2.6-Eagle3",
             backend=("trtllm", "sglang"),
             tensor_parallel_size=8,
             mini_sm=100,

--- a/tests/examples/hf_ptq/test_deploy.py
+++ b/tests/examples/hf_ptq/test_deploy.py
@@ -513,7 +513,6 @@ def test_minimax(command):
     ],
     ids=idfn,
 )
-@pytest.mark.timeout(3600)
 def test_llama_nemotron(command):
     command.run()
 
@@ -658,7 +657,6 @@ def test_eagle(command):
     ],
     ids=idfn,
 )
-@pytest.mark.timeout(14400)
 def test_nvidia_nemotron_3_ultra_550b_a55b_nvfp4(command):
     command.run()
 
@@ -729,7 +727,6 @@ def test_diffusiongemma_26b_a4b_it_nvfp4(command):
     ],
     ids=idfn,
 )
-@pytest.mark.timeout(7200)
 def test_nemotron(command):
     command.run()
 
@@ -745,6 +742,5 @@ def test_nemotron(command):
     ],
     ids=idfn,
 )
-@pytest.mark.timeout(14400)
 def test_nvidia_nemotron_3_ultra_550b_a55b_bf16(command):
     command.run()


### PR DESCRIPTION
### What does this PR do?

Type of change: ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

<!-- Details about the change. -->

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment test reliability by standardizing prompt rendering and output validation across multiple inference backends, including consistent chat-template handling and clearer generated-text assertions.
* **Tests**
  * Made example test timeouts configurable via `MODELOPT_QA_TEST_TIMEOUT` (default: 300s).
  * Updated the HF PTQ deployment model matrix and added new coverage for additional model variants (including Nemotron and diffusion/reasoning models), with targeted timeout adjustments for specific cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->