### PR TITLE
fix: flatten_tree fails loudly on flattened-key collisions instead of corrupting silently

### DIFF
--- a/modelopt/torch/utils/_pytree.py
+++ b/modelopt/torch/utils/_pytree.py
@@ -128,6 +128,16 @@ def flatten_tree(pytree: Any, prefix: str = "") -> tuple[list[Any], TreeSpec]:
             yield prefix, pytree
 
     # retrieve flattened values and names. Then initialize tree_spec with the flattened names.
-    flattened = dict(collect_spec(pytree, prefix))
+    seen_names: set[str] = set()
+    names: list[str] = []
+    values: list[Any] = []
+    for name, value in collect_spec(pytree, prefix):
+        if name in seen_names:
+            raise ValueError(
+                f"Cannot flatten pytree: multiple leaves map to the flattened key {name!r}!"
+            )
+        seen_names.add(name)
+        names.append(name)
+        values.append(value)
 
-    return list(flattened.values()), TreeSpec(pytree, list(flattened.keys()))
+    return values, TreeSpec(pytree, names)

--- a/modelopt/torch/utils/_pytree.py
+++ b/modelopt/torch/utils/_pytree.py
@@ -114,6 +114,10 @@ def flatten_tree(pytree: Any, prefix: str = "") -> tuple[list[Any], TreeSpec]:
     Returns: A tuple (values, pytree) where
         values is a list of values flattened from the provided pytree, and
         tree_spec is the pytree spec describing the structure of the pytree.
+
+    Raises:
+        ValueError: If two leaves map to the same flattened key (nested keys
+            are joined with ".", so ``{"a": {"b": 1}, "a.b": 2}`` collides).
     """
 
     def collect_spec(pytree, prefix):

--- a/tests/unit/torch/utils/test_pytree.py
+++ b/tests/unit/torch/utils/test_pytree.py
@@ -72,3 +72,31 @@ def test_flatten_tree(data, expected_keys):
     # try re-building to see if we get same structure
     tree_rebuilt = unflatten_tree(copy.deepcopy(values), tree_spec)
     assert data == tree_rebuilt
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"a": {"b": 1}, "a.b": 2},
+        {"a": [1], "a.0": 2},
+        {"a.b": 1, "a": {"b": 2}},
+    ],
+)
+def test_flatten_tree_key_collision(data):
+    """Colliding flattened keys must raise instead of silently dropping values."""
+    with pytest.raises(ValueError, match=r"'a\.(b|0)'"):
+        flatten_tree(data)
+
+
+@pytest.mark.parametrize(
+    ("data", "expected_keys"),
+    [
+        ({"a": {"b": 1}, "ab": 2}, ["a.b", "ab"]),
+        ({"a": {"b": 1}, "a_b": 2}, ["a.b", "a_b"]),
+    ],
+)
+def test_flatten_tree_near_collision(data, expected_keys):
+    """Distinct flattened keys that merely look similar must still round-trip."""
+    values, tree_spec = flatten_tree(data)
+    assert expected_keys == tree_spec.names
+    assert data == unflatten_tree(copy.deepcopy(values), tree_spec)


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Silent value loss + delayed crash in flatten_tree (found writing #1916): dotted-key collisions ({'a': {'b': 1}, 'a.b': 2}) were deduped by a dict() pass that dropped a VALUE while TreeSpec kept both leaf slots — unflatten_tree then died with IndexError far from the cause. The ONNX deploy paths flatten user-supplied input/output mappings where state-dict-style dotted keys are idiomatic, so this was reachable at inference time. Duplicate flattened names now raise ValueError naming the colliding key. Caller audit and near-collision round-trip tests included; collision tests verified to fail pre-fix (silent loss reproduced).

### Usage

N/A

### Testing

Regression tests included, each verified to FAIL with the fix reverted. Combined battery with all sibling wave fixes: 381 passed across tests/unit/torch/opt, tests/unit/torch/utils, tests/unit/recipe, and quantization test_mode. Note: the unmerged suite PRs #1913-#1916 contain behavior-documenting NOTE tests pinning the OLD behavior fixed here — whichever lands second gets the NOTE tests flipped (happy to rebase either way).

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in CONTRIBUTING.md: N/A
- Did you write any new necessary tests?: ✅
- Did you update Changelog?: N/A
- Did you get Claude approval on this PR?: N/A (external contributor)

### Additional Information

Issue: #1902 (wave-2 findings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tree flattening to raise an error when flattened keys collide, preventing silent overwrites.
  * Improved key-collision handling to reliably reject true flattened-key conflicts while allowing near-matching keys to round-trip correctly.
* **Tests**
  * Added unit tests covering flattened key collisions and non-colliding “near-looking” keys.
* **Documentation**
  * Clarified flattening behavior when duplicate flattened keys would be produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->