### PR TITLE
[6385268][ONNX][Autocast] Fix BF16 autocast for FP16 initializers

### DIFF
--- a/modelopt/onnx/autocast/precisionconverter.py
+++ b/modelopt/onnx/autocast/precisionconverter.py
@@ -621,7 +621,6 @@ class PrecisionConverter:
                         f"Convert initializer {init_name} to "
                         f"{self.low_precision_type.str_short}, only used by low precision nodes"
                     )
-                    from_type = self.high_precision_type
                     to_type = self.low_precision_type
                 elif len(tracker.high_precision_nodes) > 0:
                     logger.debug(
@@ -629,12 +628,16 @@ class PrecisionConverter:
                         f"{self.high_precision_type.str_short}, "
                         "only used by high precision nodes"
                     )
-                    from_type = self.low_precision_type
                     to_type = self.high_precision_type
                 else:
                     raise ValueError(
                         f"Unexpected: initializer {init_name} is not used by any "
                         "nodes and is not a float"
+                    )
+                from_type = self._precision_type_from_onnx_type(init.data_type)
+                if from_type is None:
+                    raise ValueError(
+                        f"Unexpected: initializer {init_name} is not a supported float"
                     )
 
                 new_init = self._cast_initializer(
@@ -743,6 +746,10 @@ class PrecisionConverter:
 
         utils.walk_subgraphs_recursive(self.model.graph, _convert_subgraph_callback)
 
+    def _precision_type_from_onnx_type(self, onnx_type: int) -> PrecisionTypes | None:
+        """Return the converter precision metadata for a supported ONNX float type."""
+        return next((p for p in PRECISION_MAP.values() if p.onnx_type == onnx_type), None)
+
     def _convert_initializer_data(
         self,
         init: onnx.TensorProto,
@@ -762,15 +769,19 @@ class PrecisionConverter:
         Returns:
             onnx.TensorProto: The converted initializer.
         """
-        np_array = numpy_helper.to_array(init)
+        np_array = (
+            onnx_utils.read_f16_tensor_as_fp32(init)
+            if self._is_bf16(from_type)
+            else numpy_helper.to_array(init)
+        )
 
         # Handle bfloat16 conversion
-        if self._is_bf16(to_type) and self._is_fp32(from_type):
+        if self._is_bf16(to_type):
             new_init = onnx.TensorProto()
             new_init.dims.extend(np_array.shape)
             new_init.name = init.name
             new_init.data_type = onnx.TensorProto.BFLOAT16
-            bf16_bytes = np_array.astype(ml_dtypes.bfloat16).view(np.uint16)
+            bf16_bytes = np_array.astype(np.float32).astype(ml_dtypes.bfloat16).view(np.uint16)
             new_init.raw_data = bf16_bytes.tobytes()
         else:
             assert to_type.numpy_type is not None
@@ -1185,10 +1196,10 @@ class PrecisionConverter:
                 converted_type = tensor.type.tensor_type.elem_type
 
                 if converted_type != original_type:
-                    # There's one allowed exception: FP32 I/O converted to the selected low precision type with
-                    # keep_io_types=False
+                    # There's one allowed exception: floating point I/O converted to the selected low
+                    # precision type with keep_io_types=False.
                     if (
-                        original_type == onnx.TensorProto.FLOAT
+                        original_type in ONNX_TYPES
                         and converted_type == self.low_precision_type.onnx_type
                         and not self.keep_io_types
                     ):

--- a/modelopt/onnx/autocast/precisionconverter.py
+++ b/modelopt/onnx/autocast/precisionconverter.py
@@ -727,14 +727,7 @@ class PrecisionConverter:
                 if init.data_type not in ONNX_TYPES or init.data_type == target_type.onnx_type:
                     continue
 
-                from_type = (
-                    self.high_precision_type
-                    if init.data_type == self.high_precision_type.onnx_type
-                    else self.low_precision_type
-                    if init.data_type == self.low_precision_type.onnx_type
-                    else None
-                )
-
+                from_type = self._precision_type_from_onnx_type(init.data_type)
                 if from_type is None:
                     logger.debug(
                         f"Skipping subgraph initializer {init.name} with unsupported type {init.data_type}"

--- a/tests/unit/onnx/autocast/test_precisionconverter.py
+++ b/tests/unit/onnx/autocast/test_precisionconverter.py
@@ -1696,6 +1696,45 @@ def test_if_subgraph_initializer_conversion(
         )
 
 
+@pytest.mark.parametrize("use_standalone_type_inference", [True, False])
+def test_bf16_if_subgraph_conversion_accepts_fp16_initializers(
+    model_with_if_subgraph, use_standalone_type_inference
+):
+    model, value_info_map, initializer_map, node_to_init_map = model_with_if_subgraph
+    for node in model.graph.node:
+        if node.op_type != "If":
+            continue
+        for attr in node.attribute:
+            if attr.name not in ("then_branch", "else_branch"):
+                continue
+            for init in attr.g.initializer:
+                init.CopyFrom(
+                    numpy_helper.from_array(
+                        numpy_helper.to_array(init).astype(np.float16), init.name
+                    )
+                )
+
+    model, value_info_map, initializer_map, node_to_init_map = setup_mappings(
+        model, use_standalone_type_inference
+    )
+    converter = PrecisionConverter(
+        model,
+        value_info_map,
+        initializer_map,
+        node_to_init_map,
+        keep_io_types=False,
+        low_precision_type="bf16",
+        use_standalone_type_inference=use_standalone_type_inference,
+    )
+
+    converted_model = converter.convert(high_precision_nodes=[], low_precision_nodes=["if_node"])
+
+    if_node = next(n for n in converted_model.graph.node if n.op_type == "If")
+    for attr in if_node.attribute:
+        if attr.name in ("then_branch", "else_branch"):
+            assert all(init.data_type == TensorProto.BFLOAT16 for init in attr.g.initializer)
+
+
 @pytest.mark.parametrize("low_precision_type", ["fp16", "bf16"])
 @pytest.mark.parametrize("use_standalone_type_inference", [True, False])
 def test_if_subgraph_mixed_precision_boundary(

--- a/tests/unit/onnx/autocast/test_precisionconverter.py
+++ b/tests/unit/onnx/autocast/test_precisionconverter.py
@@ -555,6 +555,42 @@ def test_bf16_no_clamping_initializers_out_of_range(
     assert np.all(add_init_converted_array == add_init_out_of_range)
 
 
+@pytest.mark.parametrize("use_standalone_type_inference", [True, False])
+def test_bf16_conversion_accepts_fp16_initializer(use_standalone_type_inference):
+    x = helper.make_tensor_value_info("X", TensorProto.FLOAT16, [2])
+    y = helper.make_tensor_value_info("Y", TensorProto.FLOAT16, [2])
+    weight = numpy_helper.from_array(np.array([1.0, 2.0], dtype=np.float16), "weight")
+    add = helper.make_node("Add", ["X", "weight"], ["Y"], name="add")
+    graph = helper.make_graph([add], "fp16_init", [x], [y], initializer=[weight])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 20)])
+    model.ir_version = LATEST_IR_VERSION_SUPPORTED_BY_ORT
+    onnx.checker.check_model(model)
+
+    model, value_info_map, initializer_map, node_to_init_map = setup_mappings(
+        model, use_standalone_type_inference
+    )
+    converter = PrecisionConverter(
+        model,
+        value_info_map,
+        initializer_map,
+        node_to_init_map,
+        low_precision_type="bf16",
+        use_standalone_type_inference=use_standalone_type_inference,
+    )
+
+    converted_model = converter.convert(high_precision_nodes=[], low_precision_nodes=["add"])
+
+    converted_weight = next(
+        init for init in converted_model.graph.initializer if init.name == "weight"
+    )
+    assert converted_weight.data_type == TensorProto.BFLOAT16
+    assert converted_model.graph.output[0].type.tensor_type.elem_type == TensorProto.BFLOAT16
+    np.testing.assert_allclose(
+        onnx_utils.read_f16_tensor_as_fp32(converted_weight),
+        np.array([1.0, 2.0], dtype=np.float32),
+    )
+
+
 ####################################################################################################
 # Testing with dynamic shapes, since shape_inference invoked in PrecisionConverter
 ####################################################################################################


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

- Fixes ONNX autocast when converting a valid model with a FLOAT16 initializer to BF16.
- `PrecisionConverter` now derives initializer conversion from the initializer's actual ONNX dtype instead of assuming the source dtype from consumer precision.
- BF16 initializer serialization now works from supported source float types via an fp32 intermediate.
- The `keep_io_types=False` sanity check now allows supported floating-point I/O to convert to the selected low precision.
- Applies the same actual-dtype initializer handling to control-flow subgraphs.
- Adds regression tests covering BF16 conversion of FP16 initializers in the main graph and If subgraphs.

### Usage

```python
$ python -m modelopt.onnx.autocast --onnx=model.onnx --low_precision_type bf16
```

### Testing

- Reproduce the failure locally before the fix: `AssertionError: Initializer w0 is not of type fp32`.
- Verified the minimal reproducer now converts successfully: `Converted 1/1 nodes (100.00%) to bf16`.
- Ran `python -m pytest tests/unit/onnx/autocast/test_precisionconverter.py::test_bf16_conversion_accepts_fp16_initializer tests/unit/onnx/autocast/test_precisionconverter.py::test_bf16_if_subgraph_conversion_accepts_fp16_initializers -q`.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initializer precision handling by deriving conversion type from each initializer’s actual ONNX data type.
  * Enhanced BF16 downcasting support, including BF16 conversion of FP16 initializers and correct value decoding.
  * Broadened validation when preserving I/O types, allowing more original floating-point formats to convert cleanly.

* **Tests**
  * Added unit coverage for converting FP16 initializers to BF16, including graphs with FP16 value infos.
  * Added tests verifying FP16 initializers inside `If` subgraphs are converted to BF16 as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->