### PR TITLE
[Chore]Dspark license

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,6 +116,8 @@ repos:
               modelopt/torch/speculative/plugins/modeling_domino.py|
               modelopt/torch/speculative/plugins/hf_dflash.py|
               modelopt/torch/speculative/plugins/modeling_dflash.py|
+              modelopt/torch/speculative/plugins/hf_dspark.py|
+              modelopt/torch/speculative/plugins/modeling_dspark.py|
               modelopt/torch/speculative/plugins/hf_medusa.py|
               modelopt/torch/utils/plugins/megatron_mmlu.py|
               examples/deepseek/deepseek_v3/quantize_to_nvfp4.py|

--- a/LICENSE
+++ b/LICENSE
@@ -247,6 +247,7 @@ the following copyright holders, licensed under the MIT License:
   Copyright (c) 2023 Deep Cognition and Language Research (DeCLaRe) Lab
   Copyright (c) 2023 DeepSeek
   Copyright (c) 2025 sgl-project
+  Copyright (c) 2026 The DeepSpec Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modelopt/torch/speculative/plugins/hf_dspark.py
+++ b/modelopt/torch/speculative/plugins/hf_dspark.py
@@ -1,19 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Adapted from https://github.com/deepseek-ai/DeepSpec/blob/main/deepspec/modeling/dspark/loss.py
+# Adapted from https://github.com/deepseek-ai/DeepSpec/blob/add63ba/deepspec/modeling/dspark/loss.py
 # Copyright (c) 2026 The DeepSpec Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/modelopt/torch/speculative/plugins/modeling_dspark.py
+++ b/modelopt/torch/speculative/plugins/modeling_dspark.py
@@ -1,19 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-# Adapted from https://github.com/deepseek-ai/DeepSpec/blob/main/deepspec/modeling/dspark/markov_head.py
+# Adapted from https://github.com/deepseek-ai/DeepSpec/blob/add63ba/deepspec/modeling/dspark/markov_head.py
 # Copyright (c) 2026 The DeepSpec Authors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
### What does this PR do?

Type of change: Chore (license compliance)

Adds the required third-party attribution for the DSpark plugin code adapted from [DeepSpec](https://github.com/deepseek-ai/DeepSpec) (MIT), per the "Copying code from other sources" guidance in `CONTRIBUTING.md`:
- Fix the header order in `hf_dspark.py` / `modeling_dspark.py`: upstream ref (with commit hash) → DeepSpec MIT → NVIDIA `Apache-2.0 AND MIT`.
- Add `Copyright (c) 2026 The DeepSpec Authors` to the MIT section of `LICENSE`.
- Exclude both files from the `insert-license` pre-commit hook so it no longer prepends an extra NVIDIA header.

### Usage

N/A — no functional or API change.

### Testing

`pre-commit run insert-license` on both files → skipped (excluded), files unchanged.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated license notices to include a new third-party attribution.
  * Adjusted repository checks so license headers are not added to two specific Python modules.
* **Documentation**
  * Refreshed source attribution comments in two modules to point to the latest reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->