### PR TITLE
[Examples]: Kimi-K2.6/K2.7-Code Dflash/Dspark

### DIFF
--- a/modelopt_recipes/general/speculative_decoding/dspark.yaml
+++ b/modelopt_recipes/general/speculative_decoding/dspark.yaml
@@ -1,0 +1,96 @@
+# DSpark speculative-decoding training recipe.
+#
+# DSpark reuses the DFlash mode/pipeline and adds a lightweight sequential
+# (Markov) head plus an optional confidence head, selected via
+# dflash_architecture_config.projector_type=dspark. The Markov head adds a
+# prefix-dependent transition bias to the backbone base logits, inducing a causal
+# block distribution (semi-autoregressive generation). Trained with a three-term
+# loss: ce_alpha*CE + l1_alpha*TVD + conf_alpha*confidence_BCE. Online training is
+# the default path (data.mode=online). Override fields via an OmegaConf dotlist.
+
+metadata:
+  recipe_type: speculative_dflash
+  description: DSpark training recipe (DFlash backbone + Markov head + confidence head).
+
+# maps to ModelArguments (main.py)
+model:
+  model_name_or_path:
+  trust_remote_code: false
+  use_fake_base_for_offline: false
+
+# maps to DataArguments (main.py)
+data:
+  mode: online
+  data_path:
+  offline_data_path:
+  # Jinja chat template with {% generation %} tags for answer_only_loss.
+  chat_template:
+
+# maps to TrainingArguments (main.py)
+training:
+  # --- commonly modified ---
+  output_dir:
+  num_train_epochs: 6
+  per_device_train_batch_size: 1
+  learning_rate: 6.0e-4
+  warmup_ratio: 0.04
+  training_seq_len: 3072
+  logging_steps: 50
+  save_steps: 2000
+  cp_size: 1
+  dp_shard_size: 1
+  disable_tqdm: true
+  # Keep off: eval runs the DFlash backbone only (Markov head not applied yet),
+  # so AR would reflect the backbone alone, not the trained model. Compare via
+  # export + the offline acceptance-length harness instead.
+  estimate_ar: false
+  ar_validate_steps: 0
+  answer_only_loss: true
+
+  # --- rarely modified ---
+  do_eval: false
+  lr_scheduler_type: linear
+  save_strategy: steps
+  weight_decay: 0.0
+  max_grad_norm: 1.0
+  dataloader_drop_last: true
+  bf16: true
+  tf32: true
+  remove_unused_columns: false
+  # Safe default: the confidence head params are unused when
+  # dflash_confidence_head_alpha == 0, which would otherwise trip DDP.
+  ddp_find_unused_parameters: true
+  ddp_timeout: 1800
+  report_to: tensorboard
+
+# maps to DFlashConfig (modelopt/torch/speculative/config.py).
+dflash:
+  dflash_block_size: 16
+  dflash_num_anchors: 256
+  dflash_use_torch_compile: false
+  # DSpark computes the target distribution internally for its TVD/confidence
+  # terms; the DFlash KD path is unused.
+  dflash_self_logit_distillation: false
+  # gamma for exponential loss decay (block_size=16 -> 7).
+  dflash_loss_decay_factor: 7.0
+  # Qwen3 has no native mask token; 151669 is an unused id used by the reference.
+  dflash_mask_token_id: 151669
+  # Three-term loss weights (DeepSpec defaults: L1/TVD-dominant).
+  dflash_ce_loss_alpha: 0.1
+  dflash_l1_loss_alpha: 0.9
+  dflash_confidence_head_alpha: 1.0
+  dflash_architecture_config:
+    num_hidden_layers: 5
+    # Draft attention/MLP dims — set explicitly (the draft is an independent
+    # Qwen3 model and does NOT inherit these from the base). GQA: 8 KV heads.
+    num_attention_heads: 32
+    num_key_value_heads: 8
+    head_dim: 128
+    intermediate_size: 12288
+    projector_type: dspark
+    # Markov head: low-rank first-order transition bias. 'vanilla' (memoryless),
+    # 'gated' (hidden-gated), or 'rnn' (recurrent, closest to Domino's GRU).
+    markov_rank: 256
+    markov_head_type: vanilla
+    # Build + train the confidence head (per-position acceptance predictor).
+    use_confidence_head: true

