### PR TITLE
ci: gate example and GPU tests on changes to their own runner and cache action

### DIFF
--- a/.github/workflows/example_tests.yml
+++ b/.github/workflows/example_tests.yml
@@ -22,6 +22,8 @@ jobs:
     secrets: inherit
     with:
       files: |
+        .github/actions/cache-extensions/**
+        .github/workflows/_example_tests_runner.yml
         .github/workflows/example_tests.yml
         examples/**
         modelopt/**

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -22,6 +22,7 @@ jobs:
     secrets: inherit
     with:
       files: |
+        .github/actions/cache-extensions/**
         .github/workflows/gpu_tests.yml
         modelopt/**
         noxfile.py


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Adds `.github/workflows/_example_tests_runner.yml` and `.github/actions/cache-extensions/**` to the example_tests pr-gate `files:` list, and `cache-extensions/**` to the gpu_tests gate. Every example-test job executes through the reusable runner (which is taken from the PR's ref), so a PR changing only the runner previously merged with all example-test jobs skipped — observed on PR #1651, whose example-tests run shows pr-gate success with torch/trtllm-pr/megatron/onnx all skipped. Gating on the workflow's own machinery matches the existing intent (the gate already lists `example_tests.yml` itself).

### Usage

N/A — CI workflow configuration change.

### Testing

YAML validated; the change is additive to the gate lists only. The observed-failure evidence is PR #1651's run history (linked in #1890).

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A (workflow config; validated as described above)
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A (CI-only change)
- Did you get Claude approval on this PR?: N/A (external contributor; cannot trigger `/claude review`)

### Additional Information

Part of #1890 (item 1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated test-triggering rules to cover additional workflow and action changes.
  * Updated gating for example and GPU test runs so more relevant changes are validated automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->