### PR TITLE
fix: mcore_param_count for GatedDeltaNet, MLA, and latent-MoE layers

### DIFF
--- a/modelopt/torch/nas/plugins/megatron_model_stats.py
+++ b/modelopt/torch/nas/plugins/megatron_model_stats.py
@@ -149,12 +149,17 @@ def _moe_layer_params(
     normalization: str,
     moe_shared_expert_intermediate_size: int | None,
     moe_shared_expert_gate: bool = False,
+    moe_latent_size: int | None = None,
 ) -> tuple[int, int]:
     """Params for a MoE sublayer, returned as (total, active).
 
     ``pre_mlp_layernorm`` is a *separate* TENorm (not fused into expert fc1).
     Routed expert fc1/fc2 use ``TEColumnParallelLinear`` (no fused LN).
     Shared experts never carry bias regardless of ``add_bias_linear``.
+
+    With ``moe_latent_size`` (e.g. Nemotron-3 latent MoE), a shared ``fc1_latent_proj`` /
+    ``fc2_latent_proj`` compress hidden <-> latent and the routed experts run in the latent dim;
+    the router and shared experts still run on ``hidden_size``.
 
     ``total`` counts all ``num_moe_experts`` routed experts; ``active`` counts only
     ``moe_router_topk`` (the experts actually used in each forward pass).  The router,
@@ -166,16 +171,22 @@ def _moe_layer_params(
     if add_bias_linear:
         always += num_moe_experts  # router bias
 
-    # Shared expert (SharedExpertMLP always has add_bias_linear=False)
+    # Shared expert (SharedExpertMLP always has add_bias_linear=False), always on hidden_size
     if moe_shared_expert_intermediate_size:
         s_fc1_out = moe_shared_expert_intermediate_size * (2 if gated_linear_unit else 1)
         always += hidden_size * s_fc1_out + moe_shared_expert_intermediate_size * hidden_size
         if moe_shared_expert_gate:
             always += hidden_size  # gate_weight: 1 x hidden_size
 
+    # Latent MoE: shared hidden<->latent projections (always active); routed experts run in latent dim.
+    expert_io_size = hidden_size
+    if moe_latent_size:
+        always += hidden_size * moe_latent_size + moe_latent_size * hidden_size
+        expert_io_size = moe_latent_size
+
     # Per routed-expert params
     fc1_out = moe_ffn_hidden_size * (2 if gated_linear_unit else 1)
-    per_expert = hidden_size * fc1_out + moe_ffn_hidden_size * hidden_size
+    per_expert = expert_io_size * fc1_out + moe_ffn_hidden_size * expert_io_size
     if add_bias_linear:
         per_expert += fc1_out + moe_ffn_hidden_size
 
@@ -217,6 +228,82 @@ def _mamba_layer_params(
 
     # Internal RMSNorm on d_inner (always RMSNorm, 1 weight only)
     params += d_inner
+
+    return params
+
+
+def _gated_delta_net_layer_params(
+    hidden_size: int,
+    linear_num_key_heads: int,
+    linear_key_head_dim: int,
+    linear_num_value_heads: int,
+    linear_value_head_dim: int,
+    linear_conv_kernel_dim: int,
+    normalization: str,
+) -> int:
+    """Params for a single GatedDeltaNet (linear-attention) sublayer, e.g. Qwen3-Next / Qwen3.5.
+
+    ``in_proj`` (TELayerNormColumnParallelLinear with fused input LN) projects to q, k, v, the output
+    gate ``z``, and the per-value-head ``beta`` + ``alpha`` scalars; a depthwise ``conv1d`` (no bias)
+    runs over q/k/v; ``A_log`` + ``dt_bias`` are per value head; a gated RMSNorm over the value head
+    dim precedes ``out_proj``.
+    """
+    key_dim = linear_num_key_heads * linear_key_head_dim
+    value_dim = linear_num_value_heads * linear_value_head_dim
+
+    # in_proj: hidden -> (q + k + v + z-gate) + (beta + alpha), no bias, fused input LN
+    in_proj_out = 2 * key_dim + 2 * value_dim + 2 * linear_num_value_heads
+    params = hidden_size * in_proj_out
+    params += _norm_params(hidden_size, normalization)  # fused input_layernorm
+
+    # conv1d (depthwise, no bias) over q, k, v channels
+    params += (2 * key_dim + value_dim) * linear_conv_kernel_dim
+
+    # Per-value-head scalars: A_log + dt_bias
+    params += 2 * linear_num_value_heads
+
+    # Gated RMSNorm over the value head dim (always RMSNorm, 1 weight), then out_proj: value_dim -> hidden
+    params += linear_value_head_dim
+    params += value_dim * hidden_size
+
+    return params
+
+
+def _mla_layer_params(
+    hidden_size: int,
+    num_attention_heads: int,
+    q_lora_rank: int | None,
+    kv_lora_rank: int,
+    qk_head_dim: int,
+    qk_pos_emb_head_dim: int,
+    v_head_dim: int,
+    normalization: str,
+) -> int:
+    """Params for a single Multi-Latent Attention (MLA) sublayer, e.g. DeepSeek / Kimi.
+
+    The query is optionally low-rank compressed (``q_lora_rank``); the key/value share a low-rank
+    down-projection that also carries the MQA rope key, each up-projection fusing an RMSNorm on its
+    latent dim. A separate ``input_layernorm`` precedes the attention (not fused into a linear).
+    """
+    q_head_dim = qk_head_dim + qk_pos_emb_head_dim
+
+    params = _norm_params(hidden_size, normalization)  # input_layernorm
+
+    # Query: low-rank (down -> RMSNorm -> up) when q_lora_rank is set, else a single projection.
+    if q_lora_rank:
+        params += q_lora_rank * hidden_size  # q_down_proj
+        params += _norm_params(q_lora_rank, normalization)  # q up-proj fused RMSNorm
+        params += num_attention_heads * q_head_dim * q_lora_rank  # q_up_proj
+    else:
+        params += num_attention_heads * q_head_dim * hidden_size  # q_proj
+
+    # Key/Value: joint low-rank down-projection (+ shared rope key) -> RMSNorm -> up-projection.
+    params += (kv_lora_rank + qk_pos_emb_head_dim) * hidden_size  # kv_down_proj (with MQA rope)
+    params += _norm_params(kv_lora_rank, normalization)  # kv up-proj fused RMSNorm
+    params += num_attention_heads * (qk_head_dim + v_head_dim) * kv_lora_rank  # kv_up_proj
+
+    # Output projection: (num_heads * v_head_dim) -> hidden
+    params += num_attention_heads * v_head_dim * hidden_size
 
     return params
 
@@ -293,6 +380,7 @@ def mcore_param_count(
     moe_ffn_hidden_size: int | None = _get("moe_ffn_hidden_size")
     moe_shared_expert_intermediate_size: int | None = _get("moe_shared_expert_intermediate_size")
     moe_shared_expert_gate: bool = _get("moe_shared_expert_gate", False)
+    moe_latent_size: int | None = _get("moe_latent_size", None)
     mamba_num_heads: int | None = _get("mamba_num_heads")
     mamba_head_dim: int | None = _get("mamba_head_dim")
     mamba_num_groups: int | None = _get("mamba_num_groups")
@@ -303,6 +391,48 @@ def mcore_param_count(
     qk_layernorm: bool = _get("qk_layernorm", False)
     attention_output_gate: bool = _get("attention_output_gate", False)
     moe_layer_freq: int | list[int] = _get("moe_layer_freq", 1)
+    # GatedDeltaNet (linear-attention) hybrid, e.g. Qwen3-Next / Qwen3.5: every ``linear_attention_freq``-th
+    # layer keeps full attention, the rest use GatedDeltaNet linear attention.
+    experimental_attention_variant: str | None = _get("experimental_attention_variant", None)
+    linear_attention_freq: int | None = _get("linear_attention_freq", None)
+    is_gdn = experimental_attention_variant == "gated_delta_net" and bool(linear_attention_freq)
+    # Multi-Latent Attention (MLA), e.g. DeepSeek / Kimi: low-rank compressed q/kv projections.
+    multi_latent_attention: bool = _get("multi_latent_attention", False)
+
+    def _attn_params(i: int) -> int:
+        """Params for the attention sublayer of layer ``i`` (GatedDeltaNet / MLA / standard)."""
+        if is_gdn and (i + 1) % linear_attention_freq != 0:
+            return _gated_delta_net_layer_params(
+                hidden_size,
+                _get("linear_num_key_heads"),
+                _get("linear_key_head_dim"),
+                _get("linear_num_value_heads"),
+                _get("linear_value_head_dim"),
+                _get("linear_conv_kernel_dim", 4),
+                normalization,
+            )
+        if multi_latent_attention:
+            return _mla_layer_params(
+                hidden_size,
+                num_attention_heads,
+                _get("q_lora_rank"),
+                _get("kv_lora_rank"),
+                _get("qk_head_dim", kv_channels),
+                _get("qk_pos_emb_head_dim", 0),
+                _get("v_head_dim", kv_channels),
+                normalization,
+            )
+        assert kv_channels is not None, "kv_channels must be set for GPT attention layers"
+        return _attn_layer_params(
+            hidden_size,
+            num_attention_heads,
+            num_query_groups or num_attention_heads,
+            kv_channels,
+            add_bias_linear,
+            normalization,
+            qk_layernorm,
+            attention_output_gate,
+        )
 
     # Fill in derived defaults
     if num_query_groups is None:
@@ -330,16 +460,7 @@ def mcore_param_count(
             moe_pattern = [1 if (i % moe_layer_freq == 0) else 0 for i in range(num_layers)]
 
         for i in range(num_layers):
-            layer_t = layer_a = _attn_layer_params(
-                hidden_size,
-                num_attention_heads,
-                num_query_groups,
-                kv_channels,
-                add_bias_linear,
-                normalization,
-                qk_layernorm,
-                attention_output_gate,
-            )
+            layer_t = layer_a = _attn_params(i)
             if moe_pattern[i] and num_moe_experts:
                 assert moe_ffn_hidden_size is not None, (
                     "moe_ffn_hidden_size must be set for MoE layers"
@@ -354,6 +475,7 @@ def mcore_param_count(
                     normalization,
                     moe_shared_expert_intermediate_size,
                     moe_shared_expert_gate,
+                    moe_latent_size,
                 )
                 layer_t += mt
                 layer_a += ma
@@ -376,7 +498,7 @@ def mcore_param_count(
         # ---- Hybrid / MambaModel: layer type is encoded in the pattern ----
         layer_chars = parse_main_layer_chars(hybrid_layer_pattern, num_layers)
 
-        for char in layer_chars:
+        for i, char in enumerate(layer_chars):
             if char == _HYBRID_MAMBA:
                 assert mamba_num_heads is not None, "mamba_num_heads must be set for Mamba layers"
                 assert mamba_head_dim is not None, "mamba_head_dim must be set for Mamba layers"
@@ -392,16 +514,7 @@ def mcore_param_count(
                 )
             elif char == _HYBRID_ATTN:
                 assert kv_channels is not None, "kv_channels must be set for attention layers"
-                t = a = _attn_layer_params(
-                    hidden_size,
-                    num_attention_heads,
-                    num_query_groups,
-                    kv_channels,
-                    add_bias_linear,
-                    normalization,
-                    qk_layernorm,
-                    attention_output_gate,
-                )
+                t = a = _attn_params(i)
             elif char == _HYBRID_MLP:
                 assert ffn_hidden_size is not None, "ffn_hidden_size must be set for MLP layers"
                 t = a = _dense_mlp_params(
@@ -426,6 +539,7 @@ def mcore_param_count(
                     normalization,
                     moe_shared_expert_intermediate_size,
                     moe_shared_expert_gate,
+                    moe_latent_size,
                 )
             else:
                 raise ValueError(f"Unsupported hybrid layer character: {char}")

--- a/tests/gpu_megatron/torch/nas/plugins/test_megatron_model_stats.py
+++ b/tests/gpu_megatron/torch/nas/plugins/test_megatron_model_stats.py
@@ -124,6 +124,73 @@ _MAMBA = (
     + _D_INNER  # internal RMSNorm
 )  # 72 + 4 + 16 + 60 + 6 + 4 = 162
 
+# GatedDeltaNet (linear-attention) sublayer, e.g. Qwen3-Next / Qwen3.5:
+#   in_proj:  H * (2*key_dim + 2*val_dim + 2*LNV)  +  input_layernorm: H
+#   conv1d (depthwise, no bias):  (2*key_dim + val_dim) * conv_kernel
+#   scalars:  A_log + dt_bias  -> 2 * LNV
+#   gated RMSNorm over value head dim: LVD  +  out_proj: val_dim * H
+_LNK, _LKD = 2, 2  # linear_num_key_heads, linear_key_head_dim
+_LNV, _LVD = 2, 2  # linear_num_value_heads, linear_value_head_dim
+_LCK = 4  # linear_conv_kernel_dim
+_KEY_DIM = _LNK * _LKD  # 4
+_VAL_DIM = _LNV * _LVD  # 4
+_GDN = (
+    _H * (2 * _KEY_DIM + 2 * _VAL_DIM + 2 * _LNV)  # in_proj weight: 4 * 20 = 80
+    + _LN  # input_layernorm
+    + (2 * _KEY_DIM + _VAL_DIM) * _LCK  # conv1d: 12 * 4 = 48
+    + 2 * _LNV  # A_log + dt_bias
+    + _LVD  # gated RMSNorm (value head dim)
+    + _VAL_DIM * _H  # out_proj: 4 * 4 = 16
+)  # 80 + 4 + 48 + 4 + 2 + 16 = 154
+
+_GDN_OVERRIDES = {
+    "experimental_attention_variant": "gated_delta_net",
+    "linear_attention_freq": 4,
+    "linear_num_key_heads": _LNK,
+    "linear_key_head_dim": _LKD,
+    "linear_num_value_heads": _LNV,
+    "linear_value_head_dim": _LVD,
+    "linear_conv_kernel_dim": _LCK,
+}
+
+# Multi-Latent Attention (MLA) sublayer, e.g. DeepSeek:
+#   input_layernorm: H
+#   q:  q_down (q_lora*H) + q RMSNorm (q_lora) + q_up (nh*(qk_head+qk_rope)*q_lora)
+#   kv: kv_down ((kv_lora+qk_rope)*H) + kv RMSNorm (kv_lora) + kv_up (nh*(qk_head+v_head)*kv_lora)
+#   o_proj: nh*v_head*H
+_QLORA, _KVLORA = 3, 2  # q_lora_rank, kv_lora_rank
+_QKH, _QKR, _VH = 2, 2, 2  # qk_head_dim, qk_pos_emb_head_dim, v_head_dim
+_QHD = _QKH + _QKR  # q head dim = 4
+_MLA = (
+    _LN  # input_layernorm
+    + _QLORA * _H  # q_down_proj: 3*4 = 12
+    + _QLORA  # q RMSNorm
+    + _NH * _QHD * _QLORA  # q_up_proj: 2*4*3 = 24
+    + (_KVLORA + _QKR) * _H  # kv_down_proj: 4*4 = 16
+    + _KVLORA  # kv RMSNorm
+    + _NH * (_QKH + _VH) * _KVLORA  # kv_up_proj: 2*4*2 = 16
+    + _NH * _VH * _H  # o_proj: 2*2*4 = 16
+)  # 4 + 12 + 3 + 24 + 16 + 2 + 16 + 16 = 93
+
+_MLA_OVERRIDES = {
+    "multi_latent_attention": True,
+    "q_lora_rank": _QLORA,
+    "kv_lora_rank": _KVLORA,
+    "qk_head_dim": _QKH,
+    "qk_pos_emb_head_dim": _QKR,
+    "v_head_dim": _VH,
+}
+
+# Latent MoE (e.g. Nemotron-3-Super): shared hidden<->latent projections, routed experts run in
+# the latent dim; router + shared expert stay on hidden_size.
+_MOE_LATENT = 3  # moe_latent_size
+_LATENT_PROJ = (
+    _H * _MOE_LATENT + _MOE_LATENT * _H
+)  # fc1_latent_proj + fc2_latent_proj = 12 + 12 = 24
+_MOE_PER_EXP_LATENT = _MOE_LATENT * _MOE_FFN + _MOE_FFN * _MOE_LATENT  # 3*8 + 8*3 = 48
+_MOE_LATENT_TOTAL = _MOE_ALWAYS + _LATENT_PROJ + _NE * _MOE_PER_EXP_LATENT  # 12 + 24 + 2*48 = 132
+_MOE_LATENT_ACTIVE = _MOE_ALWAYS + _LATENT_PROJ + _TOPK * _MOE_PER_EXP_LATENT  # 12 + 24 + 48 = 84
+
 
 # ---------------------------------------------------------------------------
 # Formula tests (no GPU required)
@@ -211,6 +278,39 @@ class TestMcoreParamCountFormulas:
         total, active = mcore_param_count(_BASE_CFG, _V, num_layers=4, moe_layer_freq=2)
         assert total == _BASE_UNTIED + 4 * _ATTN + 2 * _MOE_TOTAL + 2 * _DENSE_MLP
         assert active == _BASE_UNTIED + 4 * _ATTN + 2 * _MOE_ACTIVE + 2 * _DENSE_MLP
+
+    def test_gated_delta_net_layers(self):
+        # GatedDeltaNet hybrid (Qwen3-Next / Qwen3.5): every linear_attention_freq-th layer keeps
+        # full attention, the rest use GDN linear attention. freq=4, num_layers=4 -> layers 0,1,2 GDN,
+        # layer 3 full attention (dense MLP throughout).
+        total, _ = mcore_param_count(
+            _BASE_CFG, _V, num_layers=4, num_moe_experts=None, **_GDN_OVERRIDES
+        )
+        assert total == _BASE_UNTIED + 3 * (_GDN + _DENSE_MLP) + (_ATTN + _DENSE_MLP)
+
+    def test_gated_delta_net_differs_from_plain_attention(self):
+        # Without the variant flag, the same layers are counted as plain attention (no GDN dispatch).
+        gdn, _ = mcore_param_count(
+            _BASE_CFG, _V, num_layers=4, num_moe_experts=None, **_GDN_OVERRIDES
+        )
+        plain, _ = mcore_param_count(_BASE_CFG, _V, num_layers=4, num_moe_experts=None)
+        assert plain == _BASE_UNTIED + 4 * (_ATTN + _DENSE_MLP)
+        assert gdn - plain == 3 * (_GDN - _ATTN)  # 3 GDN layers replace 3 attention layers
+
+    def test_multi_latent_attention_layers(self):
+        # MLA (DeepSeek): every attention sublayer uses the low-rank q/kv projections instead of QKV.
+        total, _ = mcore_param_count(
+            _BASE_CFG, _V, num_layers=2, num_moe_experts=None, **_MLA_OVERRIDES
+        )
+        assert total == _BASE_UNTIED + 2 * (_MLA + _DENSE_MLP)
+
+    def test_latent_moe_layer_total_and_active(self):
+        # Latent MoE: shared hidden<->latent projections + routed experts in the latent dim.
+        total, active = mcore_param_count(
+            _BASE_CFG, _V, hybrid_layer_pattern="E", moe_latent_size=_MOE_LATENT
+        )
+        assert total == _BASE_UNTIED + _MOE_LATENT_TOTAL
+        assert active == _BASE_UNTIED + _MOE_LATENT_ACTIVE
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The analytical ``mcore_param_count`` (Minitron pruning "Original Model Stats" + the ``--prune_target_params`` baseline) counted every attention layer as plain attention and every MoE expert on ``hidden_size``, mis-counting three pruning-supported layer variants:

- **GatedDeltaNet** linear attention (Qwen3.5 / Qwen3.6) → new ``_gated_delta_net_layer_params``
- **Multi-Latent Attention** (DeepSeek / Kimi) → new ``_mla_layer_params``
- **Latent MoE** (Nemotron-3-Super) → ``_moe_layer_params`` handles ``moe_latent_size`` (shared hidden↔latent projections; routed experts run in the latent dim)

Dispatch is unified through a single ``_attn_params(i)`` helper used by both the pure-GPT and hybrid branches. Each variant is guarded by its config flag, so non-affected models are unchanged.

## Validation

Each formula was derived from a tiny real model's actual per-layer parameters and confirmed to equal ``mcore_param_count_live`` **exactly** (delta 0): Qwen3.5-VL-MoE (GDN), DeepSeek-V3 (MLA), and a MoE with ``moe_latent_size`` (latent MoE). Added hand-verified formula unit tests; all pre-existing formula tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new attention counting options, including gated linear attention and multi-latent attention.
  * Added latent MoE parameter counting, including active and total counts for latent-dimension expert layers.

* **Bug Fixes**
  * Improved parameter estimates for mixed layer patterns so counts now reflect the correct layer type throughout the model.

* **Tests**
  * Expanded coverage with new reference cases for the latest attention and MoE configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->