--- a/tools/launcher/examples/moonshotai/Kimi-K2.6/hf_streaming_dflash_multi_node.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.6/hf_streaming_dflash_multi_node.yaml
@@ -1,0 +1,134 @@
+# DFlash streaming speculative-decoding training for Kimi-K2.6 — MULTI-NODE:
+# both the serve side (vLLM base) and the trainer side scale out. Same mechanism
+# as the Kimi-K2.5 example (common/eagle3/train_eagle_streaming.sh); this file
+# carries the K2.6-specific base, draft dims and capture ids.
+#
+# TOPOLOGY (all-4-GPU-node, no launcher dispatch change): each serve node hosts
+# one TP=4 base replica (a whole node); trainer nodes use their 4 GPUs for DDP.
+#   nodes=12, SERVE_NODES=8  -> 8 TP4 serve replicas + 4 trainer nodes
+#   DDP world = (12-8)*4 = 16 ranks
+#   global batch = 16 ranks * per_device 4 * grad_accum 1 = 64
+#
+# CAPTURE IDS (num_draft=6, 61-layer deepseek_v3/kimi_k25 base):
+#   build_target_layer_ids(num_orig=61, num_draft=6)=[1,12,24,35,47,58]
+#   -> +1 for embedding = [2,13,25,36,48,59], append the true final layer 61.
+#   7 captured = 6 aux layers, matching the 6-layer DFlash draft block below.
+#   (61 = true final hidden. Requires a vLLM with the aux-capture fix vllm#46788:
+#    aux is captured AFTER each layer at idx+1, so id 61 = output of last layer 60.
+#    Without it, id 60 = the 2nd-to-last layer, which caps acceptance length.)
+#
+# DRAFT DIMS: mtsp.convert()'s DFlash draft does NOT inherit the base GQA/FFN
+# dims — num_key_value_heads/head_dim/intermediate_size fall back to the draft
+# config's defaults, NOT the base. hidden_size/vocab/rope_theta ARE forced to the
+# base. So kv_heads / intermediate / num_hidden_layers are set explicitly below to
+# match the K2.6 backbone; leaving them default silently trains a wrong-shape draft.
+#
+# TRANSPORT: streamed hidden states move base->trainer over RDMA via NIXL. On
+# InfiniBand clusters (GB200/HSG/nrt) the default UCX backend works; on AWS EFA
+# set NIXL_BACKENDS=LIBFABRIC (UCX needs the EFA verbs driver the container lacks).
+#
+# Run ON the cluster login node (paramiko can't reach the cluster through its login proxy):
+#   export SLURM_HOST=localhost SLURM_ACCOUNT=<your_account> \
+#          SLURM_PARTITION=<multi_node_partition> \
+#          SLURM_HF_LOCAL=<hf_models_dir> \
+#          SLURM_JOB_DIR=<experiments_dir> \
+#          NEMORUN_HOME=$PWD
+#   uv run launch.py --yaml examples/moonshotai/Kimi-K2.6/hf_streaming_dflash_multi_node.yaml \
+#          identity=$HOME/.ssh/id_ecdsa detach=True --yes
+#
+# The export lands in /scratchspace/export. To benchmark it, point
+# specdec_bench.yaml's --draft_model_dir there (or copy it under /hf-local).
+
+job_name: Kimi-K2.6_DFlash_streaming_multi_node
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/moonshotai/Kimi-K2.6
+
+  # Build input conversations (produces /scratchspace/data/train.jsonl). This uses the
+  # small example dataset; to reproduce the released checkpoint, point task_1's
+  # data.data_path at the full Spec-Decoding-Dataset-v2 corpus instead.
+  task_0:
+    script: common/eagle3/make_dataset.sh
+    args:
+      - -f modules/Model-Optimizer/examples/dataset/example_data_config.yaml
+      - --full-conversations
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      # The cluster QOS requires whole-node GPU alloc even though make_dataset is CPU-only.
+      gpus_per_node: 4
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+
+  # Streaming DFlash training: 8 serve replicas (TP=4) + 4 trainer nodes.
+  task_1:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/dflash.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - model.use_fake_base_for_offline=true
+      - model.trust_remote_code=true
+      - data.mode=streaming
+      - data.data_path=/scratchspace/data/train.jsonl
+      - training.output_dir=/scratchspace/dflash
+      # Must be divisible by dflash_block_size (8).
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+      - training.num_train_epochs=1
+      - training.per_device_train_batch_size=4
+      - training.gradient_accumulation_steps=1
+      - training.save_steps=1000
+      - training.logging_steps=20
+      - training.learning_rate=1.0e-4
+      - training.warmup_steps=2000
+      # Kimi's slow tokenizer can't emit assistant masks the standard way; the mask
+      # is recovered from token ids (modelopt.torch.utils.loss_mask).
+      - training.answer_only_loss=true
+      # vLLM container has no tensorboard (dflash.yaml's default) -> init crash.
+      - training.report_to=none
+      # K2.6 draft dims (see header) — override the recipe's generic defaults.
+      - dflash.dflash_architecture_config.num_hidden_layers=6
+      - dflash.dflash_architecture_config.num_key_value_heads=8
+      - dflash.dflash_architecture_config.intermediate_size=18432
+      # D-PACE loss (dynamic, confidence-derived per-position weights).
+      - dflash.dflash_loss_objective=dpace
+      - dflash.dflash_dpace_alpha=0.5
+      # Kimi has no dedicated mask token; 163838 is a reserved slot used as the mask.
+      - dflash.dflash_mask_token_id=163838
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # See header for derivation. Requires the aux-capture-fix container (vllm#46788).
+      - EAGLE_CAPTURE_IDS: "[2,13,25,36,48,59,61]"
+      - SERVE_NODES: "8"
+      - SERVE_TP: "4"
+      # Per-rank in-flight fetches.
+      - STREAMING_NUM_WORKERS: "4"
+      # Kimi's custom-modeling base needs --trust_remote_code at export.
+      - EXPORT_EXTRA_ARGS: "--trust_remote_code"
+      # > training_seq_len: room for prompt + the 1-token decode fetch (else vLLM 400s at the cap).
+      - SERVE_MAX_MODEL_LEN: "4160"
+      - SERVE_MAX_NUM_SEQS: "24"
+      - SERVE_GPU_MEM_UTIL: "0.9"
+      # Big MoE base loads slowly off lustre -> generous readiness window.
+      - SERVE_READY_TIMEOUT: "5400"
+      - SERVE_EXTRA_ARGS: "--trust-remote-code"
+      - VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1200"
+      - VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+      # --- RDMA transport: UCX (InfiniBand) by default. On AWS EFA, uncomment: ---
+      # - NIXL_BACKENDS: "LIBFABRIC"
+      # - FI_PROVIDER: "efa"
+      # - NCCL_IB_DISABLE: "1"   # PDX ConnectX IB is not RC-routable node-to-node; force EFA/sockets
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 12
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      # vLLM x86_64 build WITH the aux-capture fix (vllm#46788) so capture id 61 = true
+      # final hidden; on AWS EFA it must also bundle libfabric. Replace with your image
+      # (the validated K2.6 runs used a nightly EFA build).
+      container: <vllm-image-with-aux-capture-fix>

