### PR TITLE
launcher: bump TRT-LLM to 1.3.0rc20, pin vLLM to v0.22.0, fix max_seq…

### DIFF
--- a/tools/launcher/examples/Qwen/Qwen3-30B-A3B/hf_streaming_dflash_multi_node.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-30B-A3B/hf_streaming_dflash_multi_node.yaml
@@ -48,7 +48,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 2: Streaming DFlash training — 2 serve replicas (TP=2) + 2 trainer nodes (2 GPU each).
   # DFlash extracts 5 target layers (build_target_layer_ids(48,5)=[1,12,23,34,45], the

--- a/tools/launcher/examples/Qwen/Qwen3-30B-A3B/hf_streaming_eagle3_multi_node.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-30B-A3B/hf_streaming_eagle3_multi_node.yaml
@@ -44,7 +44,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 2: Streaming EAGLE3 training — 2 serve replicas (TP=2) + 2 trainer nodes (2 GPU each).
   # Capture ids: default_eagle_aux_layer_ids(48)=[1,23,44] +1, plus final layer 48.

--- a/tools/launcher/examples/Qwen/Qwen3-8B/eagle3_quick_check.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/eagle3_quick_check.yaml
@@ -39,7 +39,7 @@ pipeline:
       _factory_: "slurm_factory"
       nodes: 1
       gpus_per_node: 4
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc2
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 2: Dump hidden states from target model
   task_1:
@@ -56,7 +56,7 @@ pipeline:
       _factory_: "slurm_factory"
       nodes: 1
       gpus_per_node: 4
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc2
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 3: Train EAGLE3 draft head (offline, single task)
   task_2:
@@ -78,7 +78,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 4
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc2
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 4: Benchmark speculative decoding (VLLM backend)
   #
@@ -90,7 +90,7 @@ pipeline:
   #   TRTLLM_LAUNCH_SCRIPT: trtllm-llmapi-launch
   # slurm_config:
   #   ntasks_per_node: 4
-  #   container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc2
+  #   container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
   #
   # To use SGLang
   #

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_eagle3_dryrun.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_eagle3_dryrun.yaml
@@ -53,4 +53,4 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_offline_eagle3.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_offline_eagle3.yaml
@@ -43,7 +43,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 8
       gpus_per_node: 8
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 2: Dump hidden states from target model
   task_1:
@@ -61,7 +61,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 8
       gpus_per_node: 8
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 3: Train EAGLE3 draft head (offline, single task)
   task_2:
@@ -79,7 +79,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 8
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 4: Benchmark speculative decoding (VLLM backend)
   task_3:

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_offline_eagle3_ptq.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_offline_eagle3_ptq.yaml
@@ -44,7 +44,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 4
       gpus_per_node: 4
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 2: Dump hidden states from target model
   task_1:
@@ -62,7 +62,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 4
       gpus_per_node: 4
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 3: Train EAGLE3 draft head (offline, single task) and export checkpoint
   task_2:
@@ -87,7 +87,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 4
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.2.0
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 4: PTQ — quantize the EAGLE3 model using offline hidden states
   task_3:

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_online_eagle3.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_online_eagle3.yaml
@@ -31,7 +31,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   task_1:
     script: common/eagle3/train_eagle.sh
@@ -49,7 +49,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 8
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   task_2:
     script: common/specdec_bench/quick_check.sh

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_ptq.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_ptq.yaml
@@ -48,4 +48,4 @@ pipeline:
       ntasks_per_node: 1
       gpus_per_node: 1
       time: "04:00:00"
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc7
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_dflash.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_dflash.yaml
@@ -36,7 +36,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 2: Streaming DFlash training — node 0 vllm serve, node 1 trainer.
   # DFlash extracts 5 target layers (build_target_layer_ids(36,5)=[1,9,17,25,33], the
@@ -90,7 +90,7 @@ pipeline:
       - MIN_ACCEPTANCE_LENGTH: "1.2"
     slurm_config:
       _factory_: "slurm_factory"
-      container: "vllm/vllm-openai:nightly"
+      container: vllm/vllm-openai:nightly
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_dflash_multi_node.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_dflash_multi_node.yaml
@@ -34,7 +34,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 2: Streaming DFlash training — 2 serve replicas (TP=2) + 2 trainer nodes (2 GPU each).
   # DFlash extracts 5 target layers (build_target_layer_ids(36,5)=[1,9,17,25,33], the
@@ -93,7 +93,7 @@ pipeline:
       - MIN_ACCEPTANCE_LENGTH: "1.2"
     slurm_config:
       _factory_: "slurm_factory"
