### PR TITLE
docs(recipes): sync ptq.md with shipped recipes and enforce via unit tests

### DIFF
--- a/modelopt_recipes/ptq.md
+++ b/modelopt_recipes/ptq.md
@@ -3,9 +3,10 @@
 This doc walks through the **PTQ quantization schemes** in two parts: the
 model-agnostic recipes under [`general/ptq/`](general/ptq/) (the recommended
 starting point for any model), and then the
-[model-specific recipes](#model-specific-recipes-huggingface-and-models) under
-`huggingface/` and `models/` — comparing each to its general baseline and
-explaining why it deviates.
+[model-specific recipes](#model-specific-recipes-huggingface) under
+`huggingface/` — per-`model_type` folders plus the
+`huggingface/models/<org>/<checkpoint>/` tier — comparing each to its general
+baseline and explaining why it deviates.
 
 ---
 
@@ -28,7 +29,7 @@ supported combinations.
 ### The shipped recipes
 
 <details>
-<summary>All 19 <code>general/ptq/</code> recipes (click to expand)</summary>
+<summary>All 20 <code>general/ptq/</code> recipes (click to expand)</summary>
 
 | Recipe | Model body | KV cache | Calibration |
 |--------|-----------|----------|-------------|
@@ -46,6 +47,7 @@ supported combinations.
 | `nvfp4_experts_only-kv_fp8_cast` | NVFP4 W4A4, MoE experts only | FP8 (constant amax) | max |
 | `nvfp4_experts_only-kv_fp8_layerwise` | NVFP4 W4A4, MoE experts only | FP8 (calibrated) | max, layerwise |
 | `nvfp4_experts_only_mse-kv_fp8_cast` | NVFP4 W4A4, MoE experts only | FP8 (constant amax) | MSE + FP8 sweep |
+| `nvfp4_experts_only_input_scale1-kv_fp8_cast` | NVFP4 W4A4, MoE experts only, expert `input_scale` pinned to 1.0 | FP8 (constant amax) | max (weights); expert activations uncalibrated |
 | `nvfp4_omlp_only-kv_fp8` | NVFP4 W4A4, o_proj + MLP/MoE | FP8 (calibrated) | max |
 | `nvfp4_omlp_only-kv_fp8_cast` | NVFP4 W4A4, o_proj + MLP/MoE | FP8 (constant amax) | max |
 | `nvfp4_weight_only-kv_fp16` | NVFP4 W4A16, weights only | none (BF16/FP16) | max |
@@ -160,6 +162,15 @@ How the quantization scales are searched. The default (no suffix) is `max`.
   (amax) calibrated as in the default recipes. Costs more calibration time but
   recovers accuracy NVFP4 W4A4 can lose under plain max. Reach for it when a
   `max` recipe regresses.
+- **`input_scale1`** (`nvfp4_experts_only_input_scale1-kv_fp8_cast`) — pins the
+  expert **activation** per-tensor amax to a constant `2688.0`
+  (= E2M1_MAX × E4M3_MAX = 6 × 448) via `constant_amax`, so the exported NVFP4
+  `input_scale` is exactly **1.0** and those quantizers skip activation
+  calibration entirely (no forward statistics collected). Weights are still
+  max-calibrated, and the per-block E4M3 activation scales remain dynamic. Use
+  it when the deployment stack expects a unit expert `input_scale` (e.g. NVFP4
+  expert kernels that assume `input_scale == 1.0`) or to take expert activation
+  calibration out of the picture.
 - **`gptq`** (`nvfp4_default-kv_none-gptq`) — GPTQ layerwise calibration of the
   weight scales; writes layerwise checkpoints. GPTQ is best established for
   **INT4 weight-only** quantization; its effectiveness on **NVFP4** weight
@@ -195,29 +206,34 @@ These can also be **stacked** when a single method isn't enough — e.g. `mse` +
    accurate as calibrated `kv_fp8`); use `kv_nvfp4_cast` for maximum KV
    compression.
 
+> **Beyond PTQ:** these recipes' `quantize` sections are also reused as the
+> quantization config for QAT/QAD training flows. Dedicated scale-learning
+> (LSQ / Dual-LSQ) QAD recipes live separately under [`general/qad/`](general/qad/).
+
 ---
 
-## Model-specific recipes (`huggingface/` and `models/`)
+## Model-specific recipes (`huggingface/`)
 
 The general recipes above are **model-agnostic**: they select layers by wildcard
 (`*mlp*`, `*self_attn*`, `*[kv]_bmm_quantizer`) and lean on the shared
 `default_disabled_quantizers` exclusions, so the same file works on any
 architecture whose module names follow the usual conventions. A recipe only
-earns a place under `huggingface/<model_type>/` or `models/<checkpoint>/` when a
-model has to **deviate** from that baseline. The deviations come in four kinds:
+earns a place under `huggingface/<model_type>/` or
+`huggingface/models/<org>/<checkpoint>/` when a model has to **deviate** from
+that baseline. The deviations come in four kinds:
 
 | Kind | What changes vs. the general recipe | Examples |
 |------|-------------------------------------|----------|
-| **Architecture-aware `quant_cfg`** | Per-sub-module format choices a single wildcard scheme can't express | `qwen3_5`, `qwen3_5_moe` |
-| **Algorithm override** | Same numerics & scope, but the *calibration algorithm* is tweaked because the default breaks or regresses | `gemma`, `mpt` |
-| **Extra exclusions** | Adds disabled-quantizer patterns so non-language branches stay full precision | `nemotron_vl`, `phi4mm` |
-| **Checkpoint mirror** | A mixed-precision map reproducing one published checkpoint exactly | `models/Nemotron-3-Super-120B-A12B` |
+| **Architecture-aware `quant_cfg`** | Per-sub-module format choices a single wildcard scheme can't express | `qwen3_5`, `qwen3_5_moe`, `vit` |
+| **Algorithm override** | Same numerics & scope, but the *calibration algorithm* is tweaked because the default breaks or regresses | `gemma`, `gemma4`, `mpt` |
+| **Extra exclusions** | Adds disabled-quantizer patterns so non-language branches stay full precision | `nemotron_vl`, `phi4mm`, `diffusion_gemma` |
+| **Checkpoint mirror** | A mixed-precision map reproducing one published checkpoint exactly | `models/nvidia/Nemotron-3-*` |
 
 The numerics and standard exclusions are still inherited from `configs/`
 wherever possible — the model folder captures *only* the delta. Each `<task>/`
 folder carries a `README.md` spelling out that delta.
 
-### Architecture-aware `quant_cfg` — `qwen3_5`, `qwen3_5_moe`
+### Architecture-aware `quant_cfg` — `qwen3_5`, `qwen3_5_moe`, `vit`
 
 `huggingface/qwen3_5/ptq/w4a16_nvfp4-fp8_attn-kv_fp8_cast` (and its MoE twin,
 which shares the same `quant_cfg` snippet) is a **mixed scheme no single general
@@ -236,23 +252,36 @@ families share the identical wildcard rules, so one snippet drives both.
 On Qwen3.5 / Qwen3.6 this W4A16 recipe **usually does not regress accuracy**
 versus the official checkpoint, and it is designed for **best performance in
 low-concurrency use cases** (weight-only on the MLP keeps the memory-bound decode
-path fast without quantizing activations).
+path fast without quantizing activations). Both the dense and MoE folders also
+ship an MSE twin, **`w4a16_nvfp4_mse-fp8_attn-kv_fp8_cast`** — the identical
+layout with the NVFP4 weight scales chosen by an MSE FP8-scale sweep instead of
+max calibration (the [`mse` variant](#calibration-variants) applied to this
+architecture-specific scheme) — for when the max-calibrated recipe regresses.
+
+**`vit/ptq/fp8`** covers ViT image classifiers (the FP8 + Torch-TRT example):
+FP8 W8A8 on every linear, like `fp8_default`, but it additionally enables the
+**attention BMM quantizers** — q/k/v BMM plus the softmax-P quantizer — in FP8
+and disables the output quantizers. *Why special:* the general LLM recipes never
+quantize the attention BMM inputs; for ViT the whole attention block runs in FP8
+so Torch-TRT can compile it end-to-end.
 
 A lighter case: **`step3p5/Step3.5-Flash/ptq/nvfp4-mlp-only`** is close to
 `general/ptq/nvfp4_mlp_only` (NVFP4 on MoE/MLP weights+inputs, FP8 KV) but pinned
 to one released checkpoint and carrying instance-specific disables
 (`share_expert`, `moe.gate`, the conv1d branches).
 
-### Algorithm overrides — `gemma`, `mpt`
+### Algorithm overrides — `gemma`, `gemma4`, `mpt`
 
 These quantize the **same layers** as the general recipes; only the
 `quantize.algorithm` block differs, to work around model-specific numerics:
 
 - **`gemma/ptq/w4a8_awq-kv_fp8_cast`** (INT4 block weights + FP8 inputs + FP8 KV
-  cast) and **`mpt/ptq/w4a8_awq-kv_fp8_cast`** use `awq_lite` with `alpha_step: 1`
-  instead of the default AWQ search. The default search overflows the TRT-LLM
-  kernels on these models; the coarser sweep avoids it without measurably hurting
-  accuracy.
+  cast), its multimodal sibling **`gemma4/ptq/w4a8_awq-kv_fp8_cast`** (the
+  Gemma 4 `gemma4` model type, whose vision branch stays BF16 via the standard
+  exclusions), and **`mpt/ptq/w4a8_awq-kv_fp8_cast`** use `awq_lite` with
+  `alpha_step: 1` instead of the default AWQ search. The default search
+  overflows the TRT-LLM kernels on these models; the coarser sweep avoids it
+  without measurably hurting accuracy.
 - **`gemma/ptq/int8_sq-kv_fp8_cast`** (INT8 per-channel weights + INT8 inputs +
   FP8 KV cast) sets SmoothQuant `alpha: 0.5` instead of the default `1.0` —
   Gemma 7B regresses at `1.0`, and `0.5` recovers it.