--- a/tools/launcher/examples/moonshotai/Kimi-K2.6/hf_streaming_dflash_multi_node.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.6/hf_streaming_dflash_multi_node.yaml
@@ -1,33 +1,10 @@
-# DFlash streaming speculative-decoding training for Kimi-K2.6 — MULTI-NODE:
-# both the serve side (vLLM base) and the trainer side scale out. Same mechanism
-# as the Kimi-K2.5 example (common/eagle3/train_eagle_streaming.sh); this file
-# carries the K2.6-specific base, draft dims and capture ids.
+# DFlash streaming speculative-decoding training for Kimi-K2.6 (multi-node: the
+# vLLM base and the trainer both scale out). Runs the shared streaming pipeline
+# (common/eagle3/train_eagle_streaming.sh) with the K2.6-specific base, draft
+# dims and capture ids. A starting point for reproduction — tune node counts,
+# batch, steps and serve limits for your cluster.
 #
-# TOPOLOGY (all-4-GPU-node, no launcher dispatch change): each serve node hosts
-# one TP=4 base replica (a whole node); trainer nodes use their 4 GPUs for DDP.
-#   nodes=12, SERVE_NODES=8  -> 8 TP4 serve replicas + 4 trainer nodes
-#   DDP world = (12-8)*4 = 16 ranks
-#   global batch = 16 ranks * per_device 4 * grad_accum 1 = 64
-#
-# CAPTURE IDS (num_draft=6, 61-layer deepseek_v3/kimi_k25 base):
-#   build_target_layer_ids(num_orig=61, num_draft=6)=[1,12,24,35,47,58]
-#   -> +1 for embedding = [2,13,25,36,48,59], append the true final layer 61.
-#   7 captured = 6 aux layers, matching the 6-layer DFlash draft block below.
-#   (61 = true final hidden. Requires a vLLM with the aux-capture fix vllm#46788:
-#    aux is captured AFTER each layer at idx+1, so id 61 = output of last layer 60.
-#    Without it, id 60 = the 2nd-to-last layer, which caps acceptance length.)
-#
-# DRAFT DIMS: mtsp.convert()'s DFlash draft does NOT inherit the base GQA/FFN
-# dims — num_key_value_heads/head_dim/intermediate_size fall back to the draft
-# config's defaults, NOT the base. hidden_size/vocab/rope_theta ARE forced to the
-# base. So kv_heads / intermediate / num_hidden_layers are set explicitly below to
-# match the K2.6 backbone; leaving them default silently trains a wrong-shape draft.
-#
-# TRANSPORT: streamed hidden states move base->trainer over RDMA via NIXL. On
-# InfiniBand clusters (GB200/HSG/nrt) the default UCX backend works; on AWS EFA
-# set NIXL_BACKENDS=LIBFABRIC (UCX needs the EFA verbs driver the container lacks).
-#
-# Run ON the cluster login node (paramiko can't reach the cluster through its login proxy):
+# Run ON the cluster login node (paramiko can't reach it through the login proxy):
 #   export SLURM_HOST=localhost SLURM_ACCOUNT=<your_account> \
 #          SLURM_PARTITION=<multi_node_partition> \
 #          SLURM_HF_LOCAL=<hf_models_dir> \
@@ -36,8 +13,7 @@
 #   uv run launch.py --yaml examples/moonshotai/Kimi-K2.6/hf_streaming_dflash_multi_node.yaml \
 #          identity=$HOME/.ssh/id_ecdsa detach=True --yes
 #
