### PR TITLE
fix: SequentialQuantizer children no longer match singular wildcards via fused-experts normalization

### DIFF
--- a/modelopt/torch/quantization/conversion.py
+++ b/modelopt/torch/quantization/conversion.py
@@ -348,12 +348,23 @@ def _match_quantizer(
     if not isinstance(module, (TensorQuantizer, SequentialQuantizer)):
         return False
     if isinstance(wildcard_or_filter_func, str):
-        normalized = _normalize_fused_experts_quantizer_name(name)
-        if not (
-            fnmatch.fnmatch(name, wildcard_or_filter_func)
-            or (normalized != name and fnmatch.fnmatch(normalized, wildcard_or_filter_func))
-        ):
-            return False
+        if not fnmatch.fnmatch(name, wildcard_or_filter_func):
+            normalized = _normalize_fused_experts_quantizer_name(name)
+            if normalized == name or not fnmatch.fnmatch(normalized, wildcard_or_filter_func):
+                return False
+            # The index-stripping normalization exists solely for fused-experts layouts
+            # that hold per-expert quantizers in an ``nn.ModuleList``. A
+            # ``SequentialQuantizer`` stored at attribute ``weight_quantizer`` exposes
+            # children with the same dotted shape (``...weight_quantizer.0``), so
+            # normalizing them would make each sub-quantizer match singular wildcards
+            # like ``*weight_quantizer`` on its own. That corrupts re-application of
+            # list configs (nesting SequentialQuantizers inside sub-slots) and breaks
+            # list-based partial updates on existing SequentialQuantizers. Sub-quantizers
+            # must only be addressed through their container, so skip the normalized
+            # match when the quantizer's direct parent is a SequentialQuantizer.
+            parent_name = name.rpartition(".")[0]
+            if isinstance(full_model.get_submodule(parent_name), SequentialQuantizer):
+                return False
     elif callable(wildcard_or_filter_func):
         if not wildcard_or_filter_func(name):
             return False

--- a/tests/unit/torch/quantization/test_quantize_cpu.py
+++ b/tests/unit/torch/quantization/test_quantize_cpu.py
@@ -33,7 +33,10 @@ import modelopt.torch.opt as mto
 import modelopt.torch.quantization as mtq
 from modelopt.torch.quantization.calib import MaxCalibrator
 from modelopt.torch.quantization.config import QuantizerAttributeConfig
-from modelopt.torch.quantization.conversion import set_quantizer_attributes_full
+from modelopt.torch.quantization.conversion import (
+    set_quantizer_attributes_full,
+    set_quantizer_attributes_partial,
+)
 from modelopt.torch.quantization.nn.modules.tensor_quantizer import (
     SequentialQuantizer,
     TensorQuantizer,
@@ -400,6 +403,72 @@ class TestSetQuantizerAttributesFull:
             if name.endswith("weight_quantizer"):
                 assert isinstance(module, SequentialQuantizer)
                 assert len(module) == 2
+
+    def test_list_attributes_double_application_is_idempotent(self):
+        """Applying the same list config twice must not nest SequentialQuantizers.
+
+        Regression test: the fused-experts name normalization used to collapse a
+        SequentialQuantizer child name like ``...weight_quantizer.0`` down to
+        ``...weight_quantizer``, so on a second pass each sub-quantizer matched the
+        singular wildcard on its own and was replaced with a nested
+        SequentialQuantizer.
+        """
+        model = self._quantize(SimpleLinear())
+        attrs = [
+            QuantizerAttributeConfig(num_bits=4, block_sizes={-1: 128}),
+            QuantizerAttributeConfig(num_bits=8, axis=0),
+        ]
+        set_quantizer_attributes_full(model, "*weight_quantizer", attrs)
+        set_quantizer_attributes_full(model, "*weight_quantizer", attrs)
+        seen = 0
+        for name, module in model.named_modules():
+            if name.endswith("weight_quantizer"):
+                seen += 1
+                assert isinstance(module, SequentialQuantizer)
+                assert len(module) == 2
+                for sub in module:
+                    assert isinstance(sub, TensorQuantizer)
+                    assert not isinstance(sub, SequentialQuantizer), (
+                        f"{name} has a nested SequentialQuantizer sub-quantizer"
+                    )
+                assert module[0].num_bits == 4
+                assert module[1].num_bits == 8
+        assert seen > 0
+
+
+def test_partial_list_on_existing_sequential_quantizer():
+    """A list partial config applies per-position to an existing SequentialQuantizer.
+
+    This is the documented contract of set_quantizer_attributes_partial. Regression
+    test: the fused-experts name normalization made the SequentialQuantizer's child
+    TensorQuantizers (``...weight_quantizer.0``) match ``*weight_quantizer`` too, and
+    the list-on-TensorQuantizer check then raised ValueError mid-iteration.
+    """
+    model = mtq.quantize(SimpleLinear(), mtq.INT8_DEFAULT_CFG, lambda m: m(m.get_input()))
+    set_quantizer_attributes_full(
+        model,
+        "*weight_quantizer",
+        [
+            QuantizerAttributeConfig(num_bits=4, block_sizes={-1: 128}),
+            QuantizerAttributeConfig(num_bits=8, axis=0),
+        ],
+    )
+    # Must not raise: only the SequentialQuantizer containers should match, never
+    # their child TensorQuantizers.
+    set_quantizer_attributes_partial(
+        model, "*weight_quantizer", [{"enable": False}, {"num_bits": 4}]
+    )
+    seen = 0
+    for name, module in model.named_modules():
+        if name.endswith("weight_quantizer"):
+            seen += 1
+            assert isinstance(module, SequentialQuantizer)
+            assert not module[0].is_enabled, f"{name}[0] should be disabled"
+            assert module[0].num_bits == 4, "unspecified attribute should be preserved"
+            assert module[1].is_enabled, f"{name}[1] should stay enabled"
+            assert module[1].num_bits == 4, "per-position update should apply to slot 1"
+            assert module[1].axis == 0, "unspecified attribute should be preserved"
+    assert seen > 0
 
 
 def test_ordering_later_entry_overrides_earlier():


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Bug 1 in #1902 (regression from #1340): the fused-experts name normalization collapses weight_quantizer.N — exactly a SequentialQuantizer's child names — so sub-quantizers matched *weight_quantizer on their own. Consequences reproduced: re-applying a list config nests SequentialQuantizers inside sub-slots (corrupt state), and set_quantizer_attributes_partial with a list + wildcard raises mid-iteration against its own docstring. Fix skips the normalized match only when the direct parent is a SequentialQuantizer; raw wildcards, callable filters, and the plural weight_quantizers.N path are unchanged, and all #1340 fused-experts tests still pass. Two regression tests pin idempotent re-application and the docstring's list-on-sequential contract.

### Usage

N/A

### Testing

Regression tests included (added to existing unit test files; each was verified to fail with the fix reverted). Full tests/unit/torch quantization+export+utils+opt battery passes locally with all sibling fixes applied (962 passed). Note: the test-suite PRs #1903-#1907 contain behavior-documenting NOTE tests that pin the OLD behavior fixed here — whichever lands second will be rebased to flip those assertions (happy to do so).

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ (error-raising on previously-silent invalid input / warning removal / exception-path cleanup only)
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in CONTRIBUTING.md: N/A
- Did you write any new necessary tests?: ✅
- Did you update Changelog?: N/A
- Did you get Claude approval on this PR?: N/A (external contributor)

### Additional Information

Issue: #1902
