### PR TITLE
Fix expert-only MSE recipe matching for NemotronH

### DIFF
--- a/modelopt_recipes/general/ptq/nvfp4_experts_only-kv_fp8.yaml
+++ b/modelopt_recipes/general/ptq/nvfp4_experts_only-kv_fp8.yaml
@@ -36,10 +36,10 @@ quantize:
       enable: false
   quant_cfg:
     - $import: base_disable_all
-    - quantizer_name: '*mlp.experts*weight_quantizer'
+    - quantizer_name: '*.experts.*weight_quantizer'
       cfg:
         $import: nvfp4
-    - quantizer_name: '*mlp.experts*input_quantizer'
+    - quantizer_name: '*.experts.*input_quantizer'
       cfg:
         $import: nvfp4
     - quantizer_name: '*block_sparse_moe*weight_quantizer'

--- a/modelopt_recipes/general/ptq/nvfp4_experts_only-kv_fp8_cast.yaml
+++ b/modelopt_recipes/general/ptq/nvfp4_experts_only-kv_fp8_cast.yaml
@@ -35,10 +35,10 @@ quantize:
     layerwise: false
   quant_cfg:
     - $import: base_disable_all
-    - quantizer_name: '*mlp.experts*weight_quantizer'
+    - quantizer_name: '*.experts.*weight_quantizer'
       cfg:
         $import: nvfp4
-    - quantizer_name: '*mlp.experts*input_quantizer'
+    - quantizer_name: '*.experts.*input_quantizer'
       cfg:
         $import: nvfp4
     - quantizer_name: '*block_sparse_moe*weight_quantizer'

--- a/modelopt_recipes/general/ptq/nvfp4_experts_only-kv_fp8_layerwise.yaml
+++ b/modelopt_recipes/general/ptq/nvfp4_experts_only-kv_fp8_layerwise.yaml
@@ -30,10 +30,10 @@ quantize:
       enable: true
   quant_cfg:
     - $import: base_disable_all
-    - quantizer_name: '*mlp.experts*weight_quantizer'
+    - quantizer_name: '*.experts.*weight_quantizer'
       cfg:
         $import: nvfp4
-    - quantizer_name: '*mlp.experts*input_quantizer'
+    - quantizer_name: '*.experts.*input_quantizer'
       cfg:
         $import: nvfp4
     - quantizer_name: '*block_sparse_moe*weight_quantizer'

--- a/modelopt_recipes/general/ptq/nvfp4_experts_only_mse-kv_fp8_cast.yaml
+++ b/modelopt_recipes/general/ptq/nvfp4_experts_only_mse-kv_fp8_cast.yaml
@@ -37,10 +37,10 @@ quantize:
       enable: false
   quant_cfg:
     - $import: base_disable_all
-    - quantizer_name: '*mlp.experts*weight_quantizer'
+    - quantizer_name: '*.experts.*weight_quantizer'
       cfg:
         $import: nvfp4_static
-    - quantizer_name: '*mlp.experts*input_quantizer'
+    - quantizer_name: '*.experts.*input_quantizer'
       cfg:
         $import: nvfp4
     - quantizer_name: '*block_sparse_moe*weight_quantizer'

--- a/modelopt_recipes/ptq.md
+++ b/modelopt_recipes/ptq.md
@@ -78,7 +78,7 @@ activations are quantized too** (W4A4/W8A8 vs weight-only W4A16).
 #### Scoped schemes (quantize part of the model)
 
 - **`nvfp4_experts_only`** — NVFP4 W4A4 on **MoE routed experts only**
-  (`*mlp.experts*`, `*block_sparse_moe*`). Dense layers, shared experts, and
+  (`*.experts.*`, `*block_sparse_moe*`). Dense layers, shared experts, and
   attention stay BF16. **The most recommended NVFP4 recipe for MoE models**: it's
   the narrowest, most accuracy-preserving NVFP4 scope, so it recovers the most
   accuracy — while still compressing well, because the routed experts are usually

--- a/tests/unit/recipe/test_loader.py
+++ b/tests/unit/recipe/test_loader.py
@@ -211,8 +211,17 @@ def test_nvfp4_mlp_only_novit_recipe_disables_vision_quantizers():
     assert {"*visual*", "*vision_tower*"} <= disabled_quantizers
 
 
-def test_nvfp4_experts_only_mse_recipe_matches_nemotron_h_experts():
-    recipe = load_recipe("general/ptq/nvfp4_experts_only_mse-kv_fp8_cast")
+@pytest.mark.parametrize(
+    "recipe_path",
+    [
+        "general/ptq/nvfp4_experts_only-kv_fp8",
+        "general/ptq/nvfp4_experts_only-kv_fp8_cast",
+        "general/ptq/nvfp4_experts_only-kv_fp8_layerwise",
+        "general/ptq/nvfp4_experts_only_mse-kv_fp8_cast",
+    ],
+)
+def test_nvfp4_experts_only_recipes_match_nemotron_h_experts(recipe_path):
+    recipe = load_recipe(recipe_path)
     enabled_patterns = [
         entry["quantizer_name"]
         for entry in recipe.quantize.model_dump()["quant_cfg"]

--- a/tests/unit/recipe/test_loader.py
+++ b/tests/unit/recipe/test_loader.py
@@ -20,6 +20,7 @@ import os
 import re
 import sys
 import types
+from fnmatch import fnmatch
 from importlib.resources import files
 
 import pytest
@@ -208,6 +209,25 @@ def test_nvfp4_mlp_only_novit_recipe_disables_vision_quantizers():
     }
 
     assert {"*visual*", "*vision_tower*"} <= disabled_quantizers
