### PR TITLE
ci: give non-PR code quality runs distinct concurrency groups

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   # Cancel previous runs if new commit is pushed to the same PR
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

The concurrency group used `github.event.pull_request.number` with no fallback, so every nightly and manually dispatched run shared the literal group `Code Quality-` with `cancel-in-progress: true` — a manual dispatch cancels an in-flight nightly and vice versa. Adds the `|| github.sha` fallback already used by `unit_tests.yml`.

### Usage

N/A — CI workflow configuration change.

### Testing

Matches the existing pattern in `unit_tests.yml` line-for-line. YAML validated.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A (workflow config; validated as described above)
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A (CI-only change)
- Did you get Claude approval on this PR?: N/A (external contributor; cannot trigger `/claude review`)

### Additional Information

Part of #1890 (item 4).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow concurrency handling so automated runs are grouped and canceled more reliably across pull request, manual, and scheduled triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->