### PR TITLE
Skip zero-quota splits in get_dataset_samples

### DIFF
--- a/modelopt/torch/utils/dataset_utils.py
+++ b/modelopt/torch/utils/dataset_utils.py
@@ -497,6 +497,8 @@ def get_dataset_samples(
             "Use ``get_dataset_dataloader`` to expand combos, or pass one of "
             f"its members: {DATASET_COMBOS[dataset_name]}"
         )
+    if num_samples < 0:
+        raise ValueError(f"``num_samples`` must be non-negative, got {num_samples}.")
 
     # Local JSONL: load via HF's ``json`` builder and route through the same
     # auto-preprocess path as unregistered HF datasets so chat / prompt / text
@@ -615,7 +617,7 @@ def get_dataset_samples(
     # load_dataset does not support a list of splits while streaming, so load each separately.
     print_rank_0(f"Loading dataset with {config=} and {splits=} {data_files_tmpl=}")
 
-    def _load_split(s: str):
+    def _load_split(s: str | None):
         if data_files_tmpl:
             # Raw files via the ``json`` builder: schema is inferred from data, and the
             # file-based builder labels everything as the ``train`` split.
@@ -628,14 +630,15 @@ def get_dataset_samples(
         return load_dataset(streaming=True, **config, split=s)
 
     try:
-        dataset_splits = [_load_split(s) for s in splits]
-
-        num_per_split = [num_samples // len(dataset_splits)] * len(dataset_splits)
+        num_per_split = [num_samples // len(splits)] * len(splits)
         num_per_split[-1] += num_samples - sum(num_per_split)
 
         samples: list[str] = []
-        for dataset, n in zip(dataset_splits, num_per_split):
-            for i, sample in enumerate(dataset):
+        for split_name, n in zip(splits, num_per_split):
+            # Skip zero-quota splits: starting a streamed split fetches its first record batch.
+            if n == 0:
+                continue
+            for i, sample in enumerate(_load_split(split_name)):
                 if i >= n:
                     break
                 text = _preprocess(sample)

--- a/tests/unit/torch/utils/test_dataset_utils.py
+++ b/tests/unit/torch/utils/test_dataset_utils.py
@@ -871,6 +871,19 @@ class TestLocalDatasetDirRoundTrips:
         train_samples = get_dataset_samples(dataset, num_samples=4, split="train")
         assert default_samples == train_samples
 
+    def test_zero_quota_split_is_not_loaded(self, monkeypatch, make_toy_hf_dataset):
+        """1 sample over 2 splits → quotas [0, 1]: the zero-quota split is never opened."""
+        datasets = pytest.importorskip("datasets")
+        loaded, real_load_dataset = [], datasets.load_dataset
+
+        def _spy(*args, **kwargs):
+            loaded.append(kwargs.get("split"))
+            return real_load_dataset(*args, **kwargs)
+
+        monkeypatch.setattr(datasets, "load_dataset", _spy)
+        get_dataset_samples(make_toy_hf_dataset(), num_samples=1, split=["train", "test"])
+        assert loaded == ["test"]
+
     def test_download_to_jsonl_then_load(self, tmp_path, make_toy_hf_dataset):
         """Dump the dataset to JSONL, then reload it via the local-jsonl path."""
         dataset = make_toy_hf_dataset()


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

`get_dataset_samples` divides `num_samples` evenly across splits and dumps the remainder on the last one. When `num_samples` is smaller than the split count, most splits get a quota of `0` — but the old code still opened them:

```python
dataset_splits = [_load_split(s) for s in splits]   # all splits, eagerly
for dataset, n in zip(dataset_splits, num_per_split):
    for i, sample in enumerate(dataset):            # starts the iterator even when n == 0
        if i >= n:
            break
```

Merely starting a streamed split's iterator makes `datasets` fetch its first record batch, so a zero-quota split costs a real download and yields nothing.

For the `nemotron-post-training-v3` combo (14 samples over 7 datasets → 2 each) this is **24 split-opens that contribute zero samples**, including 4 splits of `nvidia/Nemotron-Math-v2`, whose parquet shards are ~12.6 GB each. Streaming those means reading a footer at byte ~12.6 GB and then pulling multi-MB row groups, all discarded.

This PR loads splits lazily and skips zero-quota ones. **Sample output is unchanged** — the remainder still lands on the last split, so the same rows are returned.

### Testing

`tests/gpu/torch/utils/test_dataset_utils.py::test_get_dataset_dataloader_nemotron_v3_chat_template` has been timing out on the 120 s `tests/gpu` cap in CI since 2026-07-31 — on `main`'s nightly and on every PR that runs the GPU job ([example](https://github.com/NVIDIA/Model-Optimizer/actions/runs/30657911036/job/91249036652)). The dumped stack shows it blocked in a socket read inside `hf_file_system._fetch_range` while streaming `Nemotron-Math-v2`.

Reproduced locally against the real gated datasets and measured:

| | runtime | result |
|---|---|---|
| before | 120.00 s | **FAIL** — same `Timeout (>120.0s)` as CI |
| after | 25 s | **PASS** |

- `tests/gpu/torch/utils/test_dataset_utils.py` — 7 passed
- `tests/unit/torch/utils/test_dataset_utils.py` — 49 passed

Note the timeout is not a recent code regression: the test ran 50–72 s for weeks, then stepped to >120 s on 2026-07-31 with no ModelOpt commit, dependency change (`datasets` 4.8.5 / `huggingface_hub` 1.14.0 / `hf-xet` 1.5.0 / `pyarrow` 24.0.0 identical across the boundary), or dataset-repo commit to explain it — Hub-side latency on Xet-backed range reads is the likely trigger. The wasted downloads were what left the test with no margin to absorb it; it now has ~4× headroom.

Also rejects negative `num_samples` at the interface boundary ([CodeRabbit](https://github.com/NVIDIA/Model-Optimizer/pull/2043#discussion_r3695434265)) — floor division turned `num_samples=-1` over 3 splits into quotas `[-1, -1, 1]`, silently returning one sample. Pre-existing on `main`, fixed here since it is adjacent to the quota logic.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅ — `test_zero_quota_split_is_not_loaded` in `tests/unit/torch/utils/test_dataset_utils.py` (offline, uses the toy local dataset fixture); the existing `tests/gpu/torch/utils/test_dataset_utils.py` is the test this unblocks
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A — internal perf fix, no API or behavior change
- Did you get Claude approval on this PR?: ❌ — not yet run

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Dataset loading now supports an optional split name.
  * Sample quotas are calculated independently for each split.
  * Negative sample counts are rejected with clear validation.
* **Performance Improvements**
  * Dataset splits load only when needed during sample iteration.
  * Splits with no assigned samples are skipped to avoid unnecessary initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
