### PR TITLE
test: fix vacuous registry-cleanup assertion in test_mode_registry

### DIFF
--- a/tests/unit/torch/opt/test_mode_registry.py
+++ b/tests/unit/torch/opt/test_mode_registry.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest import mock
+
+import pytest
+
 from modelopt.torch.opt.mode import ModeDescriptor, _ModeRegistryCls
 
 
@@ -47,8 +51,20 @@ def test_mode_registry():
 
     registry.remove_mode("a_test_mode")
 
+    # after removal, the mode must no longer resolve via any registry
     assert not _ModeRegistryCls.contained_in_any("a_test_mode")
+    with pytest.raises(KeyError, match="a_test_mode"):
+        _ModeRegistryCls.get_from_any("a_test_mode")
 
-    del registry
+    # NOTE: `del registry` alone does NOT remove the registry from
+    # `_ModeRegistryCls._all_registries`: the class-level list holds a strong reference, so the
+    # local `del` never drops the refcount to zero and `__del__` (which would remove it from the
+    # list) is unreachable. Remove it explicitly so this test leaves no residue behind for other
+    # tests sharing the process. Since `__del__` unconditionally calls `list.remove`, it would
+    # then raise ValueError once the orphaned object is garbage collected, so neutralize it for
+    # the actual destruction.
+    _ModeRegistryCls._all_registries.remove(registry)
+    with mock.patch.object(_ModeRegistryCls, "__del__", return_value=None):
+        del registry  # refcount now drops to zero -> patched `__del__` runs here
 
-    assert "test_registry" not in _ModeRegistryCls._all_registries
+    assert all(r._registry_name != "test_registry" for r in _ModeRegistryCls._all_registries)


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Test-only fix (found writing #1915): test_mode_registry.py's final assertion compared the STRING 'test_registry' against registry OBJECTS in _all_registries — vacuously true regardless of behavior. It masked two real warts, now documented in-test: _ModeRegistryCls.__del__ is unreachable (the class-level list holds a strong reference), and if a registry is removed from the list first, a later GC-triggered __del__ raises ValueError from its unconditional list.remove (surfaced as PytestUnraisableExceptionWarning). The test now asserts the removed mode no longer resolves, cleans the registry from _all_registries explicitly, and checks residue by name — mutation-verified non-vacuous. The __del__ warts may deserve a small source fix; happy to follow up.

### Usage

N/A

### Testing

Regression tests included, each verified to FAIL with the fix reverted. Combined battery with all sibling wave fixes: 381 passed across tests/unit/torch/opt, tests/unit/torch/utils, tests/unit/recipe, and quantization test_mode. Note: the unmerged suite PRs #1913-#1916 contain behavior-documenting NOTE tests pinning the OLD behavior fixed here — whichever lands second gets the NOTE tests flipped (happy to rebase either way).

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in CONTRIBUTING.md: N/A
- Did you write any new necessary tests?: ✅
- Did you update Changelog?: N/A
- Did you get Claude approval on this PR?: N/A (external contributor)

### Additional Information

Issue: #1902 (wave-2 findings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for mode registration and removal behavior.
  * Verified removed modes are no longer available and missing lookups fail as expected.
  * Strengthened test cleanup to prevent leftover state between runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->