### PR TITLE
Update documentation guide for ONNX INT4 PTQ on Windows cuda13 host

### DIFF
--- a/docs/source/getting_started/windows/_installation_standalone.rst
+++ b/docs/source/getting_started/windows/_installation_standalone.rst
@@ -13,7 +13,7 @@ Before using ModelOpt-Windows, the following components must be installed:
       - NVIDIA GPU and Graphics Driver
       - Python version >= 3.10 and < 3.13
       - Visual Studio 2022 / MSVC / C/C++ Build Tools
-      - CUDA Toolkit, CuDNN for using CUDA path during calibration (e.g. for calibration of ONNX models using `onnxruntime-gpu` or CUDA EP)
+      - CUDA Toolkit and matching CuDNN for using CUDA path during calibration (e.g. for calibration of ONNX models using `onnxruntime-gpu` or CUDA EP)
 
 Update ``PATH`` environment variable as needed for above prerequisites.
 
@@ -62,23 +62,31 @@ If you need to use any other EP for calibration, you can uninstall the existing 
 
 **5. Setup GPU Acceleration Tool for Quantization**
 
-By default, ModelOpt-Windows utilizes the `cupy-cuda12x <https://cupy.dev//>`_ tool for GPU acceleration during the INT4 ONNX quantization process. This is compatible with CUDA 12.x.
+ModelOpt uses `CuPy <https://docs.cupy.dev/en/stable/install.html>`_ to accelerate
+INT4 ONNX quantization. The ``nvidia-modelopt[onnx]`` extra installs ``cupy-cuda12x`` and
+a CUDA 12-compatible *onnxruntime-gpu* version by default.
 
-If you are using CUDA 13.x, update CUDA-dependent packages manually:
+**CUDA 13.x Setup**
 
-For official ONNX Runtime guidance, see `Nightly builds for CUDA 13.x <https://onnxruntime.ai/docs/install/#nightly-for-cuda-13x>`_.
+The steps below assume a CUDA 13.x Toolkit, compatible cudnn, and a compatible driver are already installed on the host.
 
-1. Uninstall ``cupy-cuda12x`` and install ``cupy-cuda13x``.
-2. Uninstall ``onnxruntime-genai-cuda`` and ``onnxruntime-gpu``.
-3. Install ONNX Runtime CUDA 13 nightly and the pre-release ``onnxruntime-genai-cuda`` package.
+Replace the CUDA-dependent packages installed by the default ONNX extra:
 
-.. code-block:: bash
+.. code-block:: bat
 
-    pip uninstall -y cupy-cuda12x onnxruntime-genai-cuda onnxruntime-gpu
-    pip install cupy-cuda13x
-    pip install coloredlogs flatbuffers numpy packaging protobuf sympy
-    pip install --pre --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/ort-cuda-13-nightly/pypi/simple/ onnxruntime-gpu
-    pip install --pre onnxruntime-genai-cuda
+    python -m pip uninstall -y cupy-cuda12x onnxruntime-gpu
+    python -m pip install cupy-cuda13x "onnxruntime-gpu>=1.27"
+
+ONNX Runtime 1.27 and later GPU packages published on PyPI use CUDA 13.x by default.
+Refer to the `ONNX Runtime CUDA Execution Provider requirements
+<https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#requirements>`_
+before selecting or pinning an ONNX Runtime version.
+
+.. note::
+
+    Make sure a cuDNN 9 build for CUDA 13 is available on the host (for example, via the
+    NVIDIA Windows installer/zip package, or the ``nvidia-cudnn-cu13`` Python wheel), and
+    that the relevant environment variables like ``CUDA_PATH``, ``CUDA_HOME``, and ``PATH`` point to the CUDA 13.x installation).
 
 **6. Verify Installation**
 
@@ -90,11 +98,27 @@ Ensure the following steps are verified:
             - *onnxruntime-trt-rtx* (TensorRT-RTX EP)
             - *onnxruntime-gpu* (CUDA EP)
             - *onnxruntime* (CPU EP)
-      - **Onnx and Onnxruntime Import**: Ensure that following python command runs successfully.
+      - **CUDA Toolkit**: For CUDA workflows, verify that the selected Toolkit is found first and that ``nvcc`` reports the expected major version:
+
+            .. code-block:: bat
+
+                where nvcc
+                nvcc --version
+
+      - **ONNX and ONNX Runtime**: Ensure that imports succeed and that CUDA EP is available for CUDA workflows:
+
             .. code-block:: python
 
