### PR TITLE
ci: fix torch_trt on torch 2.13; default unit tests to torch 2.13; add example allow-failure hatch

### DIFF
--- a/.github/workflows/_example_tests_runner.yml
+++ b/.github/workflows/_example_tests_runner.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: string
         default: "linux-amd64-gpu-rtxpro6000-latest-1"
+      allow_failure:
+        description: "If true, test failures are reported as a warning and do not fail the job (used to keep a known-broken example non-blocking)"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   run-test:
@@ -66,6 +71,8 @@ jobs:
 
           find examples/${{ inputs.example }} -name "requirements.txt" | while read req_file; do python -m pip install -r "$req_file" || exit 1; done
       - name: Run tests
+        id: run_tests
+        continue-on-error: ${{ inputs.allow_failure }}
         env:
           # Absolute paths so subprocesses running from different working directories
           # all find the config and write .coverage.* files to the same location.
@@ -74,6 +81,10 @@ jobs:
         run: |
           echo "Running tests for: ${{ inputs.example }}"
           python -m pytest tests/examples/${{ inputs.example }} --cov
+      - name: Flag allowed failure
+        if: ${{ inputs.allow_failure && steps.run_tests.outcome == 'failure' }}
+        run: |
+          echo "::warning title=Allowed example failure::'${{ inputs.example }}' failed but is in the allow-failure list (vars.ALLOW_FAILURE_EXAMPLE_TESTS); not blocking. Remove it from the variable once fixed."
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/_example_tests_runner.yml
+++ b/.github/workflows/_example_tests_runner.yml
@@ -37,6 +37,8 @@ jobs:
   run-test:
     runs-on: ${{ inputs.runner }}
     timeout-minutes: ${{ inputs.timeout_minutes }}
+    permissions:
+      contents: read
     container:
       image: ${{ inputs.docker_image }}
       options: --shm-size=2gb # TRT-LLM tests on 2-GPU runner needs more shared memory

--- a/.github/workflows/example_tests.yml
+++ b/.github/workflows/example_tests.yml
@@ -49,7 +49,7 @@ jobs:
       contents: read
     secrets: inherit
     with:
-      docker_image: "nvcr.io/nvidia/pytorch:${{ matrix.docker_image || '26.05' }}-py3"
+      docker_image: "nvcr.io/nvidia/pytorch:${{ matrix.docker_image || '26.06' }}-py3"
       example: ${{ matrix.example }}
       timeout_minutes: 30
       pip_install_extras: "[hf,dev-test]"
@@ -69,7 +69,7 @@ jobs:
       contents: read
     secrets: inherit
     with:
-      docker_image: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc19"
+      docker_image: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20"
       example: ${{ matrix.example }}
       pip_install_extras: "[hf,dev-test]"
       runner: linux-amd64-gpu-rtxpro6000-latest-1
@@ -86,7 +86,7 @@ jobs:
       contents: read
     secrets: inherit
     with:
-      docker_image: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc19"
+      docker_image: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20"
       example: ${{ matrix.example }}
       pip_install_extras: "[hf,dev-test]"
       runner: linux-amd64-gpu-rtxpro6000-latest-2
@@ -121,7 +121,7 @@ jobs:
       contents: read
     secrets: inherit
     with:
-      docker_image: "nvcr.io/nvidia/tensorrt:26.05-py3"
+      docker_image: "nvcr.io/nvidia/tensorrt:26.06-py3"
       example: ${{ matrix.example }}
       timeout_minutes: 45
       pip_install_extras: "[onnx,hf,dev-test]"

--- a/.github/workflows/example_tests.yml
+++ b/.github/workflows/example_tests.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ startsWith(github.ref, 'refs/heads/pull-request/') && github.ref || github.sha }}
   cancel-in-progress: true
 
+# Each job's `allow_failure` reads the repo variable ALLOW_FAILURE_EXAMPLE_TESTS:
+# a comma-separated list of example names whose test failures should be non-blocking, e.g. "torch_trt,llm_qat"
+
 jobs:
   pr-gate:
     uses: ./.github/workflows/_pr_gate.yml
@@ -42,6 +45,8 @@ jobs:
           - example: speculative_decoding
             docker_image: "26.01"
     uses: ./.github/workflows/_example_tests_runner.yml
+    permissions:
+      contents: read
     secrets: inherit
     with:
       docker_image: "nvcr.io/nvidia/pytorch:${{ matrix.docker_image || '26.05' }}-py3"
