### PR TITLE
draft: Add Decoupled Scale Search for NVFP4 local_hessian calibration

### DIFF
--- a/examples/hf_ptq/dss_diagnostic.py
+++ b/examples/hf_ptq/dss_diagnostic.py
@@ -1,0 +1,435 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Diagnostic: does Decoupled Scale Search (DSS) help the NVFP4 weight-MSE FP8 sweep?
+
+For every NVFP4 weight block this measures the best reconstruction loss of the *coupled*
+sweep (today's behavior, ``s_q == s_d``) against DSS's decoupled ``(s_q, s_d)`` search, and
+reports how often DSS picks ``beta != 1`` and by how much it reduces the L2 loss. It runs the
+search only — no two-scale export plumbing — so it is a cheap probe before committing to that.
+
+Two modes:
+  * ``model``         : load the model and run ``mtq.quantize`` with the real NVFP4 weight-MSE
+                        FP8-sweep config so each weight quantizer's ``global_amax`` is the
+                        grouping-synced production value (dense + fused-MoE). Fits in GPU.
+  * ``weights-only``  : stream safetensors shards and use per-tensor ``global_amax`` (no model
+                        instantiation). For checkpoints too large to load (e.g. 397B). The
+                        sibling global_amax grouping is approximated as per-tensor.
+
+Example::
+
+    CUDA_VISIBLE_DEVICES=2,3 python examples/llm_ptq/dss_diagnostic.py \
+        --model /path/to/Qwen3-8B --output-dir /path/to/logs/Qwen3-8B
+"""
+
+import argparse
+import glob
+import json
+import os
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+import torch
+
+from modelopt.torch.kernels.quantization.gemm import nvfp4_dss_diag_sweep
+
+# Relative-improvement thresholds used to bucket "did DSS actually help this block".
+REL_THRESHOLDS = (1e-6, 1e-4, 1e-2)
+BLOCK_SIZE = 16
+
+
+def build_betas(step: float, device="cpu") -> torch.Tensor:
+    """Symmetric quant-scale grid over [0.5, 1.5] with exact 1.0 at the center (coupled ref).
+
+    ``step=0.01`` reproduces SOAR's 101-point grid; a coarser step trades search density for
+    speed on huge checkpoints (parity already established with the full grid).
+    """
+    n = round(0.5 / step)
+    k = torch.arange(-n, n + 1, device=device, dtype=torch.float32)
+    return 1.0 + k * step
+
+
+def classify_layer(name: str) -> str:
+    """Coarse layer-type bucket from a module/weight name."""
+    n = name.lower()
+    if "expert" in n:
+        return "experts"
+    if any(k in n for k in ("q_proj", "k_proj", "v_proj", "o_proj", "qkv", "self_attn", "attn")):
+        return "attn"
+    if "router" in n or "gate.weight" in n or n.endswith(".gate"):
+        return "router"
+    if any(k in n for k in ("gate_proj", "up_proj", "down_proj", "gate_up", "mlp", "fc")):
+        return "mlp"
+    return "other"
+
+
+@dataclass
+class Bucket:
+    """Streaming aggregate of per-block DSS-vs-coupled stats for one layer type."""
+
+    n_weights: int = 0
+    n_blocks: int = 0
+    n_beta_ne1: int = 0
+    sum_rel: float = 0.0
+    max_rel: float = 0.0
+    rel_over: dict[float, int] = field(default_factory=lambda: dict.fromkeys(REL_THRESHOLDS, 0))
+    beta_hist: torch.Tensor = field(default_factory=lambda: torch.zeros(101, dtype=torch.int64))
+
+    def update(self, coupled, dss, best_beta):
+        rel = (coupled - dss) / coupled.clamp_min(1e-12)
+        self.n_weights += 1
+        self.n_blocks += rel.numel()
+        self.n_beta_ne1 += int((best_beta != 1.0).sum())
+        self.sum_rel += float(rel.sum())
+        self.max_rel = max(self.max_rel, float(rel.max()))
+        for t in REL_THRESHOLDS:
+            self.rel_over[t] += int((rel > t).sum())
+        # beta in [0.50, 1.50] step 0.01 -> bin index round((beta-0.5)*100).
+        idx = ((best_beta - 0.5) * 100.0).round().clamp(0, 100).to(torch.int64)
+        self.beta_hist += torch.bincount(idx.flatten(), minlength=101).cpu()
+
+    def to_raw(self) -> dict:
+        """Picklable additive state, for merging buckets across worker processes."""
+        return {
+            "n_weights": self.n_weights,
+            "n_blocks": self.n_blocks,
+            "n_beta_ne1": self.n_beta_ne1,
+            "sum_rel": self.sum_rel,
+            "max_rel": self.max_rel,
+            "rel_over": {f"{t:.0e}": self.rel_over[t] for t in REL_THRESHOLDS},
+            "beta_hist": self.beta_hist.tolist(),
+        }
+
+    def merge_raw(self, raw: dict):
+        self.n_weights += raw["n_weights"]
+        self.n_blocks += raw["n_blocks"]
+        self.n_beta_ne1 += raw["n_beta_ne1"]
+        self.sum_rel += raw["sum_rel"]
+        self.max_rel = max(self.max_rel, raw["max_rel"])
+        for t in REL_THRESHOLDS:
+            self.rel_over[t] += raw["rel_over"][f"{t:.0e}"]
+        self.beta_hist += torch.tensor(raw["beta_hist"], dtype=torch.int64)
+
+    def as_dict(self) -> dict:
+        mean_rel = self.sum_rel / self.n_blocks if self.n_blocks else 0.0
+        return {
+            "n_weights": self.n_weights,
+            "n_blocks": self.n_blocks,
+            "frac_beta_ne1": self.n_beta_ne1 / self.n_blocks if self.n_blocks else 0.0,
+            "mean_rel_improvement": mean_rel,
+            "max_rel_improvement": self.max_rel,
+            "frac_blocks_rel_over": {
+                f"{t:.0e}": (self.rel_over[t] / self.n_blocks if self.n_blocks else 0.0)
+                for t in REL_THRESHOLDS
+            },
+        }
+
+
+class Report:
+    """Per-layer-type + overall accumulator and Markdown/JSON writer."""
+
+    def __init__(self):
+        self.buckets: dict[str, Bucket] = defaultdict(Bucket)
+        self.overall = Bucket()
+
+    def add(self, name: str, coupled, dss, best_beta):
+        self.buckets[classify_layer(name)].update(coupled, dss, best_beta)
+        self.overall.update(coupled, dss, best_beta)
+
+    def to_raw(self) -> dict:
+        return {"buckets": {k: v.to_raw() for k, v in self.buckets.items()}}
+
+    def merge_raw(self, raw: dict):
+        for k, b in raw["buckets"].items():
+            self.buckets[k].merge_raw(b)
+            self.overall.merge_raw(b)
+
+    def to_json(self, meta: dict) -> dict:
+        return {
+            "meta": meta,
+            "overall": self.overall.as_dict(),
+            "by_layer_type": {k: v.as_dict() for k, v in sorted(self.buckets.items())},
+        }
+
+    def to_markdown(self, meta: dict) -> str:
+        o = self.overall.as_dict()
+        verdict = (
+            "PARITY (DSS does not help the L2 objective)"
+            if o["max_rel_improvement"] < 1e-4
+            else "DSS SHOWS A MEASURABLE GAIN — investigate"
+        )
+        lines = [
+            f"# DSS diagnostic — {meta.get('model', '?')}",
+            "",
+            f"- mode: `{meta.get('mode')}`  block_size: {meta.get('block_size')}  "
+            f"betas: {meta.get('num_betas')} in [0.50, 1.50]",
+            f"- weights analyzed: {self.overall.n_weights}  blocks: {self.overall.n_blocks:,}",
+            f"- elapsed: {meta.get('elapsed_s', 0):.1f}s",
+            "",
+            f"## Verdict: {verdict}",
+            "",
+            f"- fraction of blocks where DSS picks beta != 1: **{o['frac_beta_ne1']:.3%}**",
+            f"- mean relative L2 improvement (coupled->dss): **{o['mean_rel_improvement']:.3e}**",
+            f"- max  relative L2 improvement over any block: **{o['max_rel_improvement']:.3e}**",
+            "- fraction of blocks with relative improvement over threshold:",
+        ]
+        lines += [
+            f"    - > {t:.0e}: {o['frac_blocks_rel_over'][f'{t:.0e}']:.3%}" for t in REL_THRESHOLDS
+        ]
+        lines += [
+            "",
+            "## By layer type",
+            "",
+            "| type | weights | blocks | beta!=1 | mean rel | max rel |",
+            "|---|---|---|---|---|---|",
+        ]
+        for k, v in sorted(self.buckets.items()):
+            d = v.as_dict()
+            lines.append(
+                f"| {k} | {d['n_weights']} | {d['n_blocks']:,} | {d['frac_beta_ne1']:.2%} | "
+                f"{d['mean_rel_improvement']:.2e} | {d['max_rel_improvement']:.2e} |"
+            )
+        return "\n".join(lines) + "\n"
+
+
+@torch.no_grad()
+def analyze_model_mode(args, report: Report) -> int:
+    """Faithful path: load the model, calibrate, iterate production weight quantizers."""
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    import modelopt.torch.quantization as mtq
+    from modelopt.torch.quantization.model_calib import _uses_modelopt_fp8_weight_scales
+    from modelopt.torch.quantization.nn.modules.quant_module import QuantModule
+    from modelopt.torch.quantization.utils import enable_weight_access_and_writeback
+    from modelopt.torch.utils.dataset_utils import create_forward_loop
+
+    print(f"[dss] loading {args.model} ...", flush=True)
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model, torch_dtype="auto", device_map="auto", trust_remote_code=True
+    )
+    model.eval()
+
+    forward_loop = create_forward_loop(
+        model=model,
+        dataset_name=args.dataset,
+        tokenizer=tokenizer,
+        batch_size=args.batch_size,
+        num_samples=args.calib_size,
+        max_sample_length=args.calib_seq,
+    )
+    print("[dss] calibrating (NVFP4 weight-MSE FP8 sweep) to populate global_amax ...", flush=True)
+    mtq.quantize(model, mtq.NVFP4_W4A4_WEIGHT_MSE_FP8_SWEEP_CFG, forward_loop=forward_loop)
+
+    print("[dss] running DSS-vs-coupled search over weight quantizers ...", flush=True)
+    name_to_module = dict(model.named_modules())
+    seen: set[int] = set()
+    n_done = 0
+    for name, module in name_to_module.items():
+        if id(module) in seen or not isinstance(module, QuantModule):
+            continue
+        seen.add(id(module))
+        with enable_weight_access_and_writeback(module, model, name_to_module):
+            for sub_idx, (weight, wq) in enumerate(module.iter_weights_for_calibration()):
+                # global_amax exists only after NVFP4-static promotion; the format-only
+                # is_nvfp4_static check can be true before that, so fetch defensively.
+                global_amax = getattr(wq, "global_amax", None)
+                if not _uses_modelopt_fp8_weight_scales(wq) or global_amax is None:
+                    continue
+                if weight is None or weight.dim() < 2 or weight.numel() % args.block_size:
+                    continue
+                betas = build_betas(args.beta_step, weight.device)
+                coupled, dss, best_beta = nvfp4_dss_diag_sweep(
+                    weight, global_amax, betas, args.block_size
+                )
+                report.add(f"{name}.{sub_idx}", coupled, dss, best_beta)
+                n_done += 1
+                if n_done % 50 == 0:
+                    print(f"[dss]   {n_done} weights analyzed", flush=True)
+                if args.max_weights and n_done >= args.max_weights:
+                    return n_done
+    return n_done
+
+
+_SKIP_KEYS = ("embed", "lm_head", "norm", "bias", "rotary", "router", "gate.weight")
+
+
+def _is_quantizable_tensor(name: str, shape, block_size: int) -> bool:
+    """Raw-checkpoint linear/expert weights the NVFP4 weight sweep would touch.
+
+    Accepts 2-D linear weights (``...proj.weight``) and 3-D fused-expert stacks
+    (``...experts.gate_up_proj`` / ``down_proj`` of shape ``[n_experts, out, in]``); both
+    quantize along the last (contraction) dim, which must be block-divisible.
+    """
+    if len(shape) not in (2, 3) or shape[-1] % block_size:
+        return False
+    return not any(k in name.lower() for k in _SKIP_KEYS)
+
+
+@torch.no_grad()
+def _process_shards(shards, device, block_size, max_weights, beta_step, log_prefix=""):
+    """Run the DSS-vs-coupled search over one worker's shards; return raw report state.
+
+    Per-expert ``global_amax = max|slice|`` is faithful for fused experts (per-expert weight
+    quantizers); for grouped linears (qkv/gate_up siblings) it is a per-tensor approximation.
+    """
+    from safetensors import safe_open
+
+    report = Report()
+    betas = build_betas(beta_step, device)
+    n_done = 0
+    for si, shard in enumerate(shards):
+        print(
+            f"[dss]{log_prefix} shard {si + 1}/{len(shards)}: {os.path.basename(shard)}", flush=True
+        )
+        with safe_open(shard, framework="pt", device=device) as f:
+            for key in f.keys():  # noqa: SIM118  (safetensors handle, not a dict)
+                shape = f.get_slice(key).get_shape()
+                if not _is_quantizable_tensor(key, shape, block_size):
+                    continue
+                t = f.get_tensor(key)
+                # 2-D linear -> one weight; 3-D expert stack -> one weight per expert slice.
+                slices = t.unsqueeze(0) if t.ndim == 2 else t
+                for w in slices:
+                    wf = w.to(torch.float32)
+                    coupled, dss, best_beta = nvfp4_dss_diag_sweep(
+                        wf, wf.abs().max(), betas, block_size
+                    )
+                    report.add(key, coupled, dss, best_beta)
+                    n_done += 1
+                    del wf, coupled, dss, best_beta
+                del t
+                if n_done % 200 == 0:
+                    print(f"[dss]{log_prefix}   {n_done} weights analyzed", flush=True)
+                if max_weights and n_done >= max_weights:
+                    return report.to_raw(), n_done
+    return report.to_raw(), n_done
+
+
+def _worker(arg):
+    """ProcessPool entry: pin to the assigned GPU and process a shard subset."""
+    shards, gpu_id, block_size, max_weights, beta_step = arg
+    import torch as _torch
+
+    _torch.cuda.set_device(gpu_id)
+    return _process_shards(
+        shards, f"cuda:{gpu_id}", block_size, max_weights, beta_step, f"[gpu{gpu_id}]"
+    )
+
+
+@torch.no_grad()
+def analyze_weights_only_mode(args, report: Report) -> int:
+    """Streaming path for checkpoints too large to instantiate, parallelized across GPUs."""
+    shards = sorted(glob.glob(os.path.join(args.model, "*.safetensors")))
+    if not shards:
+        raise FileNotFoundError(f"no .safetensors shards under {args.model}")
+
+    n_gpus = args.num_gpus or torch.cuda.device_count()
+    if n_gpus <= 1:
+        raw, n = _process_shards(
+            shards, "cuda:0", args.block_size, args.max_weights, args.beta_step
+        )
+        report.merge_raw(raw)
+        return n
+
+    # One worker per GPU; round-robin shards so disk I/O + compute overlap across devices.
+    import torch.multiprocessing as mp
+
+    tasks = [
+        (
+            shards[i::n_gpus],
+            i,
+            args.block_size,
+            args.max_weights // n_gpus if args.max_weights else 0,
+            args.beta_step,
+        )
+        for i in range(n_gpus)
+    ]
+    print(f"[dss] launching {n_gpus} GPU workers over {len(shards)} shards", flush=True)
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(n_gpus) as pool:
+        results = pool.map(_worker, tasks)
+    n_done = 0
+    for raw, n in results:
+        report.merge_raw(raw)
+        n_done += n
+    return n_done
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True, help="HF model path")
+    ap.add_argument("--mode", choices=["auto", "model", "weights-only"], default="auto")
+    ap.add_argument("--output-dir", required=True)
+    ap.add_argument("--dataset", default="cnn_dailymail")
+    ap.add_argument("--calib-size", type=int, default=128)
+    ap.add_argument("--calib-seq", type=int, default=512)
+    ap.add_argument("--batch-size", type=int, default=4)
+    ap.add_argument("--block-size", type=int, default=BLOCK_SIZE)
+    ap.add_argument("--max-weights", type=int, default=0, help="cap analyzed weights (0 = all)")
+    ap.add_argument(
+        "--num-gpus",
+        type=int,
+        default=0,
+        help="GPU workers for weights-only mode (0 = all visible). Each handles a shard subset.",
+    )
+    ap.add_argument(
+        "--beta-step",
+        type=float,
+        default=0.01,
+        help="Quant-scale grid step over [0.5, 1.5] (0.01 = SOAR's 101 pts; coarser = faster).",
+    )
+    args = ap.parse_args()
+
+    if args.mode == "auto":
+        # Pick streaming for checkpoints that clearly won't fit; else load the model.
+        total_bytes = sum(
+            os.path.getsize(p) for p in glob.glob(os.path.join(args.model, "*.safetensors"))
+        )
+        args.mode = "weights-only" if total_bytes > 150 * 2**30 else "model"
+    print(f"[dss] mode = {args.mode}", flush=True)
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    report = Report()
+    t0 = time.perf_counter()
+    if args.mode == "model":
+        n = analyze_model_mode(args, report)
+    else:
+        n = analyze_weights_only_mode(args, report)
+    elapsed = time.perf_counter() - t0
+
+    meta = {
+        "model": args.model,
+        "mode": args.mode,
+        "block_size": args.block_size,
+        "num_betas": int(build_betas(args.beta_step).numel()),
+        "n_weights": n,
+        "elapsed_s": elapsed,
+    }
+    base = os.path.join(args.output_dir, "dss_diagnostic")
+    with open(base + ".json", "w") as f:
+        json.dump(report.to_json(meta), f, indent=2)
+    md = report.to_markdown(meta)
+    with open(base + ".md", "w") as f:
+        f.write(md)
+    print("\n" + md, flush=True)
+    print(f"[dss] wrote {base}.json and {base}.md", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hf_ptq/dss_local_hessian_e2e.py
+++ b/examples/hf_ptq/dss_local_hessian_e2e.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end NVFP4 local-Hessian PTQ with optional Decoupled Scale Search (DSS).
+
+Quantizes a HF model with the ``local_hessian`` algorithm (NVFP4 W4A4), optionally enabling DSS
+(``--dss``), prints a short generation preview for a sanity check, and optionally exports a
+HuggingFace checkpoint. Intended to validate Stage 1 (calibration + fake-quant) and Stage 2
+(export) of DSS on real models.
+"""
+
+import argparse
+import copy
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+import modelopt.torch.quantization as mtq
+from modelopt.torch.export import export_hf_checkpoint
+from modelopt.torch.quantization.nn import TensorQuantizer
+from modelopt.torch.utils.dataset_utils import create_forward_loop
+
+PROMPT = "The key idea behind post-training quantization is"
+
+
+@torch.no_grad()
+def preview(model, tokenizer, max_new_tokens=48):
+    inputs = tokenizer(PROMPT, return_tensors="pt").to(model.device)
+    out = model.generate(**inputs, max_new_tokens=max_new_tokens, do_sample=False)
+    return tokenizer.decode(out[0], skip_special_tokens=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--dss", action="store_true", help="enable Decoupled Scale Search")
+    ap.add_argument("--dss-beta-step", type=float, default=0.05)
+    ap.add_argument("--calib-size", type=int, default=128)
+    ap.add_argument("--calib-seq", type=int, default=512)
+    ap.add_argument("--batch-size", type=int, default=4)
+    ap.add_argument("--dataset", default="cnn_dailymail")
+    ap.add_argument("--export-dir", default=None, help="if set, export an HF checkpoint here")
+    args = ap.parse_args()
+
+    print(f"[dss-e2e] loading {args.model} (dss={args.dss}) ...", flush=True)
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model, torch_dtype="auto", device_map="auto", trust_remote_code=True
+    )
+    model.eval()
+
+    print("[dss-e2e] baseline (unquantized) preview:\n  " + preview(model, tokenizer), flush=True)
+
+    cfg = copy.deepcopy(mtq.NVFP4_W4A4_WEIGHT_LOCAL_HESSIAN_CFG)
+    cfg["algorithm"]["decoupled_scale_search"] = args.dss
+    cfg["algorithm"]["dss_beta_step"] = args.dss_beta_step
+
+    forward_loop = create_forward_loop(
+        model=model,
+        dataset_name=args.dataset,
+        tokenizer=tokenizer,
+        batch_size=args.batch_size,
+        num_samples=args.calib_size,
+        max_sample_length=args.calib_seq,
+    )
+    print("[dss-e2e] quantizing (NVFP4 local_hessian) ...", flush=True)
+    mtq.quantize(model, cfg, forward_loop=forward_loop)
+
+    n_dss = sum(
+        1
+        for _, m in model.named_modules()
+        if isinstance(m, TensorQuantizer) and getattr(m, "quant_amax", None) is not None
+    )
+    print(f"[dss-e2e] weight quantizers carrying a DSS quant_amax: {n_dss}", flush=True)
+    print("[dss-e2e] quantized preview:\n  " + preview(model, tokenizer), flush=True)
+
+    if args.export_dir:
+        print(f"[dss-e2e] exporting HF checkpoint to {args.export_dir} ...", flush=True)
+        export_hf_checkpoint(model, export_dir=args.export_dir)
+        print("[dss-e2e] export complete.", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hf_ptq/dss_saturation_check.py
+++ b/examples/hf_ptq/dss_saturation_check.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Is DSS's beta!=1 driven by rounding ties or by saturation/clipping?
+
+For each NVFP4 block we already know DSS never reduces the L2 loss beyond fp32 noise. This
+script asks *why* DSS still picks beta!=1, separating the two candidate mechanisms:
+
+  * rounding ties     : a value sits on an FP4 rounding boundary, so a range of s_q yields the
+                        same codes -> same loss -> argmin lands on some beta!=1 arbitrarily.
+  * saturation/clip   : with the coupled s_d, some |w| > 6*s_d clips to code 6, making Q no
+                        longer a plain nearest map. A different s_q could move values in/out of
+                        saturation -- the case where the per-element-optimal proof might break.
+
+A block is "saturated" under the coupled optimum iff max|w| > coupled_amax (since the FP4 max
+code is 6 and recon_max = 6*(amax/6) = amax). We cross-tabulate saturated x (beta!=1) and report
+the MAX and mean relative L2 gain in each cell. If the max gain among *saturated* blocks is still
+fp-noise, saturation does not open a real gap and the proof holds there too.
+
+Reuses the production coupled sweep (``nvfp4_fp8_scale_sweep``) and the diagnostic
+(``nvfp4_dss_diag_sweep``); no kernel changes.
+"""
+
+import argparse
+import glob
+import json
+import os
+import time
+
+import torch
+
+from modelopt.torch.kernels.quantization.gemm import nvfp4_dss_diag_sweep, nvfp4_fp8_scale_sweep
+
+BLOCK_SIZE = 16
+TIE_REL = 1e-7  # rel gain below this is numerically a tie (no real improvement)
+SKIP_KEYS = ("embed", "lm_head", "norm", "bias", "rotary", "router", "gate.weight")
+
+
+def build_betas(step, device):
+    n = round(0.5 / step)
+    return 1.0 + torch.arange(-n, n + 1, device=device, dtype=torch.float32) * step
+
+
+class Acc:
+    """Scalar cross-tab accumulators (saturated x beta!=1) over per-block stats."""
+
+    def __init__(self):
+        self.keys = [
+            "n_blocks",
+            "n_sat",
+            "n_bne1",
+            "n_sat_bne1",
+            "n_notsat_bne1",
+            "n_sat_bne1_tie",
+            "n_sat_bne1_real",  # real = rel > 1e-5
+            "sum_rel_sat",
+            "sum_rel_notsat",
+            "sum_beta_sat_bne1",
+            "sum_beta_notsat_bne1",
+        ]
+        self.s = dict.fromkeys(self.keys, 0.0)
+        self.max_rel_sat = 0.0
+        self.max_rel_notsat = 0.0
+
+    @torch.no_grad()
+    def update(self, w, global_amax, betas):
+        nb = w.numel() // BLOCK_SIZE
+        coupled_amax = nvfp4_fp8_scale_sweep(w, global_amax, block_size=BLOCK_SIZE).reshape(nb)
+        coupled, dss, beta = nvfp4_dss_diag_sweep(w, global_amax, betas, BLOCK_SIZE)
+        block_max = w.reshape(nb, BLOCK_SIZE).abs().amax(dim=1)
+
+        sat = block_max > coupled_amax
+        notsat = ~sat
+        rel = (coupled - dss) / coupled.clamp_min(1e-12)
+        bne1 = beta != 1.0
+
+        self.s["n_blocks"] += nb
+        self.s["n_sat"] += int(sat.sum())
+        self.s["n_bne1"] += int(bne1.sum())
+        self.s["n_sat_bne1"] += int((sat & bne1).sum())
+        self.s["n_notsat_bne1"] += int((notsat & bne1).sum())
+        self.s["n_sat_bne1_tie"] += int((sat & bne1 & (rel < TIE_REL)).sum())
+        self.s["n_sat_bne1_real"] += int((sat & bne1 & (rel > 1e-5)).sum())
+        self.s["sum_rel_sat"] += float(rel[sat].sum()) if sat.any() else 0.0
+        self.s["sum_rel_notsat"] += float(rel[notsat].sum()) if notsat.any() else 0.0
+        self.s["sum_beta_sat_bne1"] += float(beta[sat & bne1].sum()) if (sat & bne1).any() else 0.0
+        self.s["sum_beta_notsat_bne1"] += (
+            float(beta[notsat & bne1].sum()) if (notsat & bne1).any() else 0.0
+        )
+        if sat.any():
+            self.max_rel_sat = max(self.max_rel_sat, float(rel[sat].max()))
+        if notsat.any():
+            self.max_rel_notsat = max(self.max_rel_notsat, float(rel[notsat].max()))
+
+    def report(self) -> dict:
+        s = self.s
+        nb = s["n_blocks"] or 1
+        nsat = s["n_sat"] or 1
+        nnotsat = (s["n_blocks"] - s["n_sat"]) or 1
+        return {
+            "n_blocks": s["n_blocks"],
+            "frac_saturated": s["n_sat"] / nb,
+            "frac_beta_ne1": s["n_bne1"] / nb,
+            "saturated": {
+                "max_rel_gain": self.max_rel_sat,
+                "mean_rel_gain": s["sum_rel_sat"] / nsat,
+                "frac_with_beta_ne1": s["n_sat_bne1"] / nsat,
+                "of_those_beta_ne1_fraction_ties": (s["n_sat_bne1_tie"] / (s["n_sat_bne1"] or 1)),
+                "of_those_beta_ne1_count_real_gain_gt_1e-5": int(s["n_sat_bne1_real"]),
+                "mean_beta_when_ne1": (s["sum_beta_sat_bne1"] / (s["n_sat_bne1"] or 1)),
+            },
+            "not_saturated": {
+                "max_rel_gain": self.max_rel_notsat,
+                "mean_rel_gain": s["sum_rel_notsat"] / nnotsat,
+                "frac_with_beta_ne1": s["n_notsat_bne1"] / nnotsat,
+                "mean_beta_when_ne1": (s["sum_beta_notsat_bne1"] / (s["n_notsat_bne1"] or 1)),
+            },
+        }
+
+
+@torch.no_grad()
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--output-dir", required=True)
+    ap.add_argument("--max-shards", type=int, default=6, help="cap shards (0 = all)")
+    ap.add_argument("--beta-step", type=float, default=0.05)
+    ap.add_argument("--device", default="cuda:0")
+    args = ap.parse_args()
+    from safetensors import safe_open
+
+    shards = sorted(glob.glob(os.path.join(args.model, "*.safetensors")))
+    if args.max_shards:
+        shards = shards[: args.max_shards]
+    betas = build_betas(args.beta_step, args.device)
+    acc = Acc()
+    t0 = time.perf_counter()
+    for si, shard in enumerate(shards):
+        print(f"[sat] shard {si + 1}/{len(shards)}: {os.path.basename(shard)}", flush=True)
+        with safe_open(shard, framework="pt", device=args.device) as f:
+            for key in f.keys():  # noqa: SIM118  (safetensors handle, not a dict)
+                shape = f.get_slice(key).get_shape()
+                if len(shape) not in (2, 3) or shape[-1] % BLOCK_SIZE:
+                    continue
+                if any(k in key.lower() for k in SKIP_KEYS):
+                    continue
+                t = f.get_tensor(key)
+                slices = t.unsqueeze(0) if t.ndim == 2 else t
+                for w in slices:
+                    wf = w.to(torch.float32)
+                    acc.update(wf, wf.abs().max(), betas)
+                    del wf
+                del t
+    rep = {
+        "model": args.model,
+        "shards": len(shards),
+        "beta_step": args.beta_step,
+        "elapsed_s": time.perf_counter() - t0,
+        **acc.report(),
+    }
+    os.makedirs(args.output_dir, exist_ok=True)
+    out = os.path.join(args.output_dir, "dss_saturation_check.json")
+    with open(out, "w") as fp:
+        json.dump(rep, fp, indent=2)
+    print(json.dumps(rep, indent=2), flush=True)
+    print(f"[sat] wrote {out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/modelopt/torch/export/quant_utils.py
+++ b/modelopt/torch/export/quant_utils.py
@@ -837,8 +837,14 @@ def to_quantized_weight(
     quantization: str,
     weights_scaling_factor2: torch.Tensor | None = None,
     block_size: int | None = None,
+    quant_scaling_factor: torch.Tensor | None = None,
 ):
-    """Converts the weight to the quantized (packed) format."""
+    """Converts the weight to the quantized (packed) format.
+
+    ``quant_scaling_factor`` (NVFP4 only) is the optional absolute per-block quantization scale for
+    Decoupled Scale Search — codes are chosen with it while ``weights_scaling_factor`` stays the
+    stored FP8 scale. ``None`` keeps the standard coupled behavior.
+    """
     if weights_scaling_factor is not None:
         weights_scaling_factor = weights_scaling_factor.to(weight.device)
 
@@ -928,6 +934,7 @@ def to_quantized_weight(
             weights_scaling_factor2.view(-1, 1, 1)
             if weights_scaling_factor2.dim() != 0
             else weights_scaling_factor2,
+            quant_scaling_factor=quant_scaling_factor,
         )[0]._quantized_data
 
     if quantization in [QUANTIZATION_W4A8_MXFP4_FP8, QUANTIZATION_MXFP4]:

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -694,12 +694,18 @@ def _export_quantized_weight(
             weight, is_bmm_expert_weight=is_bmm_expert_weight
         )
 
+        # Decoupled Scale Search: choose FP4 codes with the high-precision quant scale (if the
+        # quantizer carries ``_quant_amax``); the stored ``weight_scale`` remains the FP8 scale.
+        quant_scaling_factor = None
         if NVFP4QTensor._is_static_quantizer(weight_quantizer):
             weight_scale = NVFP4QTensor.get_weights_scaling_factor_from_quantizer(
                 weight_quantizer,
                 weight,
                 weight_scale_2,
             )[0]
+            quant_scaling_factor = NVFP4QTensor.get_weights_quant_scaling_factor_from_quantizer(
+                weight_quantizer, weight
+            )
         else:
             weight_scale = NVFP4QTensor.get_weights_scaling_factor(
                 weight,
@@ -713,6 +719,7 @@ def _export_quantized_weight(
             quantization_format,
             weight_scale_2,
             block_size,
+            quant_scaling_factor=quant_scaling_factor,
         )
 
         quantized_weight, weight_scale = maybe_transpose_expert_weight_dimensions(

--- a/modelopt/torch/kernels/quantization/common/nvfp4_quant.py
+++ b/modelopt/torch/kernels/quantization/common/nvfp4_quant.py
@@ -102,6 +102,30 @@ def nvfp4_scalar_quant(
 
 
 @triton.jit
+def nvfp4_scalar_quant_decoupled(
+    x,  # [N] float32, already loaded
+    quant_scale,  # float32 scalar: high-precision scale used to pick FP4 codes (s_q)
+    dequant_scale,  # float32 scalar: stored FP8 block scale used to reconstruct (s_d)
+    N: tl.constexpr,
+):
+    """NVFP4 scalar fake quantization with decoupled quant/dequant scales (DSS).
+
+    Codes are chosen by rounding ``|x| / quant_scale`` to the nearest FP4 magnitude, but the
+    reconstruction multiplies by ``dequant_scale`` (the FP8-representable stored scale). With
+    ``quant_scale == dequant_scale`` this is identical to :func:`nvfp4_scalar_quant`.
+    """
+    x_abs = tl.abs(x)
+    quant_scale_safe = tl.where(
+        (quant_scale == 0.0) | libdevice.isnan(quant_scale) | (tl.abs(quant_scale) == float("inf")),
+        1.0,
+        quant_scale,
+    )
+    q_val = fp4_round_magnitude(x_abs / quant_scale_safe)
+    x_rescaled = q_val * dequant_scale
+    return tl.where(x >= 0, x_rescaled, -x_rescaled)
+
+
+@triton.jit
 def fp8_quantize_scale(block_amax, global_scale):
     """FP8 E4M3 fake-quantize the per-block NVFP4 scale.
 

--- a/modelopt/torch/kernels/quantization/gemm/__init__.py
+++ b/modelopt/torch/kernels/quantization/gemm/__init__.py
@@ -32,6 +32,7 @@ if torch.cuda.is_available():
         # fp4_kernel works on any CUDA GPU with triton
         from .fp4_kernel import *
         from .fp8_kernel import *
+        from .nvfp4_dss_diag import *
         from .nvfp4_fp8_sweep import *
 
         # fp4_kernel_hopper requires compute >= 8.9 (uses tl.float8e4nv)

--- a/modelopt/torch/kernels/quantization/gemm/fp4_kernel.py
+++ b/modelopt/torch/kernels/quantization/gemm/fp4_kernel.py
@@ -26,7 +26,7 @@ import triton.language as tl
 
 from modelopt.torch.quantization.utils.numeric_utils import E4M3_MAX
 
-from ..common.nvfp4_quant import nvfp4_scalar_quant
+from ..common.nvfp4_quant import nvfp4_scalar_quant, nvfp4_scalar_quant_decoupled
 
 __all__ = [
     "compute_fp4_scales",
@@ -214,6 +214,32 @@ def static_blockwise_fp4_fake_quant_kernel(
     tl.store(y_ptr + idx, x_quant.to(OUT_DTYPE))
 
 
+@triton.jit
+def static_blockwise_fp4_fake_quant_decoupled_kernel(
+    x_ptr,  # [NUM_FP4_BLOCKS * BLOCK_SIZE]
+    y_ptr,  # [NUM_FP4_BLOCKS * BLOCK_SIZE]
+    quant_scale_ptr,  # [NUM_FP4_BLOCKS] high-precision scale for choosing codes (s_q)
+    dequant_scale_ptr,  # [NUM_FP4_BLOCKS] FP8 stored scale for reconstruction (s_d)
+    NUM_FP4_BLOCKS,
+    BLOCK_SIZE: tl.constexpr,
+    OUT_DTYPE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    if pid >= NUM_FP4_BLOCKS:
+        return
+
+    block_offset = pid * BLOCK_SIZE
+    idx = block_offset + tl.arange(0, BLOCK_SIZE)
+
+    quant_scale = tl.load(quant_scale_ptr + pid).to(tl.float32)
+    dequant_scale = tl.load(dequant_scale_ptr + pid).to(tl.float32)
+    x = tl.load(x_ptr + idx).to(tl.float32)
+
+    x_quant = nvfp4_scalar_quant_decoupled(x, quant_scale, dequant_scale, BLOCK_SIZE)
+
+    tl.store(y_ptr + idx, x_quant.to(OUT_DTYPE))
+
+
 def compute_fp4_scales(
     amax: torch.Tensor,
     global_amax: torch.Tensor | None = None,
@@ -258,6 +284,7 @@ def static_blockwise_fp4_fake_quant(
     quantize_block_scales: bool = True,
     fp8_max_for_normalization: float = E4M3_MAX,
     out_dtype: torch.dtype | None = None,
+    quant_amax: torch.Tensor | None = None,
 ):
     """Static blockwise FP4 fake quantization using Triton kernel.
 
@@ -275,6 +302,10 @@ def static_blockwise_fp4_fake_quant(
         fp8_max_for_normalization: FP8 max value used to normalize per-block scales
             before FP8 quantization (default 448.0; use 256.0 for NVFP4 4/6 mode).
         out_dtype: Output dtype. Defaults to x.dtype if None.
+        quant_amax: Optional per-block *quantization* amax for Decoupled Scale Search (DSS).
+            When given, codes are chosen with the high-precision scale ``quant_amax / 6`` while
+            reconstruction uses the (FP8) dequant scale derived from ``amax``. ``None`` (default)
+            keeps the coupled behavior (``s_q == s_d``). Same shape/count as ``amax``.
     """
     original_shape = x.shape
     NUM_FP4_BLOCKS = amax.numel()
@@ -303,10 +334,30 @@ def static_blockwise_fp4_fake_quant(
 
     grid = (NUM_FP4_BLOCKS,)
 
+    if quant_amax is None:
+        with torch.cuda.device(x.device):
+            static_blockwise_fp4_fake_quant_kernel[grid](
+                x_flat,
+                y_flat,
+                scale_flat,
+                NUM_FP4_BLOCKS,
+                BLOCK_SIZE,
+                OUT_DTYPE=tl_out_dtype,
+            )
+        return y_flat.view(original_shape)
+
+    # DSS: choose codes with the high-precision quant scale (quant_amax / 6), reconstruct
+    # with the FP8 dequant scale computed above.
+    if quant_amax.numel() != NUM_FP4_BLOCKS:
+        raise ValueError(
+            f"quant_amax.numel() ({quant_amax.numel()}) must equal amax.numel() ({NUM_FP4_BLOCKS})."
+        )
+    quant_scale_flat = (quant_amax.float() / 6.0).contiguous().view(NUM_FP4_BLOCKS)
     with torch.cuda.device(x.device):
-        static_blockwise_fp4_fake_quant_kernel[grid](
+        static_blockwise_fp4_fake_quant_decoupled_kernel[grid](
             x_flat,
             y_flat,
+            quant_scale_flat,
             scale_flat,
             NUM_FP4_BLOCKS,
             BLOCK_SIZE,

--- a/modelopt/torch/kernels/quantization/gemm/nvfp4_dss_diag.py
+++ b/modelopt/torch/kernels/quantization/gemm/nvfp4_dss_diag.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Diagnostic Triton kernel for Decoupled Scale Search (DSS) on the NVFP4 weight-MSE sweep.
+
+DSS (SOAR, arXiv:2605.12245) decouples the FP4 *quantization* scale ``s_q`` (high precision)
+from the stored *dequantization* scale ``s_d`` (FP8 E4M3-constrained)::
+
+    for s_d in nearby_E4M3_scales:  # stored, FP8-constrained
+        for s_q in nearby_real_scales:  # free, high-precision
+            q = round_fp4(w / s_q)
+            w_hat = q * s_d
+
+This kernel does NOT change calibration. It only *measures* how much DSS could reduce the
+per-block reconstruction loss versus the coupled (``s_q == s_d``) sweep that
+:class:`NVFP4MSECalibrator` already runs. For each NVFP4 block it sweeps every FP8 ``s_d``
+candidate against a multiplicative ``s_q = beta * s_d`` grid and reports, per block:
+
+  * ``coupled_loss`` — best loss over ``s_d`` at ``beta == 1`` (reproduces today's sweep),
+  * ``dss_loss``     — best loss over the full ``(s_d, beta)`` grid,
+  * ``best_beta``    — the ``beta`` at the DSS optimum.
+
+Because ``beta == 1`` is in the grid, ``dss_loss <= coupled_loss`` by construction; the
+diagnostic question is whether ``coupled_loss - dss_loss`` is ever materially positive.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from ..common.nvfp4_quant import fp4_round_magnitude
+from ._fp8_scale_candidates import fp8_scale_candidates
+
+__all__ = ["default_dss_betas", "nvfp4_dss_diag_sweep"]
+
+
+def default_dss_betas(device: torch.device | str = "cpu") -> torch.Tensor:
+    """SOAR's quant-scale grid: ``s_q = beta * s_d`` for ``beta`` in ``[0.50, 1.50]`` step 0.01.
+
+    Built as ``arange(50, 151) / 100`` so the coupled reference ``beta == 1.0`` is exactly
+    representable (``100 / 100``), which :func:`nvfp4_dss_diag_sweep` requires.
+    """
+    return torch.arange(50, 151, dtype=torch.float32, device=device) / 100.0
+
+
+# Mirror nvfp4_fp8_sweep.py's tile/warp shape. Both sweep loops are runtime ``tl.range`` (not
+# unrolled): a 126x101 ``static_range`` unroll overruns the NVPTX compiler. The candidate and
+# beta tables are read from global memory per iteration instead.
+_DSS_DIAG_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCKS_PER_PROGRAM": 16}, num_warps=4),
+    triton.Config({"BLOCKS_PER_PROGRAM": 32}, num_warps=8),
+]
+
+
+@triton.autotune(configs=_DSS_DIAG_AUTOTUNE_CONFIGS, key=["N_BLOCKS"])
+@triton.jit
+def _dss_diag_sweep_kernel(
+    x_ptr,  # [N_BLOCKS * BLOCK_SIZE], any float dtype (loaded as fp32)
+    candidates_ptr,  # [NUM_CANDIDATES] fp32 (FP8 E4M3 values / 448)
+    betas_ptr,  # [NUM_BETAS] fp32 quant-scale multipliers
+    global_amax_ptr,  # scalar fp32
+    coupled_loss_ptr,  # [N_BLOCKS] fp32 output (best loss at beta == 1)
+    dss_loss_ptr,  # [N_BLOCKS] fp32 output (best loss over full grid)
+    best_beta_ptr,  # [N_BLOCKS] fp32 output (beta at the dss optimum)
+    N_BLOCKS,
+    BLOCK_SIZE: tl.constexpr,
+    NUM_CANDIDATES,
+    NUM_BETAS,
+    BLOCKS_PER_PROGRAM: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCKS_PER_PROGRAM
+    block_idx = block_start + tl.arange(0, BLOCKS_PER_PROGRAM)
+    block_mask = block_idx < N_BLOCKS
+
+    # Load weights once; |w| suffices since FP4 quant preserves sign:
+    #   (w - w_q)^2 = (|w| - q_mag * s_d)^2.
+    elem_offs = block_idx[:, None] * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)[None, :]
+    elem_mask = block_mask[:, None]
+    w_abs = tl.abs(tl.load(x_ptr + elem_offs, mask=elem_mask, other=0.0).to(tl.float32))
+
+    global_amax = tl.load(global_amax_ptr).to(tl.float32)
+
+    best_dss_loss = tl.full([BLOCKS_PER_PROGRAM], float("inf"), dtype=tl.float32)
+    best_beta = tl.zeros([BLOCKS_PER_PROGRAM], dtype=tl.float32)
+    best_coupled_loss = tl.full([BLOCKS_PER_PROGRAM], float("inf"), dtype=tl.float32)
+
+    for k in tl.range(NUM_CANDIDATES):
+        c = tl.load(candidates_ptr + k).to(tl.float32)
+        s_d = c * global_amax / 6.0
+        # global_amax == 0 implies w_abs == 0 (global_amax = max|w|), so every loss is 0.
+        s_d_safe = tl.where(s_d == 0.0, 1.0, s_d)
+        for j in tl.range(NUM_BETAS):
+            beta = tl.load(betas_ptr + j).to(tl.float32)
+            s_q = beta * s_d_safe
+            q_mag = fp4_round_magnitude(w_abs / s_q)
+            diff = w_abs - q_mag * s_d_safe
+            loss = tl.sum(diff * diff, axis=1)  # [BLOCKS_PER_PROGRAM]
+
+            is_better = loss < best_dss_loss
+            best_dss_loss = tl.where(is_better, loss, best_dss_loss)
+            best_beta = tl.where(is_better, beta, best_beta)
+
+            # betas holds exactly one 1.0 entry -> this captures the coupled (s_q == s_d) slice.
+            is_coupled = beta == 1.0
+            best_coupled_loss = tl.where(
+                is_coupled & (loss < best_coupled_loss), loss, best_coupled_loss
+            )
+
+    tl.store(coupled_loss_ptr + block_idx, best_coupled_loss, mask=block_mask)
+    tl.store(dss_loss_ptr + block_idx, best_dss_loss, mask=block_mask)
+    tl.store(best_beta_ptr + block_idx, best_beta, mask=block_mask)
+
+
+def nvfp4_dss_diag_sweep(
+    x: torch.Tensor,
+    global_amax: torch.Tensor,
+    betas: torch.Tensor,
+    block_size: int = 16,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Measure DSS vs. coupled NVFP4 per-block reconstruction loss.
+
+    Args:
+        x: Weight tensor on CUDA. Total element count must be divisible by ``block_size``;
+            layout is treated as a flat ``[N_BLOCKS, BLOCK_SIZE]`` (matching the calibrator).
+        global_amax: Scalar FP32 global amax (``= reduce_amax(per_block_amax)``).
+        betas: 1-D FP32 quant-scale multipliers ``s_q = beta * s_d``. Must contain exactly one
+            entry equal to ``1.0`` (the coupled reference); its index drives ``coupled_loss``.
+        block_size: NVFP4 block size (typically 16).
+
+    Returns:
+        ``(coupled_loss, dss_loss, best_beta)``, each shape ``[N_BLOCKS]`` fp32 on ``x``'s
+        device. ``dss_loss <= coupled_loss`` elementwise by construction.
+    """
+    if not x.is_cuda:
+        raise ValueError("nvfp4_dss_diag_sweep requires a CUDA tensor.")
+    if not isinstance(block_size, int) or block_size <= 0:
+        raise ValueError(f"block_size must be a positive int, got {block_size!r}.")
+    if x.numel() % block_size != 0:
+        raise ValueError(f"x.numel() ({x.numel()}) is not divisible by block_size ({block_size}).")
+
+    betas = betas.detach().to(device=x.device, dtype=torch.float32).contiguous()
+    if int((betas == 1.0).sum()) != 1:
+        raise ValueError("betas must contain exactly one entry equal to 1.0 (coupled reference).")
+
+    candidates = fp8_scale_candidates(x.device).to(dtype=torch.float32)
+
+    n_blocks = x.numel() // block_size
+    x_flat = x.contiguous().view(-1)
+    global_amax_f32 = global_amax.detach().to(device=x.device, dtype=torch.float32).reshape(1)
+    coupled_loss = torch.empty(n_blocks, dtype=torch.float32, device=x.device)
+    dss_loss = torch.empty(n_blocks, dtype=torch.float32, device=x.device)
+    best_beta = torch.empty(n_blocks, dtype=torch.float32, device=x.device)
+
+    grid = lambda meta: (triton.cdiv(n_blocks, meta["BLOCKS_PER_PROGRAM"]),)
+    with torch.cuda.device(x.device):
+        _dss_diag_sweep_kernel[grid](
+            x_flat,
+            candidates,
+            betas,
+            global_amax_f32,
+            coupled_loss,
+            dss_loss,
+            best_beta,
+            n_blocks,
+            BLOCK_SIZE=block_size,
+            NUM_CANDIDATES=int(candidates.numel()),
+            NUM_BETAS=int(betas.numel()),
+        )
+    return coupled_loss, dss_loss, best_beta

--- a/modelopt/torch/quantization/calib/calibrator.py
+++ b/modelopt/torch/quantization/calib/calibrator.py
@@ -68,6 +68,14 @@ class _Calibrator:
         """
         raise NotImplementedError
 
+    def compute_quant_amax(self, *args, **kwargs):
+        """Per-block quantization amax for Decoupled Scale Search, or ``None`` if unsupported.
+
+        Only calibrators that decouple the quantization scale from the stored dequantization
+        scale (e.g. :class:`NVFP4DSSCalibrator`) return a tensor; all others use the default.
+        """
+        return None
+
     def __repr__(self):
         s = "num_bits={_num_bits}"
         s += " axis={_axis}"

--- a/modelopt/torch/quantization/calib/mse.py
+++ b/modelopt/torch/quantization/calib/mse.py
@@ -25,7 +25,7 @@ import torch.nn.functional as F
 from .. import utils as quant_utils
 from .calibrator import _Calibrator
 
-__all__ = ["MseCalibrator", "NVFP4MSECalibrator"]
+__all__ = ["MseCalibrator", "NVFP4DSSCalibrator", "NVFP4MSECalibrator"]
 
 
 class MseCalibrator(_Calibrator):
@@ -38,7 +38,7 @@ class MseCalibrator(_Calibrator):
         step_size: float = 0.1,
         start_multiplier: float = 0.25,
         stop_multiplier: float = 4.0,
-        quant_func: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None = None,
+        quant_func: Callable[..., torch.Tensor] | None = None,
         error_func: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None = None,
     ):
         """Initialize MSE calibrator.
@@ -80,6 +80,15 @@ class MseCalibrator(_Calibrator):
             candidates = candidates.view_as(self._initial_amax)
         return self._initial_amax * candidates
 
+    def _reduced_loss(self, x: torch.Tensor, xq: torch.Tensor, reduce_axis) -> torch.Tensor:
+        """Error between ``x`` and ``xq`` reduced over the quantization axes (metric-aware)."""
+        error = (
+            self._error_func(x, xq)
+            if self._error_func is not None
+            else F.mse_loss(x, xq, reduction="none")
+        )
+        return quant_utils.reduce_sum(error, axis=reduce_axis, keepdims=False)
+
     @torch.no_grad()
     def collect(self, x: torch.Tensor):
         """Collect input tensor statistics and compute losses for MSE calibration.
@@ -105,13 +114,7 @@ class MseCalibrator(_Calibrator):
         for step, candidate in enumerate(candidates):
             candidate_amax = self._compute_candidate_amax(candidate)
             xq = self._quant_func(x, candidate_amax)
-
-            if self._error_func is not None:
-                error = self._error_func(x, xq)
-            else:
-                error = F.mse_loss(x, xq, reduction="none")
-
-            loss = quant_utils.reduce_sum(error, axis=reduce_axis, keepdims=False)
+            loss = self._reduced_loss(x, xq, reduce_axis)
 
             if self._losses_sum[step] is None:
                 self._losses_sum[step] = loss.clone()
@@ -309,3 +312,122 @@ class NVFP4MSECalibrator(MseCalibrator):
         self._losses_sum = None
         self._candidates = None
         self._amax = None
+
+
+def default_dss_betas(step: float = 0.05) -> torch.Tensor:
+    """Quant-scale multipliers ``s_q = beta * s_d`` centered on ``1.0`` and spanning ``[0.5, 1.5]``.
+
+    Built symmetrically around 1.0 so the coupled reference (``beta == 1``) is always searched;
+    ``step`` trades search density for calibration cost. The span is exactly ``[0.5, 1.5]`` when
+    ``0.5 / step`` is an integer (e.g. the recommended ``0.05`` or ``0.01``); otherwise it is the
+    nearest symmetric grid. ``step`` is bounded to a sane range so a stray value can't build a
+    multi-million-entry grid (which would make calibration hang).
+    """
+    if step is None or not (0.005 <= step <= 0.5):
+        raise ValueError(f"dss_beta_step must be in [0.005, 0.5]; got {step!r}")
+    n = round(0.5 / step)
+    return 1.0 + torch.arange(-n, n + 1, dtype=torch.float32) * step
+
+
+class NVFP4DSSCalibrator(NVFP4MSECalibrator):
+    """Decoupled Scale Search (DSS) calibrator for NVFP4 static weights (SOAR, arXiv:2605.12245).
+
+    Extends the coupled per-block sweep with a decoupled ``(s_d, s_q)`` search under a custom
+    (typically local-Hessian) ``error_func``: the FP4 codes are chosen with a high-precision
+    quantization scale ``s_q = beta * s_d`` while reconstruction uses the FP8-representable stored
+    scale ``s_d``. Following SOAR, the dequant scale is searched over the coupled optimum's nearest
+    FP8 neighbors while ``s_q`` sweeps a multiplicative ``beta`` grid.
+
+    Because ``beta == 1`` at the coupled optimum is always in the search, the result never does
+    worse than the coupled sweep. Populates ``compute_amax`` (``s_d`` amax -> ``_amax``) and
+    ``compute_quant_amax`` (``s_q`` amax -> the quantizer's ``_quant_amax``).
+    """
+
+    _SD_NEIGHBOR_OFFSETS = (-1, 0, 1)
+
+    def __init__(
+        self,
+        amax: torch.Tensor,
+        global_amax: torch.Tensor,
+        axis: int | tuple | list | None = None,
+        quant_func: Callable | None = None,
+        error_func: Callable | None = None,
+        betas: torch.Tensor | None = None,
+    ):
+        """Initialize the DSS calibrator; ``betas`` defaults to :func:`default_dss_betas`."""
+        super().__init__(
+            amax=amax,
+            global_amax=global_amax,
+            axis=axis,
+            quant_func=quant_func,
+            error_func=error_func,
+        )
+        self._betas = default_dss_betas() if betas is None else betas.to(dtype=torch.float32)
+        self._best_quant_amax: torch.Tensor | None = None
+
+    def _block_loss(self, x: torch.Tensor, xq: torch.Tensor, reduce_axis) -> torch.Tensor:
+        """Per-block error flattened to ``[num_blocks]`` under the configured metric."""
+        return self._reduced_loss(x, xq, reduce_axis).reshape(-1)
+
+    @torch.no_grad()
+    def collect(self, x: torch.Tensor):
+        """Run the decoupled 2-D search and cache the per-block ``s_d`` and ``s_q`` amaxes."""
+        if self._best_amax is not None:
+            raise RuntimeError(
+                "NVFP4DSSCalibrator: a previous collect() produced final scales; call reset()."
+            )
+        if self._quant_func is None:
+            raise RuntimeError("Quantization function not set.")
+
+        x = x.detach().to(dtype=torch.float32)
+        candidates = self._generate_candidates(x.device)  # FP8 E4M3 values / 448
+        ncand = len(candidates)
+        betas = self._betas.to(x.device)
+        reduce_axis = quant_utils.convert_quantization_axis_to_reduce_axis(x, self._axis)
+        shape = self._initial_amax.shape
+
+        # Step 1 — coupled sweep to locate each block's best FP8 dequant candidate.
+        coupled = torch.stack(
+            [
+                self._block_loss(
+                    x, self._quant_func(x, self._compute_candidate_amax(c)), reduce_axis
+                )
+                for c in candidates
+            ]
+        )  # [ncand, num_blocks]
+        coupled_idx = torch.argmin(coupled, dim=0)  # [num_blocks]
+
+        # Step 2 — decoupled search over the coupled optimum's FP8 neighbors x the beta grid.
+        # Seeded from the coupled optimum (beta == 1), so DSS never does worse than coupling.
+        best_loss = coupled.gather(0, coupled_idx.unsqueeze(0)).squeeze(0)
+        best_amax = self._global_amax * candidates[coupled_idx]  # [num_blocks]
+        best_quant_amax = best_amax
+        for offset in self._SD_NEIGHBOR_OFFSETS:
+            idx = (coupled_idx + offset).clamp(0, ncand - 1)
+            amax_d = self._global_amax * candidates[idx]  # per-block s_d amax [num_blocks]
+            amax_d_arg = amax_d.reshape(shape)  # shape the quant func / quantizer expects
+            for beta in betas:
+                quant_amax = beta * amax_d
+                xq = self._quant_func(x, amax_d_arg, quant_amax=quant_amax.reshape(shape))
+                loss = self._block_loss(x, xq, reduce_axis)
+                better = loss < best_loss
+                best_loss = torch.where(better, loss, best_loss)
+                best_amax = torch.where(better, amax_d, best_amax)
+                best_quant_amax = torch.where(better, quant_amax, best_quant_amax)
+
+        self._best_amax = best_amax.reshape(shape).to(dtype=torch.float32)
+        self._best_quant_amax = best_quant_amax.reshape(shape).to(dtype=torch.float32)
+        # Sync before the next weight so this weight's ~189 async sweeps and the [ncand, num_blocks]
+        # transients drain instead of piling up across weights (mirrors the reference sweep path).
+        if x.is_cuda:
+            torch.cuda.synchronize(x.device)
+
+    @torch.no_grad()
+    def compute_quant_amax(self):
+        """Return the cached per-block quantization amax (``s_q`` scale * 6)."""
+        return self._best_quant_amax
+
+    def reset(self):
+        """Reset per-cycle state (keeps ``_initial_amax`` and ``_betas`` for reuse)."""
+        super().reset()
+        self._best_quant_amax = None

--- a/modelopt/torch/quantization/config.py
+++ b/modelopt/torch/quantization/config.py
@@ -1106,6 +1106,24 @@ class LocalHessianCalibConfig(_SharedStatesConfig, QuantizeAlgorithmConfig):
         description="If True, module's local Hessian metadata will be kept as a module attribute.",
     )
 
+    decoupled_scale_search: bool | None = ModeloptField(
+        default=False,
+        title="Enable Decoupled Scale Search (DSS) for NVFP4 static weights.",
+        description="If True, decouple the FP4 quantization scale (high precision) from the stored "
+        "FP8 dequantization scale (SOAR, arXiv:2605.12245), searching per block for the pair that "
+        "minimizes the local-Hessian error. Only affects ModelOpt static NVFP4 weights with a "
+        "Hessian error function; other quantizers use the coupled sweep.",
+    )
+
+    dss_beta_step: float | None = ModeloptField(
+        default=0.05,
+        gt=0.0,
+        title="Quantization-scale grid step for Decoupled Scale Search.",
+        description="Step of the multiplicative quant-scale grid s_q = beta * s_d over [0.5, 1.5] "
+        "(smaller = denser search, higher calibration cost). Only used when "
+        "decoupled_scale_search is True.",
+    )
+
 
 class SmoothQuantCalibConfig(QuantizeAlgorithmConfig):
     """The config for ``smoothquant`` algorithm (SmoothQuant).

--- a/modelopt/torch/quantization/model_calib.py
+++ b/modelopt/torch/quantization/model_calib.py
@@ -41,7 +41,8 @@ from modelopt.torch.utils.distributed import is_initialized as dist_is_initializ
 from modelopt.torch.utils.distributed import size as dist_size
 from modelopt.torch.utils.network import bind_forward_method, unpatch_forward_method
 
-from .calib import MseCalibrator, NVFP4MSECalibrator, _Calibrator
+from .calib import MseCalibrator, NVFP4DSSCalibrator, NVFP4MSECalibrator, _Calibrator
+from .calib.mse import default_dss_betas
 from .conversion import create_and_replace_svdquant_linear_on_the_fly, set_quantizer_by_cfg_context
 from .nn import QuantModule, SequentialQuantizer, StaticBlockScaleQuantizer, TensorQuantizer
 from .utils import (
@@ -490,10 +491,20 @@ def max_calibrate(
     _finalize_with_shared_state(model, weight_patterns)
 
 
-def _mse_quant_func(x, amax, quantizer):
-    """Quantization function for MSE calibration."""
+def _mse_quant_func(x, amax, quantizer, quant_amax=None):
+    """Quantization function for MSE calibration.
+
+    ``quant_amax`` (Decoupled Scale Search) temporarily sets the quantizer's per-block
+    quantization amax so codes are chosen with ``quant_amax / 6`` while reconstruction uses the
+    ``amax``-derived (FP8) scale. ``quant_amax=None`` forces coupled behavior for this call,
+    neutralizing any ``_quant_amax`` left over from an earlier DSS pass so the coupled sweep is
+    never silently decoupled.
+    """
     original_amax = quantizer._amax.clone() if hasattr(quantizer, "_amax") else None
     quantizer._amax = amax
+    had_quant_amax = hasattr(quantizer, "_quant_amax")
+    original_quant_amax = quantizer._quant_amax if had_quant_amax else None
+    quantizer._quant_amax = quant_amax  # None -> coupled forward regardless of prior state
 
     try:
         with (
@@ -512,6 +523,10 @@ def _mse_quant_func(x, amax, quantizer):
             quantizer._amax = original_amax
         else:
             delattr(quantizer, "_amax")
+        if had_quant_amax:
+            quantizer._quant_amax = original_quant_amax
+        else:
+            delattr(quantizer, "_quant_amax")
 
     return xq
 
@@ -524,12 +539,16 @@ def _make_weight_mse_calibrator(
     fp8_scale_sweep: bool,
     error_func: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None = None,
     hessian: torch.Tensor | None = None,
+    decoupled_scale_search: bool = False,
+    dss_betas: torch.Tensor | None = None,
 ) -> _Calibrator | None:
     """Create the MSE calibrator for one eligible weight quantizer (``None`` if ineligible).
 
     ``error_func`` overrides the squared-error metric (local-Hessian's per-block weighting).
     ``hessian`` (the same per-cin-block metric as a raw tensor) enables NVFP4's Hessian-weighted
-    Triton fast path; ``error_func`` then serves only as the reference fallback.
+    Triton fast path; ``error_func`` then serves only as the reference fallback. When
+    ``decoupled_scale_search`` is set (and an ``error_func`` is present), NVFP4 static weights use
+    :class:`NVFP4DSSCalibrator` to search decoupled quant/dequant scales.
     """
     if (
         not isinstance(weight_quantizer, TensorQuantizer)
@@ -560,6 +579,17 @@ def _make_weight_mse_calibrator(
                 return None
             return backend_factory(initial_amax, axis, quant_func)
         if _uses_modelopt_fp8_weight_scales(weight_quantizer):
+            # DSS only changes the result under a non-separable metric; for plain squared error
+            # it is a provable no-op, so fall back to the coupled calibrator when error_func is None.
+            if decoupled_scale_search and error_func is not None:
+                return NVFP4DSSCalibrator(
+                    amax=initial_amax,
+                    axis=axis,
+                    global_amax=weight_quantizer.global_amax,
+                    quant_func=quant_func,
+                    error_func=error_func,
+                    betas=dss_betas,
+                )
             return NVFP4MSECalibrator(
                 amax=initial_amax,
                 axis=axis,
@@ -640,13 +670,16 @@ def _mse_calibrate_weights(
     fp8_scale_sweep: bool,
     error_func_for: Callable[[TensorQuantizer], Callable | None] | None = None,
     hessian_for: Callable[[TensorQuantizer], torch.Tensor | None] | None = None,
+    decoupled_scale_search: bool = False,
+    dss_betas: torch.Tensor | None = None,
 ):
     """Run MSE weight calibration over all eligible quantizers (shared by mse / local-Hessian).
 
     ``error_func_for`` maps a weight quantizer to an optional per-weight error function
     (local-Hessian's Hessian metric); ``None`` means plain squared error. ``hessian_for``
     maps a weight quantizer to the same metric as a raw per-cin-block Hessian tensor,
-    enabling the Hessian-weighted Triton fast path.
+    enabling the Hessian-weighted Triton fast path. ``decoupled_scale_search`` enables the DSS
+    calibrator (NVFP4 static weights with an error function).
     """
     seen_modules: set[int] = set()
     pbar = tqdm(desc="MSE weight calibration")
@@ -666,6 +699,8 @@ def _mse_calibrate_weights(
                     fp8_scale_sweep,
                     error_func=error_func,
                     hessian=hessian,
+                    decoupled_scale_search=decoupled_scale_search,
+                    dss_betas=dss_betas,
                 )
                 if cal is None:
                     continue
@@ -673,6 +708,13 @@ def _mse_calibrate_weights(
                 _run_and_load_max_stats(
                     weight_quantizer, partial(_collect_weight_stats, weight=weight)
                 )
+                # DSS: persist the decoupled quantization scale (read before reset() clears it);
+                # otherwise clear any scale left over from a previous DSS calibration of this weight.
+                quant_amax = cal.compute_quant_amax()
+                if quant_amax is not None:
+                    weight_quantizer.quant_amax = quant_amax
+                elif getattr(weight_quantizer, "quant_amax", None) is not None:
+                    weight_quantizer.quant_amax = None
                 if hasattr(cal, "reset"):
                     cal.reset()
 
@@ -867,6 +909,8 @@ def local_hessian_calibrate(
     block_size: int = 16,
     debug: bool = False,
     shared_states: Mapping[str, Mapping[str, Sequence[str]]] | None = None,
+    decoupled_scale_search: bool = False,
+    dss_beta_step: float = 0.05,
 ):
     """Calibrate weight quantizers by minimizing the Hessian-weighted error.
 
@@ -892,6 +936,10 @@ def local_hessian_calibrate(
         block_size: Block size for local Hessian computation (default: 16).
         debug: If True, retain the per-quantizer Hessian accumulators on the model
             (``model._local_hessian_accumulators``) for inspection.
+        decoupled_scale_search: If True, use Decoupled Scale Search (DSS) for NVFP4 static
+            weights — search a high-precision quantization scale separately from the stored FP8
+            dequantization scale (default: False).
+        dss_beta_step: Step of the DSS quant-scale grid over [0.5, 1.5] (default: 0.05).
 
     See :class:`LocalHessianCalibConfig <modelopt.torch.quantization.config.LocalHessianCalibConfig>`
     for details on the configuration options.
@@ -949,6 +997,7 @@ def local_hessian_calibrate(
     }
     hessians = {qid: acc.normalized_hessian() for qid, acc in accumulators.items()}
     print_rank_0("local_hessian: Running MSE calibration with local Hessian loss...")
+    dss_betas = default_dss_betas(dss_beta_step or 0.05) if decoupled_scale_search else None
     _mse_calibrate_weights(
         model,
         name_to_module,
@@ -958,6 +1007,8 @@ def local_hessian_calibrate(
         fp8_scale_sweep=fp8_scale_sweep,
         error_func_for=lambda q: error_funcs.get(id(q)),
         hessian_for=lambda q: hessians.get(id(q)),
+        decoupled_scale_search=decoupled_scale_search,
+        dss_betas=dss_betas,
     )
 
     # Release the per-block Hessians (held by the error_func closures, calibrators, and the

--- a/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
+++ b/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
@@ -1511,6 +1511,9 @@ class StaticBlockScaleQuantizer(TensorQuantizer):
                 global_amax.data = global_amax.to(dtype=torch.float32)
             else:
                 self._global_amax = global_amax.to(dtype=torch.float32)
+        quant_amax = getattr(self, "_quant_amax", None)
+        if quant_amax is not None:
+            self._quant_amax = quant_amax.to(dtype=torch.float32)
 
     def _amax_setter_helper(self, value):
         super()._amax_setter_helper(value)
@@ -1543,6 +1546,22 @@ class StaticBlockScaleQuantizer(TensorQuantizer):
         tq._quant_max_bound = float(tq.maxbound)
         _preserve_and_set_global_amax(tq)
         return tq
+
+    def _set_lazy_amax_buffer(self, name: str, value):
+        """Set/update a lazily-registered fp32 scale buffer (``_global_amax``/``_quant_amax``)."""
+        if value is None:
+            if hasattr(self, name):
+                setattr(self, name, None)
+            return
+        if not isinstance(value, torch.Tensor):
+            value = torch.tensor(value)
+
+        buffer = getattr(self, name, None)
+        if buffer is None:
+            self.register_buffer(name, value.clone().detach())
+        else:
+            buffer.data.copy_(value.clone().detach().to(buffer.device))
+        self._preserve_amax_in_fp32()
 
     @property
     def amax_pre(self):
@@ -1586,20 +1605,20 @@ class StaticBlockScaleQuantizer(TensorQuantizer):
 
     @global_amax.setter
     def global_amax(self, value):
-        if value is None:
-            if hasattr(self, "_global_amax"):
-                self._global_amax = None
-            return
-        if not isinstance(value, torch.Tensor):
-            value = torch.tensor(value)
+        self._set_lazy_amax_buffer("_global_amax", value)
 
-        global_amax = getattr(self, "_global_amax", None)
-        if global_amax is None:
-            self.register_buffer("_global_amax", value.clone().detach())
-            global_amax = self._global_amax
-        else:
-            global_amax.data.copy_(value.clone().detach().to(global_amax.device))
-        self._preserve_amax_in_fp32()
+    @property
+    def quant_amax(self):
+        """Per-block *quantization* amax for Decoupled Scale Search (``None`` if unset).
+
+        When present, codes are chosen with the high-precision scale ``quant_amax / 6`` while
+        the stored/dequant scale is derived from ``_amax`` (coupled behavior when unset).
+        """
+        return getattr(self, "_quant_amax", None)
+
+    @quant_amax.setter
+    def quant_amax(self, value):
+        self._set_lazy_amax_buffer("_quant_amax", value)
 
     @property
     def has_quantized_block_scale(self):
@@ -1610,6 +1629,7 @@ class StaticBlockScaleQuantizer(TensorQuantizer):
         """Apply module transforms without rounding static scale state."""
         amax = getattr(self, "_amax", None)
         global_amax = getattr(self, "_global_amax", None)
+        quant_amax = getattr(self, "_quant_amax", None)
 
         module = super()._apply(fn, recurse=recurse)
         self._preserve_amax_in_fp32()
@@ -1617,6 +1637,8 @@ class StaticBlockScaleQuantizer(TensorQuantizer):
             self.amax = amax
         if global_amax is not None and global_amax.device.type != "meta":
             self.global_amax = global_amax
+        if quant_amax is not None:
+            self.quant_amax = quant_amax
         return module
 
     def _short_amax(self, fmt=".4f"):
@@ -1726,6 +1748,7 @@ class StaticBlockScaleQuantizer(TensorQuantizer):
                 fp8_max_for_normalization(self),
                 inputs.dtype,
                 self._pass_through_bwd,
+                self.quant_amax,  # None -> coupled; else DSS decoupled rounding
             )
         return super()._fake_quantize(inputs)
 

--- a/modelopt/torch/quantization/qtensor/nvfp4_tensor.py
+++ b/modelopt/torch/quantization/qtensor/nvfp4_tensor.py
@@ -108,6 +108,25 @@ class NVFP4QTensor(BaseQuantizedTensor):
             return weight_quantizer._amax.float() / (E2M1_MAX * m_fp8)
 
     @classmethod
+    def get_weights_quant_scaling_factor_from_quantizer(
+        cls, weight_quantizer, weight: torch.Tensor
+    ) -> torch.Tensor | None:
+        """Return the per-block *quantization* scale ``s_q = quant_amax / 6`` for DSS export.
+
+        Decoupled Scale Search (DSS) picks FP4 codes with this high-precision scale while storing
+        the FP8 dequant scale. Returns ``None`` when the quantizer has no ``quant_amax`` (coupled),
+        so callers fall back to the standard single-scale path.
+        """
+        quant_amax = getattr(weight_quantizer, "quant_amax", None)
+        if quant_amax is None:
+            return None
+        block_size = weight_quantizer.block_sizes[-1]
+        per_block_quant_scale = quant_amax.float() / E2M1_MAX
+        per_block_quant_scale[per_block_quant_scale == 0] = 1.0
+        num_blocks_per_row = weight.shape[-1] // block_size
+        return per_block_quant_scale.view((*weight.shape[:-1], num_blocks_per_row))
+
+    @classmethod
     def get_weights_scaling_factor_from_quantizer(
         cls,
         weight_quantizer,
@@ -258,6 +277,7 @@ class NVFP4QTensor(BaseQuantizedTensor):
         weights_scaling_factor_2: torch.Tensor | None = None,
         keep_high_precision: bool = False,
         try_tensorrt: bool = False,
+        quant_scaling_factor: torch.Tensor | None = None,
     ):
         """Converting a tensor to a quantized format based on NVFP4 quantization.
 
@@ -267,6 +287,10 @@ class NVFP4QTensor(BaseQuantizedTensor):
             weights_scaling_factor (torch.Tensor): The scaling factor for the weights.
             weights_scaling_factor_2 (torch.Tensor): The scaling factor for the weights.
             keep_high_precision (bool): Whether to keep output scales at high precision.
+            quant_scaling_factor (torch.Tensor): Optional absolute per-block *quantization* scale
+                (``quant_amax / 6``) for Decoupled Scale Search. When given, FP4 codes are chosen
+                by dividing by this high-precision scale, while the stored/returned scale remains
+                ``weights_scaling_factor`` (the FP8 dequant scale). ``None`` keeps coupling.
 
         Returns:
         tuple: Contains quantized data, quantized per block scaling factor, and per tensor scaling factor.
@@ -321,10 +345,14 @@ class NVFP4QTensor(BaseQuantizedTensor):
         original_shape = input.shape
         input = input.view((*tuple(input.shape[:-1]), -1, block_size))
 
-        # Scale weights
-        scaled_weight = input / (
-            (weights_scaling_factor.to(torch.float32) * weights_scaling_factor_2).unsqueeze(-1)
-        )
+        # Scale weights. DSS: choose codes with the high-precision quant scale (absolute), but keep
+        # weights_scaling_factor (the FP8 dequant scale) as the stored/returned scale.
+        round_divisor = (
+            quant_scaling_factor.to(torch.float32)
+            if quant_scaling_factor is not None
+            else weights_scaling_factor.to(torch.float32) * weights_scaling_factor_2
+        ).unsqueeze(-1)
+        scaled_weight = input / round_divisor
 
         # Reshape weights to original
         scaled_weight = scaled_weight.view(original_shape)

--- a/modelopt/torch/quantization/tensor_quant.py
+++ b/modelopt/torch/quantization/tensor_quant.py
@@ -581,6 +581,7 @@ class StaticBlockwiseFP4FakeQuantFunction(Function):
         fp8_max_for_normalization=E4M3_MAX,
         out_dtype=None,
         pass_through_bwd=False,
+        quant_amax=None,
     ):
         """Forward method."""
         if not triton_kernel.IS_AVAILABLE:
@@ -596,6 +597,7 @@ class StaticBlockwiseFP4FakeQuantFunction(Function):
             quantize_block_scales,
             fp8_max_for_normalization,
             out_dtype,
+            quant_amax=quant_amax,
         )
 
     @staticmethod

--- a/tests/gpu/torch/quantization/test_nvfp4_dss_diag_kernel.py
+++ b/tests/gpu/torch/quantization/test_nvfp4_dss_diag_kernel.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parity probe for Decoupled Scale Search (DSS) on the NVFP4 weight-MSE FP8 sweep.
+
+DSS decouples the FP4 quantization scale ``s_q`` from the FP8-constrained dequantization
+scale ``s_d``. For the plain per-block weight-L2 objective, the existing sweep already
+enumerates every FP8 ``s_d`` with its per-element-optimal coupled assignment, so DSS cannot
+reduce the loss: for any fixed ``s_d`` the best ``s_q`` is ``s_d`` itself (``beta == 1``).
+
+These tests pin that proof: ``dss_loss`` must never beat ``coupled_loss`` by more than fp32
+noise, on both random weights and the SOAR-style regression example where the *continuous*
+optimal scale falls between two FP8 values.
+"""
+
+import pytest
+import torch
+from conftest import requires_triton
+
+from modelopt.torch.kernels.quantization.gemm import default_dss_betas, nvfp4_dss_diag_sweep
+
+BLOCK_SIZE = 16
+
+
+def _rel_improvement(coupled_loss, dss_loss):
+    """Relative loss reduction DSS achieves over coupling, per block (>= 0 by construction)."""
+    return (coupled_loss - dss_loss) / coupled_loss.clamp_min(1e-12)
+
+
+@requires_triton
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("num_blocks", [4, 4096])
+@pytest.mark.parametrize("seed", [0, 1])
+def test_dss_is_parity_on_random_weights(seed, num_blocks, dtype):
+    """On random weights, DSS must not beat the coupled sweep beyond fp32 tie-break noise."""
+    torch.manual_seed(seed)
+    x = torch.randn(num_blocks, BLOCK_SIZE, device="cuda", dtype=dtype)
+    global_amax = x.float().abs().max()
+    betas = default_dss_betas("cuda")
+
+    coupled_loss, dss_loss, best_beta = nvfp4_dss_diag_sweep(x, global_amax, betas, BLOCK_SIZE)
+
+    # By construction (beta == 1 is in the grid) DSS is never worse.
+    assert torch.all(dss_loss <= coupled_loss + 1e-6)
+    # The substantive claim: the improvement is fp-noise, not a real gain.
+    worst = _rel_improvement(coupled_loss, dss_loss).max().item()
+    assert worst < 1e-5, (
+        f"DSS beat coupling by relative {worst:.3e} on random weights — exceeds tie-break "
+        f"noise; the L2-parity proof would be violated. beta!=1 on "
+        f"{int((best_beta != 1.0).sum())}/{num_blocks} blocks."
+    )
+
+
+@requires_triton
+def test_dss_parity_on_soar_regression_example():
+    """SOAR's intuition case: block whose continuous-optimal scale lies between FP8 values.
+
+    Even here DSS reproduces the coupled loss, because the dequant scale must still snap to
+    FP8 and coupling at that FP8 scale already yields the per-element-optimal codes.
+    """
+    # [1, 1, 1, 1.8]-style block padded to BLOCK_SIZE; mild magnitude spread.
+    block = torch.tensor([1.0, 1.0, 1.0, 1.8] * 4, device="cuda", dtype=torch.float32)
+    x = block.view(1, BLOCK_SIZE)
+    global_amax = x.abs().max()
+    betas = default_dss_betas("cuda")
+
+    coupled_loss, dss_loss, _ = nvfp4_dss_diag_sweep(x, global_amax, betas, BLOCK_SIZE)
+
+    assert dss_loss.item() <= coupled_loss.item() + 1e-6
+    assert _rel_improvement(coupled_loss, dss_loss).item() < 1e-5
+
+
+@requires_triton
+def test_coupled_loss_matches_reference_sweep_amax():
+    """``coupled_loss`` (beta == 1 slice) must equal the loss of the existing sweep's amax.
+
+    Ties the diagnostic's coupled baseline to ``nvfp4_fp8_scale_sweep``'s chosen per-block
+    amax, so the reported gap is genuinely DSS-vs-today, not two different baselines.
+    """
+    from modelopt.torch.kernels.quantization.gemm import nvfp4_fp8_scale_sweep
+    from modelopt.torch.quantization.tensor_quant import static_blockwise_fp4_fake_quant
+
+    torch.manual_seed(3)
+    num_blocks = 256
+    x = torch.randn(num_blocks, BLOCK_SIZE, device="cuda", dtype=torch.float32)
+    global_amax = x.abs().max()
+    betas = default_dss_betas("cuda")
+
+    coupled_loss, _, _ = nvfp4_dss_diag_sweep(x, global_amax, betas, BLOCK_SIZE)
+
+    sweep_amax = nvfp4_fp8_scale_sweep(x, global_amax, block_size=BLOCK_SIZE).reshape(num_blocks)
+    xq = static_blockwise_fp4_fake_quant(x, sweep_amax, global_amax)
+    ref_loss = (x - xq).pow(2).sum(dim=-1)
+
+    rel = (coupled_loss - ref_loss).abs() / ref_loss.clamp_min(1e-12)
+    assert rel.max().item() < 1e-5, f"coupled_loss diverged from sweep amax loss: {rel.max():.3e}"
+
+
+@requires_triton
+def test_betas_must_contain_exactly_one_unit():
+    """The coupled reference requires exactly one beta == 1.0."""
+    x = torch.randn(8, BLOCK_SIZE, device="cuda")
+    g = x.abs().max()
+
+    with pytest.raises(ValueError, match="exactly one"):
+        nvfp4_dss_diag_sweep(x, g, torch.tensor([0.9, 1.1], device="cuda"), BLOCK_SIZE)

--- a/tests/gpu/torch/quantization/test_nvfp4_dss_local_hessian.py
+++ b/tests/gpu/torch/quantization/test_nvfp4_dss_local_hessian.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Decoupled Scale Search (DSS) for NVFP4 static weights, targeted at the local-Hessian objective.
+
+DSS decouples the FP4 quantization scale ``s_q`` (high precision) from the stored FP8
+dequantization scale ``s_d``. For a *separable* (diagonal) metric this is a no-op — per-element
+coupled rounding is already optimal — but for a *non-separable* (off-diagonal Hessian) metric it
+can strictly reduce the block error. These tests pin both, plus the two-scale fake-quant primitive
+and the decoupled export round-trip.
+"""
+
+import pytest
+import torch
+from conftest import requires_triton
+
+from modelopt.torch.kernels.quantization.gemm.fp4_kernel import (
+    compute_fp4_scales,
+    static_blockwise_fp4_fake_quant,
+)
+from modelopt.torch.quantization.calib import NVFP4DSSCalibrator, NVFP4MSECalibrator
+from modelopt.torch.quantization.calib.mse import default_dss_betas
+
+BLOCK_SIZE = 16
+
+
+def test_default_dss_betas_grid_and_guards():
+    """The beta grid is centered on an exact 1.0, and absurd/None steps fail fast (not hang)."""
+    betas = default_dss_betas(0.05)
+    assert int((betas == 1.0).sum()) == 1  # exactly one coupled reference
+    assert float(betas.min()) == pytest.approx(0.5) and float(betas.max()) == pytest.approx(1.5)
+    # Out-of-range / None steps raise instead of building a giant grid or crashing on round(0.5/None).
+    for bad in (None, 1e-6, 0.6, 0.0, -0.05):
+        with pytest.raises(ValueError, match="dss_beta_step"):
+            default_dss_betas(bad)
+
+
+FP4_LEVELS = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
+
+
+def _round_fp4(a):
+    lv = FP4_LEVELS.to(a.device)
+    return lv[(a.unsqueeze(-1) - lv).abs().argmin(-1)]
+
+
+# --------------------------------------------------------------------------------------------
+# Two-scale fake-quant primitive
+# --------------------------------------------------------------------------------------------
+@requires_triton
+def test_two_scale_fake_quant_matches_manual_reference():
+    """``quant_amax`` rounds codes with ``s_q`` but reconstructs with the FP8 ``s_d``."""
+    torch.manual_seed(0)
+    x = torch.randn(128, BLOCK_SIZE, device="cuda")
+    amax = x.abs().amax(-1)
+    g = amax.max()
+    quant_amax = amax * 1.3
+
+    y = static_blockwise_fp4_fake_quant(x, amax, g, quant_amax=quant_amax)
+
+    s_q = (quant_amax / 6.0).unsqueeze(-1)
+    s_d = compute_fp4_scales(amax, g, True).unsqueeze(-1)  # FP8(amax/6)
+    ref = torch.sign(x) * _round_fp4(x.abs() / s_q) * s_d
+    assert torch.allclose(y, ref, atol=1e-5), f"maxdiff {(y - ref).abs().max().item():.3e}"
+
+
+@requires_triton
+def test_two_scale_fake_quant_beta_one_matches_coupled_for_fp8_exact_sd():
+    """With an FP8-exact ``s_d`` and ``quant_amax == amax``, DSS reproduces the coupled result."""
+    torch.manual_seed(1)
+    x = torch.randn(64, BLOCK_SIZE, device="cuda")
+    amax = x.abs().amax(-1)
+    g = amax.max()
+    # Snap amax so amax/6 is exactly FP8-representable (what the calibrated s_d candidates are).
+    amax_exact = compute_fp4_scales(amax, g, True) * 6.0
+
+    coupled = static_blockwise_fp4_fake_quant(x, amax_exact, g)
+    dss = static_blockwise_fp4_fake_quant(x, amax_exact, g, quant_amax=amax_exact)
+    assert torch.equal(coupled, dss)
+
+
+# --------------------------------------------------------------------------------------------
+# DSS calibrator: helps the non-separable metric, ties the separable one
+# --------------------------------------------------------------------------------------------
+def _dss_quant_func(global_amax):
+    def quant_func(x, amax, quant_amax=None):
+        return static_blockwise_fp4_fake_quant(
+            x, amax, global_amax, out_dtype=x.dtype, quant_amax=quant_amax
+        )
+
+    return quant_func
+
+
+def _hessian_error_func(hessian):
+    """Per-block ``dwᵀ H dw`` expanded to element shape (row-sum == the quadratic form * bs)."""
+
+    def error_func(x, xq):
+        dw = (x - xq).to(torch.float32)  # [n_blocks, bs]
+        qf = torch.einsum("nb,bd,nd->n", dw, hessian, dw)  # [n_blocks]
+        return qf.unsqueeze(-1).expand(-1, dw.shape[-1])
+
+    return error_func
+
+
+def _achieved_loss(x, quant_func, amax, error_func, quant_amax=None):
+    xq = quant_func(x, amax, quant_amax=quant_amax)
+    return float(error_func(x, xq)[:, 0].sum())  # column 0 == per-block qf; sum over blocks
+
+
+@requires_triton
+@pytest.mark.parametrize("off_diagonal", [False, True])
+def test_dss_calibrator_vs_coupled(off_diagonal):
+    """DSS never loses to coupled; it strictly wins only for a non-separable (off-diagonal) H."""
+    torch.manual_seed(7)
+    device = "cuda"
+    n_blocks = 512
+    x = torch.randn(n_blocks, BLOCK_SIZE, device=device)
+    per_block_amax = x.abs().amax(-1)
+    global_amax = per_block_amax.max()
+    quant_func = _dss_quant_func(global_amax)
+
+    if off_diagonal:
+        a = torch.randn(BLOCK_SIZE, BLOCK_SIZE, device=device)
+        hessian = a @ a.t() + BLOCK_SIZE * torch.eye(BLOCK_SIZE, device=device)  # SPD, off-diagonal
+    else:
+        hessian = torch.diag(torch.rand(BLOCK_SIZE, device=device) + 0.5)  # SPD, diagonal
+    error_func = _hessian_error_func(hessian)
+
+    # Coupled baseline.
+    coupled_cal = NVFP4MSECalibrator(
+        amax=per_block_amax.clone(),
+        axis=0,
+        global_amax=global_amax,
+        quant_func=quant_func,
+        error_func=error_func,
+    )
+    coupled_cal.collect(x)
+    coupled_amax = coupled_cal.compute_amax()
+    coupled_loss = _achieved_loss(x, quant_func, coupled_amax, error_func)
+
+    # DSS.
+    dss_cal = NVFP4DSSCalibrator(
+        amax=per_block_amax.clone(),
+        axis=0,
+        global_amax=global_amax,
+        quant_func=quant_func,
+        error_func=error_func,
+        betas=default_dss_betas(0.05),
+    )
+    dss_cal.collect(x)
+    dss_amax = dss_cal.compute_amax()
+    dss_quant_amax = dss_cal.compute_quant_amax()
+    dss_loss = _achieved_loss(x, quant_func, dss_amax, error_func, quant_amax=dss_quant_amax)
+
+    assert dss_quant_amax is not None and dss_quant_amax.shape == dss_amax.shape
+    # DSS is never worse than coupled (beta == 1 at the coupled optimum is always searched).
+    assert dss_loss <= coupled_loss * (1 + 1e-5)
+
+    if off_diagonal:
+        # Non-separable metric: decoupling should strictly help, and pick s_q != s_d somewhere.
+        assert dss_loss < coupled_loss, f"dss {dss_loss:.6f} !< coupled {coupled_loss:.6f}"
+        assert not torch.allclose(dss_quant_amax, dss_amax)
+    else:
+        # Separable metric: coupled rounding is per-element optimal -> DSS ties it.
+        assert dss_loss == pytest.approx(coupled_loss, rel=1e-5)
+
+
+# --------------------------------------------------------------------------------------------
+# Decoupled export round-trip (deploy parity)
+# --------------------------------------------------------------------------------------------
+@requires_triton
+def test_decoupled_export_matches_fake_quant():
+    """NVFP4 export with a quant scale reproduces the two-scale fake-quant reconstruction.
+
+    The stored codes come from ``s_q`` and the stored scale is ``s_d``; dequantizing
+    ``codes * s_d`` must equal ``static_blockwise_fp4_fake_quant(..., quant_amax=s_q*6)`` — so a
+    standard NVFP4 runtime (which computes ``code * scale``) sees the DSS result.
+    """
+    from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
+
+    torch.manual_seed(3)
+    cout, cin = 32, 128
+    weight = torch.randn(cout, cin, device="cuda")
+    n_blocks = cout * (cin // BLOCK_SIZE)
+    per_block_amax = weight.reshape(n_blocks, BLOCK_SIZE).abs().amax(-1)
+    global_amax = per_block_amax.max()
+    # FP8-exact s_d (calibrated candidates are), high-precision s_q = 1.2 * s_d.
+    amax_d = compute_fp4_scales(per_block_amax, global_amax, True).reshape(n_blocks) * 6.0
+    quant_amax = amax_d * 1.2
+
+    wsf2 = global_amax.float() / (6.0 * 448.0)
+    wsf = (amax_d / 6.0 / wsf2).reshape(cout, cin // BLOCK_SIZE)  # FP8 units of s_d
+    quant_scale = (quant_amax / 6.0).reshape(cout, cin // BLOCK_SIZE)  # absolute s_q
+
+    qtensor, out_wsf, out_wsf2 = NVFP4QTensor.quantize(
+        weight, BLOCK_SIZE, wsf, wsf2, quant_scaling_factor=quant_scale
+    )
+    dequant = qtensor.dequantize(
+        dtype=torch.float32,
+        scale=out_wsf,
+        double_scale=out_wsf2,
+        block_sizes={-1: BLOCK_SIZE},
+    )
+
+    fq = static_blockwise_fp4_fake_quant(
+        weight, amax_d.reshape(cout, cin // BLOCK_SIZE), global_amax, quant_amax=quant_amax
+    ).float()
+    assert torch.allclose(dequant, fq, atol=1e-4), (
+        f"maxdiff {(dequant - fq).abs().max().item():.3e}"
+    )


### PR DESCRIPTION
DSS (SOAR, arXiv:2605.12245) decouples the FP4 quantization scale s_q (high precision) from the stored FP8 dequantization scale s_d. A diagnostic (examples/llm_ptq/dss_diagnostic.py + the nvfp4_dss_diag kernel) confirmed DSS is a no-op for the plain weight-MSE L2 sweep (the existing 126-candidate FP8 sweep is already optimal, incl. saturated blocks), so DSS is wired into the non-separable local_hessian objective where it provably helps.

- Two-scale fake-quant: nvfp4_scalar_quant_decoupled + static_blockwise_fp4_fake_quant(quant_amax=...)
- NVFP4StaticQuantizer._quant_amax buffer (save/restore/_apply)
- NVFP4DSSCalibrator: SOAR 2-neighbor s_d x beta-grid search under the Hessian error
- decoupled_scale_search + dss_beta_step flags on LocalHessianCalibConfig
- decoupled NVFP4 HF export (codes from s_q, stored FP8 scale s_d); stored format unchanged so inference runtimes need no changes
- tests + e2e driver (examples/llm_ptq/dss_local_hessian_e2e.py)

Known limitation: DSS export/restore is wired for the HF path only; the Megatron export + TP-resize restore paths still produce coupled codes.

### What does this PR do?

Type of change: ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

<!-- Details about the change. -->

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->
