### PR TITLE
fix: handle Qwen3-VL-MoE expert dimensions

### DIFF
--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -884,6 +884,12 @@ class _QuantQwen3VLMoeTextExperts(QuantModule):
             with torch.no_grad():
                 module.weight.data = weight.detach().data.to(dtype=dtype, device=device)
 
+        hidden_dim = getattr(self, "hidden_dim", None)
+        if hidden_dim is None:
+            hidden_dim = getattr(self, "hidden_size", None)
+        if hidden_dim is None:
+            hidden_dim = self.gate_up_proj.shape[-1]
+
         # The attribute name was changed from `intermediate_size` to `intermediate_dim` in
         # https://github.com/huggingface/transformers/commit/0642963ba13f2dae0596fe489415569e1d91fbda
         if hasattr(self, "intermediate_size"):
@@ -891,32 +897,22 @@ class _QuantQwen3VLMoeTextExperts(QuantModule):
         elif hasattr(self, "intermediate_dim"):
             expert_dim = self.intermediate_dim
         else:
-            raise AttributeError("Could not find intermediate dimension size in model")
+            expert_dim = self.gate_up_proj.shape[1] // 2
 
         with init_empty_weights():
             gate_proj = nn.ModuleList(
-                [
-                    nn.Linear(self.hidden_size, expert_dim, bias=False)
-                    for _ in range(self.num_experts)
-                ]
+                [nn.Linear(hidden_dim, expert_dim, bias=False) for _ in range(self.num_experts)]
             )
             up_proj = nn.ModuleList(
-                [
-                    nn.Linear(self.hidden_size, expert_dim, bias=False)
-                    for _ in range(self.num_experts)
-                ]
+                [nn.Linear(hidden_dim, expert_dim, bias=False) for _ in range(self.num_experts)]
             )
             down_proj = nn.ModuleList(
-                [
-                    nn.Linear(expert_dim, self.hidden_size, bias=False)
-                    for _ in range(self.num_experts)
-                ]
+                [nn.Linear(expert_dim, hidden_dim, bias=False) for _ in range(self.num_experts)]
             )
-
         for idx in range(self.num_experts):
-            _copy_weight(gate_proj[idx], self.gate_up_proj[idx, :, :expert_dim].T)
-            _copy_weight(up_proj[idx], self.gate_up_proj[idx, :, expert_dim:].T)
-            _copy_weight(down_proj[idx], self.down_proj[idx, :].T)
+            _copy_weight(gate_proj[idx], self.gate_up_proj[idx, :expert_dim, :])
+            _copy_weight(up_proj[idx], self.gate_up_proj[idx, expert_dim:, :])
+            _copy_weight(down_proj[idx], self.down_proj[idx])
 
         delattr(self, "gate_up_proj")
         delattr(self, "down_proj")
@@ -930,26 +926,26 @@ class _QuantQwen3VLMoeTextExperts(QuantModule):
         routing_weights: torch.Tensor,
         router_indices: torch.Tensor,
     ) -> torch.Tensor:
-        batch_size = hidden_states.shape[0]
-        hidden_states = hidden_states.reshape(-1, self.hidden_size)
+        orig_shape = hidden_states.shape
+        hidden_dim = getattr(self, "hidden_dim", getattr(self, "hidden_size", None))
+        hidden_states = hidden_states.reshape(-1, hidden_dim)
         next_states = torch.zeros_like(hidden_states)
         with torch.no_grad():
             expert_mask = torch.nn.functional.one_hot(router_indices, num_classes=self.num_experts)
             expert_mask = expert_mask.permute(2, 1, 0)
             expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
         for expert_idx in expert_hit:
+            expert_idx = expert_idx[0]
             with torch.no_grad():
-                _, token_idx = torch.where(expert_mask[expert_idx[0]])
+                top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
             current_state = hidden_states[token_idx]
             gate = self.gate_proj[expert_idx](current_state)
             up = self.up_proj[expert_idx](current_state)
             gated_output = up * self.act_fn(gate)
             out = self.down_proj[expert_idx](gated_output)
-            weighted_output = out * routing_weights[token_idx, expert_idx, None]
+            weighted_output = out * routing_weights[token_idx, top_k_pos, None]
             next_states.index_add_(0, token_idx, weighted_output.to(hidden_states.dtype))
