### PR TITLE
example(megatron_lm): Llama-3.2-1B-Instruct Megatron QAD launcher example

### DIFF
--- a/tools/launcher/common/megatron_lm/train/sft.sh
+++ b/tools/launcher/common/megatron_lm/train/sft.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source ${SCRIPT_DIR}/../../service_utils.sh
+
+util_install_extra_dep
+
+trap 'error_handler $0 $LINENO' ERR # ERROR HANDLER
+###################################################################################################
+
+# Quantization-Aware Distillation / SFT training on a quantized MCore checkpoint
+# (the output of common/megatron_lm/quantize/quantize.sh). Wraps the Megatron-LM
+# ModelOpt post-training train.sh example (QAT: --modelopt-enabled).
+#
+# Extra flags (data/train/optim/eval, e.g. --sft, --seq-length, --lr,
+# --dist-ckpt-strictness) are forwarded as CLI args and assembled into
+# MLM_EXTRA_ARGS here, so callers pass them via a launcher `args:` list rather
+# than space-containing env vars (which don't survive intact to the sbatch).
+#
+# Required env: MLM_MODEL_CFG.
+# Optional env:
+#   MLM_MODEL_CKPT  Quantized MCore ckpt to load (default: /cicd/megatron-lm/${MLM_MODEL_CFG})
+#   MLM_MODEL_SAVE  Where to save the trained ckpt (default: MLM_MODEL_CKPT)
+#   HF_MODEL_CKPT   HF source ckpt for tokenizer/config (default: /hf-local/${MLM_MODEL_CFG})
+#   DP CP TP PP EP ETP  Parallelism (defaults from train.sh)
+
+if [[ -z ${MLM_MODEL_CFG} ]]; then
+    echo "[ERROR] MLM_MODEL_CFG is required." >&2
+    exit 1
+fi
+if [[ -z ${MLM_MODEL_CKPT} ]]; then
+    export MLM_MODEL_CKPT="/cicd/megatron-lm/${MLM_MODEL_CFG}"
+fi
+if [[ -z ${HF_MODEL_CKPT} ]]; then
+    export HF_MODEL_CKPT="/hf-local/${MLM_MODEL_CFG}"
+fi
+export MLM_MODEL_SAVE=${MLM_MODEL_SAVE:-${MLM_MODEL_CKPT}}
+export MLM_SKIP_INSTALL=1
+
+TRAIN_EXE="bash modules/Megatron-LM/examples/post_training/modelopt/train.sh"
+
+export MLM_EXTRA_ARGS=${@}
+echo "=== QAD/SFT training ${MLM_MODEL_CFG} (load ${MLM_MODEL_CKPT}) ==="
+${TRAIN_EXE} ${MLM_MODEL_CFG}
+
+###################################################################################################
+
+# Pass/fail is driven by the wrapped train.sh's own reporting, the ERR trap
+# (error_handler), and exit_handler — matching quantize.sh/export.sh. No
+# unconditional trailing PASS report (it would misreport a failed train run).
+exit_handler $0