@@ -60,6 +65,8 @@ jobs:
       matrix:
         example: [hf_ptq]
     uses: ./.github/workflows/_example_tests_runner.yml
+    permissions:
+      contents: read
     secrets: inherit
     with:
       docker_image: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc19"
@@ -75,6 +82,8 @@ jobs:
       matrix:
         example: [llm_eval, hf_ptq]
     uses: ./.github/workflows/_example_tests_runner.yml
+    permissions:
+      contents: read
     secrets: inherit
     with:
       docker_image: "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc19"
@@ -88,6 +97,8 @@ jobs:
     needs: [pr-gate]
     if: needs.pr-gate.outputs.any_changed == 'true'
     uses: ./.github/workflows/_example_tests_runner.yml
+    permissions:
+      contents: read
     secrets: inherit
     with:
       docker_image: "nvcr.io/nvidia/nemo:26.06"
@@ -106,6 +117,8 @@ jobs:
       matrix:
         example: [diffusers, torch_onnx, torch_trt]
     uses: ./.github/workflows/_example_tests_runner.yml
+    permissions:
+      contents: read
     secrets: inherit
     with:
       docker_image: "nvcr.io/nvidia/tensorrt:26.05-py3"

--- a/.github/workflows/example_tests.yml
+++ b/.github/workflows/example_tests.yml
@@ -121,7 +121,10 @@ jobs:
       contents: read
     secrets: inherit
     with:
-      docker_image: "nvcr.io/nvidia/tensorrt:26.06-py3"
+      # Pinned to 26.05 (TensorRT 10): torch-tensorrt is capped at <2.13 (== 2.12.1),
+      # which needs libnvinfer.so.10; newer tensorrt containers drop it. Bump only once
+      # a torch-tensorrt build for the newer TensorRT is available.
+      docker_image: "nvcr.io/nvidia/tensorrt:26.05-py3"
       example: ${{ matrix.example }}
       timeout_minutes: 45
       pip_install_extras: "[onnx,hf,dev-test]"

--- a/.github/workflows/example_tests.yml
+++ b/.github/workflows/example_tests.yml
@@ -49,6 +49,7 @@ jobs:
       timeout_minutes: 30
       pip_install_extras: "[hf,dev-test]"
       runner: ${{ startsWith(github.ref, 'refs/heads/pull-request/') && 'linux-amd64-gpu-rtxpro6000-latest-1' || 'linux-amd64-gpu-rtxpro6000-latest-2' }}
+      allow_failure: ${{ contains(format(',{0},', vars.ALLOW_FAILURE_EXAMPLE_TESTS), format(',{0},', matrix.example)) }}
 
   ##### TensorRT-LLM Example Tests (pr/non-pr split: non-pr runs extra eval examples) #####
   trtllm-pr:
@@ -65,6 +66,7 @@ jobs:
       example: ${{ matrix.example }}
       pip_install_extras: "[hf,dev-test]"
       runner: linux-amd64-gpu-rtxpro6000-latest-1
+      allow_failure: ${{ contains(format(',{0},', vars.ALLOW_FAILURE_EXAMPLE_TESTS), format(',{0},', matrix.example)) }}
 
   trtllm-non-pr:
     if: ${{ !startsWith(github.ref, 'refs/heads/pull-request/') }}
@@ -79,6 +81,7 @@ jobs:
       example: ${{ matrix.example }}
       pip_install_extras: "[hf,dev-test]"
       runner: linux-amd64-gpu-rtxpro6000-latest-2
+      allow_failure: ${{ contains(format(',{0},', vars.ALLOW_FAILURE_EXAMPLE_TESTS), format(',{0},', matrix.example)) }}
 
   ##### Megatron Example Tests #####
   megatron:
@@ -92,6 +95,7 @@ jobs:
       timeout_minutes: 60
       pip_install_extras: "[hf,puzzletron,dev-test]"
       runner: ${{ startsWith(github.ref, 'refs/heads/pull-request/') && 'linux-amd64-gpu-rtxpro6000-latest-1' || 'linux-amd64-gpu-rtxpro6000-latest-2' }}
+      allow_failure: ${{ contains(format(',{0},', vars.ALLOW_FAILURE_EXAMPLE_TESTS), ',megatron_bridge,') }}
 
   ##### ONNX/TensorRT Example Tests #####
   onnx:
@@ -109,6 +113,7 @@ jobs:
       timeout_minutes: 45
       pip_install_extras: "[onnx,hf,dev-test]"
       runner: ${{ startsWith(github.ref, 'refs/heads/pull-request/') && 'linux-amd64-gpu-rtxpro6000-latest-1' || 'linux-amd64-gpu-rtxpro6000-latest-2' }}
+      allow_failure: ${{ contains(format(',{0},', vars.ALLOW_FAILURE_EXAMPLE_TESTS), format(',{0},', matrix.example)) }}
 
   ##### Required Check for PR #####
   example-pr-required-check:

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -41,13 +41,13 @@ jobs:
         include:
           - example: gpu
             timeout: 60
-            container_image: nvcr.io/nvidia/pytorch:26.05-py3
+            container_image: nvcr.io/nvidia/pytorch:26.06-py3
           - example: gpu_megatron
             timeout: 60
             container_image: nvcr.io/nvidia/nemo:26.06
           - example: gpu_trtllm
             timeout: 15
-            container_image: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc19
+            container_image: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
           - example: gpu_vllm
             timeout: 15
             container_image: docker.io/vllm/vllm-openai:v0.20.0

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -41,7 +41,9 @@ jobs:
         include:
           - example: gpu
             timeout: 60
-            container_image: nvcr.io/nvidia/pytorch:26.06-py3
+            # Pinned to 26.05: benchmark.py uses trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH,
+            # which newer TensorRT (26.06) removed. Bump once the source is updated for TensorRT 10.
+            container_image: nvcr.io/nvidia/pytorch:26.05-py3
           - example: gpu_megatron
             timeout: 60
             container_image: nvcr.io/nvidia/nemo:26.06

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -43,7 +43,7 @@ jobs:
             timeout: 60
             container_image: nvcr.io/nvidia/pytorch:26.05-py3
           - example: gpu_megatron
-            timeout: 75
+            timeout: 60
             container_image: nvcr.io/nvidia/nemo:26.06
           - example: gpu_trtllm
             timeout: 15

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           COVERAGE_PROCESS_START: ${{ github.workspace }}/pyproject.toml
           COVERAGE_FILE: ${{ github.workspace }}/.coverage
-        run: pip install nox uv && nox -s "unit-3.12(torch_212, tf_latest)"
+        run: pip install nox uv && nox -s "unit-3.12(torch_213, tf_latest)"
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -92,7 +92,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Run unit tests (without coverage)
-        run: pip install nox uv && nox -s "unit-3.12(torch_212, tf_latest)"
+        run: pip install nox uv && nox -s "unit-3.12(torch_213, tf_latest)"
   multi-version:
     if: needs.check-file-changes.outputs.any_changed == 'true'
     needs: [linux, check-file-changes]
@@ -102,15 +102,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {nox_session: "unit-3.10(torch_212, tf_latest)", python_version: "3.10"}
-          - {nox_session: "unit-3.11(torch_212, tf_latest)", python_version: "3.11"}
-          - {nox_session: "unit-3.13(torch_212, tf_latest)", python_version: "3.13"}
-          - {nox_session: "unit-3.14(torch_212, tf_latest)", python_version: "3.14"}
+          # Default torch (2.13) across the other supported Python versions
+          - {nox_session: "unit-3.10(torch_213, tf_latest)", python_version: "3.10"}
+          - {nox_session: "unit-3.11(torch_213, tf_latest)", python_version: "3.11"}
+          - {nox_session: "unit-3.13(torch_213, tf_latest)", python_version: "3.13"}
+          - {nox_session: "unit-3.14(torch_213, tf_latest)", python_version: "3.14"}
+          # Older torch versions on the default Python (3.12) for back-compat.
           - {nox_session: "unit-3.12(torch_28, tf_latest)", python_version: "3.12"}
           - {nox_session: "unit-3.12(torch_29, tf_latest)", python_version: "3.12"}
           - {nox_session: "unit-3.12(torch_210, tf_latest)", python_version: "3.12"}
           - {nox_session: "unit-3.12(torch_211, tf_latest)", python_version: "3.12"}
-          - {nox_session: "unit-3.12(torch_212, tf_min)", python_version: "3.12"}
+          - {nox_session: "unit-3.12(torch_212, tf_latest)", python_version: "3.12"}
+          # Minimum supported transformers on the default torch.
+          - {nox_session: "unit-3.12(torch_213, tf_min)", python_version: "3.12"}
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/ubuntu-setup

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -86,6 +86,8 @@ jobs:
     needs: [linux, check-file-changes]
     runs-on: windows-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/examples/torch_trt/requirements.txt
