### PR TITLE
Add stochastic rounding for dynamic FP4 fake quantization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ Changelog
 
 **New Features**
 
+*Quantization*
+
+- Add opt-in stochastic rounding for E2M1 payloads in dynamic MXFP4 and NVFP4 fake quantization.
+
 **Backward Breaking Changes**
 
 **Deprecations**

--- a/docs/source/guides/_quant_cfg.rst
+++ b/docs/source/guides/_quant_cfg.rst
@@ -99,6 +99,7 @@ with the default attributes of
         "num_bits":                 8,       # 8-bit integer quantization
         "axis":                     None,    # per-tensor scale (no per-channel axis)
         "fake_quant":               True,    # simulate quantization in forward pass (PTQ / QAT)
+        "stochastic_rounding":       False,   # deterministic E2M1 payload rounding by default
         "unsigned":                 False,   # signed integer range, e.g. [-128, 127] for INT8
         "narrow_range":             False,   # full range; True would restrict to [-127, 127] for INT8
         "type":                     "static",  # static calibration (not dynamic per-inference)
@@ -116,6 +117,14 @@ with the default attributes of
 In practice this means an un-configured but enabled quantizer performs **INT8 per-tensor static
 fake-quantization** with a max-calibrated scale. This is rarely the intended behavior — every
 quantizer you want active should be explicitly configured with a ``cfg`` entry.
+
+For MXFP4 or dynamic NVFP4 fake quantization, set ``stochastic_rounding=True`` to
+stochastically round only the E2M1 payload; block-scale rounding and deployment export remain
+deterministic. The option uses PyTorch's CUDA generator, so resetting
+``torch.cuda.manual_seed(...)`` reproduces results for the same device, input shape, kernel launch
+configuration, and RNG call order. Consecutive calls advance the generator state. Bitwise identity
+is not guaranteed across GPU architectures, launch-geometry changes, distributed rank ordering,
+or future RNG implementation changes.
 
 ----------
 

--- a/modelopt/torch/kernels/quantization/gemm/tensor_quant_mx.cu
+++ b/modelopt/torch/kernels/quantization/gemm/tensor_quant_mx.cu
@@ -16,18 +16,22 @@
  */
 
 #include <ATen/ATen.h>
+#include <ATen/cuda/CUDAGeneratorImpl.h>
+#include <ATen/cuda/PhiloxUtils.cuh>
 #include <c10/cuda/CUDAStream.h>
 #include <cuda.h>
 #include <cuda/std/bit>
 #include <cuda/std/tuple>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#include <curand_kernel.h>
 
 #include <torch/extension.h>
 
 #include <algorithm>
 #include <cmath>
 #include <cub/cub.cuh>
+#include <mutex>
 
 #include "tensor_quant_mx.h"
 