-# The export lands in /scratchspace/export. To benchmark it, point
-# specdec_bench.yaml's --draft_model_dir there (or copy it under /hf-local).
+# The export lands in /scratchspace/export.
 
 job_name: Kimi-K2.6_DFlash_streaming_multi_node
 pipeline:
@@ -48,9 +24,8 @@ pipeline:
   global_vars:
     hf_model: /hf-local/moonshotai/Kimi-K2.6
 
-  # Build input conversations (produces /scratchspace/data/train.jsonl). This uses the
-  # small example dataset; to reproduce the released checkpoint, point task_1's
-  # data.data_path at the full Spec-Decoding-Dataset-v2 corpus instead.
+  # Build /scratchspace/data/train.jsonl. Point data.data_path at the full
+  # Spec-Decoding-Dataset-v2 corpus to reproduce the released checkpoint.
   task_0:
     script: common/eagle3/make_dataset.sh
     args:
@@ -60,11 +35,9 @@ pipeline:
       _factory_: "slurm_factory"
       nodes: 1
       ntasks_per_node: 1
-      # The cluster QOS requires whole-node GPU alloc even though make_dataset is CPU-only.
       gpus_per_node: 4
       container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
 
-  # Streaming DFlash training: 8 serve replicas (TP=4) + 4 trainer nodes.
   task_1:
     script: common/eagle3/train_eagle_streaming.sh
     args:
@@ -75,7 +48,6 @@ pipeline:
       - data.mode=streaming
       - data.data_path=/scratchspace/data/train.jsonl
       - training.output_dir=/scratchspace/dflash
-      # Must be divisible by dflash_block_size (8).
       - training.training_seq_len=4096
       - training.disable_tqdm=true
       - training.ar_validate_steps=500000
@@ -86,49 +58,44 @@ pipeline:
       - training.logging_steps=20
       - training.learning_rate=1.0e-4
       - training.warmup_steps=2000
-      # Kimi's slow tokenizer can't emit assistant masks the standard way; the mask
-      # is recovered from token ids (modelopt.torch.utils.loss_mask).
+      # Kimi's slow tokenizer can't emit assistant masks; recovered from token ids.
       - training.answer_only_loss=true
-      # vLLM container has no tensorboard (dflash.yaml's default) -> init crash.
+      # The vLLM serve container has no tensorboard -> trainer init crash.
       - training.report_to=none
-      # K2.6 draft dims (see header) — override the recipe's generic defaults.
+      # The DFlash draft does NOT inherit the base GQA/FFN dims, so set them
+      # explicitly to match the K2.6 backbone (else a silently wrong-shape draft).
       - dflash.dflash_architecture_config.num_hidden_layers=6
       - dflash.dflash_architecture_config.num_key_value_heads=8
       - dflash.dflash_architecture_config.intermediate_size=18432
-      # D-PACE loss (dynamic, confidence-derived per-position weights).
       - dflash.dflash_loss_objective=dpace
       - dflash.dflash_dpace_alpha=0.5
-      # Kimi has no dedicated mask token; 163838 is a reserved slot used as the mask.
+      # Kimi has no dedicated mask token; 163838 is a reserved slot.
       - dflash.dflash_mask_token_id=163838
     environment:
       - HF_MODEL_CKPT: <<global_vars.hf_model>>
-      # See header for derivation. Requires the aux-capture-fix container (vllm#46788).
+      # 6 aux capture layers + the true final hidden (61). Requires the aux-capture
+      # fix vllm#46788; without it use 60, which caps acceptance length.
       - EAGLE_CAPTURE_IDS: "[2,13,25,36,48,59,61]"
       - SERVE_NODES: "8"
       - SERVE_TP: "4"
-      # Per-rank in-flight fetches.
       - STREAMING_NUM_WORKERS: "4"
       # Kimi's custom-modeling base needs --trust_remote_code at export.
       - EXPORT_EXTRA_ARGS: "--trust_remote_code"
-      # > training_seq_len: room for prompt + the 1-token decode fetch (else vLLM 400s at the cap).
       - SERVE_MAX_MODEL_LEN: "4160"
       - SERVE_MAX_NUM_SEQS: "24"
       - SERVE_GPU_MEM_UTIL: "0.9"
-      # Big MoE base loads slowly off lustre -> generous readiness window.
       - SERVE_READY_TIMEOUT: "5400"
       - SERVE_EXTRA_ARGS: "--trust-remote-code"
       - VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1200"
       - VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
-      # --- RDMA transport: UCX (InfiniBand) by default. On AWS EFA, uncomment: ---
+      # RDMA transport is UCX (InfiniBand) by default. On AWS EFA, uncomment:
       # - NIXL_BACKENDS: "LIBFABRIC"
       # - FI_PROVIDER: "efa"
-      # - NCCL_IB_DISABLE: "1"   # PDX ConnectX IB is not RC-routable node-to-node; force EFA/sockets
+      # - NCCL_IB_DISABLE: "1"
     slurm_config:
       _factory_: "slurm_factory"
       nodes: 12
       ntasks_per_node: 1
       gpus_per_node: 4