-      container: "vllm/vllm-openai:nightly"
+      container: vllm/vllm-openai:nightly
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_eagle3.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_eagle3.yaml
@@ -30,7 +30,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # capture ids = default_eagle_aux_layer_ids(36)=[1,17,32] shifted +1, plus final
   # layer 36 -> [2,18,33,36].

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_eagle3_multi_node.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_eagle3_multi_node.yaml
@@ -31,7 +31,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 2: Streaming EAGLE3 training — 2 serve replicas (TP=2) + 2 trainer nodes (2 GPU each).
   # Capture ids: default_eagle_aux_layer_ids(36)=[1,17,32] +1, plus final layer 36.

--- a/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench.yaml
@@ -76,7 +76,7 @@ pipeline:
       - --concurrency 8
       - --num_requests 80
       - --output_length 4096
-      - --max_seq_len 40960
+      - --max_seq_len 65536
       - --aa_timing
       - --show_progress
       - --save_dir /scratchspace/qwen35_4b_none_vllm/throughput_32k

--- a/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3.5-4B/specdec_bench_mtp_vllm.yaml
@@ -51,7 +51,7 @@ pipeline:
       - --ep_size 1
       - --concurrency 8
       - --num_requests 80
-      - --runtime_params common/specdec_bench/runtime_params_throughput_32k.yaml
+      - --max_seq_len 65536
       - --output_length 4096
       - --aa_timing
       - --show_progress

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_dflash_dryrun.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_dflash_dryrun.yaml
@@ -36,4 +36,4 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_eagle3_dryrun.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_eagle3_dryrun.yaml
@@ -57,4 +57,4 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_offline_dflash.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_offline_dflash.yaml
@@ -39,4 +39,4 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 8
-      container: vllm/vllm-openai:v0.22.0-aarch64
+      container: vllm/vllm-openai:v0.22.0

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_dflash.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_dflash.yaml
@@ -48,7 +48,7 @@ pipeline:
       ntasks_per_node: 1
       # The cluster QOS requires whole-node GPU allocation though make_dataset is CPU-only.
       gpus_per_node: 4
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   task_1:
     script: common/eagle3/train_eagle_streaming.sh
@@ -96,4 +96,4 @@ pipeline:
       segment: 2
       ntasks_per_node: 1
       gpus_per_node: 4
-      container: vllm/vllm-openai:v0.22.0-aarch64
+      container: vllm/vllm-openai:v0.22.0

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_dflash_multi_node.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_dflash_multi_node.yaml
@@ -45,7 +45,7 @@ pipeline:
       ntasks_per_node: 1
       # The cluster QOS requires whole-node GPU alloc even though make_dataset is CPU-only.
       gpus_per_node: 4
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Streaming DFlash training: 2 serve replicas (TP=4) + 2 trainer nodes.
   task_1:
@@ -99,4 +99,4 @@ pipeline:
       gpus_per_node: 4
       # Pin 0.22.0: 0.22.1 regressed Kimi serve (profile_run runs the ViT and hits
       # a `fmax()` crash in kimi_k25_vit.py); 0.17.0 fails SpeculativeConfig validation.
-      container: vllm/vllm-openai:v0.22.0-aarch64
+      container: vllm/vllm-openai:v0.22.0

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_eagle3.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_eagle3.yaml
@@ -37,7 +37,7 @@ pipeline:
       ntasks_per_node: 1
       # The cluster QOS requires whole-node GPU alloc (4) even though make_dataset is CPU-only.
       gpus_per_node: 4
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 2: Streaming EAGLE3 training (node0 serve TP=4 / node1 train), 4 GPU/node
   task_1:
@@ -79,7 +79,7 @@ pipeline:
       segment: 2
       ntasks_per_node: 1
       gpus_per_node: 4
-      container: vllm/vllm-openai:v0.22.0-aarch64
+      container: vllm/vllm-openai:v0.22.0
 
   # Step 3: Benchmark speculative decoding (VLLM backend, Kimi served at TP=4)
   task_2:
@@ -103,4 +103,4 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 4
-      container: vllm/vllm-openai:v0.22.0-aarch64
+      container: vllm/vllm-openai:v0.22.0

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_eagle3_multi_node.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/hf_streaming_eagle3_multi_node.yaml
@@ -37,7 +37,7 @@ pipeline:
       ntasks_per_node: 1
       # The cluster QOS requires whole-node GPU allocation though make_dataset is CPU-only.
       gpus_per_node: 4
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   task_1:
     script: common/eagle3/train_eagle_streaming.sh
@@ -81,7 +81,7 @@ pipeline:
       gpus_per_node: 4
       # Pin 0.22.0: 0.22.1 regressed Kimi serve (profile_run runs the ViT and hits
       # a `fmax()` crash in kimi_k25_vit.py); 0.17.0 fails SpeculativeConfig validation.
-      container: vllm/vllm-openai:v0.22.0-aarch64
+      container: vllm/vllm-openai:v0.22.0
 
   task_2:
     script: common/specdec_bench/quick_check.sh