-        next_states = next_states.view(batch_size, -1, self.hidden_size)
-
-        return next_states
+        return next_states.view(orig_shape)
 
 
 def _get_fused_expert_intermediate_dim(module):

--- a/tests/unit/torch/quantization/test_qwen3_vl_moe_experts.py
+++ b/tests/unit/torch/quantization/test_qwen3_vl_moe_experts.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+
+import pytest
+import torch
+
+from modelopt.torch.quantization.plugins.huggingface import _QuantQwen3VLMoeTextExperts
+
+try:
+    from transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import Qwen3VLMoeTextExperts
+except ImportError:
+    Qwen3VLMoeTextExperts = None
+
+
+class TinyQwen3VLMoeTextConfig:
+    num_experts = 2
+    hidden_size = 8
+    moe_intermediate_size = 4
+    hidden_act = "silu"
+    _experts_implementation = "eager"
+
+
+def _convert_to_quant_wrapper(module):
+    module.__class__ = type(
+        "QuantQwen3VLMoeTextExpertsForTest",
+        (_QuantQwen3VLMoeTextExperts, Qwen3VLMoeTextExperts),
+        {},
+    )
+    module._setup()
+    return module
+
+
+@pytest.mark.skipif(
+    Qwen3VLMoeTextExperts is None, reason="Qwen3-VL-MoE is not available in transformers"
+)
+def test_qwen3_vl_moe_text_experts_quant_wrapper_matches_hf_forward():
+    torch.manual_seed(0)
+
+    original = Qwen3VLMoeTextExperts(TinyQwen3VLMoeTextConfig())
+    torch.nn.init.normal_(original.gate_up_proj)
+    torch.nn.init.normal_(original.down_proj)
+
+    wrapped = _convert_to_quant_wrapper(copy.deepcopy(original))
+
+    hidden_states = torch.randn(5, TinyQwen3VLMoeTextConfig.hidden_size)
+    top_k_index = torch.tensor([[0], [1], [0], [1], [0]])
+    top_k_weights = torch.ones(5, 1)
+
+    expected = original(hidden_states, top_k_index, top_k_weights)
+    actual = wrapped(hidden_states, top_k_weights, top_k_index)
+
+    torch.testing.assert_close(actual, expected)
+    assert actual.shape == hidden_states.shape


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fixes Qwen3-VL-MoE expert quantization wrapper handling for Hugging Face `Qwen3VLMoeTextExperts`.

The wrapper previously assumed the expert module exposed `hidden_size`, but the current Hugging Face implementation exposes `hidden_dim`. It also split `gate_up_proj` along the wrong dimension and transposed fused expert weights incorrectly for the current HF layout. This caused `AttributeError: hidden_size` and could later lead to matmul shape mismatches during expert forward.

This PR:

* Resolves the hidden dimension from `hidden_dim`, `hidden_size`, or the fused weight shape.
* Splits `gate_up_proj` along the fused gate/up output dimension.
* Copies `down_proj` in the layout expected by `nn.Linear`.
* Uses `top_k_pos` instead of expert id when indexing routing weights.
* Preserves the original hidden state shape in the wrapper output.
* Adds a small offline CPU unit test comparing the quant wrapper output against the HF expert forward.

### Usage

No user-facing API changes.

This fix is exercised internally when ModelOpt wraps Hugging Face `Qwen3VLMoeTextExperts` during quantization.

### Testing

```bash
pytest tests/unit/torch/quantization/test_qwen3_vl_moe_experts.py -q
pytest tests/unit/torch/quantization -q
pre-commit run --files modelopt/torch/quantization/plugins/huggingface.py tests/unit/torch/quantization/test_qwen3_vl_moe_experts.py
```

### Before your PR is "*Ready for review*"

Make sure you read and follow [[Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [[Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors)](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

* Is this change backward compatible?: ✅
* If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
* Did you write any new necessary tests?: ✅
* Did you update [[Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
* Did you get Claude approval on this PR?: N/A

### Additional Information

Fixes #1720.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quantized routing for Mixture-of-Experts text layers so outputs now match the expected model behavior more closely.
  * Fixed tensor reshaping and expert weight handling to produce consistent results across small and larger routing setups.

* **Tests**
  * Added coverage to verify the quantized wrapper matches the reference model’s outputs and shapes for a representative MoE configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->