@@ -52,6 +56,26 @@ static __device__ __host__ __inline__ float quantize(const float x, const float 
 
   // Apply sign.
   return sign * xabs;
+}
+
+static __device__ __inline__ float quantize_e2m1_stochastic(const float x, const float scale,
+                                                            const float unscale,
+                                                            const float random) {
+  const float scaled = fabsf(x) * scale;
+  if (isinf(scaled) || isnan(scaled) || scaled >= e2m1_table_values[7]) {
+    const float saturated = e2m1_table_values[7] * unscale;
+    return x < 0.0f ? -saturated : saturated;
+  }
+
+  int lower_index = 0;
+  while (scaled > e2m1_table_values[lower_index + 1]) {
+    ++lower_index;
+  }
+  const float lower = e2m1_table_values[lower_index];
+  const float upper = e2m1_table_values[lower_index + 1];
+  const float upper_probability = (scaled - lower) / (upper - lower);
+  const float rounded = random <= upper_probability ? upper : lower;
+  return copysignf(rounded * unscale, x);
 }
 
 /*
@@ -236,12 +260,13 @@ __device__ float compute_max(const float x, const int block_size, const float cl
 
 }; // namespace
 
-template <typename T, typename T_y, int THREAD_X, int THREAD_Y>
+template <bool STOCHASTIC_ROUNDING, typename T, typename T_y, int THREAD_X, int THREAD_Y>
 __global__ void amax_and_convert_kernel(const T *x, T_y *y, const int64_t n, const int blocksize,
                                         const int actual_cols, const int padded_cols, Types format,
                                         Types scale_format, const float *global_amax = nullptr,
                                         const bool per_channel_scaling = false,
-                                        const int ncols = -1) {
+                                        const int ncols = -1,
+                                        const at::PhiloxCudaState philox_args = {}) {
   // map thread -> element
   const uint64_t block_idx = blockIdx.x * blockDim.y + threadIdx.y;
   const int thread_id = threadIdx.x;
@@ -290,7 +315,14 @@ __global__ void amax_and_convert_kernel(const T *x, T_y *y, const int64_t n, con
   if (in_padding)
     return;
 
-  y[real_idx] = quantize(thread_val, scale, unscale, format);
+  if constexpr (STOCHASTIC_ROUNDING) {
+    auto [seed, offset] = at::cuda::philox::unpack(philox_args);
+    curandStatePhilox4_32_10_t state;
+    curand_init(seed, real_idx, offset, &state);
+    y[real_idx] = quantize_e2m1_stochastic(thread_val, scale, unscale, curand_uniform(&state));
+  } else {
+    y[real_idx] = quantize(thread_val, scale, unscale, format);
+  }
 }
 
 std::tuple<float *, bool> get_global_scaling(at::Tensor x, std::optional<at::Tensor> global_amax) {
@@ -312,19 +344,19 @@ std::tuple<float *, bool> get_global_scaling(at::Tensor x, std::optional<at::Ten
 
 using output_t = std::tuple<at::Tensor, std::optional<at::Tensor>>;
 
-#define DISPATCH_FUSED_AMAX_KERNEL(T, TX, TY)                                                      \
-  amax_and_convert_kernel<scalar_t, T, TX, TY>                                                     \
+#define DISPATCH_FUSED_AMAX_KERNEL(T, TX, TY, STOCHASTIC_ROUNDING, PHILOX_ARGS)                    \
+  amax_and_convert_kernel<STOCHASTIC_ROUNDING, scalar_t, T, TX, TY>                                \
       <<<blocks, block, 0, c10::cuda::getCurrentCUDAStream()>>>(                                   \
           x.data_ptr<scalar_t>(), y.data_ptr<T>(), n, blocksize, actual_cols, padded_cols, format, \
-          scale_format, global_amax_ptr, per_channel_scaling, x.size(-1))
+          scale_format, global_amax_ptr, per_channel_scaling, x.size(-1), PHILOX_ARGS)
 
-#define DISPATCH_SINGLE_TYPE(T)                                                                    \
+#define DISPATCH_SINGLE_TYPE(T, STOCHASTIC_ROUNDING, PHILOX_ARGS)                                  \
   if (blocksize == 8) {                                                                            \
-    DISPATCH_FUSED_AMAX_KERNEL(T, 8, blocks_per_cta);                                              \
+    DISPATCH_FUSED_AMAX_KERNEL(T, 8, blocks_per_cta, STOCHASTIC_ROUNDING, PHILOX_ARGS);            \
   } else if (blocksize == 16) {                                                                    \
-    DISPATCH_FUSED_AMAX_KERNEL(T, 16, blocks_per_cta);                                             \
+    DISPATCH_FUSED_AMAX_KERNEL(T, 16, blocks_per_cta, STOCHASTIC_ROUNDING, PHILOX_ARGS);           \
   } else if (blocksize == 32) {                                                                    \
-    DISPATCH_FUSED_AMAX_KERNEL(T, 32, blocks_per_cta);                                             \
+    DISPATCH_FUSED_AMAX_KERNEL(T, 32, blocks_per_cta, STOCHASTIC_ROUNDING, PHILOX_ARGS);           \
   } else {                                                                                         \
     throw std::invalid_argument("Blocksize for fused call must be one of {8, 16, 32}");            \
   }
@@ -353,7 +385,10 @@ using output_t = std::tuple<at::Tensor, std::optional<at::Tensor>>;
 int pad_dim_to_blocksize(const int dim, const int bs) { return dim + (bs - (dim % bs)); }
 
 at::Tensor fused_amax_convert(at::Tensor x, const int blocksize, Types format, Types scale_format,
-                              std::optional<at::Tensor> global_amax) {
+                              std::optional<at::Tensor> global_amax,
+                              const bool stochastic_rounding) {
+  TORCH_CHECK(!stochastic_rounding || format == Types::E2M1,
+              "Stochastic rounding is supported only for E2M1 payloads.");
   std::optional<at::Tensor> global_amax_float = std::nullopt;
 
   if (global_amax.has_value()) {
@@ -380,8 +415,21 @@ at::Tensor fused_amax_convert(at::Tensor x, const int blocksize, Types format, T
 
   auto [global_amax_ptr, per_channel_scaling] = get_global_scaling(x, global_amax_float);
 
-  DISPATCH_FLOAT_AND_HALF_AND_BFLOAT(x.scalar_type(), "fused_amax_convert_kernel",
-                                     { DISPATCH_SINGLE_TYPE(scalar_t); });
+  if (stochastic_rounding) {
+    auto gen = at::get_generator_or_default<at::CUDAGeneratorImpl>(
+        std::nullopt, at::cuda::detail::getDefaultCUDAGenerator(x.get_device()));
+    at::PhiloxCudaState philox_args;
+    {
+      std::lock_guard<std::mutex> lock(gen->mutex_);
+      philox_args = gen->philox_cuda_state(1);
+    }
+    DISPATCH_FLOAT_AND_HALF_AND_BFLOAT(x.scalar_type(), "fused_amax_convert_kernel",
+                                       { DISPATCH_SINGLE_TYPE(scalar_t, true, philox_args); });
+  } else {
+    DISPATCH_FLOAT_AND_HALF_AND_BFLOAT(x.scalar_type(), "fused_amax_convert_kernel", {
+      DISPATCH_SINGLE_TYPE(scalar_t, false, at::PhiloxCudaState{});
+    });
+  }
 
   return y;
 }
@@ -394,7 +442,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("fused_amax_convert", &fused_amax_convert,
         "Compute block amax and quantize the tensor to mx formats", py::arg("inputs"),
         py::arg("block_size"), py::arg("format"), py::arg("scale_format"),
-        py::arg("global_amax") = py::none());
+        py::arg("global_amax") = py::none(), py::arg("stochastic_rounding") = false);
   m.def("convert_to_exmy", &convert_to_types, "Convert value to exmy format.", py::arg("x"),
         py::arg("format"));
   py::enum_<Types>(m, "Types")

--- a/modelopt/torch/quantization/config.py
+++ b/modelopt/torch/quantization/config.py
@@ -457,6 +457,15 @@ class QuantizerAttributeConfig(ModeloptBaseConfig):
         description="""If True, enable fake quantization.""",
     )
 
+    stochastic_rounding: bool = ModeloptField(
+        default=False,
+        title="Enable stochastic rounding.",
+        description=(
+            "If True, stochastically round E2M1 payloads during dynamic block fake "
+            "quantization. Supported for MXFP4 and dynamic NVFP4 only."
+        ),
+    )
+
     unsigned: bool = ModeloptField(
         default=False,
         title="Enable unsigned quantization.",
@@ -713,6 +722,26 @@ class QuantizerAttributeConfig(ModeloptBaseConfig):
         assert not (self.use_constant_amax and self.constant_amax is not None), (
             "use_constant_amax and constant_amax are mutually exclusive; set only one."
         )
+        return self
+
+    @model_validator(mode="after")
+    def validate_stochastic_rounding(self):
+        """Restrict stochastic rounding to dynamic E2M1 fake quantization."""
+        if not self.stochastic_rounding:
+            return self
+        if not (
+            self.fake_quant
+            and self.num_bits == (2, 1)
+            and self.block_sizes is not None
+            and self.block_sizes.get("type") == "dynamic"
+        ):
+            raise ValueError(
+                "stochastic_rounding=True requires fake, dynamic block E2M1 quantization."
+            )
+        if self.block_sizes.get("scale_bits") not in [(8, 0), (4, 3)]:
+            raise ValueError(
+                "stochastic_rounding=True requires scale_bits to be exactly (8, 0) or (4, 3)."
+            )
         return self
 
 

--- a/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
+++ b/modelopt/torch/quantization/nn/modules/tensor_quantizer.py
@@ -916,6 +916,7 @@ class TensorQuantizer(nn.Module):
                 getattr(self, "_trt_high_precision_dtype", None),
                 getattr(self, "_onnx_quantizer_type", None),
                 self._pass_through_bwd,
+                getattr(self, "_stochastic_rounding", False),
             )
         elif isinstance(self._num_bits, tuple):
             # Float-point quantization, e.g., FP8

--- a/modelopt/torch/quantization/tensor_quant.py
+++ b/modelopt/torch/quantization/tensor_quant.py
@@ -157,11 +157,12 @@ def _quantize_impl_abstract(
 def _dynamic_block_quantize_impl(
     inputs: torch.Tensor,
     block_size: int,
-    amax: torch.Tensor,
+    amax: torch.Tensor | None,
     num_bits: int,
     exponent_bits: int,
     scale_num_bits: int,
     scale_exponent_bits: int,
+    stochastic_rounding: bool = False,
 ):
     scale_bits = (scale_exponent_bits, scale_num_bits - scale_exponent_bits - 1)
     if exponent_bits != 0:
@@ -169,7 +170,9 @@ def _dynamic_block_quantize_impl(
     if num_bits in mx_format_map:
         assert scale_bits in mx_format_map, f"Scale bits should be in {mx_format_map.keys()}"
         if scale_bits != (8, 0):
-            assert amax.is_cuda, "amax must be a CUDA tensor for dynamic block quantization."
+            assert amax is not None and amax.is_cuda, (
+                "amax must be a CUDA tensor for dynamic block quantization."
+            )
             if amax.numel() != 1:
                 amax = amax.amax()
         if (
@@ -179,6 +182,7 @@ def _dynamic_block_quantize_impl(
             and hasattr(triton_kernel, "fp4_fake_quant_block")  # requires compute >= 8.9
             and not DISABLE_TRITON_KERNEL
             and amax is not None
+            and not stochastic_rounding
         ):
             return triton_kernel.fp4_fake_quant_block(inputs, amax)
         cuda_ext_mx = get_cuda_ext_mx(raise_if_failed=True)
@@ -188,6 +192,7 @@ def _dynamic_block_quantize_impl(
             getattr(cuda_ext_mx.Types, mx_format_map[num_bits]),
             getattr(cuda_ext_mx.Types, mx_format_map[scale_bits]),
             amax,
+            stochastic_rounding,
         )
     else:
         raise NotImplementedError(
@@ -203,6 +208,7 @@ def _dynamic_block_quantize_impl_abstract(
     exponent_bits: int,
     scale_num_bits: int,
     scale_exponent_bits: int,
+    stochastic_rounding: bool = False,
 ):
     """Register an abstract implementation for dynamic block quantization.
 
@@ -228,12 +234,12 @@ try:
     torch.library.define(
         "tensorrt::dynamic_block_quantize_op",
         "(Tensor input, int block_size, Tensor amax, int num_bits, int exponent_bits, "
-        "int scale_num_bits, int scale_exponent_bits) -> Tensor",
+        "int scale_num_bits, int scale_exponent_bits, bool stochastic_rounding=False) -> Tensor",
     )
     torch.library.define(
         "tensorrt::dynamic_block_quantize_op.overload",
         "(Tensor input, int block_size, None amax, int num_bits, int exponent_bits, "
-        "int scale_num_bits, int scale_exponent_bits) -> Tensor",
+        "int scale_num_bits, int scale_exponent_bits, bool stochastic_rounding=False) -> Tensor",
     )
 
     # Implement the None amax case
@@ -245,8 +251,18 @@ try:
         exponent_bits: int,
         scale_num_bits: int,
         scale_exponent_bits: int,
+        stochastic_rounding: bool = False,
     ):
-        return torch.empty_like(inputs)
+        return _dynamic_block_quantize_impl(
+            inputs,
+            block_size,
+            amax,
+            num_bits,
+            exponent_bits,
+            scale_num_bits,
+            scale_exponent_bits,
+            stochastic_rounding,
+        )
 
     # Register the implementation for both CPU and CUDA
     torch.library.impl("tensorrt::quantize_op", ["cpu", "cuda"])(_quantize_impl)
@@ -470,6 +486,7 @@ def _dynamic_block_quantize_forward(
     trt_high_precision_dtype=None,
     onnx_quantizer_type="dynamic",
     pass_through_bwd=True,
+    stochastic_rounding=False,
 ):
     """Forward method."""
     if isinstance(num_bits, int):
@@ -490,6 +507,7 @@ def _dynamic_block_quantize_forward(
         exponent_bits,
         scale_num_bits,
         scale_exponent_bits,
+        stochastic_rounding,
     )
     return outputs
 
@@ -498,7 +516,7 @@ class DynamicBlockQuantizationFunction(Function):
     """Dynamic block quantization functional."""
 
     @staticmethod
-    @symbolic_helper.parse_args("v", "i", "v", "t", "is", "is", "s", "s", "b")
+    @symbolic_helper.parse_args("v", "i", "v", "t", "is", "is", "s", "s", "b", "b")
     def symbolic(
         g,
         inputs,
@@ -510,6 +528,7 @@ class DynamicBlockQuantizationFunction(Function):
         trt_high_precision_dtype=None,
         onnx_quantizer_type="dynamic",
         pass_through_bwd=True,
+        stochastic_rounding=False,
     ):
         """ONNX symbolic function."""
         from .export_onnx import export_fp4, export_mxfp8
@@ -547,6 +566,7 @@ class DynamicBlockQuantizationFunction(Function):
         trt_high_precision_dtype=None,
         onnx_quantizer_type="dynamic",
         pass_through_bwd=True,
+        stochastic_rounding=False,
     ):
         """Forward method."""
         _save_for_backward_if_needed(ctx, pass_through_bwd, inputs, amax)
@@ -560,12 +580,13 @@ class DynamicBlockQuantizationFunction(Function):
             trt_high_precision_dtype,
             onnx_quantizer_type,
             pass_through_bwd,
+            stochastic_rounding,
         )
 
     @staticmethod
     def backward(ctx, grad_outputs):
         """Implements straight through estimation with clipping."""
-        return _fake_quant_backward_function(ctx, grad_outputs, num_args=9)
+        return _fake_quant_backward_function(ctx, grad_outputs, num_args=10)
 
 
 class StaticBlockwiseFP4FakeQuantFunction(Function):

--- a/tests/gpu/torch/quantization/test_quantize_mxformats_cuda.py
+++ b/tests/gpu/torch/quantization/test_quantize_mxformats_cuda.py
@@ -37,6 +37,29 @@ def _get_test_inputs_outputs(test_in, test_out, block_size, in_size):
     )
 
 
+def _stochastic_e2m1(inputs, scale_bits):
+    global_amax = torch.tensor(2688.0, device=inputs.device) if scale_bits == (4, 3) else None
+    return cuda_ext_mx.fused_amax_convert(
+        inputs,
+        inputs.shape[-1],
+        cuda_ext_mx.Types.E2M1,
+        getattr(cuda_ext_mx.Types, mx_format_map[scale_bits]),
+        global_amax,
+        True,
+    )
+
+
+def _deterministic_e2m1(inputs, scale_bits):
+    global_amax = torch.tensor(2688.0, device=inputs.device) if scale_bits == (4, 3) else None
+    return cuda_ext_mx.fused_amax_convert(
+        inputs,
+        inputs.shape[-1],
+        cuda_ext_mx.Types.E2M1,
+        getattr(cuda_ext_mx.Types, mx_format_map[scale_bits]),
+        global_amax,
+    )
+
+
 @pytest.mark.parametrize("shape", shapes)
 @pytest.mark.parametrize("block_size", block_sizes)
 @pytest.mark.parametrize("dtype", dtypes)
@@ -95,6 +118,106 @@ def test_mxfp4(block_size, dtype):
         None,
     )
     assert torch.allclose(expected_outputs, outputs)
+
+
+@pytest.mark.parametrize("scale_bits", [(8, 0), (4, 3)])
+def test_stochastic_e2m1_rng_contract(scale_bits):
+    inputs = torch.full((64, 16), 2.25, device="cuda")
+    inputs[:, -1] = 6.0
+
+    torch.cuda.manual_seed(1234)
+    first = _stochastic_e2m1(inputs, scale_bits)
+    torch.cuda.manual_seed(1234)
+    repeated = _stochastic_e2m1(inputs, scale_bits)
+    successive = _stochastic_e2m1(inputs, scale_bits)
+    torch.cuda.manual_seed(5678)
+    different_seed = _stochastic_e2m1(inputs, scale_bits)
+
+    assert torch.equal(first, repeated)
+    assert not torch.equal(repeated, successive)
+    assert not torch.equal(first, different_seed)
+
+
+def test_default_e2m1_does_not_consume_cuda_rng():
+    inputs = torch.randn(8, 16, device="cuda")
+    state = torch.cuda.get_rng_state()
+
+    cuda_ext_mx.fused_amax_convert(
+        inputs,
+        16,
+        cuda_ext_mx.Types.E2M1,
+        cuda_ext_mx.Types.E8M0,
+        None,
+    )
+
+    assert torch.equal(state, torch.cuda.get_rng_state())
+
+
+@pytest.mark.parametrize("dtype", dtypes)
+@pytest.mark.parametrize("scale_bits", [(8, 0), (4, 3)])
+def test_stochastic_e2m1_legal_values_and_invariants(dtype, scale_bits):
+    table = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], device="cuda")
+    between = torch.tensor([0.2, 0.6, 1.2, 1.7, 2.3, 3.4, 4.5], device="cuda")
+    inputs = torch.zeros((2 * (table.numel() + between.numel()), 16), device="cuda")
+    values = torch.cat((table, between))
+    inputs[: values.numel(), 0] = values
+    inputs[values.numel() :, 0] = -values
+    inputs[:, -1] = 6.0
+    inputs = inputs.to(dtype)
+
+    outputs = _stochastic_e2m1(inputs, scale_bits)[:, 0].float()
+    deterministic = _deterministic_e2m1(inputs, scale_bits)[:, 0].float()
+    invariant_indices = torch.arange(table.numel(), device="cuda")
+    positive = outputs[: values.numel()]
+    negative = outputs[values.numel() :]
+
+    assert torch.equal(outputs[invariant_indices], deterministic[invariant_indices])
+    negative_invariant_indices = invariant_indices + values.numel()
+    assert torch.equal(
+        outputs[negative_invariant_indices],
+        deterministic[negative_invariant_indices],
+    )
+    positive_between = positive[table.numel() : table.numel() + between.numel()]
+    negative_between = negative[table.numel() : table.numel() + between.numel()]
+    assert torch.all(
+        torch.isclose(positive_between, table[:-1], atol=1e-5, rtol=0)
+        | torch.isclose(positive_between, table[1:], atol=1e-5, rtol=0)
+    )
+    assert torch.all(
+        torch.isclose(negative_between, -table[:-1], atol=1e-5, rtol=0)
+        | torch.isclose(negative_between, -table[1:], atol=1e-5, rtol=0)
+    )
+
+
+@pytest.mark.parametrize("scale_bits", [(8, 0), (4, 3)])
+def test_stochastic_e2m1_saturates_nan_to_positive_max(scale_bits):
+    negative_nan = torch.copysign(torch.tensor(float("nan")), torch.tensor(-1.0))
+    inputs = torch.zeros((1, 16), device="cuda")
+    inputs[0, :2] = torch.tensor([float("nan"), negative_nan], device="cuda")
+    inputs[0, -1] = 6.0
+
+    outputs = _stochastic_e2m1(inputs, scale_bits)
+
+    assert torch.allclose(outputs[0, :2], outputs.new_tensor([6.0, 6.0]), atol=1e-5, rtol=0)
+
+
+@pytest.mark.parametrize("scale_bits", [(8, 0), (4, 3)])
+def test_stochastic_e2m1_is_unbiased(scale_bits):
+    num_samples = 16384
+    target = 2.25
+    upper_probability = 0.25
+    inputs = torch.full((num_samples, 16), target, device="cuda")
+    inputs[:, -1] = 6.0
+
+    torch.cuda.manual_seed(1234)
+    samples = _stochastic_e2m1(inputs, scale_bits)[:, 0]
+    probability_tolerance = 6 * (upper_probability * (1 - upper_probability) / num_samples) ** 0.5
+
+    observed_upper_probability = (
+        torch.isclose(samples, samples.new_tensor(3.0), atol=1e-5).float().mean()
+    )
+    assert abs(observed_upper_probability - upper_probability) <= probability_tolerance
+    assert abs(samples.mean() - target) <= probability_tolerance
 
 
 def test_mxfp6():

--- a/tests/gpu/torch/quantization/test_tensor_quantizer_cuda.py
+++ b/tests/gpu/torch/quantization/test_tensor_quantizer_cuda.py
@@ -81,6 +81,52 @@ class TestTensorQuantizerfp4:
 
         assert fp4_quantizer._get_amax(x) == x.abs().amax()
 
+    @pytest.mark.parametrize("scale_bits", [(8, 0), (4, 3)])
+    def test_stochastic_rounding_is_propagated(self, scale_bits):
+        quantizer = tensor_quantizer.TensorQuantizer(
+            QuantizerAttributeConfig(
+                num_bits=(2, 1),
+                block_sizes={-1: 16, "type": "dynamic", "scale_bits": scale_bits},
+                stochastic_rounding=True,
+            )
+        ).cuda()
+        x = torch.full((64, 16), 2.25, device="cuda")
+        x[:, -1] = 6.0
+        amax = None if scale_bits == (8, 0) else x.abs().amax()
+
+        torch.cuda.manual_seed(1234)
+        output = quantizer(x)
+        torch.cuda.manual_seed(1234)
+        reference = tensor_quant.dynamic_block_quant(
+            x,
+            16,
+            amax,
+            None,
+            (2, 1),
+            scale_bits,
+            None,
+            "dynamic",
+            True,
+            True,
+        )
+
+        assert torch.equal(output, reference)
+
+    def test_missing_stochastic_rounding_state_defaults_to_deterministic(self):
+        quantizer = tensor_quantizer.TensorQuantizer(
+            QuantizerAttributeConfig(
+                num_bits=(2, 1),
+                block_sizes={-1: 16, "type": "dynamic", "scale_bits": (8, 0)},
+            )
+        ).cuda()
+        del quantizer._stochastic_rounding
+        x = torch.randn(2, 16, device="cuda")
+        rng_state = torch.cuda.get_rng_state()
+
+        quantizer(x)
+
+        assert torch.equal(rng_state, torch.cuda.get_rng_state())
+
     @pytest.mark.parametrize("pass_through_bwd", [True, False])
     def test_fp4_backward(self, pass_through_bwd):
         fp4_quantizer = tensor_quantizer.TensorQuantizer(

--- a/tests/unit/torch/quantization/test_config_validation.py
+++ b/tests/unit/torch/quantization/test_config_validation.py
@@ -85,6 +85,64 @@ def test_need_calibration_with_list_cfg():
     assert not need_calibration(cfg_dynamic)
 
 
+class TestStochasticRoundingConfig:
+    @pytest.mark.parametrize("scale_bits", [(8, 0), (4, 3)])
+    def test_dynamic_e2m1_fake_quantization_is_supported(self, scale_bits):
+        cfg = QuantizerAttributeConfig(
+            num_bits=(2, 1),
+            block_sizes={-1: 16, "type": "dynamic", "scale_bits": scale_bits},
+            stochastic_rounding=True,
+        )
+
+        assert cfg.stochastic_rounding
+        assert QuantizerAttributeConfig(**cfg.model_dump()).stochastic_rounding
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"num_bits": (4, 3)},
+            {"block_sizes": {-1: 16, "type": "static", "scale_bits": (4, 3)}},
+            {"block_sizes": None},
+            {"fake_quant": False},
+        ],
+    )
+    def test_unsupported_quantization_is_rejected(self, overrides):
+        attributes = {
+            "num_bits": (2, 1),
+            "block_sizes": {-1: 16, "type": "dynamic", "scale_bits": (4, 3)},
+            "stochastic_rounding": True,
+            **overrides,
+        }
+
+        with pytest.raises(
+            ValidationError,
+            match="requires fake, dynamic block E2M1 quantization",
+        ):
+            QuantizerAttributeConfig(**attributes)
+
+    @pytest.mark.parametrize("scale_bits", [None, (5, 2)], ids=["missing", "unsupported"])
+    def test_unsupported_scale_format_is_rejected(self, scale_bits):
+        block_sizes = {-1: 16, "type": "dynamic"}
+        if scale_bits is not None:
+            block_sizes["scale_bits"] = scale_bits
+
+        with pytest.raises(
+            ValidationError,
+            match=r"requires scale_bits to be exactly \(8, 0\) or \(4, 3\)",
+        ):
+            QuantizerAttributeConfig(
+                num_bits=(2, 1),
+                block_sizes=block_sizes,
+                stochastic_rounding=True,
+            )
+
+    def test_default_is_deterministic(self):
+        cfg = QuantizerAttributeConfig()
+
+        assert cfg.stochastic_rounding is False
+        assert "stochastic_rounding" not in cfg.model_dump(exclude_unset=True)
+
+
 class TestNormalizeQuantCfgList:
     def test_new_format_passthrough(self):
         """New-format entries are returned unchanged (only canonical defaults added)."""


### PR DESCRIPTION
### What does this PR do?

Type of change: new feature

Adds opt-in stochastic rounding for E2M1 payloads in dynamic MXFP4 and NVFP4 fake quantization.

- Adds a backward-compatible `stochastic_rounding=False` quantizer attribute restricted to dynamic E2M1 fake quantization with E8M0 or E4M3 block scales.
- Threads the option through `TensorQuantizer`, the dynamic-block custom operator, and the existing MX CUDA extension.
- Uses PyTorch CUDA Philox state for payload-only stochastic rounding; deterministic defaults do not consume RNG state.
- Preserves deterministic block-scale rounding, deployment export behavior, the NVFP4 Triton fast path when disabled, and legacy quantizer state.

### Usage

```python
import torch
from modelopt.torch.quantization.config import QuantizerAttributeConfig
from modelopt.torch.quantization.nn import TensorQuantizer

torch.cuda.manual_seed(1234)
quantizer = TensorQuantizer(
    QuantizerAttributeConfig(
        num_bits=(2, 1),
        block_sizes={-1: 16, "type": "dynamic", "scale_bits": (8, 0)},
        stochastic_rounding=True,
    )
).cuda()
output = quantizer(inputs)
```

Use `scale_bits=(4, 3)` for dynamic NVFP4. Resetting the CUDA seed reproduces results for the same device, input shape, launch configuration, and RNG call order.

### Testing

- `pytest_pwd tests/unit/torch/quantization/test_config_validation.py` — 92 passed
- `pytest_pwd tests/gpu/torch/quantization/test_quantize_mxformats_cuda.py` — 241 passed
- `pytest_pwd tests/gpu/torch/quantization/test_tensor_quantizer_cuda.py` — 40 passed in the full implementation pass; focused stochastic subset revalidated after the final audit
- `pytest_pwd tests/unit/torch/quantization/test_export_onnx.py` — 27 passed
- `pre-commit run --files <all 9 changed files>` — all hooks passed

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update Changelog?: ✅
- Did you get Claude approval on this PR?: N/A — draft; no reviewer workflow triggered yet

### Additional Information

- Stochastic rounding applies only to the E2M1 payload. Scale quantization and deployment export remain deterministic.
- Bitwise identity is intentionally not guaranteed across GPU architectures, launch-geometry changes, distributed rank ordering, or future RNG implementation changes.