+++ b/examples/torch_trt/requirements.txt
@@ -1,3 +1,8 @@
 datasets>=2.14.4
-torch-tensorrt>=2.4.0
+# torch-tensorrt has no 2.13 release yet and pins torch<2.13. Cap the whole
+# torch / torchvision / torch-tensorrt trio together: torchvision pins an exact
+# torch, so if the base install pulls a newer torch (e.g. 2.13) the torch-tensorrt
+# downgrade would otherwise leave torchvision mismatched and break `import`.
+torch-tensorrt>=2.4.0,<2.13
+torchvision<0.28
 transformers>=4.56

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,6 +39,7 @@ TORCH_VERSIONS = {
     "torch_210": "torchvision~=0.25.0",
     "torch_211": "torchvision~=0.26.0",
     "torch_212": "torchvision~=0.27.0",
+    "torch_213": "torchvision~=0.28.0",
 }
 
 TRANSFORMERS_VERSIONS = {


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix + CI / infra

torch 2.13 + torchvision 0.28 were published to PyPI on 2026-07-08 and broke the `onnx (torch_trt)` example job (which had passed the day before). This PR fixes that break and hardens CI against the next one:

1. **Fix `torch_trt` (torch/torchvision/torch-tensorrt trio pin).** The base install pulled torch 2.13 / torchvision 0.28, then `torch-tensorrt 2.12.1` downgraded torch back to 2.12 but left torchvision at 0.28 (which pins `torch==2.13`) — breaking `import`. `examples/torch_trt/requirements.txt` now caps `torch-tensorrt>=2.4.0,<2.13` + `torchvision<0.28` so the trio stays consistent (also protects direct `pip install -r` users).
2. **Unit tests default to torch 2.13.** `noxfile.py` gains `torch_213` (`torchvision~=0.28.0`); the required `linux`/`windows` jobs and the multi-version Python spread (3.10/3.11/3.13/3.14) now run torch 2.13, with torch 2.8–2.12 kept as back-compat legs on Python 3.12.
3. **Per-example allow-failure escape hatch.** `_example_tests_runner.yml` gains an `allow_failure` input; when set, a **test-run** failure is surfaced as a `::warning::` via `continue-on-error` instead of blocking the PR. `example_tests.yml` derives it per example from the repo variable **`ALLOW_FAILURE_EXAMPLE_TESTS`** (comma-separated example names, comma-wrapped so `onnx` ≠ `torch_onnx`). Future breakages can be quarantined by updating the variable — no code change / PR required.

### Testing

- Ran the new default unit session locally in an isolated uv venv (torch **2.13.0**+cu130, torchvision **0.28.0**+cu130, transformers **5.12.1**):
  ```
  nox -s "unit-3.12(torch_213, tf_latest)"
  => 2813 passed, 15 skipped, 1786 warnings in 250.37s
  ```
- Verified the allow-failure hatch: with `ALLOW_FAILURE_EXAMPLE_TESTS=torch_trt`, the (previously failing) `torch_trt` job reports success with a warning and does not block the required example check. `vars` is re-read on each job attempt, so "Re-run failed jobs" picks up the variable without a fresh trigger.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ (CI-only; older torch versions still covered)
- If you copied code from any other sources or added a new PIP dependency: N/A (no new dependency; only version caps)
- Did you write any new necessary tests?: N/A (CI configuration change)
- Did you update Changelog?: N/A (CI infra, no user-facing API change)
- Did you get Claude approval on this PR?: ❌ (pending — will run `/claude review`)

### Additional Information

The `ALLOW_FAILURE_EXAMPLE_TESTS` repo variable can be cleared for `torch_trt` now that the requirements pin lands the real fix; keep it as the standing escape hatch for future example breakages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Example test jobs can now be configured to “allow failure” without failing the workflow; when enabled, a warning annotation is emitted.
* **Bug Fixes**
  * CI unit-test and GPU-test configurations were refreshed (including a reduced timeout for the `gpu_megatron` job).
* **Tests**
  * Updated unit-test coverage to use the newest Torch 2.13-based setup by default, with back-compat retained where applicable.
* **Documentation**
  * Added inline guidance for how the allow-failure examples list is specified.
* **Chores**
  * Refreshed `torch_trt` example dependency constraints to improve compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->