### PR TITLE
[NVBug: 6445613] handle nested vocab_size for multimodal configs (Gemma4)

### DIFF
--- a/modelopt/torch/export/model_config_export.py
+++ b/modelopt/torch/export/model_config_export.py
@@ -149,7 +149,10 @@ def torch_to_tensorrt_llm_checkpoint(
     elif hasattr(model, "config"):
         # Huggingface models
         model_metadata_config = model.config.__dict__
-        vocab_size = model.config.vocab_size
+        if hasattr(model.config, "vocab_size"):
+            vocab_size = model.config.vocab_size
+        else:
+            vocab_size = model.config.text_config.vocab_size
         hf_config = model.config
         architectures = getattr(model.config, "architectures", None)
         architecture = architectures[0] if architectures else ""


### PR DESCRIPTION
## Summary

- `Gemma4Config` stores `vocab_size` under `text_config.vocab_size` rather than at the top level, causing `AttributeError` during TRT-LLM checkpoint export
- Added `hasattr` fallback so multimodal configs with nested `vocab_size` work correctly while all flat-config models (Llama, Mistral, etc.) are unaffected

## Root cause

`torch_to_tensorrt_llm_checkpoint` in `model_config_export.py` assumed `model.config.vocab_size` always exists. For multimodal HF models (Gemma4 and similar), `vocab_size` is nested under `text_config`.

## Test plan

- [ ] Verified fix logic inside `epic_banach` container with `AutoConfig.for_model("gemma4")` — correctly reads `text_config.vocab_size = 262144`
- [ ] Verified flat-config models (Llama) still read `vocab_size` directly — unchanged behavior
- [ ] Full end-to-end test with `google/gemma-4-E2B-it` + INT4 AWQ quantization pending model weights

## References

- NVBug: https://nvbugspro.nvidia.com/bug/6445613
- GitHub issue: https://github.com/NVIDIA/TensorRT-LLM/issues/16171