### PR TITLE
Reduce the list of codeowners for feature/puzzletron_v2 branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,49 +13,11 @@ noxfile.py @NVIDIA/modelopt-setup-codeowners
 uv.lock @NVIDIA/modelopt-setup-codeowners
 
 # Library
-modelopt/deploy @NVIDIA/modelopt-deploy-codeowners
-modelopt/onnx @NVIDIA/modelopt-onnx-codeowners
-modelopt/onnx/autocast @NVIDIA/modelopt-onnx-autocast-codeowners
-modelopt/torch @NVIDIA/modelopt-torch-codeowners
-modelopt/torch/_deploy @NVIDIA/modelopt-torch-deploy-codeowners
-modelopt/torch/distill @NVIDIA/modelopt-torch-distill-codeowners
-modelopt/torch/export @NVIDIA/modelopt-torch-export-codeowners
-modelopt/torch/nas @NVIDIA/modelopt-torch-nas-prune-codeowners
-modelopt/torch/opt @NVIDIA/modelopt-torch-opt-codeowners
-modelopt/torch/peft @NVIDIA/modelopt-torch-peft-codeowners
-modelopt/torch/prune @NVIDIA/modelopt-torch-nas-prune-codeowners
 modelopt/torch/puzzletron @NVIDIA/modelopt-torch-puzzletron-codeowners
-modelopt/torch/quantization @NVIDIA/modelopt-torch-quantization-codeowners
-modelopt/torch/sparsity @NVIDIA/modelopt-torch-sparsity-codeowners
-modelopt/torch/speculative @NVIDIA/modelopt-torch-speculative-codeowners
-modelopt/torch/trace @NVIDIA/modelopt-torch-nas-prune-codeowners
-modelopt/torch/utils @NVIDIA/modelopt-torch-utils-codeowners
-modelopt_recipes @NVIDIA/modelopt-recipes-codeowners
 
 # Examples
 /README.md @NVIDIA/modelopt-examples-codeowners
-/examples @NVIDIA/modelopt-examples-codeowners
-/examples/cnn_qat @NVIDIA/modelopt-examples-cnn_qat-codeowners
-/examples/deepseek @NVIDIA/modelopt-deploy-codeowners
-/examples/diffusers @NVIDIA/modelopt-examples-diffusers-codeowners
-/examples/gpt-oss @NVIDIA/modelopt-examples-gpt-oss-codeowners
-/examples/llm_autodeploy @NVIDIA/modelopt-deploy-codeowners
-/examples/llm_distill @NVIDIA/modelopt-torch-distill-codeowners
-/examples/llm_eval @NVIDIA/modelopt-examples-llm_ptq-codeowners
-/examples/llm_ptq @NVIDIA/modelopt-examples-llm_ptq-codeowners
-/examples/llm_qat @NVIDIA/modelopt-examples-llm_qat-codeowners
-/examples/llm_sparsity @NVIDIA/modelopt-torch-sparsity-codeowners
-/examples/megatron_bridge @NVIDIA/modelopt-examples-megatron-codeowners
-/examples/model_hub @NVIDIA/modelopt-examples-model_hub-codeowners
-/examples/onnx_ptq @NVIDIA/modelopt-onnx-codeowners
-/examples/pruning @NVIDIA/modelopt-torch-nas-prune-codeowners
 /examples/puzzletron @NVIDIA/modelopt-torch-puzzletron-codeowners
-/examples/specdec_bench @NVIDIA/modelopt-torch-speculative-codeowners
-/examples/speculative_decoding @NVIDIA/modelopt-torch-speculative-codeowners
-/examples/torch_onnx @NVIDIA/modelopt-onnx-codeowners
-/examples/vlm_ptq @NVIDIA/modelopt-examples-vlm-codeowners
-/examples/vllm_serve @NVIDIA/modelopt-examples-llm_ptq-codeowners
-/examples/windows @NVIDIA/modelopt-windows-codeowners
 
 # Requirements files are owned by the setup team regardless of location
 requirements*.txt @NVIDIA/modelopt-setup-codeowners


### PR DESCRIPTION
### What does this PR do?

Type of change: ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

<!-- Details about the change. -->

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, API changes, critical bug fixes or backward incompatible changes. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository code ownership coverage.
  * Ownership is now focused on Puzzletron-related code, the main README, and corresponding examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->