### PR TITLE
[skill] evaluation: correct the stale vLLM CUDA-13 image tag rule

### DIFF
--- a/.agents/skills/deployment/SKILL.md
+++ b/.agents/skills/deployment/SKILL.md
@@ -125,12 +125,16 @@ python -m vllm.entrypoints.openai.api_server \
 
 For NVFP4 checkpoints, use `--quantization modelopt_fp4`.
 
-> **NVFP4 on Blackwell B300/GB300 (sm_103): append `-cu130` to the image tag**
-> (e.g. `vllm/vllm-openai:v0.19.1-cu130` — release tags are multi-arch). The
-> default cu12 build has **no sm_103 FP4 kernel**, so vLLM loads the checkpoint
-> then dies at engine init with `CUDA error: no kernel image is available for
-> execution on the device` (affects the `flashinfer` and `cutlass` NVFP4
-> backends; `marlin` separately fails on non-64-divisible layer dims).
+> **NVFP4 on Blackwell B300/GB300 (sm_103) needs a CUDA-13 image.** Current vLLM
+> release tags are CUDA-13 unsuffixed (e.g. `vllm/vllm-openai:v0.26.0` — release
+> tags are multi-arch), with `-cu129` as the CUDA-12 opt-out; older releases
+> spelled it the other way round (`-cu130` suffix = CUDA 13), so `-cu130` does
+> not exist on current tags. Don't trust the tag name — read `CUDA_VERSION` from
+> the tag's arm64 config blob. A cu12 build has **no sm_103 FP4 kernel**, so vLLM
+> loads the checkpoint then dies at engine init with `CUDA error: no kernel image
+> is available for execution on the device` (affects the `flashinfer` and
+> `cutlass` NVFP4 backends; `marlin` separately fails on non-64-divisible layer
+> dims).
 > Cross-check via
 > `recipes.vllm.ai/<org>/<model>?hardware=b300` (JS-rendered — fetch the raw
 > markdown at `github.com/vllm-project/recipes/blob/main/<org>/<model>.md`). For

--- a/.agents/skills/deployment/SKILL.md
+++ b/.agents/skills/deployment/SKILL.md
@@ -125,12 +125,13 @@ python -m vllm.entrypoints.openai.api_server \
 
 For NVFP4 checkpoints, use `--quantization modelopt_fp4`.
 
-> **NVFP4 on Blackwell B300/GB300 (sm_103) needs a CUDA-13 image.** Current vLLM
-> release tags are CUDA-13 unsuffixed (e.g. `vllm/vllm-openai:v0.26.0` — release
-> tags are multi-arch), with `-cu129` as the CUDA-12 opt-out; older releases
-> spelled it the other way round (`-cu130` suffix = CUDA 13), so `-cu130` does
-> not exist on current tags. Don't trust the tag name — read `CUDA_VERSION` from
-> the tag's arm64 config blob. A cu12 build has **no sm_103 FP4 kernel**, so vLLM
+> **NVFP4 on Blackwell B300/GB300 (sm_103) needs a CUDA-13 image.** From v0.20.0
+> on, vLLM release tags are CUDA-13 unsuffixed (e.g. `vllm/vllm-openai:v0.26.0` —
+> release tags are multi-arch), with `-cu129` as the CUDA-12 opt-out; v0.19.x and
+> earlier spelled it the other way round (`-cu130` suffix = CUDA 13). v0.20.0
+> ships both suffixes; after it, `-cu130` does not exist. Don't trust the tag
+> name — select a tag whose arm64 config blob reports `CUDA_VERSION` >= 13. A
+> cu12 build has **no sm_103 FP4 kernel**, so vLLM
 > loads the checkpoint then dies at engine init with `CUDA error: no kernel image
 > is available for execution on the device` (affects the `flashinfer` and
 > `cutlass` NVFP4 backends; `marlin` separately fails on non-64-divisible layer

--- a/.agents/skills/deployment/SKILL.md
+++ b/.agents/skills/deployment/SKILL.md
@@ -130,7 +130,9 @@ For NVFP4 checkpoints, use `--quantization modelopt_fp4`.
 > release tags are multi-arch), with `-cu129` as the CUDA-12 opt-out; v0.19.x and
 > earlier spelled it the other way round (`-cu130` suffix = CUDA 13). v0.20.0
 > ships both suffixes; after it, `-cu130` does not exist. Don't trust the tag