--- a/tools/launcher/examples/meta-llama/Llama-3.2-1B-Instruct/megatron_lm_qad.yaml
+++ b/tools/launcher/examples/meta-llama/Llama-3.2-1B-Instruct/megatron_lm_qad.yaml
@@ -1,0 +1,107 @@
+# Llama-3.2-1B-Instruct Megatron QAD (Quantization-Aware Distillation / SFT).
+#
+# 2-step pipeline (tasks share the persisted /cicd checkpoint dir):
+#   task_0: common/megatron_lm/quantize/quantize.sh — NVFP4 PTQ quantize + MMLU
+#           gate (--lower-bound is the regression floor); export skipped. Saves an
+#           MCore ckpt to /cicd/megatron-lm/meta-llama/Llama-3.2-1B-Instruct.
+#   task_1: common/megatron_lm/train/sft.sh — QAD/SFT training (--modelopt-enabled)
+#           that loads that quantized ckpt.
+#
+# Uses nvcr.io/nvidia/nemo:26.06.00 (ships nvidia-resiliency-ext>=0.6.0). The
+# common/* wrappers install extra deps and assemble MLM_EXTRA_ARGS from the CLI
+# args below, so flags pass via `args:` (robust) rather than space-containing env
+# vars. (Making the Megatron-LM example scripts accept CLI args directly, to drop
+# these wrappers, is tracked in OMNIML-5421.)
+#
+# The QAD train step loads a quantized ckpt whose TE mcore model declares
+# `decoder.final_layernorm._extra_state` that the PTQ save doesn't emit; it passes
+# `--dist-ckpt-strictness log_all` so the main model load drops only that
+# genuinely-missing key instead of the DCP planner hard-raising.
+#
+# Usage:
+#   uv run launch.py --yaml examples/meta-llama/Llama-3.2-1B-Instruct/megatron_lm_qad.yaml --yes
+
+job_name: Llama-3.2-1B-Instruct_Megatron_QAD
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  # Step 1: PTQ quantize (NVFP4) + MMLU gate. export skipped (QAD only needs the
+  # MCore ckpt). Calib flags pass via args: → MLM_EXTRA_ARGS inside quantize.sh.
+  task_0:
+    script: common/megatron_lm/quantize/quantize.sh
+    args:
+      - --calib-dataset-path-or-name /hf-local/abisee/cnn_dailymail
+      - --calib-size 32
+      - --calib-max-sequence-length 512
+    environment:
+      - MLM_MODEL_CFG: meta-llama/Llama-3.2-1B-Instruct
+      - QUANT_CFG: NVFP4_DEFAULT_CFG
+      - HF_MODEL_CKPT: /hf-local/meta-llama/Llama-3.2-1B-Instruct
+      - MMLU_DATASET: /hf-local/cais/mmlu
+      - MMLU_LOWER_BOUND: "0.40"
+      - RUN_EXPORT: "false"
+      - TP: 1
+      - EP: 1
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      container: nvcr.io/nvidia/nemo:26.06.00
+
+  # Step 2: QAD/SFT training on the quantized checkpoint from task_0. All train
+  # flags pass via args: → MLM_EXTRA_ARGS inside sft.sh (MLM_DATA_ARGS=--sft keeps
+  # train.sh from falling back to its default data block).
+  task_1:
+    script: common/megatron_lm/train/sft.sh
+    args:
+      # data
+      - --seq-length 1024
+      - --train-samples 1024
+      - --lr-decay-samples 256
+      - --lr-warmup-samples 128
+      - --sft
+      - --sft-tokenizer-prompt-format default
+      - --tokenizer-type SFTTokenizer
+      - --no-create-attention-mask-in-dataloader
+      - --per-split-data-args-path /hf-local/modelopt/test-sft/blend.json
+      - --data-cache-path /hf-local/modelopt/test-nemotron-sft/cache
+      # train
+      - --micro-batch-size 1
+      - --attention-dropout 0.0
+      - --hidden-dropout 0.0
+      - --no-check-for-nan-in-loss-and-grad
+      - --recompute-granularity selective
+      - --recompute-modules layernorm moe
+      # optimizer
+      - --lr 5.0e-5
+      - --min-lr 5.0e-6
+      - --lr-decay-style cosine
+      - --clip-grad 1.0
+      - --weight-decay 0.0
+      - --adam-beta1 0.9
+      - --adam-beta2 0.95
+      - --init-method-std 0.010
+      - --use-distributed-optimizer
+      # evaluate
+      - --eval-iters 4
+      - --eval-interval 1000
+      - --save-interval 1000
+      - --log-interval 100
+      # load the quantized ckpt: drop only the genuinely-missing norm _extra_state
+      - --dist-ckpt-strictness log_all
+    environment:
+      - MLM_MODEL_CFG: meta-llama/Llama-3.2-1B-Instruct
+      - MLM_MODEL_CKPT: /cicd/megatron-lm/meta-llama/Llama-3.2-1B-Instruct
+      - HF_MODEL_CKPT: /hf-local/meta-llama/Llama-3.2-1B-Instruct
+      - MLM_DATA_ARGS: --sft
+      - DP: 1
+      - CP: 1
+      - TP: 1
+      - PP: 1
+      - EP: 1
+      - ETP: 1
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      container: nvcr.io/nvidia/nemo:26.06.00

