### PR TITLE
[6382837][ONNX][Quantization] Validate empty QuantizeLinear inputs in qdq_to_dq

### DIFF
--- a/modelopt/onnx/quantization/qdq_utils.py
+++ b/modelopt/onnx/quantization/qdq_utils.py
@@ -734,6 +734,8 @@ def qdq_to_dq(onnx_model: onnx.ModelProto) -> onnx.ModelProto:
     q_indices = []
 
     for node_idx, node in q_nodes:
+        if not node.input:
+            raise ValueError(f"QuantizeLinear node {node.name} has no inputs")
         weight_name = node.input[0]
         logger.debug(f"Processing QDQ node for weight {weight_name}")
 

--- a/tests/unit/onnx/quantization/test_qdq_utils.py
+++ b/tests/unit/onnx/quantization/test_qdq_utils.py
@@ -27,6 +27,7 @@ from modelopt.onnx.quantization.qdq_utils import (
     apply_column_major_transformation,
     fp4qdq_to_2dq,
     insert_transpose_nodes_for_column_major,
+    qdq_to_dq,
     quantize_weights_to_int4,
     quantize_weights_to_mxfp8,
     replace_zero_scale_with_smallest_nonzero,
@@ -1097,6 +1098,23 @@ class TestReplaceZeroScaleWithSmallestNonzero:
         scale_arr = numpy_helper.to_array(value_attr.t)
         assert not (scale_arr == 0).any()
         assert (scale_arr > 0).all()
+
+
+class TestQdqToDqValidation:
+    """Regression tests for qdq_to_dq input validation."""
+
+    def test_quantize_linear_without_inputs_raises_value_error(self):
+        q_node = helper.make_node("QuantizeLinear", inputs=[], outputs=["q_output"], name="bad_q")
+        graph = helper.make_graph(
+            nodes=[q_node],
+            name="test_graph",
+            inputs=[],
+            outputs=[helper.make_tensor_value_info("q_output", TensorProto.INT8, [1])],
+        )
+        model = helper.make_model(graph)
+
+        with pytest.raises(ValueError, match="QuantizeLinear node bad_q has no inputs"):
+            qdq_to_dq(model)
 
 
 class TestLegacyEdgeLLMShims:


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

- Adds validation for malformed `QuantizeLinear` nodes with no inputs before `qdq_to_dq()` reads `node.input[0]`.
- Converts an uncaught `IndexError` into the documented `ValueError` path for invalid ONNX input.
- Adds a focused ONNX quantization regression test for the empty-input `QuantizeLinear` case.

### Usage

```python
from onnx import TensorProto, helper
from modelopt.onnx.quantization.qdq_utils import qdq_to_dq

q_node = helper.make_node("QuantizeLinear", inputs=[], outputs=["q_output"], name="bad_q")
graph = helper.make_graph(
    nodes=[q_node],
    name="test_graph",
    inputs=[],
    outputs=[helper.make_tensor_value_info("q_output", TensorProto.INT8, [1])],
)
model = helper.make_model(graph)

qdq_to_dq(model)  # raises ValueError instead of leaking IndexError
```

### Testing

- Issue reproduced with ModelOpt 0.44.0 and main ToT (`9038b71`).
- Applied the fix locally and reran the reproducer; the `IndexError` signature is gone and the malformed node is rejected with `ValueError`.
- Ran `python -m pytest tests/unit/onnx/quantization/test_qdq_utils.py::TestQdqToDqValidation::test_quantize_linear_without_inputs_raises_value_error -q`.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to catch malformed quantization nodes earlier and return a clear error when a required input is missing.
  * Prevents unexpected failures during model conversion by surfacing a readable message instead of crashing later.

* **Tests**
  * Added a regression test covering the missing-input case to ensure the error is raised as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->