### PR TITLE
fix: reject amax assignment on dynamic quantizers

### DIFF
--- a/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
+++ b/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
@@ -348,6 +348,12 @@ class TensorQuantizer(nn.Module):
     @amax.setter
     def amax(self, value):
         assert value is not None, "amax cannot be set to None."
+        # getattr (not self._dynamic): __init__ assigns self.amax = amax before
+        # set_from_attribute_config creates the _dynamic attribute, so a bare
+        # attribute access would break the amax= constructor argument.
+        assert not getattr(self, "_dynamic", False), (
+            "Dynamic quantization does not have fixed amax; amax cannot be set."
+        )
 
         if not isinstance(value, torch.Tensor):
             value = torch.tensor(value)

--- a/tests/unit/torch/quantization/test_tensor_quantizer_cpu.py
+++ b/tests/unit/torch/quantization/test_tensor_quantizer_cpu.py
@@ -15,15 +15,34 @@
 
 """Tests of tensor quantizer."""
 
+import pytest
+import torch
 from _test_utils.torch.quantization.tensor_quantizer_common import (
     BlockQuantTester,
     SequentialQuantizerTester,
     TensorQuantizerTester,
 )
 
+from modelopt.torch.quantization.config import QuantizerAttributeConfig
+from modelopt.torch.quantization.nn import TensorQuantizer
+
 
 class TestTensorQuantizerCPU(TensorQuantizerTester):
     device = "cpu"
+
+    def test_disabled_extra_repr(self):
+        quantizer = TensorQuantizer(QuantizerAttributeConfig(enable=False)).to(self.device)
+        assert quantizer.extra_repr() == "disabled"
+
+        quantizer.pre_quant_scale = torch.tensor([0.5, 2.0]).to(self.device)
+        extra_repr = quantizer.extra_repr()
+        assert extra_repr.startswith("disabled")
+        assert "pre_quant_scale=" in extra_repr
+
+    def test_dynamic_amax_set_rejected(self):
+        quantizer = TensorQuantizer(QuantizerAttributeConfig(type="dynamic")).to(self.device)
+        with pytest.raises(AssertionError, match="Dynamic quantization"):
+            quantizer.amax = 1.0
 
 
 class TestBlockQuantCPU(BlockQuantTester):


### PR DESCRIPTION
## What does this PR do?

**Type of change:** Bug fix

**Overview:** Setting `amax` on a dynamic `TensorQuantizer` silently stored a value dynamic quantization never uses; the setter now fails fast. `getattr(self, "_dynamic", False)` rather than `self._dynamic` because `__init__` assigns `self.amax = amax` before `set_from_attribute_config` creates the `_dynamic` attribute — a bare attribute access would break the `amax=` constructor argument (all 28 assignment sites audited).

**Scope note:** this PR originally also fixed the `extra_repr` dead code in the disabled branch (built a detail string, returned the literal `"disabled"`). #1879 has since made that branch reachable on `main`, so that part is now upstream; this PR keeps a regression test pinning the disabled `extra_repr` detail output and retains only the amax-setter fix. Rebased accordingly.

## Testing

`tests/unit/torch/quantization/test_tensor_quantizer_cpu.py`: `test_dynamic_amax_set_rejected` (fails without the fix) and `test_disabled_extra_repr` (pins the now-live disabled branch). Full file: 28 passed.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ (only rejects a write that was previously a silent no-op footgun)
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in CONTRIBUTING.md: N/A
- Did you write any new necessary tests?: ✅
- Did you update Changelog?: N/A
- Did you get Claude approval on this PR?: N/A (external contributor)

### Additional Information

Issue: #1902

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented setting a fixed `amax` when quantization is configured as dynamic, raising a clear assertion error instead.
  * Improved quantizer status display for disabled quantizers so any additional pre-quantization scale details are preserved in the output.
* **Tests**
  * Added unit tests covering the disabled quantizer `extra_repr()` output (including pre-quant scale) and verifying that `amax` updates are rejected in dynamic mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->