-> name — select a tag whose arm64 config blob reports `CUDA_VERSION` >= 13. A
+> name — select a tag whose config blob reports `CUDA_VERSION` >= 13, resolving
+> the child manifest for the platform you deploy on (arm64 for Grace/GB300,
+> amd64 for x86 hosts); `TORCH_CUDA_ARCH_LIST` differs between the two. A
 > cu12 build has **no sm_103 FP4 kernel**, so vLLM
 > loads the checkpoint then dies at engine init with `CUDA error: no kernel image
 > is available for execution on the device` (affects the `flashinfer` and

--- a/.agents/skills/deployment/SKILL.md
+++ b/.agents/skills/deployment/SKILL.md
@@ -126,18 +126,16 @@ python -m vllm.entrypoints.openai.api_server \
 For NVFP4 checkpoints, use `--quantization modelopt_fp4`.
 
 > **NVFP4 on Blackwell B300/GB300 (sm_103) needs a CUDA-13 image.** From v0.20.0
-> on, vLLM release tags are CUDA-13 unsuffixed (e.g. `vllm/vllm-openai:v0.26.0` —
-> release tags are multi-arch), with `-cu129` as the CUDA-12 opt-out; v0.19.x and
-> earlier spelled it the other way round (`-cu130` suffix = CUDA 13). v0.20.0
-> ships both suffixes; after it, `-cu130` does not exist. Don't trust the tag
-> name — select a tag whose config blob reports `CUDA_VERSION` >= 13, resolving
-> the child manifest for the platform you deploy on (arm64 for Grace/GB300,
-> amd64 for x86 hosts); `TORCH_CUDA_ARCH_LIST` differs between the two. A
-> cu12 build has **no sm_103 FP4 kernel**, so vLLM
-> loads the checkpoint then dies at engine init with `CUDA error: no kernel image
-> is available for execution on the device` (affects the `flashinfer` and
-> `cutlass` NVFP4 backends; `marlin` separately fails on non-64-divisible layer
-> dims).
+> on, release tags are CUDA-13 unsuffixed (e.g. `vllm/vllm-openai:v0.26.0`) with
+> `-cu129` the CUDA-12 opt-out; v0.19.x and earlier were the other way round
+> (`-cu130` = CUDA 13), and `-cu130` no longer exists after v0.20.0. Don't trust
+> the tag name — select a tag reporting `CUDA_VERSION` >= 13 in the config blob
+> of your platform's child manifest (arm64 Grace/GB300, amd64 x86);
+> `TORCH_CUDA_ARCH_LIST` differs between the two. A cu12 build has **no sm_103
+> FP4 kernel**, so vLLM loads the checkpoint then dies at engine init with `CUDA
+> error: no kernel image is available for execution on the device` (affects the
+> `flashinfer` and `cutlass` NVFP4 backends; `marlin` separately fails on
+> non-64-divisible layer dims).
 > Cross-check via
 > `recipes.vllm.ai/<org>/<model>?hardware=b300` (JS-rendered — fetch the raw
 > markdown at `github.com/vllm-project/recipes/blob/main/<org>/<model>.md`). For

--- a/.agents/skills/deployment/references/benchmarking.md
+++ b/.agents/skills/deployment/references/benchmarking.md
@@ -121,5 +121,5 @@ baseline precision of the same model) at matched ISL/OSL.
 - **Match the serving config across compared runs** — image, tensor/expert
   parallelism, KV dtype, and token shapes must be identical, or the comparison
   isn't apples-to-apples.
-- **NVFP4 on Blackwell sm_103 needs a cu130 image** — see the vLLM note in the
+- **NVFP4 on Blackwell sm_103 needs a CUDA-13 image** — see the vLLM note in the
   main `SKILL.md`; a wrong image serves nothing (or the coherence gate fails).

--- a/.agents/skills/deployment/references/setup.md
+++ b/.agents/skills/deployment/references/setup.md
@@ -74,7 +74,7 @@ squeue -u $USER -o "%j %N %S"  # Get the node name
 
 | Framework | Image | Source |
 |-----------|-------|--------|
-| vLLM | `vllm/vllm-openai:v0.26.0` | <https://hub.docker.com/r/vllm/vllm-openai> |
+| vLLM | `vllm/vllm-openai:latest` | <https://hub.docker.com/r/vllm/vllm-openai> |
 | SGLang | `lmsysorg/sglang:latest` | <https://hub.docker.com/r/lmsysorg/sglang> |
 | TRT-LLM | `nvcr.io/nvidia/tensorrt-llm/release:latest` | <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-llm/containers/release/> |
 
@@ -83,7 +83,7 @@ Example with the official vLLM image:
 ```bash
 docker run --gpus all -p 8000:8000 \
     -v /path/to/checkpoint:/model \
-    vllm/vllm-openai:v0.26.0 \
+    vllm/vllm-openai:latest \
     --model /model \
     --quantization modelopt \
     --host 0.0.0.0 --port 8000

--- a/.agents/skills/deployment/references/setup.md
+++ b/.agents/skills/deployment/references/setup.md
@@ -74,7 +74,7 @@ squeue -u $USER -o "%j %N %S"  # Get the node name
 
 | Framework | Image | Source |
 |-----------|-------|--------|
-| vLLM | `vllm/vllm-openai:latest` | <https://hub.docker.com/r/vllm/vllm-openai> |
+| vLLM | `vllm/vllm-openai:v0.26.0` | <https://hub.docker.com/r/vllm/vllm-openai> |
 | SGLang | `lmsysorg/sglang:latest` | <https://hub.docker.com/r/lmsysorg/sglang> |
 | TRT-LLM | `nvcr.io/nvidia/tensorrt-llm/release:latest` | <https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-llm/containers/release/> |
 
@@ -83,7 +83,7 @@ Example with the official vLLM image:
 ```bash
 docker run --gpus all -p 8000:8000 \
     -v /path/to/checkpoint:/model \
-    vllm/vllm-openai:latest \
+    vllm/vllm-openai:v0.26.0 \
     --model /model \
     --quantization modelopt \
     --host 0.0.0.0 --port 8000

--- a/.agents/skills/deployment/references/support-matrix.md
+++ b/.agents/skills/deployment/references/support-matrix.md
@@ -61,7 +61,7 @@ This matrix covers officially validated combinations. For unlisted models:
 ## Notes
 
 - **NVFP4 inference requires Blackwell GPUs** (B100, B200, B300, GB200, GB300). Hopper can run FP4 calibration but not inference.
-  - **B300/GB300 are `sm_103`** and need a CUDA-13 (`cu130`) serving image — now the vLLM default, but older `cu12` images lack the `sm_103` FP4 kernel and serve NVFP4 as gibberish or error out. See the deployment `SKILL.md` `-cu130` note.
+  - **B300/GB300 are `sm_103`** and need a **CUDA-13** serving image — current vLLM release tags are CUDA-13 unsuffixed (`-cu129` opts back to CUDA 12), but `cu12` images lack the `sm_103` FP4 kernel and serve NVFP4 as gibberish or error out. See the CUDA-13 note in the deployment `SKILL.md`.
   - **Verify the GPU with `nvidia-smi`** before choosing the image — cluster GPU labels can be stale.
 - INT4_AWQ and W4A8_AWQ are only supported by TRT-LLM (not vLLM or SGLang).
 - Source: `examples/hf_ptq/README.md` and `docs/source/deployment/3_unified_hf.rst`

