### PR TITLE
ci: run path-gated unit test lanes on push events

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -38,7 +38,11 @@ jobs:
       any_changed: ${{ steps.changed.outputs.any_changed || steps.non-pr.outputs.any_changed }}
     steps:
       - id: non-pr
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        # push is included: the workflow-level push paths filter already guarantees
+        # a relevant file changed, but this step never ran for push events, so
+        # any_changed stayed empty and every gated lane (windows, multi-version,
+        # partial-install, launcher, mcp, skills) was silently skipped on pushes.
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
         run: echo "any_changed=true" >> $GITHUB_OUTPUT
       - if: github.event_name == 'pull_request'
         uses: actions/checkout@v6


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

In `check-file-changes`, the `non-pr` step ran only for `schedule`/`workflow_dispatch` and the `changed` step only for `pull_request`, so for `push` events `any_changed` stayed empty and the windows, multi-version, partial-install, launcher, mcp, and skills lanes were all silently skipped — despite the workflow-level push `paths:` filter listing their directories. Treating push like the other non-PR triggers is safe because that paths filter already guarantees a relevant file changed before the workflow starts.

### Usage

N/A — CI workflow configuration change.

### Testing

Evidence from run history: the latest push-event run on main shows check-file-changes success and every gated lane skipped (details in #1890). YAML validated.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A (workflow config; validated as described above)
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A (CI-only change)
- Did you get Claude approval on this PR?: N/A (external contributor; cannot trigger `/claude review`)

### Additional Information

Part of #1890 (item 3).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where test-related jobs could be skipped on push events.
  * Improved workflow behavior so change detection now runs consistently for push, scheduled, and manually triggered runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->