@@ -104,4 +104,4 @@ pipeline:
       ntasks_per_node: 1
       gpus_per_node: 4
       # Match the serve task's pin (see task_1) — 0.22.1 broke Kimi serve.
-      container: vllm/vllm-openai:v0.22.0-aarch64
+      container: vllm/vllm-openai:v0.22.0

--- a/tools/launcher/examples/moonshotai/Kimi-K2.5/specdec_bench.yaml
+++ b/tools/launcher/examples/moonshotai/Kimi-K2.5/specdec_bench.yaml
@@ -12,7 +12,7 @@
 # `prepare_data.py --dataset speed --config all`, then replace --mtbench with
 # `--dataset speed` + `--dataset_path .../data/speed/<split>`.
 #
-# NOTE on container: pinned to the aarch64 v0.22.0 image (GB200).
+# NOTE on container: multi-arch v0.22.0 tag (resolves to amd64 on x86_64, arm64 on GB200).
 #
 # Run ON the cluster login node (paramiko can't reach the cluster through its login proxy):
 #   export SLURM_HOST=localhost SLURM_ACCOUNT=<your_account> \
@@ -58,4 +58,4 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 4
-      container: vllm/vllm-openai:v0.22.0-aarch64
+      container: vllm/vllm-openai:v0.22.0

--- a/tools/launcher/examples/openai/gpt-oss-20b/hf_streaming_dflash_multi_node.yaml
+++ b/tools/launcher/examples/openai/gpt-oss-20b/hf_streaming_dflash_multi_node.yaml
@@ -46,7 +46,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 2: Streaming DFlash training — 2 serve replicas (TP=2) + 2 trainer nodes (2 GPU each).
   # DFlash extracts 5 target layers (build_target_layer_ids(24,5)=[1,6,11,16,21], the

--- a/tools/launcher/examples/openai/gpt-oss-20b/hf_streaming_eagle3_multi_node.yaml
+++ b/tools/launcher/examples/openai/gpt-oss-20b/hf_streaming_eagle3_multi_node.yaml
@@ -41,7 +41,7 @@ pipeline:
       nodes: 1
       ntasks_per_node: 1
       gpus_per_node: 1
-      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc10
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
 
   # Step 2: Streaming EAGLE3 training — 2 serve replicas (TP=2) + 2 trainer nodes (2 GPU each).
   # Capture ids: default_eagle_aux_layer_ids(24)=[1,11,20] +1, plus final layer 24.

--- a/tools/launcher/slurm_config.py
+++ b/tools/launcher/slurm_config.py
@@ -71,7 +71,7 @@ def slurm_factory(
     nodes: int = 1,
     ntasks_per_node: int = 1,
     gpus_per_node: Optional[int] = 1,
-    container: str = "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc8",
+    container: str = "nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20",
     modelopt_install_path: str = "/usr/local/lib/python3.12/dist-packages/modelopt",
     container_mounts: list[str] = [
         "{}:/hf-local".format(os.environ.get("SLURM_HF_LOCAL", "/hf-local")),


### PR DESCRIPTION
bump TRT-LLM to 1.3.0rc20, pin vLLM to v0.22.0, fix max_seq_len for Qwen3.5-4B

### What does this PR do?

Type of change: Bug fix, new feature

- Upgrade TRT-LLM container from 1.3.0rc10 to 1.3.0rc20 across all
  Qwen3-8B, Qwen3-30B-A3B, Kimi-K2.5, and gpt-oss-20b launcher configs.
- Replace Kimi-K2.5 aarch64-specific vLLM image (v0.22.0-aarch64) with
  the multi-arch v0.22.0 tag, which resolves to amd64/arm64 automatically.
- Fix Qwen3.5-4B throughput_32k runs: raise max_seq_len from 40960 to
  65536 to accommodate outlier prompts (~46.6K tokens) that caused
  VLLMValidationError and aborted the entire benchmark run.
- Fix specdec_bench_mtp_vllm.yaml: remove reference to non-existent
  runtime_params_throughput_32k.yaml; use --max_seq_len 65536 instead

### Usage

```
cd Model-Optimizer/tools/launcher
uv run launch.py --yaml examples/Qwen/Qwen3-8B/megatron_lm_ptq_local.yaml hf_local=/mnt/hf-local --yes
```

### Testing
N/A


- Is this change backward compatible?: N/A
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A 
- Did you write any new necessary tests?:N/A 
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?:  N/A 
- Did you get Claude approval on this PR?: N/A

### Additional Information
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated launcher example pipelines and the default launcher Slurm container to the newer TensorRT-LLM `1.3.0rc20` image.
  * Updated Kimi-K2.5 workflows to use the multi-architecture vLLM `0.22.0` image (removing prior architecture-specific variants).
  * Increased the Qwen3.5-4B long-context benchmark maximum sequence length to 65,536 tokens and simplified the corresponding throughput configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->