### PR TITLE
ci: scope bump_uv_lock change detection to uv.lock

### DIFF
--- a/.github/workflows/bump_uv_lock.yml
+++ b/.github/workflows/bump_uv_lock.yml
@@ -37,7 +37,10 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          if git diff --quiet; then
+          # Scope to uv.lock: the pyproject.toml torch-override step above rewrites
+          # the whole file (toml.dump drops comments), so an unscoped diff is always
+          # dirty and the no-update path below would fail on an empty commit.
+          if git diff --quiet -- uv.lock; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

The torch-override step rewrites `pyproject.toml` via `toml.load`/`toml.dump`, which drops comments and reformats the file, so the unscoped `git diff --quiet` was always dirty and `changed=false` unreachable. In a week where `uv lock --upgrade` produces no changes, the create-pull-request step stages nothing and `git commit` exits 1, failing the scheduled run instead of no-oping. Scoping the diff to `uv.lock` restores the intended detection.

### Usage

N/A — CI workflow configuration change.

### Testing

Reproduced the failure locally by executing the workflow's steps in a clean checkout: after the toml mutation, unscoped `git diff --quiet` exits 1 with `uv.lock` byte-identical, and `git add uv.lock && git commit -s -m x` exits 1. With `git diff --quiet -- uv.lock`, the no-update path correctly yields `changed=false`. YAML validated.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A (workflow config; validated as described above)
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A (CI-only change)
- Did you get Claude approval on this PR?: N/A (external contributor; cannot trigger `/claude review`)

### Additional Information

Part of #1890 (item 2).
