### PR TITLE
fix: apply_mode accepts ModeDescriptor instances and an empty mode list with a ModelLike

### DIFF
--- a/modelopt/torch/opt/conversion.py
+++ b/modelopt/torch/opt/conversion.py
@@ -327,7 +327,8 @@ class ModelLikeModule(nn.Module):
     def init_modellike(self) -> nn.Module:
         """Initialize the modellike to be an actual model."""
         model = init_model_from_model_like(self.modellike)
-        ModeloptStateManager.transfer_state_dict(self, model)
+        if ModeloptStateManager.is_converted(self):
+            ModeloptStateManager.transfer_state_dict(self, model)
         return model
 
 

--- a/modelopt/torch/opt/mode.py
+++ b/modelopt/torch/opt/mode.py
@@ -357,7 +357,14 @@ class _ModeRegistryCls:
 def get_mode_config(mode_like: ModeLike) -> ModeConfigList:
     """Standardize mode to ModeConfigDict and return."""
     mode_and_config = [
-        ((m, {}) if isinstance(m, str) else (m[0], m[1] or {})) for m in val2list(mode_like)
+        (
+            (m.name, {})
+            if isinstance(m, ModeDescriptor)
+            else (m, {})
+            if isinstance(m, str)
+            else (m[0], m[1] or {})
+        )
+        for m in val2list(mode_like)
     ]
 
     return mode_and_config

--- a/modelopt/torch/opt/mode.py
+++ b/modelopt/torch/opt/mode.py
@@ -356,15 +356,14 @@ class _ModeRegistryCls:
 
 def get_mode_config(mode_like: ModeLike) -> ModeConfigList:
     """Standardize mode to ModeConfigDict and return."""
-    mode_and_config = [
-        (
-            (m.name, {})
-            if isinstance(m, ModeDescriptor)
-            else (m, {})
-            if isinstance(m, str)
-            else (m[0], m[1] or {})
-        )
-        for m in val2list(mode_like)
-    ]
+
+    def _normalize(m) -> tuple[str, dict]:
+        if isinstance(m, ModeDescriptor):
+            return m.name, {}
+        if isinstance(m, str):
+            return m, {}
+        return m[0], m[1] or {}
+
+    mode_and_config = [_normalize(m) for m in val2list(mode_like)]
 
     return mode_and_config

--- a/tests/unit/torch/opt/test_chaining.py
+++ b/tests/unit/torch/opt/test_chaining.py
@@ -25,6 +25,8 @@ import modelopt.torch.nas as mtn
 import modelopt.torch.opt as mto
 import modelopt.torch.quantization as mtq
 import modelopt.torch.sparsity as mts
+from modelopt.torch.opt.conversion import ModelLikeModule
+from modelopt.torch.opt.mode import _ModeRegistryCls
 from modelopt.torch.utils.distributed import _serialize
 
 
@@ -194,6 +196,38 @@ def test_model_like_initialization(mode, modellike, expect_exception):
 
     model2 = mto.restore_from_modelopt_state(model2, modelopt_state)
     assert isinstance(model2, torch.nn.Module)
+
+
+def test_apply_mode_with_mode_descriptor_instance():
+    """Test that a ModeDescriptor instance behaves identically to its string name."""
+    model_str = SimpleLinearModel()
+    model_desc = SimpleLinearModel()
+    model_desc.load_state_dict(model_str.state_dict())
+
+    descriptor = _ModeRegistryCls.get_from_any("quantize")
+    model_str = mto.apply_mode(model_str, mode=["quantize"], init_state=True)
+    model_desc = mto.apply_mode(model_desc, mode=[descriptor], init_state=True)
+
+    # modelopt state must be identical
+    manager_str = mto.ModeloptStateManager(model_str)
+    manager_desc = mto.ModeloptStateManager(model_desc)
+    assert torch.equal(_serialize(manager_str.state_dict()), _serialize(manager_desc.state_dict()))
+
+    # model state dict must be identical
+    state_str = model_str.state_dict()
+    state_desc = model_desc.state_dict()
+    assert state_str.keys() == state_desc.keys()
+    for key in state_str:
+        assert torch.equal(state_str[key], state_desc[key])
+
+
+def test_apply_mode_empty_mode_with_model_like():
+    """Test that an empty mode list initializes and returns a plain model from a ModelLike."""
+    model = mto.apply_mode((get_model, (), {}), mode=[])
+    assert isinstance(model, torch.nn.Module)
+    assert not isinstance(model, ModelLikeModule)
+    assert not mto.ModeloptStateManager.is_converted(model)
+    model(get_input())
 
 
 def test_sparse_quantized_module():


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Two API-contract bugs in the opt mode framework (found writing #1915): apply_mode(model, [descriptor_instance]) raised TypeError despite the docstring and the ModeType = ModeDescriptor | str annotation — descriptors are now normalized to their name up front (registry descriptors are per-name singletons, so resolution round-trips; get_mode_config's only caller is apply_mode, audited); and apply_mode((cls, args, kwargs), []) — the documented vanilla initialize+return case — crashed in init_modellike's unconditional state transfer, now guarded by is_converted so both vanilla paths consistently return a plain initialized model. Existing ModelLike-with-state coverage stays green; regression tests appended to test_chaining.py, both verified to fail pre-fix with the exact reported signatures.

### Usage

N/A

### Testing

Regression tests included, each verified to FAIL with the fix reverted. Combined battery with all sibling wave fixes: 381 passed across tests/unit/torch/opt, tests/unit/torch/utils, tests/unit/recipe, and quantization test_mode. Note: the unmerged suite PRs #1913-#1916 contain behavior-documenting NOTE tests pinning the OLD behavior fixed here — whichever lands second gets the NOTE tests flipped (happy to rebase either way).

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in CONTRIBUTING.md: N/A
- Did you write any new necessary tests?: ✅
- Did you update Changelog?: N/A
- Did you get Claude approval on this PR?: N/A (external contributor)

### Additional Information

Issue: #1902 (wave-2 findings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of mode configuration inputs so descriptor-based and string-based modes behave consistently.
  * Fixed model initialization so prior optimization state is only restored when the model is actually recognized as converted.
  * Ensured applying an empty set of modes to a wrapped model returns a standard, forward-executable module.
* **Tests**
  * Added coverage for mode descriptor equivalence and empty-mode behavior on wrapped models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->