### PR TITLE
docs(puzzletron): install lm-eval in container setup

### DIFF
--- a/examples/puzzletron/README.md
+++ b/examples/puzzletron/README.md
@@ -31,6 +31,7 @@ Once inside the container with the repo available, install dependencies from the
 python -m pip uninstall nvidia-lm-eval -y 2>/dev/null
 python -m pip install -e ".[hf,puzzletron,dev-test]"
 python -m pip install -r examples/puzzletron/requirements.txt
+python -m pip install -r examples/llm_eval/requirements.txt
 ```
 
 To verify the install, you can run the GPU tests as a smoke check:


### PR DESCRIPTION
### What does this PR do?

Type of change: documentation

The container setup section uninstalls `nvidia-lm-eval` and the note above it states that it is "replaced with `lm-eval` from the repo", but none of the install commands actually install `lm-eval`. Following the README therefore leaves the environment without `lm-eval`, which the [Evaluation](https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/puzzletron/README.md#evaluation) step requires.

`lm-eval` ships in `examples/llm_eval/requirements.txt`, so this adds that one install line to the setup block.

### Usage

N/A

### Testing

Traced the dependency graph to confirm `lm-eval` is reachable from no install
path the README has currently:

- `puzzletron` extra: `fire`, `hydra-core`, `immutabledict`, `lru-dict`, `pandas`, `typeguard`
- `dev-test` extra: pytest/coverage tooling, `timm`, `torchprofile`, `torchvision`, `torch-geometric`
- `examples/puzzletron/requirements.txt`: `math-verify`, `ray`, `transformers<5.0`

`lm_eval[api,ifeval]>=0.4.10` appears only in `examples/llm_eval/requirements.txt`.

`pre-commit run --files examples/puzzletron/README.md` passes (markdownlint included).

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A <!-- docs-only -->
- Did you get Claude approval on this PR?: N/A <!-- not an NVIDIA org member, cannot self-trigger -->

### Additional Information

Fixes #1786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Puzzletron container setup instructions to include installing the LLM evaluation dependencies.
  * Clarified the setup sequence before running smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->