### PR TITLE
fix(mmlu): shard batches over expert-DP group for MoE models

### DIFF
--- a/modelopt/torch/utils/plugins/megatron_mmlu.py
+++ b/modelopt/torch/utils/plugins/megatron_mmlu.py
@@ -155,11 +155,23 @@ def megatron_mmlu(
     cp_group = mpu.get_context_parallel_group()
 
     # Shard whole batches across data-parallel ranks (each rank evaluates every ``dp_size``-th
-    # batch); per-subject counts are all-reduced over the DP group below. ``with_context_parallel``
-    # defaults to False so CP peers in the same DP group evaluate the same batches.
-    dp_size = mpu.get_data_parallel_world_size()
-    dp_rank = mpu.get_data_parallel_rank()
-    dp_group = mpu.get_data_parallel_group()
+    # batch); per-subject counts are all-reduced over the DP group below. CP peers in the same DP
+    # group evaluate the same batches.
+    #
+    # For MoE models with expert parallelism (EP>1), megatron_prefill's forward runs an expert
+    # all-to-all across the EP group, so ranks in one EP group MUST evaluate every batch in
+    # lockstep — sharding them onto disjoint batches desyncs that all-to-all (uneven batch counts /
+    # differing padded seq-lengths) and deadlocks the NCCL communicator. Shard only across
+    # expert-data-parallel replicas, whose ranks each hold a full expert set; EP peers within a
+    # replica then stay in lockstep. For dense models (EP==1) this is the standard DP sharding.
+    if mpu.get_expert_model_parallel_world_size() > 1:
+        dp_size = mpu.get_expert_data_parallel_world_size()
+        dp_rank = mpu.get_expert_data_parallel_rank()
+        dp_group = mpu.get_expert_data_parallel_group()
+    else:
+        dp_size = mpu.get_data_parallel_world_size()
+        dp_rank = mpu.get_data_parallel_rank()
+        dp_group = mpu.get_data_parallel_group()
 
     # Run inference in global batches.
     predictions: list[str] = [""] * len(encoded)


### PR DESCRIPTION
## Problem

`megatron_mmlu` shards whole batches across the **dense data-parallel group** (`get_data_parallel_world_size()`), giving each rank a disjoint subset (`if batch_idx % dp_size != dp_rank: continue`) and all-reducing per-subject counts over the DP group at the end.

That is correct for **dense** models — DP ranks are independent replicas and the forward has no cross-rank collective. It **deadlocks for MoE models with expert parallelism (EP>1)**: `megatron_prefill`'s forward runs an **expert all-to-all across the EP group**. When EP overlaps the dense-DP group (e.g. `EP=4, TP=1, PP=1` on 4 GPUs — all four ranks are both EP peers *and* dense-DP ranks), each rank runs prefill on a different batch, so their expert all-to-alls desync. Uneven batch counts (`n_batches % dp_size != 0`) and per-batch padded seq-lengths leave trailing ranks blocked at NCCL communicator creation until the c10d store times out (600 s).

Reproduced with a NemotronH-class MoE (Nano-30B-A3B) quantize → MMLU at `EP=4`: ranks 2 & 3 wait on rank 0's `ncclUniqueId` and time out.

## Fix

Shard over the **expert-data-parallel** group when `EP>1`. Ranks within one EP group then evaluate every batch in **lockstep** (so the expert all-to-all always has all participants), and only true expert-DP replicas — each holding a full expert set — take disjoint batches. Dense models (`EP==1`) keep the standard DP sharding unchanged.

- `EP=4` on 4 GPUs → expert-DP=1 → no sharding, all ranks lockstep. Final all-reduce becomes a size-1 no-op (correct).
- `EP=4` on 8 GPUs → expert-DP=2 → two replicas shard batches, each replica's 4 EP ranks lockstep.

## Test plan

- [ ] MoE MMLU (`EP>1`) completes instead of hanging — validated on Nano-30B-A3B `EP=4`.
- [ ] Dense MMLU sharding unchanged (`EP==1` path is identical to before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation stability when expert model parallelism is enabled.
  * Ensured batches are sharded consistently across expert-parallel replicas, preventing potential evaluation deadlocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->