--- a/tools/launcher/tests/test_examples_resolve.py
+++ b/tools/launcher/tests/test_examples_resolve.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structural validation of every launcher example YAML.
+
+CPU-only (no GPU, no cluster): parses each `examples/**/*.yaml` and checks the
+launcher-relevant shape — well-formed YAML, a `script:` per task, `common/*`
+scripts that actually exist on disk (catches renamed/typo'd wrapper paths), a
+`_factory_`, and list-shaped `args`. The actual quantize/train execution is
+covered by cluster integration runs, not here; this guards against config
+regressions (e.g. a new example pointing at a missing wrapper).
+"""
+
+import glob
+import os
+
+import pytest
+import yaml
+
+_LAUNCHER_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_EXAMPLES = sorted(
+    glob.glob(os.path.join(_LAUNCHER_DIR, "examples", "**", "*.yaml"), recursive=True)
+)
+
+# Pre-existing examples that reference a common/ script which no longer exists on
+# disk (renamed/removed upstream, example not updated). Excluded from the
+# script-exists check so this test guards NEW examples without failing on
+# unrelated pre-existing drift. These are worth fixing separately:
+#   common/smoke/hostname.sh          — examples/smoke/hostname.yaml
+#   common/eagle3/offline_training.sh — examples/Qwen/Qwen3-8B/hf_offline_eagle3_ptq.yaml
+#                                       (common/eagle3/ has train_eagle.sh, not offline_training.sh)
+_KNOWN_MISSING_SCRIPTS = {
+    "common/smoke/hostname.sh",
+    "common/eagle3/offline_training.sh",
+}
+
+
+def _tasks(cfg):
+    """Yield (name, task_dict) for a single-task or job_name+pipeline example."""
+    if not isinstance(cfg, dict):
+        return
+    pipeline = cfg.get("pipeline")
+    if isinstance(pipeline, dict):
+        for key, val in pipeline.items():
+            if key.startswith("task_") and isinstance(val, dict):
+                yield key, val
+    elif "script" in cfg:
+        yield "task", cfg
+
+
+def test_examples_present():
+    """At least one launcher example YAML is discovered (guards the glob itself)."""
+    assert _EXAMPLES, "no launcher example YAMLs found"
+
+
+@pytest.mark.parametrize(
+    "path", _EXAMPLES, ids=[os.path.relpath(p, _LAUNCHER_DIR) for p in _EXAMPLES]
+)
+def test_example_yaml_valid(path):
+    """Each example parses and every task has a valid script/factory/args shape."""
+    with open(path) as f:
+        cfg = yaml.safe_load(f)
+    assert isinstance(cfg, (dict, list)), f"{path}: top-level YAML is not a mapping/list"
+
+    for name, task in _tasks(cfg):
+        script = task.get("script")
+        assert isinstance(script, str) and script.strip(), f"{path}:{name}: missing `script`"
+
+        # Scripts shipped with the launcher live under common/; verify the path is
+        # real so a renamed/typo'd wrapper is caught at unit-test time.
+        first_token = script.split()[0]
+        if first_token.startswith("common/") and first_token not in _KNOWN_MISSING_SCRIPTS:
+            assert os.path.exists(os.path.join(_LAUNCHER_DIR, first_token)), (
+                f"{path}:{name}: script not found: {first_token}"
+            )
+
+        slurm_config = task.get("slurm_config")
+        if slurm_config is not None:
+            assert slurm_config.get("_factory_"), (
+                f"{path}:{name}: slurm_config is missing `_factory_`"
+            )
+
+        args = task.get("args")
+        assert args is None or isinstance(args, list), f"{path}:{name}: `args` must be a list"
+
+        env = task.get("environment")
+        assert env is None or isinstance(env, (list, dict)), (
+            f"{path}:{name}: `environment` must be a list or dict"
+        )


### PR DESCRIPTION
### What does this PR do?

Type of change: new example (+ a launcher unit test)

Adds a public **Megatron QAD** (quantization-aware distillation) launcher example for `meta-llama/Llama-3.2-1B-Instruct`: PTQ (NVFP4) + MMLU gate → QAD/SFT train, plus a `common/megatron_lm/train/sft.sh` wrapper (mirrors `common/megatron_lm/quantize/quantize.sh`).

**Reworked — this no longer changes any modelopt code.** The earlier `_extra_state` plugin patch was reverted: it was the wrong load path (the crash is the *main* model load in `megatron/training/checkpointing.py`, not `_load_extra_state_from_sharded_checkpoint`) and it regressed quantizer-state loading (Nemotron `quantize_resume` MMLU 0.70 → 0.31). The correct fix is a config flag on the QAD train step:

- **`--dist-ckpt-strictness log_all`** → the main model load drops only the genuinely-missing `decoder.final_layernorm._extra_state` (via Megatron's own unexpected-key set), instead of the torch_dist DCP planner hard-raising. Present quantizer `_extra_state` is untouched.

Container `nvcr.io/nvidia/nemo:26.06.00` (ships `nvidia-resiliency-ext>=0.6.0`).

### Testing
- **Integration (GPU/cluster):** validated end-to-end on nmm-sandbox CI (CLAB-SC-01, computelab): 2/2 QAD tasks passed — quantize+MMLU gate and QAD train (the train step loads the quantized ckpt past the former `Missing key … final_layernorm._extra_state` crash). The Nemotron `quantize_resume` regression is cleared (MMLU back ≥0.70).
- **Unit (CPU):** adds `tools/launcher/tests/test_examples_resolve.py` — parses every launcher example and checks each task's `script`/`_factory_`/`args` shape and that `common/*` scripts exist (guards config regressions). 53 pass. (It also surfaced two pre-existing broken example script refs — `common/smoke/hostname.sh`, `common/eagle3/offline_training.sh` — excluded here, worth a separate fix.)

### Before your PR is "*Ready for review*"
- Backward compatible?: ✅ N/A (new example + new wrapper + new test; no code paths changed)
- New tests?: ✅ CPU example-resolution test; GPU validation is the nmm-sandbox integration run
- Changelog?: N/A (example)

### Additional Information
Follow-ups: OMNIML-5421 (make the Megatron-LM example scripts take CLI args so these `common/*` wrappers can be dropped for a direct 1-shell call). Supersedes the reverted modelopt-patch approach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a launch pipeline configuration to run Quantization-Aware Distillation (QAD) post-training SFT for the Llama 3.2 1B Instruct model.
  * Added a dedicated launcher script to simplify SFT/QAD runs with sensible defaults and CI-friendly status handling.
* **Tests**
  * Added CPU-only checks that validate all launcher example YAML files are well-formed and reference existing scripts (where applicable), preventing common runtime misconfigurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->