### PR TITLE
Support layerwise VLM image calibration in hf_ptq

### DIFF
--- a/examples/hf_ptq/hf_ptq.py
+++ b/examples/hf_ptq/hf_ptq.py
@@ -109,6 +109,23 @@ def _kv_cfg_uses_constant_amax(kv_quant_cfg: list[dict[str, Any]]) -> bool:
 mto.enable_huggingface_checkpointing()
 
 
+def _is_layerwise_quant_config(obj) -> bool:
+    if isinstance(obj, ModelOptPTQRecipe):
+        return _is_layerwise_quant_config(obj.quantize.algorithm)
+    if isinstance(obj, list):
+        return any(_is_layerwise_quant_config(item) for item in obj)
+    if isinstance(obj, dict):
+        if "quantize" in obj:
+            return _is_layerwise_quant_config(obj["quantize"])
+        if "algorithm" in obj:
+            return _is_layerwise_quant_config(obj["algorithm"])
+        layerwise = obj.get("layerwise")
+        return bool(isinstance(layerwise, dict) and layerwise.get("enable"))
+
+    layerwise = getattr(obj, "layerwise", None)
+    return bool(getattr(layerwise, "enable", False))
+
+
 def extract_and_prepare_language_model_from_vl(full_model):
     """Extract language model from VL model and disable quantization for non-language components.
 
@@ -718,12 +735,30 @@ def mono_quantize(
                     else None,
                 )
 
+        quantization_model = language_model
+        use_layerwise_vlm_calibration = (
+            args.calib_with_images
+            and is_nemotron_vl_model
+            and _is_layerwise_quant_config(quant_cfg)
+        )
+        if use_layerwise_vlm_calibration:
+            quantization_model = full_model
+
         if calibration_only:
-            language_model = mtq.calibrate(
-                language_model, quant_cfg["algorithm"], forward_loop=calibrate_loop
+            quantized_model = mtq.calibrate(
+                quantization_model, quant_cfg["algorithm"], forward_loop=calibrate_loop
             )
         else:
-            language_model = mtq.quantize(language_model, quant_cfg, forward_loop=calibrate_loop)
+            quantized_model = mtq.quantize(
+                quantization_model, quant_cfg, forward_loop=calibrate_loop
+            )
+
+        if use_layerwise_vlm_calibration:
+            quantized_language_model_lineage = get_language_model_from_vl(quantized_model)
+            if quantized_language_model_lineage is not None:
+                language_model = quantized_language_model_lineage[-1]
+        else:
+            language_model = quantized_model
 
         # For VL models, update full_model to use the quantized language model
         if is_nemotron_vl_model:
@@ -1092,15 +1127,7 @@ def quantize_main(
     else:
         aq_config = None
 
-    def _is_layerwise(obj):
-        if isinstance(obj, ModelOptPTQRecipe):
-            return _is_layerwise(obj.quantize.algorithm)
-        if isinstance(obj, list):
-            return any(_is_layerwise(a) for a in obj)
-        layerwise = getattr(obj, "layerwise", None)
-        return bool(getattr(layerwise, "enable", False))
-
-    is_layerwise = _is_layerwise(recipe)
+    is_layerwise = _is_layerwise_quant_config(recipe)
 
     if args.batch_size == 0:
         # For VL models with image-text calibration, skip automatic batch size detection

--- a/tests/examples/hf_ptq/test_hf_ptq_mono_quantize.py
+++ b/tests/examples/hf_ptq/test_hf_ptq_mono_quantize.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+_EXAMPLES_DIR = Path(__file__).resolve().parents[3] / "examples" / "hf_ptq"
+
+
+def _import_hf_ptq(monkeypatch):
+    monkeypatch.syspath_prepend(str(_EXAMPLES_DIR))
+    return importlib.import_module("hf_ptq")
+
+
+def _run_vlm_image_quantize(monkeypatch, quant_cfg):
+    hf_ptq = _import_hf_ptq(monkeypatch)
+    args = SimpleNamespace(calib_with_images=True, qformat="nvfp4", specdec_offline_dataset=None)
+    language_model = SimpleNamespace(name="language_model")
+    parent = SimpleNamespace(language_model=language_model)
+    full_model = SimpleNamespace(parent=parent)
+    calibrate_loop = Mock(name="calibrate_loop")
+
+    monkeypatch.setattr(hf_ptq, "is_quantized", Mock(return_value=False))
+    monkeypatch.setattr(hf_ptq, "need_calibration", Mock(return_value=True))
+    monkeypatch.setattr(hf_ptq, "create_vlm_calibration_loop", Mock(return_value=calibrate_loop))
+    monkeypatch.setattr(
+        hf_ptq,
+        "get_language_model_from_vl",
+        Mock(side_effect=lambda model: [parent, parent.language_model]),
+    )
+    monkeypatch.setattr(
+        hf_ptq.mtq, "quantize", Mock(side_effect=lambda model, *_args, **_kwargs: model)
+    )
+
+    hf_ptq.mono_quantize(
+        args=args,
+        quant_cfg=quant_cfg,
+        full_model=full_model,
+        language_model=language_model,
+        model_type=None,
+        calibration_only=False,
+        calib_dataloader=Mock(name="calib_dataloader"),
+        is_nemotron_vl_model=True,
+    )
+
+    return hf_ptq, full_model, language_model, calibrate_loop
+
+
+def test_layerwise_vlm_image_calibration_quantizes_full_model(monkeypatch):
+    quant_cfg = {"quant_cfg": [], "algorithm": {"layerwise": {"enable": True}}}
+
+    hf_ptq, full_model, _, calibrate_loop = _run_vlm_image_quantize(monkeypatch, quant_cfg)
+
+    hf_ptq.mtq.quantize.assert_called_once_with(full_model, quant_cfg, forward_loop=calibrate_loop)
+
+
+def test_non_layerwise_vlm_image_calibration_quantizes_language_model(monkeypatch):
+    quant_cfg = {"quant_cfg": [], "algorithm": "max"}
+
+    hf_ptq, _, language_model, calibrate_loop = _run_vlm_image_quantize(monkeypatch, quant_cfg)
+
+    hf_ptq.mtq.quantize.assert_called_once_with(
+        language_model, quant_cfg, forward_loop=calibrate_loop
+    )


### PR DESCRIPTION
## Summary
- route layerwise VLM image calibration through the full VLM wrapper so multimodal forwards reach patched decoder layers
- keep non-layerwise VLM image calibration on the extracted language model
- add focused mock coverage for both branches

## Validation
- pytest_pwd tests/examples/hf_ptq/test_hf_ptq_mono_quantize.py tests/examples/hf_ptq/test_hf_ptq_args.py
- pre-commit run --files examples/hf_ptq/hf_ptq.py tests/examples/hf_ptq/test_hf_ptq_mono_quantize.py