-      # vLLM x86_64 build WITH the aux-capture fix (vllm#46788) so capture id 61 = true
-      # final hidden; on AWS EFA it must also bundle libfabric. Replace with your image
-      # (the validated K2.6 runs used a nightly EFA build).
+      # vLLM x86_64 build with the aux-capture fix (vllm#46788).
       container: <vllm-image-with-aux-capture-fix>

--- a/tools/launcher/examples/moonshotai/Kimi-K2.6/hf_streaming_dspark_multi_node.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.6/hf_streaming_dspark_multi_node.yaml
@@ -1,35 +1,12 @@
-# DSpark streaming speculative-decoding training for Kimi-K2.6 — MULTI-NODE.
-# DSpark = the DFlash backbone + a lightweight sequential (Markov) head + a
-# confidence head; it generates a causal block semi-autoregressively and is
-# trained with a 3-term loss (ce_alpha*CE + l1_alpha*TVD + conf_alpha*confidence).
-# It uses the DSpark recipe (dspark.yaml — which sets projector_type=dspark, the
-# confidence head, and the loss weights) on the DFlash streaming pipeline
-# (common/eagle3/train_eagle_streaming.sh); only the Kimi-specific draft dims and
-# mask token are overridden below. Trained from scratch (no DFlash warm-start).
+# DSpark streaming speculative-decoding training for Kimi-K2.6 (multi-node).
+# DSpark = the DFlash backbone + a lightweight Markov head + a confidence head,
+# generating a causal block semi-autoregressively; see dspark.yaml for the head
+# and loss config. Runs the shared streaming pipeline
+# (common/eagle3/train_eagle_streaming.sh) with the K2.6-specific base, draft
+# dims and mask token; trained from scratch. A starting point for reproduction —
+# tune node counts, batch, steps and serve limits for your cluster.
 #
-# TOPOLOGY (all-4-GPU-node): each serve node hosts one TP=4 base replica (a whole
-# node); trainer nodes use their 4 GPUs for DDP.
-#   nodes=12, SERVE_NODES=8  -> 8 TP4 serve replicas + 4 trainer nodes
-#   DDP world = (12-8)*4 = 16 ranks
-#   global batch = 16 ranks * per_device 4 * grad_accum 1 = 64
-#
-# CAPTURE IDS (num_draft=6, 61-layer deepseek_v3/kimi_k25 base):
-#   build_target_layer_ids(num_orig=61, num_draft=6)=[1,12,24,35,47,58]
-#   -> +1 = [2,13,25,36,48,59], append the true final layer 61. 7 captured = 6 aux
-#   layers, matching the 6-layer draft backbone. (61 = true final hidden; requires
-#   the aux-capture fix vllm#46788. Without it use 60 — caps acceptance length.)
-#
-# DRAFT DIMS: the DSpark draft (like DFlash) does NOT inherit the base GQA/FFN dims
-# (num_key_value_heads/head_dim/intermediate_size default to the draft config, NOT
-# the base; hidden_size/vocab/rope_theta ARE forced to the base). They are set
-# explicitly below to match the K2.6 backbone. dflash_block_size=8 = the semi-AR
-# generation block (training_seq_len must be divisible by it).
-#
-# TRANSPORT: streamed hidden states move base->trainer over RDMA via NIXL. On
-# InfiniBand (GB200/HSG/nrt) the default UCX backend works; on AWS EFA set
-# NIXL_BACKENDS=LIBFABRIC (UCX needs the EFA verbs driver the container lacks).
-#
-# Run ON the cluster login node (paramiko can't reach the cluster through its login proxy):
+# Run ON the cluster login node (paramiko can't reach it through the login proxy):
 #   export SLURM_HOST=localhost SLURM_ACCOUNT=<your_account> \
 #          SLURM_PARTITION=<multi_node_partition> \
 #          SLURM_HF_LOCAL=<hf_models_dir> \
@@ -38,8 +15,7 @@
 #   uv run launch.py --yaml examples/moonshotai/Kimi-K2.6/hf_streaming_dspark_multi_node.yaml \
 #          identity=$HOME/.ssh/id_ecdsa detach=True --yes
 #
-# The export lands in /scratchspace/export. To benchmark it, point
-# specdec_bench.yaml's --draft_model_dir there (or copy it under /hf-local).
+# The export lands in /scratchspace/export.
 
 job_name: Kimi-K2.6_DSpark_streaming_multi_node
 pipeline:
@@ -50,9 +26,8 @@ pipeline:
   global_vars:
     hf_model: /hf-local/moonshotai/Kimi-K2.6
 
-  # Build input conversations (produces /scratchspace/data/train.jsonl). This uses the
-  # small example dataset; to reproduce the released checkpoint, point task_1's
-  # data.data_path at the full Spec-Decoding-Dataset-v2 corpus instead.
+  # Build /scratchspace/data/train.jsonl. Point data.data_path at the full
+  # Spec-Decoding-Dataset-v2 corpus to reproduce the released checkpoint.
   task_0:
     script: common/eagle3/make_dataset.sh
     args:
@@ -62,11 +37,9 @@ pipeline:
       _factory_: "slurm_factory"
       nodes: 1
       ntasks_per_node: 1
-      # The cluster QOS requires whole-node GPU alloc even though make_dataset is CPU-only.
       gpus_per_node: 4
       container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
 
-  # Streaming DSpark training: 8 serve replicas (TP=4) + 4 trainer nodes.
   task_1:
     script: common/eagle3/train_eagle_streaming.sh
     args:
@@ -77,7 +50,6 @@ pipeline:
       - data.mode=streaming
       - data.data_path=/scratchspace/data/train.jsonl
       - training.output_dir=/scratchspace/dflash
-      # Must be divisible by dflash_block_size (8).
       - training.training_seq_len=4096
       - training.disable_tqdm=true
       - training.ar_validate_steps=500000
@@ -88,49 +60,44 @@ pipeline:
       - training.logging_steps=20
       - training.learning_rate=1.0e-4
       - training.warmup_steps=2000
-      # Kimi's slow tokenizer can't emit assistant masks the standard way; the mask
-      # is recovered from token ids (modelopt.torch.utils.loss_mask).
+      # Kimi's slow tokenizer can't emit assistant masks; recovered from token ids.
       - training.answer_only_loss=true
-      # vLLM container has no tensorboard (recipe default) -> init crash.
+      # The vLLM serve container has no tensorboard -> trainer init crash.
       - training.report_to=none
-      # K2.6 draft dims (see header) — override dspark.yaml's generic defaults.
+      # The DSpark draft does NOT inherit the base GQA/FFN dims, so set them
+      # explicitly to match the K2.6 backbone (else a silently wrong-shape draft).
       - dflash.dflash_architecture_config.num_hidden_layers=6
       - dflash.dflash_architecture_config.num_key_value_heads=8
       - dflash.dflash_architecture_config.intermediate_size=18432
       # Semi-AR generation block (dspark.yaml ships 16; the Kimi backbone uses 8).
       - dflash.dflash_block_size=8
-      # dspark.yaml's mask default targets Qwen; Kimi has no dedicated mask token, so
-      # use reserved slot 163838.
+      # Kimi has no dedicated mask token; 163838 is a reserved slot.
       - dflash.dflash_mask_token_id=163838
     environment:
       - HF_MODEL_CKPT: <<global_vars.hf_model>>
-      # See header for derivation. Requires the aux-capture-fix container (vllm#46788).
+      # 6 aux capture layers + the true final hidden (61). Requires the aux-capture
+      # fix vllm#46788; without it use 60, which caps acceptance length.
       - EAGLE_CAPTURE_IDS: "[2,13,25,36,48,59,61]"
       - SERVE_NODES: "8"
       - SERVE_TP: "4"
-      # Per-rank in-flight fetches.
       - STREAMING_NUM_WORKERS: "4"
       # Kimi's custom-modeling base needs --trust_remote_code at export.
       - EXPORT_EXTRA_ARGS: "--trust_remote_code"
-      # > training_seq_len: room for prompt + the 1-token decode fetch (else vLLM 400s at the cap).
       - SERVE_MAX_MODEL_LEN: "4160"
       - SERVE_MAX_NUM_SEQS: "24"
       - SERVE_GPU_MEM_UTIL: "0.9"
-      # Big MoE base loads slowly off lustre -> generous readiness window.
       - SERVE_READY_TIMEOUT: "5400"
       - SERVE_EXTRA_ARGS: "--trust-remote-code"
       - VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1200"
       - VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
-      # --- RDMA transport: UCX (InfiniBand) by default. On AWS EFA, uncomment: ---
+      # RDMA transport is UCX (InfiniBand) by default. On AWS EFA, uncomment:
       # - NIXL_BACKENDS: "LIBFABRIC"
       # - FI_PROVIDER: "efa"
-      # - NCCL_IB_DISABLE: "1"   # PDX ConnectX IB is not RC-routable node-to-node; force EFA/sockets
+      # - NCCL_IB_DISABLE: "1"
     slurm_config:
       _factory_: "slurm_factory"
       nodes: 12
       ntasks_per_node: 1
       gpus_per_node: 4
-      # vLLM x86_64 build WITH the aux-capture fix (vllm#46788) so capture id 61 = true
-      # final hidden; on AWS EFA it must also bundle libfabric. Replace with your image
-      # (the validated K2.6 runs used a nightly EFA build).
+      # vLLM x86_64 build with the aux-capture fix (vllm#46788).
       container: <vllm-image-with-aux-capture-fix>