-                python -c "import onnx; import onnxruntime"
-      - **Environment Variables**: For workflows using CUDA dependencies (e.g., CUDA EP-based calibration), ensure environment variables like *CUDA_PATH*, *CUDA_V12_4*, or *CUDA_V11_8* etc. are set correctly. Reopen the command-prompt if any environment variable is updated or newly created.
+                python -c "import onnx; import onnxruntime as ort; print(ort.__version__, ort.get_available_providers())"
+
+      - **CuPy**: Verify that CuPy can allocate and execute on the GPU. For CUDA 13.x,
+        ``runtimeGetVersion()`` should report a value beginning with ``13``:
+
+            .. code-block:: python
+
+                python -c "import cupy; print(cupy.__version__, cupy.cuda.runtime.runtimeGetVersion(), cupy.arange(3).sum())"
+
+      - **Environment Variables**: For workflows using CUDA dependencies (e.g., CUDA EP-based calibration), ensure environment variables such as ``CUDA_PATH``, ``CUDA_PATH_V12_x``, or ``CUDA_PATH_V13_x`` point to the intended Toolkit. Reopen the command prompt after changing persistent environment variables.
       - **ModelOpt-Windows Import Check**: Run the following command to ensure the installation is successful:
 
             .. code-block:: python

--- a/examples/windows/onnx_ptq/genai_llm/README.md
+++ b/examples/windows/onnx_ptq/genai_llm/README.md
@@ -27,6 +27,8 @@ This example takes an ONNX model as input, along with the necessary quantization
    pip install -r requirements.txt
    ```
 
+> **CUDA 12.x / 13.x:** ModelOpt-Windows installs CUDA 12 packages (`cupy-cuda12x`, CUDA 12 `onnxruntime-gpu`) by default. To run on CUDA 13.x, switch to CUDA 13 packages (`cupy-cuda13x`, `onnxruntime-gpu>=1.27`) with a matching CUDA 13 toolkit and cuDNN. See the [standalone installation instructions](https://nvidia.github.io/Model-Optimizer/getting_started/windows/_installation_standalone.html) for details.
+
 ## Prepare ORT-GenAI Compatible Base Model
 
 You may generate the base model using the model builder that comes with onnxruntime-genai. The ORT-GenAI's [model-builder](https://github.com/microsoft/onnxruntime-genai/tree/main/src/python/py/models) downloads the original Pytorch model from Hugging Face, and produces an ONNX GenAI-compatible base model in ONNX format. See example command-line below:

--- a/examples/windows/onnx_ptq/genai_llm/quantize.py
+++ b/examples/windows/onnx_ptq/genai_llm/quantize.py
@@ -312,6 +312,14 @@ def main(args):
     if args.layers_8bit:
         args.enable_mixed_quant = True
 
+    cuda_path = os.environ.get("CUDA_PATH") or os.environ.get("CUDA_HOME") or "N/A"
+    print(
+        f"\n--Quantize-Script-- torch={torch.__version__}, "
+        f"torch.version.cuda={torch.version.cuda}, "
+        f"torch.cuda.is_available={torch.cuda.is_available()}, "
+        f"CUDA_PATH={cuda_path}\n"
+    )
+
     print(
         f"\n--Quantize-Script-- algo={args.algo}, dataset={args.dataset}, calib_size={args.calib_size}, "
         f"batch_size={args.batch_size}, block_size={args.block_size}, add-position-ids={args.add_position_ids}, "


### PR DESCRIPTION
### What does this PR do?

Type of change: Documentation update

- Update documentation guide for ONNX INT4 PTQ on Windows cuda13 host - mention about compatible onnxruntim-gpu and cupy-cuda13x packages.

### Testing

- Windows's onnx_ptq\genai_llm INT4 PTQ example with a 1B genai-cuda-ep ONNX model + local doc building

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Windows CUDA prerequisites for calibration and GPU-accelerated quantization.
  * Added setup guidance for CUDA 12 and CUDA 13.x, including compatible packages and cuDNN requirements.
  * Expanded installation verification steps for CUDA, ONNX Runtime, and CuPy.
  * Updated the GenAI LLM example with CUDA version compatibility guidance.

* **Enhancements**
  * Added runtime logging of detected CUDA environment paths and version details during quantization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->