### PR TITLE
ci: skip docs preview deploy for fork PRs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,9 +54,12 @@ jobs:
               - '.github/workflows/pages.yml'
 
   deploy-preview:
+    # Fork PRs get a read-only GITHUB_TOKEN regardless of the `permissions:` block
+    # above, so pushing the preview to gh-pages would fail with a 403. Skip them.
     if: |
       always() &&
       github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.action == 'closed' || needs.changes.outputs.docs == 'true')
     needs: [build-docs, changes]
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix (CI)

The `deploy-preview` job in the `Docs` workflow fails on **every pull request opened from a fork**, which blocks merging for all external contributors.

**Root cause.** `deploy-preview` runs `rossjrw/pr-preview-action@v1`, which pushes the built HTML to the `gh-pages` branch. The workflow declares `permissions: contents: write`, but for a `pull_request` event originating from a forked repository GitHub caps the `GITHUB_TOKEN` at **read-only** — the `permissions:` block cannot elevate above that cap. The push is therefore rejected:

```
remote: Permission to NVIDIA/Model-Optimizer.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/NVIDIA/Model-Optimizer.git/': The requested URL returned error: 403
```

The job's `if:` condition gated on `github.event_name`, `github.event.action` and the `changes` path filter, but never on whether the PR came from a fork — so it always ran and always failed.

Because the `changes` filter matches `docs/**`, `modelopt/**` and `.github/workflows/pages.yml`, essentially any substantive fork PR trips this.

**Fix.** Restrict `deploy-preview` to PRs whose head branch lives in this repository:

```yaml
github.event.pull_request.head.repo.full_name == github.repository
```

A skipped job is not a failed job, so fork PRs are no longer blocked by it.

### Usage

N/A — CI-only change.

### Testing

Behaviour by scenario:

| Scenario | Before | After |
| --- | --- | --- |
| PR from a branch in this repo | preview deployed | preview deployed (**unchanged**) |
| PR from a fork | ❌ fails with 403 | ⏭️ skipped |
| Fork deleted (`head.repo` is `null`) | ❌ fails | ⏭️ skipped |

- Confirmed against workflow history: recent `Docs` runs on in-repo branches (`main`, `chenjiel/nvfp4-act-headroom`, `mxin/qad-skill`, `haoguo/dspark-ptq-script`) all succeed, while fork-branch runs fail with the 403 above.
- `build-docs` was already passing on the affected PRs — only the deploy step failed, so documentation builds are unaffected either way.
- YAML parses; `pre-commit run --files .github/workflows/pages.yml` passes. (`yamlfmt` excludes `^.github/workflows/`, so this file is not auto-formatted.)
- This PR edits `.github/workflows/pages.yml`, which is itself in the `changes` filter, so it exercises `deploy-preview` on the in-repo path — the preview deploy on this PR passing is a self-check that the unchanged path still works.

The `closed` cleanup path is gated by the same condition. That is intentional: a fork PR never deployed a preview directory, so there is nothing to remove.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A — workflow-condition change; not unit-testable
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A — CI infrastructure, not user-facing
- Did you get Claude approval on this PR?: ❌ — not yet run

### Additional Information

Currently blocking #1975 (`add Qwen3-VL support for DFlash training`), which is approved with every other check green and sits at `mergeStateStatus: BLOCKED` solely because of this job.

Note that a PR only picks up this fix once its branch contains it, since workflows run from the PR branch's own definitions.

A follow-up option, if doc previews for external contributors are wanted: build in the `pull_request` workflow and deploy from a separate `workflow_run`-triggered workflow, which executes in the base-repo context and does get a write token. Deliberately not using `pull_request_target` here — that would run unreviewed PR code with write permissions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview deployments no longer run for pull requests from forked repositories, preventing failed deployments caused by permission restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->