+
+
+def test_nvfp4_experts_only_mse_recipe_matches_nemotron_h_experts():
+    recipe = load_recipe("general/ptq/nvfp4_experts_only_mse-kv_fp8_cast")
+    enabled_patterns = [
+        entry["quantizer_name"]
+        for entry in recipe.quantize.model_dump()["quant_cfg"]
+        if entry["enable"]
+    ]
+
+    for quantizer_name in (
+        "model.layers.0.mlp.experts.0.gate_proj.weight_quantizer",
+        "model.layers.0.mixer.experts.up_proj_weight_quantizer",
+        "model.layers.0.mixer.experts.down_proj_input_quantizer",
+    ):
+        assert any(fnmatch(quantizer_name, pattern) for pattern in enabled_patterns)
+
+    shared_expert = "model.layers.0.mixer.shared_experts.up_proj.weight_quantizer"
+    assert not any(fnmatch(shared_expert, pattern) for pattern in enabled_patterns)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/torch/quantization/plugins/test_huggingface.py
+++ b/tests/unit/torch/quantization/plugins/test_huggingface.py
@@ -25,13 +25,15 @@ from _test_utils.torch.transformers_models import (
     create_tiny_llama_dir,
     get_tiny_gpt_oss,
     get_tiny_llama,
+    get_tiny_nemotron_h,
     get_tiny_qwen3_moe,
     tf_modelopt_state_and_output_tester,
 )
 from packaging.version import Version
 
 import modelopt.torch.quantization as mtq
-from modelopt.torch.quantization.nn import QuantLinear, QuantModuleRegistry
+from modelopt.recipe.loader import load_recipe
+from modelopt.torch.quantization.nn import QuantLinear, QuantModuleRegistry, TensorQuantizer
 from modelopt.torch.quantization.plugins.huggingface import (
     _TransposedExpertsCalibMixin,
     get_homogeneous_hf_decoder_layers,
@@ -152,6 +154,47 @@ def test_dbrx():
     out_1 = model_ref(x)
     out_2 = model_test(x)
     assert torch.allclose(out_1[0], out_2[0])
+
+
+@pytest.mark.skipif(
+    not hasattr(transformers, "NemotronHConfig"),
+    reason="NemotronH is not supported by this Transformers version",
+)
+@pytest.mark.parametrize(
+    "recipe_path",
+    [
+        "general/ptq/nvfp4_experts_only-kv_fp8",
+        "general/ptq/nvfp4_experts_only-kv_fp8_cast",
+        "general/ptq/nvfp4_experts_only-kv_fp8_layerwise",
+        "general/ptq/nvfp4_experts_only_mse-kv_fp8_cast",
+    ],
+)
+def test_nemotron_h_experts_only_recipes_target_routed_experts(recipe_path):
+    model = get_tiny_nemotron_h(
+        num_hidden_layers=1,
+        hybrid_override_pattern="E",
+        n_routed_experts=2,
+    )
+    mtq.replace_quant_module(model)
+
+    recipe = load_recipe(recipe_path)
+    mtq.set_quantizer_by_cfg(model, recipe.quantize.model_dump()["quant_cfg"])
+
+    routed_expert_quantizers = {
+        name: module
+        for name, module in model.named_modules()
+        if ".mixer.experts." in name and isinstance(module, TensorQuantizer)
+    }
+    shared_expert_quantizers = {
+        name: module
+        for name, module in model.named_modules()
+        if ".mixer.shared_experts." in name and isinstance(module, TensorQuantizer)
+    }
+
+    assert routed_expert_quantizers
+    assert all(module.is_enabled for module in routed_expert_quantizers.values())
+    assert shared_expert_quantizers
+    assert not any(module.is_enabled for module in shared_expert_quantizers.values())
 
 
 @pytest.mark.parametrize("method", ["gradient", "kl_div"])


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Generalizes the expert-only NVFP4 MSE recipe selectors from `*mlp.experts*` to
`*.experts.*`. This enables routed expert quantization for architectures such as
NemotronH, where experts live under `mixer.experts`, while continuing to exclude
`shared_experts`.

Without this match, the recipe's disable-all rule leaves every routed expert
quantizer disabled and exports a checkpoint with a null weight `quant_algo`.

### Usage

```bash
python examples/hf_ptq/hf_ptq.py \
  --pyt_ckpt_path <nemotron-h-checkpoint> \
  --recipe general/ptq/nvfp4_experts_only_mse-kv_fp8_cast \
  --export_path <output-path>
```

### Testing

- `python -m pytest tests/unit/recipe/test_loader.py tests/unit/torch/quantization/plugins/test_fused_experts.py::TestNonGatedFusedExperts -q` (`195 passed`)
- Pre-commit hooks on both changed files (`Passed`)
- End-to-end NemotronH 30B smoke export on GB200 with four calibration samples:
  - `quant_algo: NVFP4`, KV cache `FP8`, group size `16`
  - `5,888` NVFP4 expert projections and `0` declaration mismatches
  - Source/output checkpoint ratio: `0.331x`

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A — narrow recipe bug fix with no API change
- Did you get Claude approval on this PR?: N/A

### Additional Information

The regression test covers legacy `mlp.experts`, NemotronH `mixer.experts`, and
verifies that `shared_experts` remains excluded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PTQ recipes to match expert-layer NVFP4 quantizers using broader wildcard patterns for expert weights and inputs (instead of narrower MLP-expert selectors).
  * Adjusted KV FP8 casting/layerwise variants to apply the updated expert-only quantizer targeting consistently.
  * Updated documentation for the nvfp4_experts_only scoped scheme to reflect the new expert-selection rules.

* **Tests**
  * Added unit coverage to ensure built-in nvfp4_experts_only recipes enable expected expert quantizers and correctly exclude shared-expert quantization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->