@@ -260,40 +289,61 @@ These quantize the **same layers** as the general recipes; only the
 *Why special:* identical scope/numerics to a general scheme, but a general
 recipe's default algorithm would overflow or regress here.
 
-### Extra exclusions (multimodal) — `nemotron_vl`, `phi4mm`
+### Extra exclusions — `nemotron_vl`, `phi4mm`, `diffusion_gemma`
 
-Both are **numerically identical** to `general/ptq/nvfp4_default-kv_fp8_cast`
-(NVFP4 W4A4 + FP8 KV cast). What makes them special is a model-local
-`disabled_quantizers.yaml` unit that *extends* the standard exclusions so only
-the **language decoder** is quantized:
+Each of these is **numerically identical** to a general recipe. What makes them
+special is a model-local `disabled_quantizers.yaml` unit that *extends* the
+standard exclusions so a model-specific branch stays in full precision:
 
-- **`nemotron_vl`** (vision-language, incl. Nemotron-Parse) adds
-  `*vision*`, `*image*`, `*radio*`, `*visual*`, `*encoder*`, `*model_encoder*`.
-- **`phi4mm`** (Phi-4-Multimodal) adds `*speech*`, `*audio*`, `*image*`,
-  `*vision*`.
+- **`nemotron_vl`** (vision-language, incl. Nemotron-Parse) — general
+  `nvfp4_default-kv_fp8_cast` numerics, adding `*vision*`, `*image*`, `*radio*`,
+  `*visual*`, `*encoder*`, `*model_encoder*` so only the language decoder is
+  quantized.
+- **`phi4mm`** (Phi-4-Multimodal) — general `nvfp4_default-kv_fp8_cast`
+  numerics, adding `*speech*`, `*audio*`, `*image*`, `*vision*`.
+- **`diffusion_gemma`** (block-diffusion encoder-decoder text LLM on a Gemma4
+  MoE backbone) — general `nvfp4_experts_only-kv_fp8_cast` numerics, adding
+  `*self_conditioning*`: the self-conditioning network is text-only and never
+  exercised by standard PTQ calibration data, so its quantizers collect no amax
+  and export crashes; the exclusion keeps it in BF16.
 
 *Why special:* a general recipe would happily quantize the vision/audio
