### PR TITLE
fix: config loader no longer discards the body of a null-header multi-document file

### DIFF
--- a/modelopt/torch/opt/config_loader.py
+++ b/modelopt/torch/opt/config_loader.py
@@ -193,7 +193,7 @@ def _load_raw_config_with_schema(config_file: str | Path | Traversable) -> _RawC
     schema = _parse_modelopt_schema(text, config_path)
     docs = list(yaml.safe_load_all(text))
 
-    if len(docs) == 0 or docs[0] is None:
+    if len(docs) == 0 or (len(docs) == 1 and docs[0] is None):
         return _RawConfig({}, schema=schema, path=config_path)
     if len(docs) == 1:
         _raw = docs[0]
@@ -201,6 +201,10 @@ def _load_raw_config_with_schema(config_file: str | Path | Traversable) -> _RawC
         # Multi-document: first doc is imports/metadata, second is content.
         # Merge the imports into the content for downstream resolution.
         header, content = docs[0], docs[1]
+        if header is None:
+            # An explicit null/empty first document is an empty header, not an
+            # empty file — the second document still carries the real body.
+            header = {}
         if not isinstance(header, dict):
             raise ValueError(
                 f"Config file {config_path}: first YAML document must be a mapping, "

--- a/tests/unit/recipe/test_loader.py
+++ b/tests/unit/recipe/test_loader.py
@@ -1611,6 +1611,38 @@ def test_load_config_multi_doc_null_content(tmp_path):
     assert data == {"key": "value"}
 
 
+def test_load_config_multi_doc_null_header_list_body(tmp_path):
+    """Multi-document YAML with a null first doc and a list body keeps the list."""
+    cfg_file = tmp_path / "null_header_list.yaml"
+    cfg_file.write_text("null\n---\n- item1\n- item2\n")
+    data = load_config(cfg_file)
+    assert data == ["item1", "item2"]
+
+
+def test_load_config_multi_doc_empty_header_list_body(tmp_path):
+    """Multi-document YAML with an empty explicit first doc and a list body keeps the list."""
+    cfg_file = tmp_path / "empty_header_list.yaml"
+    cfg_file.write_text("---\n---\n- item1\n")
+    data = load_config(cfg_file)
+    assert data == ["item1"]
+
+
+def test_load_config_multi_doc_null_header_dict_body(tmp_path):
+    """Multi-document YAML with a null first doc and a dict body keeps the dict."""
+    cfg_file = tmp_path / "null_header_dict.yaml"
+    cfg_file.write_text("~\n---\nkey: value\n")
+    data = load_config(cfg_file)
+    assert data == {"key": "value"}
+
+
+def test_load_config_lone_null_doc(tmp_path):
+    """A single explicit null document still loads as an empty dict."""
+    cfg_file = tmp_path / "lone_null.yaml"
+    cfg_file.write_text("null\n")
+    data = load_config(cfg_file)
+    assert data == {}
+
+
 def test_load_config_multi_doc_first_not_dict_raises(tmp_path):
     """Multi-document YAML with non-dict first document raises ValueError."""
     cfg_file = tmp_path / "bad_multi.yaml"


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Silent data loss in the config loader (found writing #1914): a null/~ first YAML document (or empty explicit document) tripped the empty-file early return before the two-document branch, so 'null / --- / <body>' loaded as {} and the body vanished. A null first document is now an empty header: dict bodies load as themselves, list bodies take the existing snippet path, a lone null still loads {}, and the >2-document error now applies to null-first files too (previously silently {}). Full branch-by-branch before/after table in the review notes; three regression tests in tests/unit/recipe/test_loader.py verified to fail pre-fix with the exact {}-instead-of-body symptom; builtin presets still load (import-time validation green).

### Usage

N/A

### Testing

Regression tests included, each verified to FAIL with the fix reverted. Combined battery with all sibling wave fixes: 381 passed across tests/unit/torch/opt, tests/unit/torch/utils, tests/unit/recipe, and quantization test_mode. Note: the unmerged suite PRs #1913-#1916 contain behavior-documenting NOTE tests pinning the OLD behavior fixed here — whichever lands second gets the NOTE tests flipped (happy to rebase either way).

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in CONTRIBUTING.md: N/A
- Did you write any new necessary tests?: ✅
- Did you update Changelog?: N/A
- Did you get Claude approval on this PR?: N/A (external contributor)

### Additional Information

Issue: #1902 (wave-2 findings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of YAML files with multiple documents, including cases where the first document is empty or `null`.
  * Config files with a blank or `null` header now load correctly when the actual settings are in the second document.
  * A single `null` YAML document now loads as an empty configuration.
* **Tests**
  * Added coverage for multi-document and empty-header config loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->