--- a/.agents/skills/deployment/references/support-matrix.md
+++ b/.agents/skills/deployment/references/support-matrix.md
@@ -61,7 +61,7 @@ This matrix covers officially validated combinations. For unlisted models:
 ## Notes
 
 - **NVFP4 inference requires Blackwell GPUs** (B100, B200, B300, GB200, GB300). Hopper can run FP4 calibration but not inference.
-  - **B300/GB300 are `sm_103`** and need a **CUDA-13** serving image — current vLLM release tags are CUDA-13 unsuffixed (`-cu129` opts back to CUDA 12), but `cu12` images lack the `sm_103` FP4 kernel and serve NVFP4 as gibberish or error out. See the CUDA-13 note in the deployment `SKILL.md`.
+  - **B300/GB300 are `sm_103`** and need a **CUDA-13** serving image — from v0.20.0 the unsuffixed tag is CUDA-13 (`-cu129` opts back to CUDA 12); `cu12` images lack the `sm_103` FP4 kernel and serve NVFP4 as gibberish or error out. See the CUDA-13 note in the deployment `SKILL.md`.
   - **Verify the GPU with `nvidia-smi`** before choosing the image — cluster GPU labels can be stale.
 - INT4_AWQ and W4A8_AWQ are only supported by TRT-LLM (not vLLM or SGLang).
 - Source: `examples/hf_ptq/README.md` and `docs/source/deployment/3_unified_hf.rst`

--- a/.agents/skills/evaluation/SKILL.md
+++ b/.agents/skills/evaluation/SKILL.md
@@ -166,7 +166,14 @@ For how to choose `--tensor-parallel-size` / `--data-parallel-size` / `--pipelin
 
 **Image / vLLM version.** Treat default `image: vllm/vllm-openai:v0.19.1` as a floor to verify: bump to the **exact model's** `recipes.vllm.ai` minimum if higher (e.g. `v0.20.0`). Running below minimum is a trap — the server starts, then a worker dies mid-inference with `CUDA error: an illegal memory access` (MiniMax-M2.7 NVFP4 needed ≥0.20.0), easy to misread as a kernel bug. Never `:latest` (breaks reproducibility). Surface version bumps to the user.
 
-> **NVFP4 on Blackwell B300/GB300 (sm_103): append `-cu130` to the image tag** (e.g. `vllm/vllm-openai:v0.19.1-cu130` — release tags are multi-arch). The default cu12 build has no sm_103 FP4 kernel, so engine init dies with `CUDA error: no kernel image is available`. If a pinned release predates the model's arch, use `cu130-nightly-<arch>` (Qwen3.5-9B's `qwen3_5` needed it, vLLM 0.19.2rc1.dev134). Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`. Full note in `recipes/examples/example_eval.yaml`.
+> **NVFP4 on Blackwell B300/GB300 (sm_103) needs a CUDA-13 build** — the cu12 build has no sm_103 FP4 kernel, so engine init dies with `CUDA error: no kernel image is available`. **Verify CUDA ≥13 in the tag itself; do not blindly append a suffix — vLLM inverted its tag convention:**
+>
+> | vLLM version | CUDA-13 tag | CUDA-12 tag |
+> | --- | --- | --- |
+> | ≤ v0.20.x | **suffixed** `-cu130` (e.g. `v0.20.0-cu130`) | unsuffixed |
+> | ≥ ~v0.21 | **unsuffixed** (e.g. `v0.24.0-ubuntu2404`, `v0.26.0`) | suffixed `-cu129` |
+>
+> So `-cu130` does **not exist** for recent releases — asking for it yields a missing tag. Confirm by reading `CUDA_VERSION` from the tag's **arm64** config blob (registry API) rather than trusting the name, and check the arch you need is in `TORCH_CUDA_ARCH_LIST`. Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`. Full note in `recipes/examples/example_eval.yaml`.
 
 #### vLLM-backend defaults — always include unless the recipe *contradicts*
 
@@ -329,12 +336,12 @@ Default images:
 | Framework | Image | Registry |
 | --- | --- | --- |
 | vLLM | `vllm/vllm-openai:v0.19.1` (bump per recipe; never `:latest`) | DockerHub |
-| vLLM (NVFP4 on B300/GB300) | `vllm/vllm-openai:v0.19.1-cu130` (bump to `cu130-nightly-<arch>` for new archs) | DockerHub |
+| vLLM (NVFP4 on B300/GB300) | a **CUDA-13** build: `-cu130` on ≤v0.20.x, **unsuffixed** on ≥~v0.21 (see Step 3) | DockerHub |
 | SGLang | `lmsysorg/sglang:latest` | DockerHub |
 | TRT-LLM | `nvcr.io/nvidia/tensorrt-llm/release:...` | NGC |
 | Eval tasks | `nvcr.io/nvidia/eval-factory/*:26.03` | NGC |
 
-> NVFP4 checkpoints on B300/GB300 (sm_103) need the `cu130` image — cu129/v0.19.1 lack sm_103 FP4 kernels (see the "NVFP4 on Blackwell" note in Step 3).
+> NVFP4 checkpoints on B300/GB300 (sm_103) need a **CUDA-13** image — CUDA-12 builds lack sm_103 FP4 kernels. Which tag spelling that is depends on the vLLM version (see the "NVFP4 on Blackwell" table in Step 3); verify `CUDA_VERSION` in the tag's arm64 config blob.
 
 Public images → submit without preflight. Private/restricted → check credentials:
 