-encoders, regressing those modalities. The extra patterns keep them in full
-precision; everything else matches the general recipe.
+encoders (or the never-calibrated self-conditioning branch), regressing those
+modalities or crashing export. The extra patterns keep them in full precision;
+everything else matches the general recipe.
 
-### Checkpoint mirror — `models/Nemotron-3-Super-120B-A12B`
+### Checkpoint mirrors — `models/nvidia/<checkpoint>`
 
-The `models/` tier reproduces a **single published checkpoint's** quant config
-verbatim. `super-nvfp4.yaml` mirrors
-`nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` exactly — a hybrid **Mamba-MoE**
-with a hand-mapped, **per-component** precision scheme:
+The `huggingface/models/` tier reproduces a **single published (or planned)
+checkpoint's** quant config verbatim. Three Nemotron checkpoints live there:
 
-- MoE routed experts → NVFP4 W4A4, `group_size 16`, **static** weight scales
-- shared experts and Mamba `in/out_proj` → FP8 per-tensor
-- KV cache → FP8
-- attention q/k/v, MTP head, `lm_head`, latent-MoE, Mamba conv1d → **BF16**
+- **`Nemotron-3-Super-120B-A12B/ptq/nvfp4-mse`** mirrors
+  `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` exactly — a hybrid
+  **Mamba-MoE** with a hand-mapped, **per-component** precision scheme:
+  - MoE routed experts → NVFP4 W4A4, `group_size 16`, **static** weight scales
+  - shared experts and Mamba `in/out_proj` → FP8 per-tensor
+  - KV cache → FP8
+  - attention q/k/v, MTP head, `lm_head`, latent-MoE, Mamba conv1d → **BF16**
 
