### PR TITLE
Fix per-tensor FP8 weight dequantization

### DIFF
--- a/modelopt/torch/quantization/plugins/huggingface.py
+++ b/modelopt/torch/quantization/plugins/huggingface.py
@@ -1330,13 +1330,16 @@ class _QuantFP8Linear(QuantModule):
     def _setup(self):
         self.input_quantizer = TensorQuantizer()
         self.weight_quantizer = TensorQuantizer()
-        assert self.weight_scale_inv.ndim == 2, "Weight scale inverse must be 2D"
         assert self.weight.ndim == 2, "Weight must be 2D"
-        self.block_size = max(
-            self.weight.shape[0] // self.weight_scale_inv.shape[0],
-            self.weight.shape[1] // self.weight_scale_inv.shape[1],
-        )
-        assert self.block_size == 128, "Block size must be 128"
+        if self.weight_scale_inv.ndim == 0:
+            self.block_size = None
+        else:
+            assert self.weight_scale_inv.ndim == 2, "Weight scale inverse must be 0D or 2D"
+            self.block_size = max(
+                self.weight.shape[0] // self.weight_scale_inv.shape[0],
+                self.weight.shape[1] // self.weight_scale_inv.shape[1],
+            )
+            assert self.block_size == 128, "Block size must be 128"
 
     def _get_weight_and_scale_inv(self):
         if isinstance(self.weight, torch.distributed.tensor.DTensor):
@@ -1347,12 +1350,17 @@ class _QuantFP8Linear(QuantModule):
             scale_inv = self.weight_scale_inv.contiguous()
         return weight, scale_inv
 
-    def forward(self, input: Tensor) -> Tensor:
+    def _dequantize_weight(self, dtype: torch.dtype) -> Tensor:
+        weight, scale_inv = self._get_weight_and_scale_inv()
+        if self.block_size is None:
+            return weight.to(dtype) * scale_inv.to(dtype)
         assert weight_dequant is not None, "Triton is not available"
+        return weight_dequant(weight, scale_inv, self.block_size, dtype=dtype)
+
+    def forward(self, input: Tensor) -> Tensor:
         if self.weight.element_size() == 1:
             with torch.cuda.device(self.weight.device):
-                weight, scale_inv = self._get_weight_and_scale_inv()
-                weight = weight_dequant(weight, scale_inv, self.block_size, dtype=input.dtype)
+                weight = self._dequantize_weight(input.dtype)
         else:
             weight = self.weight
         return linear(
@@ -1362,11 +1370,9 @@ class _QuantFP8Linear(QuantModule):
         )
 
     def unpack_weight(self):
-        assert weight_dequant is not None, "Triton is not available"
         with torch.cuda.device(self.weight.device):
-            weight, scale_inv = self._get_weight_and_scale_inv()
             self.weight = nn.Parameter(
-                weight_dequant(weight, scale_inv, self.block_size, dtype=torch.get_default_dtype()),
+                self._dequantize_weight(torch.get_default_dtype()),
                 requires_grad=False,
             )
         if hasattr(self, "weight_scale_inv"):