--- a/tools/launcher/examples/moonshotai/Kimi-K2.6/hf_streaming_dspark_multi_node.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.6/hf_streaming_dspark_multi_node.yaml
@@ -1,0 +1,136 @@
+# DSpark streaming speculative-decoding training for Kimi-K2.6 — MULTI-NODE.
+# DSpark = the DFlash backbone + a lightweight sequential (Markov) head + a
+# confidence head; it generates a causal block semi-autoregressively and is
+# trained with a 3-term loss (ce_alpha*CE + l1_alpha*TVD + conf_alpha*confidence).
+# It uses the DSpark recipe (dspark.yaml — which sets projector_type=dspark, the
+# confidence head, and the loss weights) on the DFlash streaming pipeline
+# (common/eagle3/train_eagle_streaming.sh); only the Kimi-specific draft dims and
+# mask token are overridden below. Trained from scratch (no DFlash warm-start).
+#
+# TOPOLOGY (all-4-GPU-node): each serve node hosts one TP=4 base replica (a whole
+# node); trainer nodes use their 4 GPUs for DDP.
+#   nodes=12, SERVE_NODES=8  -> 8 TP4 serve replicas + 4 trainer nodes
+#   DDP world = (12-8)*4 = 16 ranks
+#   global batch = 16 ranks * per_device 4 * grad_accum 1 = 64
+#
+# CAPTURE IDS (num_draft=6, 61-layer deepseek_v3/kimi_k25 base):
+#   build_target_layer_ids(num_orig=61, num_draft=6)=[1,12,24,35,47,58]
+#   -> +1 = [2,13,25,36,48,59], append the true final layer 61. 7 captured = 6 aux
+#   layers, matching the 6-layer draft backbone. (61 = true final hidden; requires
+#   the aux-capture fix vllm#46788. Without it use 60 — caps acceptance length.)
+#
+# DRAFT DIMS: the DSpark draft (like DFlash) does NOT inherit the base GQA/FFN dims
+# (num_key_value_heads/head_dim/intermediate_size default to the draft config, NOT
+# the base; hidden_size/vocab/rope_theta ARE forced to the base). They are set
+# explicitly below to match the K2.6 backbone. dflash_block_size=8 = the semi-AR
+# generation block (training_seq_len must be divisible by it).
+#
+# TRANSPORT: streamed hidden states move base->trainer over RDMA via NIXL. On
+# InfiniBand (GB200/HSG/nrt) the default UCX backend works; on AWS EFA set
+# NIXL_BACKENDS=LIBFABRIC (UCX needs the EFA verbs driver the container lacks).
+#
+# Run ON the cluster login node (paramiko can't reach the cluster through its login proxy):
+#   export SLURM_HOST=localhost SLURM_ACCOUNT=<your_account> \
+#          SLURM_PARTITION=<multi_node_partition> \
+#          SLURM_HF_LOCAL=<hf_models_dir> \
+#          SLURM_JOB_DIR=<experiments_dir> \
+#          NEMORUN_HOME=$PWD
+#   uv run launch.py --yaml examples/moonshotai/Kimi-K2.6/hf_streaming_dspark_multi_node.yaml \
+#          identity=$HOME/.ssh/id_ecdsa detach=True --yes
+#
+# The export lands in /scratchspace/export. To benchmark it, point
+# specdec_bench.yaml's --draft_model_dir there (or copy it under /hf-local).
+
+job_name: Kimi-K2.6_DSpark_streaming_multi_node
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/moonshotai/Kimi-K2.6
+
+  # Build input conversations (produces /scratchspace/data/train.jsonl). This uses the
+  # small example dataset; to reproduce the released checkpoint, point task_1's
+  # data.data_path at the full Spec-Decoding-Dataset-v2 corpus instead.
+  task_0:
+    script: common/eagle3/make_dataset.sh
+    args:
+      - -f modules/Model-Optimizer/examples/dataset/example_data_config.yaml
+      - --full-conversations
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      # The cluster QOS requires whole-node GPU alloc even though make_dataset is CPU-only.
+      gpus_per_node: 4
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+
+  # Streaming DSpark training: 8 serve replicas (TP=4) + 4 trainer nodes.
+  task_1:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/dspark.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - model.use_fake_base_for_offline=true
+      - model.trust_remote_code=true
+      - data.mode=streaming
+      - data.data_path=/scratchspace/data/train.jsonl
+      - training.output_dir=/scratchspace/dflash
+      # Must be divisible by dflash_block_size (8).
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      - training.ar_validate_steps=500000
+      - training.num_train_epochs=1
+      - training.per_device_train_batch_size=4
+      - training.gradient_accumulation_steps=1
+      - training.save_steps=1000
+      - training.logging_steps=20
+      - training.learning_rate=1.0e-4
+      - training.warmup_steps=2000
+      # Kimi's slow tokenizer can't emit assistant masks the standard way; the mask
+      # is recovered from token ids (modelopt.torch.utils.loss_mask).
+      - training.answer_only_loss=true
+      # vLLM container has no tensorboard (recipe default) -> init crash.
+      - training.report_to=none
+      # K2.6 draft dims (see header) — override dspark.yaml's generic defaults.
+      - dflash.dflash_architecture_config.num_hidden_layers=6
+      - dflash.dflash_architecture_config.num_key_value_heads=8
+      - dflash.dflash_architecture_config.intermediate_size=18432
+      # Semi-AR generation block (dspark.yaml ships 16; the Kimi backbone uses 8).
+      - dflash.dflash_block_size=8
+      # dspark.yaml's mask default targets Qwen; Kimi has no dedicated mask token, so
+      # use reserved slot 163838.
+      - dflash.dflash_mask_token_id=163838
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # See header for derivation. Requires the aux-capture-fix container (vllm#46788).
+      - EAGLE_CAPTURE_IDS: "[2,13,25,36,48,59,61]"
+      - SERVE_NODES: "8"
+      - SERVE_TP: "4"
+      # Per-rank in-flight fetches.
+      - STREAMING_NUM_WORKERS: "4"
+      # Kimi's custom-modeling base needs --trust_remote_code at export.
+      - EXPORT_EXTRA_ARGS: "--trust_remote_code"
+      # > training_seq_len: room for prompt + the 1-token decode fetch (else vLLM 400s at the cap).
+      - SERVE_MAX_MODEL_LEN: "4160"
+      - SERVE_MAX_NUM_SEQS: "24"
+      - SERVE_GPU_MEM_UTIL: "0.9"
+      # Big MoE base loads slowly off lustre -> generous readiness window.
+      - SERVE_READY_TIMEOUT: "5400"
+      - SERVE_EXTRA_ARGS: "--trust-remote-code"
+      - VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "1200"
+      - VLLM_ENGINE_ITERATION_TIMEOUT_S: "1200"
+      # --- RDMA transport: UCX (InfiniBand) by default. On AWS EFA, uncomment: ---
+      # - NIXL_BACKENDS: "LIBFABRIC"
+      # - FI_PROVIDER: "efa"
+      # - NCCL_IB_DISABLE: "1"   # PDX ConnectX IB is not RC-routable node-to-node; force EFA/sockets
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 12
+      ntasks_per_node: 1
+      gpus_per_node: 4
+      # vLLM x86_64 build WITH the aux-capture fix (vllm#46788) so capture id 61 = true
+      # final hidden; on AWS EFA it must also bundle libfabric. Replace with your image
+      # (the validated K2.6 runs used a nightly EFA build).
+      container: <vllm-image-with-aux-capture-fix>

