### PR TITLE
fix: handle TE 2.16+ GroupedLinear new signature args

### DIFF
--- a/modelopt/torch/quantization/plugins/transformer_engine.py
+++ b/modelopt/torch/quantization/plugins/transformer_engine.py
@@ -160,10 +160,15 @@ class _QuantTEGroupedLinear(_ParallelLinear):
     @staticmethod
     def te_grouped_quantized_linear_fn(package, func_name, self, *args):
         _assert_te_fp8_enabled()
-        # Locate `inp` and the m_splits-bearing arg by parameter name. The second
-        # slot was renamed from `m_splits` (TE < 2.10) to `non_tensor_args` (TE
-        # 2.10+, where m_splits is now at non_tensor_args[0]). `*weights_and_biases`
-        # is always the trailing variadic — 2 * num_gemms tensors (weights, then biases).
+        # Locate `inp` by parameter name in the un-patched `_GroupedLinear.forward`
+        # signature — robust to TE versions that move the m_splits/non_tensor_args
+        # slot around (e.g. `m_splits` was packed into `non_tensor_args[0]` in TE
+        # 2.10-2.15, then split back out into its own arg in TE 2.16+).
+        # `num_gemms` comes from `self.num_gemms` (set by the public
+        # `GroupedLinear.__init__`) rather than from introspecting `*args`, so it's
+        # unaffected by that churn.
+        # `*weights_and_biases` is always the trailing variadic — 2 * num_gemms tensors
+        # (weights, then biases).
         # See `te_quantized_linear_fn` for why we look up `_forward` here.
         # `_forward` path receives a leading None (placeholder ctx); `_apply` does not.
         orig_forward = getattr(
@@ -174,10 +179,7 @@ class _QuantTEGroupedLinear(_ParallelLinear):
         sig_params = list(inspect.signature(orig_forward).parameters)
         ctx_offset = 0 if func_name == "_forward" else 1
         inp_pos = sig_params.index("inp") - ctx_offset
-        if "non_tensor_args" in sig_params:
-            num_gemms = len(args[sig_params.index("non_tensor_args") - ctx_offset][0])
-        else:
-            num_gemms = len(args[sig_params.index("m_splits") - ctx_offset])
+        num_gemms = self.num_gemms
         weights_start = len(args) - 2 * num_gemms
 
         new_args = list(args)

--- a/tests/gpu_megatron/torch/quantization/plugins/test_transformer_engine.py
+++ b/tests/gpu_megatron/torch/quantization/plugins/test_transformer_engine.py
@@ -43,7 +43,24 @@ class TELinear(nn.Module):
         return torch.randn(2, 16)
 
 
-@pytest.mark.parametrize("model_cls", [TELinear])
+class TEGroupedLinear(nn.Module):
+    """Exercises `_QuantTEGroupedLinear`, used by MoE expert grouped GEMMs."""
+
+    num_gemms = 3
+
+    def __init__(self):
+        super().__init__()
+        self.net = te.pytorch.GroupedLinear(self.num_gemms, 16, 32)
+
+    def forward(self, x):
+        m_splits = [x.shape[0] // self.num_gemms] * self.num_gemms
+        return self.net(x, m_splits)
+
+    def get_input(self):
+        return torch.randn(self.num_gemms * 2, 16)
+
+
+@pytest.mark.parametrize("model_cls", [TELinear, TEGroupedLinear])
 @pytest.mark.parametrize(
     "config",
     [

--- a/tests/gpu_megatron/torch/quantization/plugins/test_transformer_engine.py
+++ b/tests/gpu_megatron/torch/quantization/plugins/test_transformer_engine.py
@@ -60,6 +60,20 @@ class TEGroupedLinear(nn.Module):
         return torch.randn(self.num_gemms * 2, 16)
 
 
+# AWQ-lite and SmoothQuant calibration (model_calib.py's `AWQLiteHelper` and its
+# SmoothQuant counterpart) read `module.weight` directly. `_QuantTEGroupedLinear`
+# deletes `self.weight` and stores per-expert weights as `weight0..weightN` (see
+# `iter_weights_for_calibration`), so these algorithms don't support GroupedLinear yet.
+# That's a separate, pre-existing gap from the TE-signature-compat fix this test
+# module otherwise covers - skip rather than silently expanding scope here.
+_AWQ_SMOOTHQUANT_CFGS = [
+    mtq.W4A8_AWQ_BETA_CFG,
+    mtq.INT8_SMOOTHQUANT_CFG,
+    mtq.INT4_AWQ_CFG,
+    mtq.NVFP4_AWQ_LITE_CFG,
+]
+
+
 @pytest.mark.parametrize("model_cls", [TELinear, TEGroupedLinear])
 @pytest.mark.parametrize(
     "config",
@@ -78,6 +92,9 @@ class TEGroupedLinear(nn.Module):
 )
 def test_quantize(model_cls, config):
     """Test quantize function can run without problems."""
+    if model_cls is TEGroupedLinear and config in _AWQ_SMOOTHQUANT_CFGS:
+        pytest.skip("AWQ-lite/SmoothQuant calibration doesn't support GroupedLinear yet")
+
     if (
         config
         in [


### PR DESCRIPTION
### What does this PR do?

Type of change: ? Bug fix

TE 2.16 changed `_GroupedLinear.forward` from
`forward(ctx, inp, non_tensor_args, ...)` (with `m_splits` packed as `non_tensor_args[0]`, TE 2.10-2.15) to
`forward(ctx, inp, m_splits, non_tensor_args, ...)`, splitting `m_splits` back into its own positional argument and shifting `non_tensor_args[0]` to `use_bias`.

`te_grouped_quantized_linear_fn` still assumed the 2.10-2.15 layout, so on TE 2.16 it read `use_bias` (a bool) where it expected `m_splits` (a list/tensor), crashing PTQ calibration for any MoE model using `GroupedLinear` with `TypeError: object of type 'bool' has no len()`.

Rather than adding a third args-introspection branch for the new layout (which would still break the next time TE moves this slot), derive `num_gemms` from `self.num_gemms` instead - set by the public `GroupedLinear.__init__` constructor arg and already relied on elsewhere in this class (`iter_weights_for_calibration`). This removes the args-shape dependency entirely for num_gemms, so future internal reshuffles of `_GroupedLinear.forward` can't break it again. `inp`'s position still requires signature introspection since it's a runtime argument, not a stored attribute - that part is unavoidable.

Adds a `GroupedLinear` case to test_transformer_engine.py, which previously only covered `te.pytorch.Linear`/`LayerNormLinear`.

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ 
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅ 
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?:  ❌ 
- Did you get Claude approval on this PR?: 

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grouped linear quantization compatibility across Transformer Engine argument layout variations.
  * Now uses the configured grouped GEMM count directly to reduce quantization mismatches.

* **Tests**
  * Expanded quantization test coverage to include grouped Transformer Engine linear layers.
  * Added a new multi-GEMM grouped linear test model and updated parametrization to run it alongside existing coverage.
  * Added conditional skipping for specific calibration configurations where grouped linear is not compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->