### PR TITLE
fix: raise ValueError for unknown awq() algorithm instead of silent no-op

### DIFF
--- a/modelopt/torch/quantization/model_calib.py
+++ b/modelopt/torch/quantization/model_calib.py
@@ -1161,6 +1161,11 @@ def awq(
         model: Model to be calibrated.
         forward_loop: A callable which takes the model as argument and
             forwards calibration data through the model.
+        algorithm: The AWQ variant to run; one of ``"awq_lite"``,
+            ``"awq_clip"``, or ``"awq_full"``.
+
+    Raises:
+        ValueError: If ``algorithm`` is not one of the valid AWQ algorithms.
 
     See :class:`AWQFullCalibConfig <modelopt.torch.quantization.config.AWQFullCalibConfig>` for
     details on the remaining arguments.

--- a/modelopt/torch/quantization/model_calib.py
+++ b/modelopt/torch/quantization/model_calib.py
@@ -1165,6 +1165,12 @@ def awq(
     See :class:`AWQFullCalibConfig <modelopt.torch.quantization.config.AWQFullCalibConfig>` for
     details on the remaining arguments.
     """
+    if algorithm not in ["awq_lite", "awq_clip", "awq_full"]:
+        raise ValueError(
+            f"Invalid AWQ algorithm {algorithm!r}. "
+            "Valid algorithms are 'awq_lite', 'awq_clip', and 'awq_full'."
+        )
+
     with SequentialQuantizer.convert_to_single_quantizer(model):
         if algorithm in ["awq_full", "awq_lite"]:
             awq_lite(model, forward_loop, **kwargs)

--- a/tests/unit/torch/quantization/test_calib.py
+++ b/tests/unit/torch/quantization/test_calib.py
@@ -26,6 +26,7 @@ import modelopt.torch.quantization as mtq
 from modelopt.torch.quantization.config import QuantizerAttributeConfig
 from modelopt.torch.quantization.model_calib import (
     apply_pre_quant_scale_and_smooth,
+    awq,
     disable_pre_quant_scale_and_resmooth,
     layerwise_calibrate,
 )
@@ -389,6 +390,19 @@ def test_awq_lite_uncalibrated_weight_only_keeps_input_quantizer_disabled():
         "uncalibrated layers — that would silently quantize activations "
         "the user's config left in full precision."
     )
+
+
+def test_awq_unknown_algorithm_raises():
+    """awq() must fail fast on an unknown algorithm instead of silently skipping calibration."""
+    model = _SimpleMLP()
+
+    with pytest.raises(ValueError, match="Invalid AWQ algorithm 'awq-lite'"):
+        awq(model, algorithm="awq-lite")
+
+    # Valid algorithm strings still go through: awq_lite without a forward_loop
+    # warns and skips instead of raising.
+    with pytest.warns(UserWarning, match="forward_loop must be provided"):
+        awq(model, forward_loop=None, algorithm="awq_lite")
 
 
 def test_smoothquant_enable_disable():


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Bug 2 in #1902: awq() silently no-ops on an unknown algorithm string (public __all__ API; only the mtq.quantize config layer Literal-validates). Now raises ValueError before any model mutation, listing the valid algorithms. Internal callers audited: svdquant hardcodes awq_lite; mode.py values are pydantic-validated. Regression test asserts the raise and that the valid path still works.

### Usage

N/A

### Testing

Regression tests included (added to existing unit test files; each was verified to fail with the fix reverted). Full tests/unit/torch quantization+export+utils+opt battery passes locally with all sibling fixes applied (962 passed). Note: the test-suite PRs #1903-#1907 contain behavior-documenting NOTE tests that pin the OLD behavior fixed here — whichever lands second will be rebased to flip those assertions (happy to do so).

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ (error-raising on previously-silent invalid input / warning removal / exception-path cleanup only)
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in CONTRIBUTING.md: N/A
- Did you write any new necessary tests?: ✅
- Did you update Changelog?: N/A
- Did you get Claude approval on this PR?: N/A (external contributor)

### Additional Information

Issue: #1902


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added early validation for unsupported AWQ algorithm values, now failing fast with a clear `ValueError`.
  * Improved calibration behavior when `forward_loop` isn’t provided in supported scenarios, emitting a `UserWarning` instead of failing unexpectedly.

* **Tests**
  * Added a unit test to verify an invalid AWQ algorithm raises the expected error.
  * Added coverage to confirm the `forward_loop=None` warning behavior during AWQ calibration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->