-*Why special:* unlike any general recipe, it **mixes FP8 and NVFP4 across
-different component types** and hardcodes the precise published layout (matched on
-both HF and Megatron-Core module names) rather than a portable wildcard scheme.
-`super-nvfp4.yaml` uses MSE calibration with an FP8-scale sweep (matches the
-release); `super-nvfp4-max-calib.yaml` is the identical layer map under plain
-`max` calibration, kept for comparison.
+  `nvfp4-mse.yaml` uses MSE calibration with an FP8-scale sweep (matches the
+  release); `nvfp4-max-calib.yaml` is the identical layer map under plain `max`
+  calibration, kept for comparison.
+- **`Nemotron-3-Ultra-550B-A55B/ptq/nvfp4-4o6`** follows the same Super-style
+  component map (routed experts NVFP4 W4A4 block-16; shared experts + Mamba
+  `in/out_proj` + KV cache FP8; everything else BF16), but the routed-expert
+  weights use **Four-over-Six (4/6)** NVFP4: an MSE search picks each weight's
+  amax multiplier from `[1.0, 1.5]` (M=6 vs. M=4). Activations stay dynamic
+  NVFP4 (not MSE-calibrated).
+- **`Nemotron-3-Nano-4B/ptq/nvfp4_w4a16`** mirrors the GGUF **Q4_K_M** bit
+  allocation of the Nemotron-H hybrid, mapped onto NVFP4/FP8 **per layer**:
+  Q4_K/Q5_0 linears → NVFP4 W4A4 (attention q/k/v/o kept uniform so export can
+  fuse them), the Q6_K MLP `down_proj` layers → FP8 W8A8, embeddings → NVFP4
+  W4A16, `lm_head` → FP8 W8A16, and the F32 tensors (conv1d, norms) → BF16.
+
+*Why special:* unlike any general recipe, these **mix FP8 and NVFP4 across
+different component types — or individual layers** — and hardcode the precise
+published layout (for Super, matched on both HF and Megatron-Core module names)
+rather than a portable wildcard scheme.
 
 ---
 

--- a/modelopt_recipes/ptq.md
+++ b/modelopt_recipes/ptq.md
@@ -167,10 +167,16 @@ How the quantization scales are searched. The default (no suffix) is `max`.
   (= E2M1_MAX × E4M3_MAX = 6 × 448) via `constant_amax`, so the exported NVFP4
   `input_scale` is exactly **1.0** and those quantizers skip activation
   calibration entirely (no forward statistics collected). Weights are still
