### PR TITLE
Minor fix constant amax repr

### DIFF
--- a/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
+++ b/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
@@ -1210,7 +1210,7 @@ class TensorQuantizer(nn.Module):
         if self.is_mx_format:
             return "None"
         if self._use_constant_amax:
-            return f"{torch.finfo(torch.float8_e4m3fn).max:{fmt}}"
+            return f"{torch.finfo(torch.float8_e4m3fn).max:{fmt}}(const)"
         if not hasattr(self, "_amax"):
             return "dynamic"
         if self._amax is None:

--- a/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
+++ b/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
@@ -1209,6 +1209,8 @@ class TensorQuantizer(nn.Module):
         """
         if self.is_mx_format:
             return "None"
+        if self._use_constant_amax:
+            return f"{torch.finfo(torch.float8_e4m3fn).max:{fmt}}"
         if not hasattr(self, "_amax"):
             return "dynamic"
         if self._amax is None:

--- a/tests/unit/torch/quantization/test_print.py
+++ b/tests/unit/torch/quantization/test_print.py
@@ -38,7 +38,7 @@ class TestPrint:
             QuantizerAttributeConfig(num_bits=(4, 3), use_constant_amax=True)
         )
 
-        assert "amax=4.48e+02" in repr(test_quantizer)
+        assert "amax=4.48e+02(const)" in repr(test_quantizer)
 
     def test_disabled_tensor_quantizer_repr_shows_enabled_state(self):
         test_quantizer = TensorQuantizer(

--- a/tests/unit/torch/quantization/test_print.py
+++ b/tests/unit/torch/quantization/test_print.py
@@ -33,6 +33,13 @@ class TestPrint:
         test_quantizer = TensorQuantizer()
         print(test_quantizer)
 
+    def test_constant_amax_tensor_quantizer_repr(self):
+        test_quantizer = TensorQuantizer(
+            QuantizerAttributeConfig(num_bits=(4, 3), use_constant_amax=True)
+        )
+
+        assert "amax=4.48e+02" in repr(test_quantizer)
+
     def test_disabled_tensor_quantizer_repr_shows_enabled_state(self):
         test_quantizer = TensorQuantizer(
             QuantizerAttributeConfig(


### PR DESCRIPTION
### What does this PR do?

Type of change: ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

The constant amax in kv cache is showing `dynamic` which is confusing, making it show the "value(const)".

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated quantized tensor summaries to show a constant maximum value when that mode is enabled.
  * Improved printed output so the quantizer representation now reflects the constant-amax setting more clearly.

* **Tests**
  * Added coverage to verify the quantizer’s displayed representation includes the expected constant-amax indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->