--- a/.agents/skills/evaluation/SKILL.md
+++ b/.agents/skills/evaluation/SKILL.md
@@ -164,7 +164,7 @@ Conventions: always start `vllm serve /checkpoint` (NEL mounts here); always `--
 
 For how to choose `--tensor-parallel-size` / `--data-parallel-size` / `--pipeline-parallel-size` (and EP) from the model size and your GPU count, read `references/parallelism.md` — cross-check the layout against `recipes.vllm.ai`, then adapt to the GPUs you actually have via the fit math there.
 
-**Image / vLLM version.** Treat default `image: vllm/vllm-openai:v0.19.1` as a floor to verify: bump to the **exact model's** `recipes.vllm.ai` minimum if higher (e.g. `v0.20.0`). Running below minimum is a trap — the server starts, then a worker dies mid-inference with `CUDA error: an illegal memory access` (MiniMax-M2.7 NVFP4 needed ≥0.20.0), easy to misread as a kernel bug. Never `:latest` (breaks reproducibility). Surface version bumps to the user.
+**Image / vLLM version.** Treat default `image: vllm/vllm-openai:v0.26.0` as a floor to verify: bump to the **exact model's** `recipes.vllm.ai` minimum if higher. Running below minimum is a trap — the server starts, then a worker dies mid-inference with `CUDA error: an illegal memory access`, easy to misread as a kernel bug. A model released after the newest vLLM release may have no numbered tag at all; take whatever image its recipe names. Never `:latest` (breaks reproducibility). Surface version bumps to the user.
 
 > **NVFP4 on Blackwell B300/GB300 (sm_103) needs a CUDA-13 build** — the cu12 build has no sm_103 FP4 kernel, so engine init dies with `CUDA error: no kernel image is available`. **Verify CUDA ≥13 in the tag itself; do not blindly append a suffix — vLLM inverted its tag convention:**
 >
@@ -335,8 +335,8 @@ Default images:
 
 | Framework | Image | Registry |
 | --- | --- | --- |
-| vLLM | `vllm/vllm-openai:v0.19.1` (bump per recipe; never `:latest`) | DockerHub |
-| vLLM (NVFP4 on B300/GB300) | a **CUDA-13** build: `-cu130` on ≤v0.20.x, **unsuffixed** on ≥~v0.21 (see Step 3) | DockerHub |
+| vLLM | `vllm/vllm-openai:v0.26.0` (bump per recipe; never `:latest`) | DockerHub |
+| vLLM (NVFP4 on B300/GB300) | the default tag is already a **CUDA-13** build; if you pin an older release, re-check the tag convention (see Step 3) | DockerHub |
 | SGLang | `lmsysorg/sglang:latest` | DockerHub |
 | TRT-LLM | `nvcr.io/nvidia/tensorrt-llm/release:...` | NGC |
 | Eval tasks | `nvcr.io/nvidia/eval-factory/*:26.03` | NGC |

--- a/.agents/skills/evaluation/SKILL.md
+++ b/.agents/skills/evaluation/SKILL.md
@@ -166,14 +166,14 @@ For how to choose `--tensor-parallel-size` / `--data-parallel-size` / `--pipelin
 
 **Image / vLLM version.** Treat default `image: vllm/vllm-openai:v0.26.0` as a floor to verify: bump to the **exact model's** `recipes.vllm.ai` minimum if higher. Running below minimum is a trap — the server starts, then a worker dies mid-inference with `CUDA error: an illegal memory access`, easy to misread as a kernel bug. A model released after the newest vLLM release may have no numbered tag at all; take whatever image its recipe names. Never `:latest` (breaks reproducibility). Surface version bumps to the user.
 
-> **NVFP4 on Blackwell B300/GB300 (sm_103) needs a CUDA-13 build** — the cu12 build has no sm_103 FP4 kernel, so engine init dies with `CUDA error: no kernel image is available`. **Verify CUDA ≥13 in the tag itself; do not blindly append a suffix — vLLM inverted its tag convention:**
+> **NVFP4 on Blackwell B300/GB300 (sm_103) needs a CUDA-13 build** — the cu12 build has no sm_103 FP4 kernel, so engine init dies with `CUDA error: no kernel image is available`. **Pick the tag by the CUDA version it reports, not by its name — vLLM inverted its tag convention at v0.20.0:**
 >
 > | vLLM version | CUDA-13 tag | CUDA-12 tag |
 > | --- | --- | --- |
-> | ≤ v0.20.x | **suffixed** `-cu130` (e.g. `v0.20.0-cu130`) | unsuffixed |
-> | ≥ ~v0.21 | **unsuffixed** (e.g. `v0.24.0-ubuntu2404`, `v0.26.0`) | suffixed `-cu129` |
+> | ≤ v0.19.x | **suffixed** `-cu130` | unsuffixed |
+> | ≥ v0.20.0 | **unsuffixed** | suffixed `-cu129` |
 >
-> So `-cu130` does **not exist** for recent releases — asking for it yields a missing tag. Confirm by reading `CUDA_VERSION` from the tag's **arm64** config blob (registry API) rather than trusting the name, and check the arch you need is in `TORCH_CUDA_ARCH_LIST`. Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`. Full note in `recipes/examples/example_eval.yaml`.
+> v0.20.0 straddles the switch: it publishes `-cu130` *and* `-cu129`, and its unsuffixed tag is already CUDA 13. From v0.20.1 on, `-cu130` does **not exist** — asking for it yields a missing tag. So **select any tag whose arm64 config blob reports `CUDA_VERSION` ≥ 13** (registry API) instead of trusting the name, and check the arch you need is in `TORCH_CUDA_ARCH_LIST`. Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`. Full note in `recipes/examples/example_eval.yaml`.
 
 #### vLLM-backend defaults — always include unless the recipe *contradicts*
 

--- a/.agents/skills/evaluation/SKILL.md
+++ b/.agents/skills/evaluation/SKILL.md
@@ -173,7 +173,7 @@ For how to choose `--tensor-parallel-size` / `--data-parallel-size` / `--pipelin
 > | ≤ v0.19.x | **suffixed** `-cu130` | unsuffixed |
 > | ≥ v0.20.0 | **unsuffixed** | suffixed `-cu129` |
 >
-> v0.20.0 straddles the switch: it publishes `-cu130` *and* `-cu129`, and its unsuffixed tag is already CUDA 13. From v0.20.1 on, `-cu130` does **not exist** — asking for it yields a missing tag. So **select any tag whose arm64 config blob reports `CUDA_VERSION` ≥ 13** (registry API) instead of trusting the name, and check the arch you need is in `TORCH_CUDA_ARCH_LIST`. Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`. Full note in `recipes/examples/example_eval.yaml`.
+> v0.20.0 straddles the switch: it publishes `-cu130` *and* `-cu129`, and its unsuffixed tag is already CUDA 13. From v0.20.1 on, `-cu130` does **not exist** — asking for it yields a missing tag. So **select any tag whose config blob reports `CUDA_VERSION` ≥ 13** (registry API) instead of trusting the name. Resolve the child manifest **for the platform you deploy on** — arm64 for Grace/GB300, amd64 for x86 hosts — and check the arch you need is in *that child's* `TORCH_CUDA_ARCH_LIST`: the list differs per platform (v0.26.0 publishes `7.5 8.0 8.6 8.9 9.0 10.0 12.0` on amd64 vs `8.0 8.7 8.9 9.0 10.0 11.0 12.0` on arm64). Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`. Full note in `recipes/examples/example_eval.yaml`.
 
 #### vLLM-backend defaults — always include unless the recipe *contradicts*
 
@@ -341,7 +341,7 @@ Default images:
 | TRT-LLM | `nvcr.io/nvidia/tensorrt-llm/release:...` | NGC |
 | Eval tasks | `nvcr.io/nvidia/eval-factory/*:26.03` | NGC |
 
-> NVFP4 checkpoints on B300/GB300 (sm_103) need a **CUDA-13** image — CUDA-12 builds lack sm_103 FP4 kernels. Which tag spelling that is depends on the vLLM version (see the "NVFP4 on Blackwell" table in Step 3); verify `CUDA_VERSION` in the tag's arm64 config blob.
+> NVFP4 checkpoints on B300/GB300 (sm_103) need a **CUDA-13** image — CUDA-12 builds lack sm_103 FP4 kernels. Which tag spelling that is depends on the vLLM version (see the "NVFP4 on Blackwell" table in Step 3); verify `CUDA_VERSION` in the config blob of the child manifest for the platform you deploy on.
 
 Public images → submit without preflight. Private/restricted → check credentials:
 

--- a/.agents/skills/evaluation/SKILL.md
+++ b/.agents/skills/evaluation/SKILL.md
@@ -164,7 +164,7 @@ Conventions: always start `vllm serve /checkpoint` (NEL mounts here); always `--
 
 For how to choose `--tensor-parallel-size` / `--data-parallel-size` / `--pipeline-parallel-size` (and EP) from the model size and your GPU count, read `references/parallelism.md` — cross-check the layout against `recipes.vllm.ai`, then adapt to the GPUs you actually have via the fit math there.
 
-**Image / vLLM version.** Treat default `image: vllm/vllm-openai:v0.26.0` as a floor to verify: bump to the **exact model's** `recipes.vllm.ai` minimum if higher. Running below minimum is a trap — the server starts, then a worker dies mid-inference with `CUDA error: an illegal memory access`, easy to misread as a kernel bug. A model released after the newest vLLM release may have no numbered tag at all; take whatever image its recipe names. Never `:latest` (breaks reproducibility). Surface version bumps to the user.
+**Image / vLLM version.** Treat default `image: vllm/vllm-openai:v0.26.0` as a floor to verify: bump to the **exact model's** `recipes.vllm.ai` minimum if higher. Running below minimum is a trap — the server starts, then a worker dies mid-inference with `CUDA error: an illegal memory access`, easy to misread as a kernel bug. A model newer than the latest release may have no numbered tag — use the image its recipe names. Never `:latest` (breaks reproducibility). Surface version bumps to the user.
 
 > **NVFP4 on Blackwell B300/GB300 (sm_103) needs a CUDA-13 build** — the cu12 build has no sm_103 FP4 kernel, so engine init dies with `CUDA error: no kernel image is available`. **Pick the tag by the CUDA version it reports, not by its name — vLLM inverted its tag convention at v0.20.0:**
 >
@@ -173,7 +173,7 @@ For how to choose `--tensor-parallel-size` / `--data-parallel-size` / `--pipelin
 > | ≤ v0.19.x | **suffixed** `-cu130` | unsuffixed |
 > | ≥ v0.20.0 | **unsuffixed** | suffixed `-cu129` |
 >
-> v0.20.0 straddles the switch: it publishes `-cu130` *and* `-cu129`, and its unsuffixed tag is already CUDA 13. From v0.20.1 on, `-cu130` does **not exist** — asking for it yields a missing tag. So **select any tag whose config blob reports `CUDA_VERSION` ≥ 13** (registry API) instead of trusting the name. Resolve the child manifest **for the platform you deploy on** — arm64 for Grace/GB300, amd64 for x86 hosts — and check the arch you need is in *that child's* `TORCH_CUDA_ARCH_LIST`: the list differs per platform (v0.26.0 publishes `7.5 8.0 8.6 8.9 9.0 10.0 12.0` on amd64 vs `8.0 8.7 8.9 9.0 10.0 11.0 12.0` on arm64). Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`. Full note in `recipes/examples/example_eval.yaml`.
+> v0.20.0 ships both suffixes; after it `-cu130` doesn't exist, so asking for it yields a missing tag. **Select a tag whose config blob reports `CUDA_VERSION` ≥ 13** (registry API), reading the child manifest for **the platform you deploy on** (arm64 Grace/GB300, amd64 x86) — `TORCH_CUDA_ARCH_LIST` differs per platform, so check your arch against that child. Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`. Full note in `recipes/examples/example_eval.yaml`.
 
 #### vLLM-backend defaults — always include unless the recipe *contradicts*
 
@@ -336,12 +336,12 @@ Default images:
 | Framework | Image | Registry |
 | --- | --- | --- |
 | vLLM | `vllm/vllm-openai:v0.26.0` (bump per recipe; never `:latest`) | DockerHub |
-| vLLM (NVFP4 on B300/GB300) | the default tag is already a **CUDA-13** build; if you pin an older release, re-check the tag convention (see Step 3) | DockerHub |
+| vLLM (NVFP4 on B300/GB300) | default is already **CUDA-13**; for older pins see Step 3 | DockerHub |
 | SGLang | `lmsysorg/sglang:latest` | DockerHub |
 | TRT-LLM | `nvcr.io/nvidia/tensorrt-llm/release:...` | NGC |
 | Eval tasks | `nvcr.io/nvidia/eval-factory/*:26.03` | NGC |
 
-> NVFP4 checkpoints on B300/GB300 (sm_103) need a **CUDA-13** image — CUDA-12 builds lack sm_103 FP4 kernels. Which tag spelling that is depends on the vLLM version (see the "NVFP4 on Blackwell" table in Step 3); verify `CUDA_VERSION` in the config blob of the child manifest for the platform you deploy on.
+> NVFP4 checkpoints on B300/GB300 (sm_103) need a **CUDA-13** image — CUDA-12 builds lack sm_103 FP4 kernels. The tag spelling depends on the vLLM version (Step 3 table); verify `CUDA_VERSION` in your platform's child manifest.
 
 Public images → submit without preflight. Private/restricted → check credentials:
 

--- a/.agents/skills/evaluation/recipes/examples/example_eval.yaml
+++ b/.agents/skills/evaluation/recipes/examples/example_eval.yaml
@@ -85,11 +85,12 @@ deployment:
   image: vllm/vllm-openai:v0.26.0
   # NVFP4 on Blackwell B300/GB300 (sm_103) needs a CUDA-13 build — a cu12 build
   # has no sm_103 FP4 kernel, so the deploy dies at engine init with CUDA
-  # "no kernel image is available". Current release tags are CUDA-13 unsuffixed
-  # (the tag above), with `-cu129` as the CUDA-12 opt-out; older releases spelled
-  # it the other way round (`-cu130` suffix = CUDA 13), so `-cu130` does not
-  # exist on current tags. Don't trust the tag name — read CUDA_VERSION from the
-  # tag's arm64 config blob, and check your arch is in TORCH_CUDA_ARCH_LIST.
+  # "no kernel image is available". From v0.20.0 on, release tags are CUDA-13
+  # unsuffixed (the tag above) with `-cu129` as the CUDA-12 opt-out; v0.19.x and
+  # earlier spelled it the other way round (`-cu130` = CUDA 13). v0.20.0 ships
+  # both suffixes; after it, `-cu130` does not exist. Don't trust the tag name —
+  # pick a tag whose arm64 config blob reports CUDA_VERSION >= 13, and check your
+  # arch is in TORCH_CUDA_ARCH_LIST.
   # Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`
   # (ViT flash-attn workaround; drop if the encoder loads without it).
   #

--- a/.agents/skills/evaluation/recipes/examples/example_eval.yaml
+++ b/.agents/skills/evaluation/recipes/examples/example_eval.yaml
@@ -89,8 +89,10 @@ deployment:
   # unsuffixed (the tag above) with `-cu129` as the CUDA-12 opt-out; v0.19.x and
   # earlier spelled it the other way round (`-cu130` = CUDA 13). v0.20.0 ships
   # both suffixes; after it, `-cu130` does not exist. Don't trust the tag name —
-  # pick a tag whose arm64 config blob reports CUDA_VERSION >= 13, and check your
-  # arch is in TORCH_CUDA_ARCH_LIST.
+  # pick a tag whose config blob reports CUDA_VERSION >= 13, resolving the child
+  # manifest for the platform you deploy on (arm64 for Grace/GB300, amd64 for x86
+  # hosts), and check your arch is in that child's TORCH_CUDA_ARCH_LIST — the
+  # list differs per platform.
   # Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`
   # (ViT flash-attn workaround; drop if the encoder loads without it).
   #

--- a/.agents/skills/evaluation/recipes/examples/example_eval.yaml
+++ b/.agents/skills/evaluation/recipes/examples/example_eval.yaml
@@ -82,13 +82,14 @@ deployment:
   checkpoint_path: ???
   hf_model_handle:
   served_model_name: ???
-  image: vllm/vllm-openai:v0.19.1
-  # NVFP4 on Blackwell B300/GB300 (sm_103): append `-cu130` to the (multi-arch)
-  # image tag — the default cu12 build has no sm_103 FP4 kernel, so the deploy
-  # dies at engine init with CUDA "no kernel image is available". e.g.:
-  #   image: vllm/vllm-openai:v0.19.1-cu130
-  # If a pinned release predates your model's arch, use the nightly instead
-  # (Qwen3.5-9B's qwen3_5 needed vllm/vllm-openai:cu130-nightly-x86_64, 0.19.2rc1.dev134).
+  image: vllm/vllm-openai:v0.26.0
+  # NVFP4 on Blackwell B300/GB300 (sm_103) needs a CUDA-13 build — a cu12 build
+  # has no sm_103 FP4 kernel, so the deploy dies at engine init with CUDA
+  # "no kernel image is available". Current release tags are CUDA-13 unsuffixed
+  # (the tag above), with `-cu129` as the CUDA-12 opt-out; older releases spelled
+  # it the other way round (`-cu130` suffix = CUDA 13), so `-cu130` does not
+  # exist on current tags. Don't trust the tag name — read CUDA_VERSION from the
+  # tag's arm64 config blob, and check your arch is in TORCH_CUDA_ARCH_LIST.
   # Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`
   # (ViT flash-attn workaround; drop if the encoder loads without it).
   #

--- a/.agents/skills/evaluation/recipes/examples/example_eval.yaml
+++ b/.agents/skills/evaluation/recipes/examples/example_eval.yaml
@@ -86,13 +86,12 @@ deployment:
   # NVFP4 on Blackwell B300/GB300 (sm_103) needs a CUDA-13 build — a cu12 build
   # has no sm_103 FP4 kernel, so the deploy dies at engine init with CUDA
   # "no kernel image is available". From v0.20.0 on, release tags are CUDA-13
-  # unsuffixed (the tag above) with `-cu129` as the CUDA-12 opt-out; v0.19.x and
-  # earlier spelled it the other way round (`-cu130` = CUDA 13). v0.20.0 ships
-  # both suffixes; after it, `-cu130` does not exist. Don't trust the tag name —
-  # pick a tag whose config blob reports CUDA_VERSION >= 13, resolving the child
-  # manifest for the platform you deploy on (arm64 for Grace/GB300, amd64 for x86
-  # hosts), and check your arch is in that child's TORCH_CUDA_ARCH_LIST — the
-  # list differs per platform.
+  # unsuffixed (the tag above) with `-cu129` the CUDA-12 opt-out; v0.19.x and
+  # earlier were the other way round (`-cu130` = CUDA 13), and `-cu130` no longer
+  # exists after v0.20.0. Don't trust the tag name — pick a tag reporting
+  # CUDA_VERSION >= 13 in the config blob of your platform's child manifest
+  # (arm64 Grace/GB300, amd64 x86); TORCH_CUDA_ARCH_LIST differs between the two,
+  # so check your arch against the child you'll actually run.
   # Multimodal on sm_103 may also need `--mm-encoder-attn-backend TRITON_ATTN`
   # (ViT flash-attn workaround; drop if the encoder loads without it).
   #

--- a/.agents/skills/evaluation/recipes/examples/example_eval_next.yaml
+++ b/.agents/skills/evaluation/recipes/examples/example_eval_next.yaml
@@ -21,7 +21,7 @@ services:
     tensor_parallel_size: 8          # STRUCTURED fields — don't repeat parallelism in extra_args
     data_parallel_size: 1
     num_nodes: 1
-    image: vllm/vllm-openai:v0.19.1  # vLLM SERVING image (≠ eval_image); bump to recipes.vllm.ai min (MiniMax-M2.7 NVFP4 ≥ 0.20.0)
+    image: vllm/vllm-openai:v0.26.0  # vLLM SERVING image (≠ eval_image); bump to the model's recipes.vllm.ai min
     startup_timeout: 3600.0
     extra_args:                      # raw vllm flags (cross-check model card + recipes.vllm.ai)
       - "--trust-remote-code"

--- a/.agents/skills/evaluation/references/nel-next.md
+++ b/.agents/skills/evaluation/references/nel-next.md
@@ -114,7 +114,7 @@ SKILL.md Step 3 (same vLLM). The 0.2.6 `command:` maps to structured `services.<
 | `--tensor/-data/-pipeline-parallel-size`, multi-node | `tensor_parallel_size`/`data_parallel_size`/`pipeline_parallel_size` + `num_nodes` (**not** in `extra_args`) |
 | all other serve flags (`--max-model-len`, `--max-num-seqs`, parsers, `--enable-*`, `--model-loader-extra-config`, …) | `extra_args:` |
 | `env_vars` (`VLLM_*`, NVFP4 MoE flags) | `extra_env:` |
-| `image:` (NVFP4: MiniMax-M2.7 ≥ v0.20.0; sm_103 → `-cu130`) | `image:` (serving image, ≠ `eval_image`) |
+| `image:` (bump to the model's recipe min; NVFP4 on sm_103 → CUDA-13 build, see Step 3) | `image:` (serving image, ≠ `eval_image`) |
 
 Size TP/DP + backend defaults (`--max-num-seqs = ceil(max_parallelism/DP)`, MoE
 `--enable-expert-parallel`, …) per `references/parallelism.md` + Step 3. **Sampling


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix (agent skill documentation)

The `evaluation` skill instructed the agent to **"append `-cu130` to the image tag"** for NVFP4 checkpoints on Blackwell B300/GB300 (sm_103). That was correct for v0.19.x, but **vLLM inverted its tag convention at v0.20.0**: the *unsuffixed* tag is now the CUDA-13 build, and `-cu129` is the CUDA-12 opt-out.

Consequences of the stale rule:

- `v0.20.1-cu130` / `v0.24.0-cu130` / `v0.26.0-cu130` **do not exist** — following the rule literally asks for a missing tag.
- The documented fallback (`cu130-nightly-<arch>`) points at ~v0.20-era builds that are *older* than several models' documented minimum vLLM version, so it can't serve as an escape hatch either.

This replaces the "append a suffix" instruction with a version-keyed table plus the durable check: **select a tag whose config blob reports `CUDA_VERSION` ≥ 13**, resolving the child manifest for the platform you actually deploy on.

While the PR was open the default image was also bumped, and review surfaced two follow-on corrections. Full contents:

1. **Tag-convention fix** — version-keyed table, `-cu130` fallback removed.
2. **Default image `v0.19.1` → `v0.26.0`** (latest vLLM release) everywhere it was pinned: `SKILL.md` Step 3 and the Step 7.5 table, `example_eval.yaml`, `example_eval_next.yaml`. Version specifics that the bump made stale or self-contradictory were dropped (the `e.g. v0.20.0` bump example and the MiniMax-M2.7 `≥0.20.0` anecdote, both now *below* the default; the failure-mode lesson is kept).
3. **Convention boundary corrected to v0.20.0** — the first draft said `≤ v0.20.x` suffixed / `≥ ~v0.21` unsuffixed. Off by a minor release in both rows; see Testing.
4. **Config blob resolved per deployment platform** — the check said "arm64 child". GB300/Grace is arm64, but plenty of B300 deployments are `linux/amd64`.
5. **Same corrections applied to the `deployment` skill**, which carried the original append rule untouched: its NVFP4 note, `references/support-matrix.md`, `references/benchmarking.md`, and the `:latest` pins in `references/setup.md` (now `v0.26.0`, matching the evaluation skill's never-`:latest` stance).

An earlier revision of this branch also carried a `.claude/skills/benchmark-model-kernels` symlink, added automatically by `tools/precommit/sync_claude_skills.sh` — it repairs missing symlinks repo-wide on any touch of `.agents/skills/`, and #1980 landed that skill without its link. It has been dropped from this branch to keep the scope on the vLLM image guidance. Worth its own one-line PR: without the symlink, Claude Code doesn't load that skill at all.

### Usage

```bash
# Durable check — resolve the child manifest for YOUR platform (arm64 for
# Grace/GB300, amd64 for x86) and read CUDA_VERSION from its config blob:
#   v0.19.1            -> CUDA_VERSION=12.9.1   (unsuffixed = CUDA 12, old convention)
#   v0.19.1-cu130      -> CUDA_VERSION=13.0.1   (suffixed = CUDA 13, old convention)
#   v0.20.0            -> CUDA_VERSION=13.0.2   (transition release: ships both suffixes)
#   v0.26.0            -> CUDA_VERSION=13.0.2   (unsuffixed = CUDA 13, new convention)
#   v0.26.0-cu129      -> CUDA_VERSION=12.9.1   (suffixed = CUDA 12, new convention)
```

### Testing

Verified empirically against the Docker registry API for `vllm/vllm-openai` — resolved each tag's child manifests and read `CUDA_VERSION` / `TORCH_CUDA_ARCH_LIST` from the config blob.

**Where the convention flips (arm64):**

| release | unsuffixed | `-cu130` | `-cu129` |
|---|---|---|---|
| v0.18.0 | 12.9.1 | 13.0.1 | absent |
| v0.19.0 / v0.19.1 | 12.9.1 | 13.0.1 | absent |
| **v0.20.0** | **13.0.2** | 13.0.2 | 12.9.1 |
| v0.20.1 | 13.0.2 | **absent** | 12.9.1 |
| v0.20.2 | 13.0.2 | **absent** | 12.9.1 |
| v0.21.0 … v0.26.0 | 13.0.2 | absent | 12.9.1 |

v0.20.0 is the transition release — it publishes both suffixes *and* its unsuffixed tag is already CUDA 13. That duplication is what hid the boundary: confirming `v0.20.0-cu130` exists reads as "old convention still applies at 0.20", while `v0.20.1-cu130` and `v0.20.2-cu130` don't exist at all.

**Why the platform matters.** `CUDA_VERSION` is identical across children on every tag checked (v0.26.0, v0.26.0-cu129, v0.20.0, v0.19.1, v0.19.1-cu130, kimi-k3), but `TORCH_CUDA_ARCH_LIST` is not:

```
v0.26.0  amd64  7.5 8.0 8.6 8.9 9.0 10.0 12.0
v0.26.0  arm64  8.0 8.7 8.9 9.0 10.0 11.0 12.0
v0.19.1  amd64  7.0 7.5 8.0 8.9 9.0 10.0 12.0
v0.19.1  arm64  8.7 8.9 9.0 10.0+PTX 12.0
```

`11.0` appears only on arm64, `7.5` / `8.6` only on amd64 — so the arch check has to read the child you'll actually run.

**Default bump.** The `0.26.0` family is `{,-aarch64,-x86_64} × {,-cu129} × {,-ubuntu2404}` — 12 tags, `cu129` the only CUDA axis, no `-cu130`. The new default is therefore already a CUDA-13 build, and NVFP4 on B300/GB300 needs no suffix at all.

Docs-only change; no runtime code touched. `pre-commit` clean.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A (agent skill documentation)
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌ (not yet run)

### Additional Information

Split out of the GDPVal skill work (#2039) because it is independent of GDPVal and applies to every NVFP4-on-Blackwell deployment the skill generates. Now spans both the `evaluation` and `deployment` skills, all under `.agents/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated vLLM image guidance to version 0.26.0.
  * Clarified CUDA image tag conventions across supported versions.
  * Added guidance for validating platform-specific CUDA versions and GPU architecture settings.
  * Updated NVFP4 deployment guidance for B300/GB300 hardware, including CUDA 13 requirements and known kernel limitations.
  * Refreshed evaluation recipes and serving-image requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->