### PR TITLE
feat(specdec): warm-start DFlash fine-tuning from exported drafter via dflash_init_checkpoint

### DIFF
--- a/examples/speculative_decoding/doc/dflash.md
+++ b/examples/speculative_decoding/doc/dflash.md
@@ -281,6 +281,30 @@ DFlash supports checkpoint resume transparently. Rotary embeddings are lazily
 initialized on first forward (matching EAGLE3's `_maybe_init_rope` pattern),
 avoiding meta-tensor issues during `from_pretrained` model construction.
 
+### Warm Start / Fine-Tuning (`dflash_init_checkpoint`)
+
+To fine-tune an already-trained drafter instead of training from scratch, set
+`dflash.dflash_init_checkpoint` to an exported DFlash checkpoint (the
+z-lab-compatible layout produced by `export_hf_checkpoint.py`). It accepts a
+local export directory, a direct `.safetensors` path, or a HuggingFace Hub repo
+id, e.g.:
+
+```yaml
+dflash:
+  dflash_init_checkpoint: z-lab/Qwen3-8B-DFlash-b16
+```
+
+The weights are loaded into `model.dflash_module` right after conversion.
+`dflash_architecture_config` must describe the same draft architecture as the
+checkpoint — note that draft head/MLP dims default to `Qwen3Config` values, not
+the base model's, so set `num_attention_heads` / `num_key_value_heads` /
+`head_dim` / `intermediate_size` explicitly. `dflash_block_size` may differ from
+the checkpoint's (weights are block-size agnostic); a `mask_token_id` or
+`target_layer_ids` mismatch loads but logs a degradation warning. Restore of a
+saved training checkpoint ignores the field. See
+`tools/launcher/examples/Qwen/Qwen3-8B/hf_online_dflash_finetune.yaml` for a
+full fine-tuning pipeline.
+
 ### Export
 
 ```bash

--- a/examples/speculative_decoding/doc/dflash.md
+++ b/examples/speculative_decoding/doc/dflash.md
@@ -284,14 +284,14 @@ avoiding meta-tensor issues during `from_pretrained` model construction.
 ### Warm Start / Fine-Tuning (`dflash_init_checkpoint`)
 
 To fine-tune an already-trained drafter instead of training from scratch, set
-`dflash.dflash_init_checkpoint` to an exported DFlash checkpoint (the
-z-lab-compatible layout produced by `export_hf_checkpoint.py`). It accepts a
-local export directory, a direct `.safetensors` path, or a HuggingFace Hub repo
-id, e.g.:
+`dflash.dflash_init_checkpoint` to a local directory containing an exported
+DFlash checkpoint (the z-lab-compatible `model.safetensors` layout produced by
+`export_hf_checkpoint.py`; for a public drafter, download it first, e.g.
+`hf download z-lab/Qwen3-8B-DFlash-b16`):
 
 ```yaml
 dflash:
-  dflash_init_checkpoint: z-lab/Qwen3-8B-DFlash-b16
+  dflash_init_checkpoint: /path/to/Qwen3-8B-DFlash-b16
 ```
 
 The weights are loaded into `model.dflash_module` right after conversion.

--- a/modelopt/torch/speculative/config.py
+++ b/modelopt/torch/speculative/config.py
@@ -148,12 +148,12 @@ class DFlashConfig(ModeloptBaseConfig):
         default=None,
         description=(
             "Warm-start the draft module from an exported DFlash checkpoint before "
-            "fine-tuning. Accepts a local directory containing ``model.safetensors`` (the "
-            "DFlashExporter / z-lab layout, e.g. ``z-lab/Qwen3-8B-DFlash-b16``), a direct "
-            "path to a ``.safetensors`` file, or a HuggingFace Hub repo id to download from. "
-            "``dflash_architecture_config`` must describe the same draft architecture as the "
-            "checkpoint (weights are block-size agnostic, so ``dflash_block_size`` may "
-            "differ). Ignored on restore — restored models load their own trained weights."
+            "fine-tuning. Must be a local directory containing ``model.safetensors`` in the "
+            "DFlashExporter / z-lab layout (e.g. a downloaded copy of "
+            "``z-lab/Qwen3-8B-DFlash-b16``). ``dflash_architecture_config`` must describe "
+            "the same draft architecture as the checkpoint (weights are block-size "
+            "agnostic, so ``dflash_block_size`` may differ). Ignored on restore — restored "
+            "models load their own trained weights."
         ),
     )
 

--- a/modelopt/torch/speculative/config.py
+++ b/modelopt/torch/speculative/config.py
@@ -144,6 +144,19 @@ class DFlashConfig(ModeloptBaseConfig):
         default={}, description="Config for the DFlash draft module architecture."
     )
 
+    dflash_init_checkpoint: str | None = ModeloptField(
+        default=None,
+        description=(
+            "Warm-start the draft module from an exported DFlash checkpoint before "
+            "fine-tuning. Accepts a local directory containing ``model.safetensors`` (the "
+            "DFlashExporter / z-lab layout, e.g. ``z-lab/Qwen3-8B-DFlash-b16``), a direct "
+            "path to a ``.safetensors`` file, or a HuggingFace Hub repo id to download from. "
+            "``dflash_architecture_config`` must describe the same draft architecture as the "
+            "checkpoint (weights are block-size agnostic, so ``dflash_block_size`` may "
+            "differ). Ignored on restore — restored models load their own trained weights."
+        ),
+    )
+
     dflash_use_torch_compile: bool = ModeloptField(
         default=True,
         description="Whether to use torch.compile on DFlash forward/loss methods.",

--- a/modelopt/torch/speculative/dflash/conversion.py
+++ b/modelopt/torch/speculative/dflash/conversion.py
@@ -80,4 +80,7 @@ def restore_dflash_model(
 ) -> nn.Module:
     """Function for restoring a previously converted model to a DFlash model."""
     assert not metadata, "No metadata expected!"
+    # Never warm-start on restore: the restored model loads its own trained weights,
+    # and the init checkpoint may no longer exist where the model was trained.
+    config.dflash_init_checkpoint = None
     return convert_to_dflash_model(model, config)[0]

--- a/modelopt/torch/speculative/plugins/hf_dflash.py
+++ b/modelopt/torch/speculative/plugins/hf_dflash.py
@@ -71,7 +71,6 @@ Draft model components:
            lazy rope pattern needed for MLA models.
 """
 
-import contextlib
 import json
 import logging
 import os
@@ -330,24 +329,19 @@ class HFDFlashModel(DFlashModel):
         """Warm-start ``self.dflash_module`` from an exported DFlash draft checkpoint.
 
         ``checkpoint`` is a local directory holding ``model.safetensors`` (DFlashExporter /
-        z-lab layout), a direct path to a ``.safetensors`` file, or a HuggingFace Hub repo
-        id to download from. Keys map 1:1 onto ``dflash_module``. Missing keys are
-        tolerated only for submodules entirely absent from the checkpoint (e.g. the
-        Domino/DSpark heads when warm-starting from a plain DFlash backbone); partial
-        overlap within a submodule means an architecture mismatch and raises.
+        z-lab layout). Keys map 1:1 onto ``dflash_module``. Missing keys are tolerated
+        only for submodules entirely absent from the checkpoint (e.g. the Domino/DSpark
+        heads when warm-starting from a plain DFlash backbone); partial overlap within a
+        submodule means an architecture mismatch and raises.
         """
         from safetensors.torch import load_file
 
-        weights_path = checkpoint
-        if os.path.isdir(weights_path):
-            weights_path = os.path.join(weights_path, "model.safetensors")
+        weights_path = os.path.join(checkpoint, "model.safetensors")
         if not os.path.isfile(weights_path):
-            from huggingface_hub import hf_hub_download
-
-            weights_path = hf_hub_download(repo_id=checkpoint, filename="model.safetensors")
-            # Best-effort fetch for the sibling-config consistency check below.
-            with contextlib.suppress(Exception):
-                hf_hub_download(repo_id=checkpoint, filename="config.json")
+            raise ValueError(
+                f"dflash_init_checkpoint must be a local directory containing "
+                f"model.safetensors; not found at {weights_path}."
+            )
 
         self._check_init_checkpoint_config(checkpoint, weights_path)
 

--- a/modelopt/torch/speculative/plugins/hf_dflash.py
+++ b/modelopt/torch/speculative/plugins/hf_dflash.py
@@ -71,7 +71,10 @@ Draft model components:
            lazy rope pattern needed for MLA models.
 """
 
+import contextlib
+import json
 import logging
+import os
 
 import torch
 import torch.nn.functional as F
@@ -306,6 +309,12 @@ class HFDFlashModel(DFlashModel):
         if base_device.type != "meta":
             self.dflash_module.to(self._base_model.dtype).to(base_device)
 
+        # Warm-start the draft module from an exported DFlash checkpoint (fine-tuning).
+        # Restore paths never reach here with a checkpoint set: restore_dflash_model
+        # clears the field since restored weights come from the restored model itself.
+        if config.dflash_init_checkpoint:
+            self._load_draft_init_weights(config.dflash_init_checkpoint)
+
         # Delete base model layers for offline training (save memory)
         if self.dflash_offline:
             self._base_model._modules.pop("layers")
@@ -316,6 +325,96 @@ class HFDFlashModel(DFlashModel):
     def _build_draft_module(self, dflash_config):
         """Build the draft module. Subclasses override to use an augmented module."""
         return DFlashModule(dflash_config)
+
+    def _load_draft_init_weights(self, checkpoint: str):
+        """Warm-start ``self.dflash_module`` from an exported DFlash draft checkpoint.
+
+        ``checkpoint`` is a local directory holding ``model.safetensors`` (DFlashExporter /
+        z-lab layout), a direct path to a ``.safetensors`` file, or a HuggingFace Hub repo
+        id to download from. Keys map 1:1 onto ``dflash_module``. Missing keys are
+        tolerated only for submodules entirely absent from the checkpoint (e.g. the
+        Domino/DSpark heads when warm-starting from a plain DFlash backbone); partial
+        overlap within a submodule means an architecture mismatch and raises.
+        """
+        from safetensors.torch import load_file
+
+        weights_path = checkpoint
+        if os.path.isdir(weights_path):
+            weights_path = os.path.join(weights_path, "model.safetensors")
+        if not os.path.isfile(weights_path):
+            from huggingface_hub import hf_hub_download
+
+            weights_path = hf_hub_download(repo_id=checkpoint, filename="model.safetensors")
+            # Best-effort fetch for the sibling-config consistency check below.
+            with contextlib.suppress(Exception):
+                hf_hub_download(repo_id=checkpoint, filename="config.json")
+
+        self._check_init_checkpoint_config(checkpoint, weights_path)
+
+        param = next(self.dflash_module.parameters())
+        state_dict = {
+            key: value.to(param.dtype)
+            for key, value in load_file(weights_path, device=str(param.device)).items()
+        }
+        arch_hint = (
+            "Set dflash_architecture_config to the checkpoint's architecture "
+            "(num_hidden_layers, heads, intermediate_size, ...)."
+        )
+        try:
+            # strict=False tolerates missing/unexpected keys but still raises on shape
+            # mismatches (e.g. a different draft depth changing the fc fusion width).
+            missing, unexpected = self.dflash_module.load_state_dict(state_dict, strict=False)
+        except RuntimeError as e:
+            raise ValueError(
+                f"DFlash init checkpoint {checkpoint} does not match the draft architecture "
+                f"built from dflash_architecture_config: {e} {arch_hint}"
+            ) from e
+        ckpt_submodules = {key.split(".", 1)[0] for key in state_dict}
+        hard_missing = [key for key in missing if key.split(".", 1)[0] in ckpt_submodules]
+        if unexpected or hard_missing:
+            raise ValueError(
+                f"DFlash init checkpoint {checkpoint} does not match the draft architecture "
+                f"built from dflash_architecture_config (unexpected keys: {unexpected}, "
+                f"missing keys: {hard_missing}). {arch_hint}"
+            )
+        if missing:
+            logger.warning(
+                "DFlash: submodules not in init checkpoint %s train from scratch: %s",
+                checkpoint,
+                sorted({key.split(".", 1)[0] for key in missing}),
+            )
+        logger.info(
+            "DFlash: warm-started draft module from %s (%d tensors).",
+            checkpoint,
+            len(state_dict),
+        )
+
+    def _check_init_checkpoint_config(self, checkpoint: str, weights_path: str):
+        """Warn when the init checkpoint's config disagrees with this conversion.
+
+        A ``mask_token_id`` or ``target_layer_ids`` mismatch loads cleanly (shapes match)
+        but silently degrades the warm start: the mask embedding and the fc fusion columns
+        were trained for the checkpoint's values.
+        """
+        config_path = os.path.join(os.path.dirname(weights_path), "config.json")
+        if not os.path.isfile(config_path):
+            return
+        with open(config_path) as f:
+            ckpt_dflash_config = json.load(f).get("dflash_config", {})
+        for name, ours in (
+            ("mask_token_id", self.mask_token_id),
+            ("target_layer_ids", list(self.target_layer_ids)),
+        ):
+            ckpt_value = ckpt_dflash_config.get(name)
+            if ckpt_value is not None and ckpt_value != ours:
+                logger.warning(
+                    "DFlash: init checkpoint %s was trained with %s=%s but this conversion "
+                    "uses %s — the warm start will be degraded.",
+                    checkpoint,
+                    name,
+                    ckpt_value,
+                    ours,
+                )
 
     def get_exporter(self):
         """Get the exporter for the DFlash draft model."""

--- a/tests/unit/torch/speculative/plugins/test_hf_dflash.py
+++ b/tests/unit/torch/speculative/plugins/test_hf_dflash.py
@@ -305,18 +305,13 @@ class TestDFlashWarmStart:
         for key, value in model.dflash_module.state_dict().items():
             assert torch.equal(value, ref_sd[key]), f"Mismatch after warm start: {key}"
 
-    def test_warm_start_from_safetensors_file_path(self, tmp_path):
-        """A direct path to the .safetensors file works too."""
-        model_ref, export_dir = self._export_drafter(tmp_path)
-
+    def test_warm_start_missing_checkpoint_raises(self, tmp_path):
+        """Anything but a local dir containing model.safetensors fails loudly."""
         model = get_tiny_llama(num_hidden_layers=4)
         config = _get_dflash_config()
-        config["dflash_init_checkpoint"] = str(export_dir / "model.safetensors")
-        mtsp.convert(model, [("dflash", config)])
-
-        ref_sd = model_ref.dflash_module.state_dict()
-        for key, value in model.dflash_module.state_dict().items():
-            assert torch.equal(value, ref_sd[key])
+        config["dflash_init_checkpoint"] = str(tmp_path / "no_such_dir")
+        with pytest.raises(ValueError, match="must be a local directory"):
+            mtsp.convert(model, [("dflash", config)])
 
     def test_warm_start_arch_mismatch_raises(self, tmp_path):
         """Loading a checkpoint with a different draft depth fails loudly."""

--- a/tests/unit/torch/speculative/plugins/test_hf_dflash.py
+++ b/tests/unit/torch/speculative/plugins/test_hf_dflash.py
@@ -279,6 +279,101 @@ class TestDFlashSaveRestore:
         tf_modelopt_state_and_output_tester(model_ref, model_test)
 
 
+class TestDFlashWarmStart:
+    """Test warm-starting the draft module from an exported DFlash checkpoint."""
+
+    def _export_drafter(self, tmp_path, **config_overrides):
+        """Convert a tiny model and export its drafter in z-lab layout."""
+        model = get_tiny_llama(num_hidden_layers=4)
+        config = _get_dflash_config()
+        config.update(config_overrides)
+        mtsp.convert(model, [("dflash", config)])
+        export_dir = tmp_path / "exported_drafter"
+        model.get_exporter().export(export_dir)
+        return model, export_dir
+
+    def test_warm_start_loads_exported_weights(self, tmp_path):
+        """A fresh conversion with dflash_init_checkpoint matches the exported drafter."""
+        model_ref, export_dir = self._export_drafter(tmp_path)
+
+        model = get_tiny_llama(num_hidden_layers=4)
+        config = _get_dflash_config()
+        config["dflash_init_checkpoint"] = str(export_dir)
+        mtsp.convert(model, [("dflash", config)])
+
+        ref_sd = model_ref.dflash_module.state_dict()
+        for key, value in model.dflash_module.state_dict().items():
+            assert torch.equal(value, ref_sd[key]), f"Mismatch after warm start: {key}"
+
+    def test_warm_start_from_safetensors_file_path(self, tmp_path):
+        """A direct path to the .safetensors file works too."""
+        model_ref, export_dir = self._export_drafter(tmp_path)
+
+        model = get_tiny_llama(num_hidden_layers=4)
+        config = _get_dflash_config()
+        config["dflash_init_checkpoint"] = str(export_dir / "model.safetensors")
+        mtsp.convert(model, [("dflash", config)])
+
+        ref_sd = model_ref.dflash_module.state_dict()
+        for key, value in model.dflash_module.state_dict().items():
+            assert torch.equal(value, ref_sd[key])
+
+    def test_warm_start_arch_mismatch_raises(self, tmp_path):
+        """Loading a checkpoint with a different draft depth fails loudly."""
+        _, export_dir = self._export_drafter(tmp_path)
+
+        model = get_tiny_llama(num_hidden_layers=4)
+        config = _get_dflash_config(num_layers=NUM_DRAFT_LAYERS + 1)
+        config["dflash_init_checkpoint"] = str(export_dir)
+        with pytest.raises(ValueError, match="does not match the draft architecture"):
+            mtsp.convert(model, [("dflash", config)])
+
+    def test_warm_start_mask_token_mismatch_warns(self, tmp_path, caplog):
+        """A different mask_token_id loads (shapes match) but warns about degradation."""
+        _, export_dir = self._export_drafter(tmp_path)
+
+        model = get_tiny_llama(num_hidden_layers=4)
+        config = _get_dflash_config()
+        config["dflash_init_checkpoint"] = str(export_dir)
+        config["dflash_mask_token_id"] = 1  # exported drafter used 0
+        logger_name = "modelopt.torch.speculative.plugins.hf_dflash"
+        with caplog.at_level(logging.WARNING, logger=logger_name):
+            mtsp.convert(model, [("dflash", config)])
+        assert any("mask_token_id" in r.getMessage() for r in caplog.records)
+
+    def test_warm_start_block_size_change_allowed(self, tmp_path):
+        """Weights are block-size agnostic: a b4 checkpoint warm-starts a b8 fine-tune."""
+        model_ref, export_dir = self._export_drafter(tmp_path)
+
+        model = get_tiny_llama(num_hidden_layers=4)
+        config = _get_dflash_config(block_size=2 * BLOCK_SIZE)
+        config["dflash_init_checkpoint"] = str(export_dir)
+        mtsp.convert(model, [("dflash", config)])
+
+        ref_sd = model_ref.dflash_module.state_dict()
+        for key, value in model.dflash_module.state_dict().items():
+            assert torch.equal(value, ref_sd[key])
+
+    def test_restore_ignores_init_checkpoint(self, tmp_path):
+        """Save/restore of a warm-started model must not re-read the init checkpoint."""
+        import shutil
+
+        _, export_dir = self._export_drafter(tmp_path)
+
+        mto.enable_huggingface_checkpointing()
+        model_ref = get_tiny_llama(num_hidden_layers=4)
+        config = _get_dflash_config()
+        config["dflash_init_checkpoint"] = str(export_dir)
+        mtsp.convert(model_ref, [("dflash", config)])
+        model_ref.save_pretrained(tmp_path / "warm_started_model")
+
+        # The init checkpoint is gone; restore must still work.
+        shutil.rmtree(export_dir)
+        model_test = AutoModelForCausalLM.from_pretrained(tmp_path / "warm_started_model")
+        assert isinstance(model_test, HFDFlashModel)
+        tf_modelopt_state_and_output_tester(model_ref, model_test)
+
+
 class TestDFlashLazyRotaryEmb:
     """Test lazy rotary embedding initialization (matching EAGLE3 pattern).
 

--- a/tests/unit/torch/speculative/plugins/test_hf_dflash.py
+++ b/tests/unit/torch/speculative/plugins/test_hf_dflash.py
@@ -293,51 +293,10 @@ class TestDFlashWarmStart:
         return model, export_dir
 
     def test_warm_start_loads_exported_weights(self, tmp_path):
-        """A fresh conversion with dflash_init_checkpoint matches the exported drafter."""
-        model_ref, export_dir = self._export_drafter(tmp_path)
+        """A fresh conversion with dflash_init_checkpoint matches the exported drafter.
 
-        model = get_tiny_llama(num_hidden_layers=4)
-        config = _get_dflash_config()
-        config["dflash_init_checkpoint"] = str(export_dir)
-        mtsp.convert(model, [("dflash", config)])
-
-        ref_sd = model_ref.dflash_module.state_dict()
-        for key, value in model.dflash_module.state_dict().items():
-            assert torch.equal(value, ref_sd[key]), f"Mismatch after warm start: {key}"
-
-    def test_warm_start_missing_checkpoint_raises(self, tmp_path):
-        """Anything but a local dir containing model.safetensors fails loudly."""
-        model = get_tiny_llama(num_hidden_layers=4)
-        config = _get_dflash_config()
-        config["dflash_init_checkpoint"] = str(tmp_path / "no_such_dir")
-        with pytest.raises(ValueError, match="must be a local directory"):
-            mtsp.convert(model, [("dflash", config)])
-
-    def test_warm_start_arch_mismatch_raises(self, tmp_path):
-        """Loading a checkpoint with a different draft depth fails loudly."""
-        _, export_dir = self._export_drafter(tmp_path)
-
-        model = get_tiny_llama(num_hidden_layers=4)
-        config = _get_dflash_config(num_layers=NUM_DRAFT_LAYERS + 1)
-        config["dflash_init_checkpoint"] = str(export_dir)
-        with pytest.raises(ValueError, match="does not match the draft architecture"):
-            mtsp.convert(model, [("dflash", config)])
-
-    def test_warm_start_mask_token_mismatch_warns(self, tmp_path, caplog):
-        """A different mask_token_id loads (shapes match) but warns about degradation."""
-        _, export_dir = self._export_drafter(tmp_path)
-
-        model = get_tiny_llama(num_hidden_layers=4)
-        config = _get_dflash_config()
-        config["dflash_init_checkpoint"] = str(export_dir)
-        config["dflash_mask_token_id"] = 1  # exported drafter used 0
-        logger_name = "modelopt.torch.speculative.plugins.hf_dflash"
-        with caplog.at_level(logging.WARNING, logger=logger_name):
-            mtsp.convert(model, [("dflash", config)])
-        assert any("mask_token_id" in r.getMessage() for r in caplog.records)
-
-    def test_warm_start_block_size_change_allowed(self, tmp_path):
-        """Weights are block-size agnostic: a b4 checkpoint warm-starts a b8 fine-tune."""
+        Fine-tunes at a different block size: weights are block-size agnostic.
+        """
         model_ref, export_dir = self._export_drafter(tmp_path)
 
         model = get_tiny_llama(num_hidden_layers=4)
@@ -347,7 +306,21 @@ class TestDFlashWarmStart:
 
         ref_sd = model_ref.dflash_module.state_dict()
         for key, value in model.dflash_module.state_dict().items():
-            assert torch.equal(value, ref_sd[key])
+            assert torch.equal(value, ref_sd[key]), f"Mismatch after warm start: {key}"
+
+    def test_warm_start_bad_checkpoint_raises(self, tmp_path):
+        """A missing directory or a different draft architecture fails loudly."""
+        _, export_dir = self._export_drafter(tmp_path)
+
+        config = _get_dflash_config()
+        config["dflash_init_checkpoint"] = str(tmp_path / "no_such_dir")
+        with pytest.raises(ValueError, match="must be a local directory"):
+            mtsp.convert(get_tiny_llama(num_hidden_layers=4), [("dflash", config)])
+
+        config = _get_dflash_config(num_layers=NUM_DRAFT_LAYERS + 1)
+        config["dflash_init_checkpoint"] = str(export_dir)
+        with pytest.raises(ValueError, match="does not match the draft architecture"):
+            mtsp.convert(get_tiny_llama(num_hidden_layers=4), [("dflash", config)])
 
     def test_restore_ignores_init_checkpoint(self, tmp_path):
         """Save/restore of a warm-started model must not re-read the init checkpoint."""

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_online_dflash_finetune.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_online_dflash_finetune.yaml
@@ -2,9 +2,9 @@
 #
 # Instead of training the drafter from scratch, dflash.dflash_init_checkpoint loads an
 # already-trained draft module (DFlashExporter / z-lab layout: model.safetensors +
-# config.json) into model.dflash_module before training. The default warm-start
-# checkpoint is the public z-lab/Qwen3-8B-DFlash-b16 (downloaded from the HF Hub);
-# point init_checkpoint at a local export directory to fine-tune your own drafter.
+# config.json) into model.dflash_module before training. It must be a LOCAL directory —
+# stage the public drafter first (hf download z-lab/Qwen3-8B-DFlash-b16) or point
+# init_checkpoint at your own export directory.
 #
 # NOTE: dflash_architecture_config must describe the SAME draft architecture as the
 # checkpoint. modify() takes num_attention_heads/num_key_value_heads/head_dim/
@@ -35,8 +35,8 @@ job_name: Qwen3-8B_DFlash_online_finetune
 pipeline:
   global_vars:
     hf_model: /hf-local/Qwen/Qwen3-8B
-    # HF Hub repo id, a local export dir with model.safetensors, or a .safetensors path.
-    init_checkpoint: z-lab/Qwen3-8B-DFlash-b16
+    # Local dir with model.safetensors (a staged z-lab/Qwen3-8B-DFlash-b16 or your own export).
+    init_checkpoint: /hf-local/z-lab/Qwen3-8B-DFlash-b16
 
   # Step 1: Online DFlash fine-tuning from the warm-start checkpoint
   task_0:

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_online_dflash_finetune.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_online_dflash_finetune.yaml
@@ -1,0 +1,107 @@
+# DFlash online FINE-TUNING for Qwen3-8B, warm-started from an exported DFlash checkpoint.
+#
+# Instead of training the drafter from scratch, dflash.dflash_init_checkpoint loads an
+# already-trained draft module (DFlashExporter / z-lab layout: model.safetensors +
+# config.json) into model.dflash_module before training. The default warm-start
+# checkpoint is the public z-lab/Qwen3-8B-DFlash-b16 (downloaded from the HF Hub);
+# point init_checkpoint at a local export directory to fine-tune your own drafter.
+#
+# NOTE: dflash_architecture_config must describe the SAME draft architecture as the
+# checkpoint. modify() takes num_attention_heads/num_key_value_heads/head_dim/
+# intermediate_size from Qwen3Config defaults (NOT the base model), so set them
+# explicitly below; hidden_size/vocab/rope_theta are forced to the base model and need
+# not be set. A mismatch fails at conversion with a shape error. dflash_block_size may
+# differ from the checkpoint's (weights are block-size agnostic), but mask_token_id and
+# target_layer_ids should match — the loader warns if they don't.
+#
+# 3-step pipeline:
+#   task_0: Online DFlash fine-tuning (warm start)
+#   task_1: vLLM smoke test with DFlash speculative decoding
+#   task_2: MT-Bench per-category HF AR evaluation (1 GPU)
+#
+# The warm start is visible in the very first training logs: step 100 accuracy should
+# already be near the converged from-scratch level (~0.2, see hf_online_dflash.yaml)
+# instead of ~0.03.
+#
+# Regression criteria (set via environment):
+#   MAX_FINAL_LOSS: final loss must be below this (default: 4.5)
+#   MIN_FINAL_ACC:  final accuracy must be above this (default: 0.18)
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_online_dflash_finetune.yaml --yes
+#   uv run slurm.py --yaml modules/Model-Optimizer/tools/launcher/examples/Qwen/Qwen3-8B/hf_online_dflash_finetune.yaml --yes
+
+job_name: Qwen3-8B_DFlash_online_finetune
+pipeline:
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3-8B
+    # HF Hub repo id, a local export dir with model.safetensors, or a .safetensors path.
+    init_checkpoint: z-lab/Qwen3-8B-DFlash-b16
+
+  # Step 1: Online DFlash fine-tuning from the warm-start checkpoint
+  task_0:
+    script: common/specdec/dflash_online_training.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/dflash.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.data_path=/hf-local/modelopt/Speculative-Decoding-Dataset-v1-Qwen3-8B/sample-100K-openai.jsonl
+      - data.chat_template=examples/Qwen/Qwen3-8B/chat_template_train.jinja
+      - training.output_dir=/scratchspace/dflash_bs16_finetune
+      - training.per_device_train_batch_size=1
+      - training.num_train_epochs=1
+      - training.training_seq_len=4096
+      - training.save_steps=5000
+      - training.logging_steps=100
+      - training.disable_tqdm=true
+      - training.answer_only_loss=true
+      # Fine-tuning: lower LR than the 6e-4 from-scratch default.
+      - training.learning_rate=1.0e-4
+      - dflash.dflash_init_checkpoint=<<global_vars.init_checkpoint>>
+      # Match z-lab/Qwen3-8B-DFlash-b16: block_size 16, mask token 151669,
+      # 5 draft layers with Qwen3-8B dims.
+      - dflash.dflash_block_size=16
+      - dflash.dflash_num_anchors=512
+      - dflash.dflash_loss_decay_factor=7
+      - dflash.dflash_mask_token_id=151669
+      - dflash.dflash_architecture_config.num_hidden_layers=5
+      - dflash.dflash_architecture_config.num_attention_heads=32
+      - dflash.dflash_architecture_config.num_key_value_heads=8
+      - dflash.dflash_architecture_config.head_dim=128
+      - dflash.dflash_architecture_config.intermediate_size=12288
+    environment:
+      - MAX_FINAL_LOSS: "4.5"
+      - MIN_FINAL_ACC: "0.18"
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 8
+
+  # Step 2: vLLM smoke test (uses exported checkpoint from training)
+  task_1:
+    script: common/specdec/vllm_smoke_test.sh
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - DRAFT_CKPT_DIR: /scratchspace/dflash_bs16_finetune
+      - SPEC_METHOD: "dflash"
+      - NUM_SPEC_TOKENS: "7"
+      - MIN_ACCEPTANCE_LENGTH: "1.4"
+    slurm_config:
+      _factory_: "slurm_factory"
+      container: "vllm/vllm-openai:nightly"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+
+  # Step 3: HF AR evaluation
+  task_2:
+    script: common/specdec/ar_eval_mtbench.sh
+    args:
+      - --ckpt_dir /scratchspace/dflash_bs16_finetune
+      - --osl 512
+      - --steps 15
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1


### PR DESCRIPTION
### What does this PR do?

Type of change: new feature

Adds warm-start fine-tuning for DFlash: a new `dflash_init_checkpoint` field on `DFlashConfig` loads an already-trained, exported drafter (DFlashExporter / z-lab layout) into `model.dflash_module` at conversion time, so training continues from it instead of random init. Must be a local directory containing `model.safetensors` (stage public drafters with `hf download` first).

- Shape/key mismatch vs `dflash_architecture_config` fails with a clear error; `mask_token_id` / `target_layer_ids` mismatch vs the checkpoint's `config.json` logs a degradation warning. `dflash_block_size` may differ (weights are block-size agnostic).
- Domino/DSpark can warm-start their DFlash backbone from a plain DFlash checkpoint (missing head submodules train from scratch, with a warning).
- Restore of a saved training checkpoint ignores the field (`restore_dflash_model` clears it), so resume works even if the init checkpoint is gone.

Also adds a launcher example (`tools/launcher/examples/Qwen/Qwen3-8B/hf_online_dflash_finetune.yaml`) and a doc section in `examples/speculative_decoding/doc/dflash.md`.

### Usage

```yaml
# recipe YAML (or launcher dotlist: dflash.dflash_init_checkpoint=...)
dflash:
  dflash_init_checkpoint: /hf-local/z-lab/Qwen3-8B-DFlash-b16  # local dir with model.safetensors
  dflash_block_size: 16
  dflash_mask_token_id: 151669
  # must match the checkpoint's draft architecture (dims do NOT inherit from the base model):
  dflash_architecture_config:
    num_hidden_layers: 5
    num_attention_heads: 32
    num_key_value_heads: 8
    head_dim: 128
    intermediate_size: 12288
```

```bash
uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_online_dflash_finetune.yaml --yes
```

### Testing

- New unit tests: `TestDFlashWarmStart` (export→load round-trip at a different block size, missing-dir / arch-mismatch errors, restore ignores the field). All dflash/domino/dspark unit tests pass.
- End-to-end: converted `Qwen/Qwen3-8B` with `dflash_init_checkpoint` pointing at a local copy of `z-lab/Qwen3-8B-DFlash-b16` — all 58 tensors load bit-exact, `target_layer_ids=[1, 9, 17, 25, 33]` matches the checkpoint, no warnings.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ (new optional field, default `None`; existing configs/checkpoints unaffected)
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ❌ (can add if desired)
- Did you get Claude approval on this PR?: ❌ (pending)