-  max-calibrated, and the per-block E4M3 activation scales remain dynamic. Use
-  it when the deployment stack expects a unit expert `input_scale` (e.g. NVFP4
-  expert kernels that assume `input_scale == 1.0`) or to take expert activation
-  calibration out of the picture.
+  max-calibrated (computed directly from the weight tensors, no data needed),
+  and the per-block E4M3 activation scales remain dynamic. Because nothing in
+  the recipe needs a calibration forward pass — expert activations are pinned,
+  weight amax comes from the weights, and the KV cast uses a constant amax —
+  it **may work out of the box for very large LLMs** (hundreds of billions of
+  parameters and up), where running calibration PTQ is difficult on a
+  resource-limited setup. Also reach for it when the deployment stack expects
+  a unit expert `input_scale` (e.g. NVFP4 expert kernels that assume
+  `input_scale == 1.0`) or to take expert activation calibration out of the
+  picture.
 - **`gptq`** (`nvfp4_default-kv_none-gptq`) — GPTQ layerwise calibration of the
   weight scales; writes layerwise checkpoints. GPTQ is best established for
   **INT4 weight-only** quantization; its effectiveness on **NVFP4** weight

--- a/tests/unit/recipe/test_recipe_docs.py
+++ b/tests/unit/recipe/test_recipe_docs.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Consistency checks between the shipped recipe YAML files and modelopt_recipes/ptq.md.
+
+These tests force recipe additions, removals, and renames to be reflected in the
+PTQ recipe guide so the doc never drifts from the files on disk.
+"""
+
+import re
+from importlib.resources import files
+from pathlib import Path
+
+RECIPES_DIR = Path(str(files("modelopt_recipes")))
+GENERAL_PTQ_DIR = RECIPES_DIR / "general" / "ptq"
+PTQ_MD = RECIPES_DIR / "ptq.md"
+
+
+def _ptq_md_text() -> str:
+    return PTQ_MD.read_text(encoding="utf-8")
+
+
+def _general_ptq_stems() -> list[str]:
+    return sorted(p.stem for p in GENERAL_PTQ_DIR.glob("*.yaml"))
+
+
+def test_every_general_ptq_recipe_is_documented():
+    """Every general/ptq/*.yaml recipe must be mentioned (backticked) in ptq.md."""
+    doc = _ptq_md_text()
+    missing = [stem for stem in _general_ptq_stems() if f"`{stem}`" not in doc]
+    assert not missing, (
+        f"Recipes under modelopt_recipes/general/ptq/ are missing from "
+        f"modelopt_recipes/ptq.md: {missing}. When adding a recipe, add a row to "
+        "the 'shipped recipes' table in ptq.md (and describe any new scheme, "
+        "KV mode, or calibration variant in the matching section)."
+    )
+
+
+def test_documented_general_ptq_recipes_exist_on_disk():
+    """Every recipe row in the ptq.md shipped-recipes table must exist on disk.
+
+    Catches renames/removals that leave stale rows behind. Rows are identified
+    by a first cell that is a single backticked token, which only occurs in the
+    shipped-recipes table.
+    """
+    doc = _ptq_md_text()
+    documented = re.findall(r"^\| `([^`]+)` \|", doc, flags=re.MULTILINE)
+    assert documented, "ptq.md shipped-recipes table not found — was it reformatted?"
+    stale = [name for name in documented if not (GENERAL_PTQ_DIR / f"{name}.yaml").is_file()]
+    assert not stale, (
+        f"modelopt_recipes/ptq.md documents general/ptq recipes that do not exist "
+        f"on disk: {stale}. Update the 'shipped recipes' table after renaming or "
+        "removing a recipe."
+    )
+
+
+def test_general_ptq_recipe_count_in_ptq_md():
+    """The 'All N general/ptq/ recipes' summary line must match the file count."""
+    doc = _ptq_md_text()
+    match = re.search(r"All (\d+) <code>general/ptq/</code> recipes", doc)
+    assert match, (
+        "Could not find the 'All N <code>general/ptq/</code> recipes' summary "
+        "line in modelopt_recipes/ptq.md — keep that phrasing so this check can "
+        "verify the recipe count."
+    )
+    documented_count = int(match.group(1))
+    actual_count = len(_general_ptq_stems())
+    assert documented_count == actual_count, (
+        f"modelopt_recipes/ptq.md says 'All {documented_count} general/ptq/ "
+        f"recipes' but modelopt_recipes/general/ptq/ contains {actual_count} "
+        "recipes. Update the count and the table in ptq.md."
+    )
+
+
+def test_every_model_specific_ptq_dir_is_mentioned():
+    """Every model dir under huggingface/ with PTQ recipes must appear in ptq.md.
+
+    The identifier checked is the directory containing the ptq/ folder — the
+    HF model_type (e.g. ``gemma4``), a nested checkpoint dir (e.g.
+    ``Step3.5-Flash``), or a models/<org>/<checkpoint> leaf (e.g.
+    ``Nemotron-3-Nano-4B``).
+    """
+    doc = _ptq_md_text()
+    hf_dir = RECIPES_DIR / "huggingface"
+    model_dirs = sorted(
+        {yaml_path.parent.parent.name for yaml_path in hf_dir.glob("**/ptq/*.yaml")}
+    )
+    assert model_dirs, "No model-specific PTQ recipes found under huggingface/"
+    missing = [name for name in model_dirs if name not in doc]
+    assert not missing, (
+        f"Model-specific PTQ recipe folders are missing from "
+        f"modelopt_recipes/ptq.md: {missing}. Add them to the model-specific "
+        "recipes section (kinds table and/or the matching subsection)."
+    )


### PR DESCRIPTION
### What does this PR do?

**Type of change:** documentation (+ new tests)

`modelopt_recipes/ptq.md` is meant to track every shipped PTQ recipe, but recent recipe PRs did not update it. This PR brings the doc back in sync and adds unit tests so it can't drift again.

**Doc sync — general recipes:**
- Add `nvfp4_experts_only_input_scale1-kv_fp8_cast` (#1947) to the shipped-recipes table (now 20 recipes) and document the `input_scale1` variant (constant amax 2688 → exported NVFP4 `input_scale == 1.0`, expert activations uncalibrated).
- Add a pointer that the PTQ recipes' `quantize` sections also drive QAT/QAD, with the LSQ / Dual-LSQ QAD recipes under `general/qad/` (#1884).

**Doc sync — model-specific recipes:**
- Add `gemma4` (algorithm override, #1690), `diffusion_gemma` (extra `*self_conditioning*` exclusion, #1707), `vit` (FP8 with attention BMM quantizers for Torch-TRT, #1569), and the qwen3_5 / qwen3_5_moe `w4a16_nvfp4_mse-fp8_attn-kv_fp8_cast` twins (#1620).
- Rewrite the checkpoint-mirror section for the `huggingface/models/nvidia/` tier: Super recipe rename (`super-nvfp4.yaml` → `nvfp4-mse.yaml` / `nvfp4-max-calib.yaml`), Nano-4B GGUF Q4_K_M mirror (#1327/#1606), Ultra-550B `nvfp4-4o6` (#1684); fix stale `models/<checkpoint>` paths.

**Enforcement — new `tests/unit/recipe/test_recipe_docs.py`:**
1. Every `general/ptq/*.yaml` stem must appear (backticked) in `ptq.md`.
2. Every recipe row in the shipped-recipes table must exist on disk (catches renames/removals).
3. The "All N `general/ptq/` recipes" count must match the file count.
4. Every model folder under `huggingface/` containing `ptq/*.yaml` must be mentioned in the doc.

### Usage

```bash
pytest tests/unit/recipe/test_recipe_docs.py -q
```

### Testing

- `pytest tests/unit/recipe/ -q` → 218 passed (includes the 4 new tests).
- Verified enforcement bites: against the pre-update `ptq.md`, 3 of the 4 new tests fail with actionable messages.
- `pre-commit run --files modelopt_recipes/ptq.md tests/unit/recipe/test_recipe_docs.py` → all hooks pass.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ (docs + tests only; no runtime code changed)
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅ — `tests/unit/recipe/test_recipe_docs.py`
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A (documentation/test change)
- Did you get Claude approval on this PR?: ❌ (pending)

### Additional Information

Follow-up to the recipe guide added in #1662. The doc-consistency tests could also be wired into `tools/precommit/check_modelopt_recipes.py` for commit-time feedback if reviewers prefer both layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the `nvfp4_experts_only_input_scale1-kv_fp8_cast` recipe to the general PTQ catalog.
  * Documented the new `input_scale1` calibration behavior and related quantization/caching details.
  * Expanded and reworked PTQ documentation, including updated navigation, “Beyond PTQ” guidance, new/updated model-specific recipes, and expanded checkpoint mirror entries.
  * Updated the general PTQ shipped-recipe count to 20.

* **Tests**
  * Added automated consistency checks between on-disk shipped recipe YAML files and the PTQ documentation (coverage, existence, and counts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->