--- a/modelopt_recipes/huggingface/models/nvidia/Mistral-Medium-3.5-128B-NVFP4/ptq/nvfp4-max-calib.yaml
+++ b/modelopt_recipes/huggingface/models/nvidia/Mistral-Medium-3.5-128B-NVFP4/ptq/nvfp4-max-calib.yaml
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+  base_disable_all: configs/ptq/units/base_disable_all
+  default_disabled_quantizers: configs/ptq/units/default_disabled_quantizers
+  nvfp4: configs/numerics/nvfp4
+  fp8: configs/numerics/fp8
+  kv_fp8: configs/ptq/units/kv_fp8
+
+metadata:
+  recipe_type: ptq
+  description: >-
+    NVFP4 W4A4 on interior MLP layers, FP8 W8A8 on edge MLP and attention
+    layers, and an FP8 KV cache; uses max calibration.
+quantize:
+  algorithm:
+    method: max
+    layerwise: false
+  quant_cfg:
+    - $import: base_disable_all
+    # NVFP4 on MLP and expert weight matrices.
+    - quantizer_name: '*mlp.experts*weight_quantizer'
+      cfg:
+        $import: nvfp4
+    - quantizer_name: '*mlp.experts*input_quantizer'
+      cfg:
+        $import: nvfp4
+    - quantizer_name: '*block_sparse_moe*weight_quantizer'
+      cfg:
+        $import: nvfp4
+    - quantizer_name: '*block_sparse_moe*input_quantizer'
+      cfg:
+        $import: nvfp4
+    - quantizer_name: '*mlp*weight_quantizer'
+      cfg:
+        $import: nvfp4
+    - quantizer_name: '*mlp*input_quantizer'
+      cfg:
+        $import: nvfp4
+    # FP8 on language-model attention projections.
+    - quantizer_name: '*self_attn.q_proj*weight_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*self_attn.q_proj*input_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*self_attn.k_proj*weight_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*self_attn.k_proj*input_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*self_attn.v_proj*weight_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*self_attn.v_proj*input_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*self_attn.o_proj*weight_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*self_attn.o_proj*input_quantizer'
+      cfg:
+        $import: fp8
+    # Keep the first four and final decoder MLP layers in FP8.
+    - quantizer_name: '*layers.0.mlp*weight_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*layers.0.mlp*input_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*layers.1.mlp*weight_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*layers.1.mlp*input_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*layers.2.mlp*weight_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*layers.2.mlp*input_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*layers.3.mlp*weight_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*layers.3.mlp*input_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*layers.87.mlp*weight_quantizer'
+      cfg:
+        $import: fp8
+    - quantizer_name: '*layers.87.mlp*input_quantizer'
+      cfg:
+        $import: fp8
+    - $import: kv_fp8
+    - $import: default_disabled_quantizers

--- a/modelopt_recipes/ptq.md
+++ b/modelopt_recipes/ptq.md
@@ -233,7 +233,7 @@ that baseline. The deviations come in four kinds:
 | **Architecture-aware `quant_cfg`** | Per-sub-module format choices a single wildcard scheme can't express | `qwen3_5`, `qwen3_5_moe`, `vit` |
 | **Algorithm override** | Same numerics & scope, but the *calibration algorithm* is tweaked because the default breaks or regresses | `gemma`, `gemma4`, `mpt` |
 | **Extra exclusions** | Adds disabled-quantizer patterns so non-language branches stay full precision | `nemotron_vl`, `phi4mm`, `diffusion_gemma` |
-| **Checkpoint mirror** | A mixed-precision map reproducing one published checkpoint exactly | `models/nvidia/Nemotron-3-*` |
+| **Checkpoint mirror** | A mixed-precision map reproducing one published checkpoint exactly | `models/nvidia/Nemotron-3-*`, `models/nvidia/Mistral-Medium-3.5-128B-NVFP4` |
 
 The numerics and standard exclusions are still inherited from `configs/`
 wherever possible — the model folder captures *only* the delta. Each `<task>/`
@@ -321,8 +321,12 @@ everything else matches the general recipe.
 ### Checkpoint mirrors — `models/nvidia/<checkpoint>`
 
 The `huggingface/models/` tier reproduces a **single published (or planned)
-checkpoint's** quant config verbatim. Three Nemotron checkpoints live there:
+checkpoint's** quant config verbatim:
 
+- **`Mistral-Medium-3.5-128B-NVFP4/ptq/nvfp4-max-calib`** mirrors
+  `nvidia/Mistral-Medium-3.5-128B-NVFP4`: decoder MLP layers 4–86 use NVFP4
+  W4A4, edge MLP layers 0–3 and 87 use FP8 W8A8, and all attention projections
+  and the KV cache use FP8. It uses max calibration.
 - **`Nemotron-3-Super-120B-A12B/ptq/nvfp4-mse`** mirrors
   `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` exactly — a hybrid
   **Mamba-MoE** with a hand-mapped, **per-component** precision scheme:

--- a/tests/unit/recipe/test_loader.py
+++ b/tests/unit/recipe/test_loader.py
@@ -166,6 +166,7 @@ _BUILTIN_PTQ_RECIPES = [
     "general/ptq/nvfp4_experts_only-kv_fp8",
     "general/ptq/nvfp4_experts_only-kv_fp8_cast",
     "general/ptq/nvfp4_experts_only-kv_fp8_layerwise",
+    "huggingface/models/nvidia/Mistral-Medium-3.5-128B-NVFP4/ptq/nvfp4-max-calib",
     "general/ptq/nvfp4_mlp_only-kv_fp8",
     "general/ptq/nvfp4_mlp_only-novit-kv_fp8",
     "general/ptq/nvfp4_mlp_only-kv_fp8_cast",

--- a/tests/unit/torch/quantization/plugins/test_huggingface.py
+++ b/tests/unit/torch/quantization/plugins/test_huggingface.py
@@ -45,6 +45,7 @@ pytest.importorskip("transformers")
 
 import transformers
 from transformers import AutoModelForCausalLM, LlamaForCausalLM
+from transformers.integrations.finegrained_fp8 import FP8Linear
 from transformers.models.dbrx.configuration_dbrx import DbrxConfig, DbrxFFNConfig
 from transformers.models.dbrx.modeling_dbrx import DbrxExpertGLU, DbrxExperts, DbrxFFN
 
@@ -107,6 +108,21 @@ def test_convert_conv1d():
     out_1 = model_ref(x)
     out_2 = model_test(x)
     assert torch.allclose(out_1, out_2)
+
+
+def test_fp8_linear_per_tensor_dequant(monkeypatch):
+    module = FP8Linear(2, 2, block_size=(128, 128))
+    module.weight_scale_inv = nn.Parameter(torch.tensor(2.0))
+    with torch.no_grad():
+        module.weight.copy_(torch.tensor([[-2.0, 1.0], [0.5, 4.0]], dtype=torch.float8_e4m3fn))
+
+    mtq.replace_quant_module(module)
+    monkeypatch.setattr("modelopt.torch.quantization.plugins.huggingface.weight_dequant", None)
+
+    assert module.block_size is None
+    torch.testing.assert_close(
+        module._dequantize_weight(torch.float32), module.weight.float() * 2.0
+    )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Supports scalar `weight_scale_inv` values when converting Hugging Face FP8 linear layers. The scalar path dequantizes weights directly, while the existing block-scale Triton path remains unchanged. Forward execution and `unpack_weight()` share the same dequantization helper.

### Usage

No API changes. Hugging Face FP8 checkpoints using per-tensor weight scales convert without additional configuration.

### Testing

- Focused unit test: `test_fp8_linear_per_tensor_dequant` — passed.
- Loaded `mistralai/Mistral-Medium-3.5-128B` on AWS-PDX and converted all 616 scalar-scale FP8 linear modules.
- Full-model one-token ModelOpt forward produced finite logits.
- `unpack_weight()` passed on `model.language_model.layers.0.self_attn.q_proj`.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update Changelog?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information

This isolates the per-tensor FP8 dequantization fix from commit `2f913319d2ac2fbd47397ece871f18576f2ad009`; unrelated recipe changes are excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **Bug Fixes**
  - Improved FP8 weight dequantization for per-tensor scaling by correctly deriving `block_size` and using a dedicated dequantization path for more reliable results.
- **New Features**
  - Added a PTQ recipe for **Mistral-Medium-3.5-128B-NVFP4** with mixed **NVFP4 (W4A4)** and **FP8 (W8A8)** quantization settings, including FP8 KV-cache.
- **Documentation**
  - Updated the PTQ deviations catalog with an additional checkpoint mirror example and configuration details.
- **Tests**
  - Added unit coverage for per-tensor FP8 dequantization and expanded built-in PTQ recipe smoke checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->