--- a/tools/launcher/examples/moonshotai/Kimi-K2.6/hf_streaming_dspark_multi_node.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.6/hf_streaming_dspark_multi_node.yaml
@@ -49,7 +49,7 @@ pipeline:
       - model.trust_remote_code=true
       - data.mode=streaming
       - data.data_path=/scratchspace/data/train.jsonl
-      - training.output_dir=/scratchspace/dflash
+      - training.output_dir=/scratchspace/dspark
       - training.training_seq_len=4096
       - training.disable_tqdm=true
       - training.ar_validate_steps=500000


### PR DESCRIPTION
### What does this PR do?

**Type of change:** New feature (recipe + examples)

Adds the DSpark training recipe and Kimi launcher examples for streaming speculative-decoding training. Split out of #1849 to keep that PR focused on the DSpark head implementation.

**Files added (5, all additive — no code changes):**

1. `modelopt_recipes/general/speculative_decoding/dspark.yaml` — the DSpark training recipe. Selects the DSpark head via `dflash_architecture_config.projector_type=dspark` (DFlash backbone + lightweight sequential/Markov head + optional confidence head) and sets the three-term loss weights (`dflash_ce_loss_alpha` / `dflash_l1_loss_alpha` / `dflash_confidence_head_alpha`).

2–5. `tools/launcher/examples/moonshotai/{Kimi-K2.6,Kimi-K2.7-Code}/hf_streaming_{dflash,dspark}_multi_node.yaml` — four multi-node streaming launcher examples mirroring the existing Kimi-K2.5 streaming format (`common/eagle3/train_eagle_streaming.sh`). They carry the Kimi-specific base path, draft dims, capture ids, and mask token; the DSpark examples build on `dspark.yaml` and override only the Kimi-specific fields (draft dims, `dflash_block_size=8`, mask token). K2.7-Code shares the K2.6 architecture (`kimi_k25`, 61 layers), so the draft config is identical.

### Dependency

**Stacked on #1849.** The recipe uses the config fields (`dflash_ce_loss_alpha`, `dflash_l1_loss_alpha`, `dflash_confidence_head_alpha`) added in #1849, so this PR is based on that branch and must merge **after** it. GitHub will auto-retarget the base to `main` once #1849 merges.

### Testing

- `dspark.yaml` passes the `validate modelopt recipes` schema check (against the #1849 config schema).
- The launcher examples ship a placeholder `container: <vllm-image-with-aux-capture-fix>` and are meant to be adapted per cluster (image, account, partition), not run verbatim in CI.

- Backward compatible?: ✅ (additive recipe + example files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DSpark speculative-decoding training recipe with configurable draft backbone, an optional per-position confidence head, and a Markov head.
  * Added new multi-node streaming training example workflows for Kimi-K2.6 (dataset generation + coordinated training/serve configuration), including an associated DFlash variant.
  * Enabled answer-only loss support and configurable runtime behavior (sequence/batch sizing, checkpoint/log cadence, and sensible serving/training timeout defaults), with capture-id wiring for improved correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->