### PR TITLE
[NVBug: 6538278] Pass trust_remote_code to the TRT-LLM model load in deploy/eval examples

### DIFF
--- a/examples/hf_ptq/run_tensorrt_llm.py
+++ b/examples/hf_ptq/run_tensorrt_llm.py
@@ -73,6 +73,7 @@ def run(args):
         tokenizer=tokenizer,
         max_batch_size=len(input_texts),
         enable_kv_cache_reuse=False,
+        trust_remote_code=args.trust_remote_code,
     )
     torch.cuda.cudart().cudaProfilerStart()
     outputs = llm.generate_text(input_texts, args.max_output_len)

--- a/examples/hf_ptq/scripts/huggingface_example.sh
+++ b/examples/hf_ptq/scripts/huggingface_example.sh
@@ -314,6 +314,10 @@ if [[ $TASKS =~ "mmlu" ]]; then
         mmlu_flags+=" --limit $MMLU_LIMIT "
     fi
 
+    if $TRUST_REMOTE_CODE; then
+        mmlu_flags+=" --trust_remote_code "
+    fi
+
     python mmlu.py \
         --model_name causal \
         --model_path $MODEL_ABS_PATH \

--- a/examples/llm_eval/lm_eval_tensorrt_llm.py
+++ b/examples/llm_eval/lm_eval_tensorrt_llm.py
@@ -68,6 +68,7 @@ class TRTLLM(TemplateAPI):
             # logits only for the recomputed suffix on shared-prefix requests (e.g. hellaswag),
             # truncating context_logits and breaking parse_logprobs. Disable it.
             enable_kv_cache_reuse=False,
+            trust_remote_code=bool(kwargs.get("trust_remote_code", False)),
         )
         self.max_length = max_length - 1
         logger.info("Loaded TRT-LLM")

--- a/examples/llm_eval/mmlu.py
+++ b/examples/llm_eval/mmlu.py
@@ -284,6 +284,7 @@ def main(
             medusa_choices=medusa_choices,
             max_seq_len=MAX_SEQ_LEN,
             max_batch_size=1,
+            trust_remote_code=kwargs.get("trust_remote_code", False),
         )
     else:
         model = select_model(

--- a/tests/examples/hf_ptq/test_run_tensorrt_llm.py
+++ b/tests/examples/hf_ptq/test_run_tensorrt_llm.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Argument-forwarding tests for ``examples/hf_ptq/run_tensorrt_llm.py``.
+
+``--trust_remote_code`` must reach the model load, not just the tokenizer: checkpoints
+shipping custom modeling code (``auto_map``), e.g. Llama-3.3-Nemotron-Super-49B-v1
+(DeciLM), otherwise fail executor init with "contains custom code which must be executed".
+"""
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+from _test_utils.examples.run_command import MODELOPT_ROOT
+
+_HF_PTQ_DIR = MODELOPT_ROOT / "examples" / "hf_ptq"
+
+
+class _RecordingLLM:
+    """Stands in for the TRT-LLM wrapper, capturing how the script constructs it."""
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        _RecordingLLM.last = self
+
+    def generate_text(self, prompts, max_new_tokens):
+        return ["" for _ in prompts]
+
+    def generate_tokens(self, prompts, max_new_tokens):
+        return [[0] for _ in prompts]
+
+    def generate_context_logits(self, prompts):
+        return [None for _ in prompts]
+
+
+@pytest.fixture
+def run_tensorrt_llm(monkeypatch):
+    """Import the deploy script with its tensorrt_llm-dependent import stubbed out."""
+    stub = ModuleType("modelopt.deploy.llm")
+    stub.LLM = _RecordingLLM
+    monkeypatch.setitem(sys.modules, "modelopt.deploy.llm", stub)
+    monkeypatch.syspath_prepend(str(_HF_PTQ_DIR))
+    monkeypatch.delitem(sys.modules, "run_tensorrt_llm", raising=False)
+
+    import run_tensorrt_llm as module
+
+    # run() reports GPU memory and toggles the profiler around generation; keep it CPU-only.
+    monkeypatch.setattr(module.torch.cuda, "mem_get_info", lambda: (0, 0))
+    monkeypatch.setattr(
+        module.torch.cuda,
+        "cudart",
+        lambda: SimpleNamespace(cudaProfilerStart=lambda: None, cudaProfilerStop=lambda: None),
+    )
+    return module
+
+
+@pytest.mark.parametrize("trust_remote_code", [True, False])
+def test_run_forwards_trust_remote_code(run_tensorrt_llm, monkeypatch, trust_remote_code):
+    tokenizer_kwargs = {}
+    monkeypatch.setattr(
+        run_tensorrt_llm,
+        "get_tokenizer",
+        lambda **kwargs: tokenizer_kwargs.update(kwargs) or object(),
+    )
+
+    run_tensorrt_llm.run(
+        SimpleNamespace(
+            tokenizer="",
+            checkpoint_dir="/fake/checkpoint",
+            max_output_len=8,
+            input_texts="hello|world",
+            trust_remote_code=trust_remote_code,
+        )
+    )
+
+    # The model load, not just the tokenizer, must honor the flag.
+    assert _RecordingLLM.last.kwargs["trust_remote_code"] is trust_remote_code
+    assert tokenizer_kwargs["trust_remote_code"] is trust_remote_code
+    # Context logits are requested below, so KV cache reuse must stay off.
+    assert _RecordingLLM.last.kwargs["enable_kv_cache_reuse"] is False


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fixes [nvbug 6538278](https://nvbugspro.nvidia.com/bug/6538278).

`examples/hf_ptq/run_tensorrt_llm.py` loaded the **tokenizer** with `args.trust_remote_code` but constructed `LLM()` without it, so it defaulted to `False`. Deploying any checkpoint that ships custom modeling code (`auto_map`) — e.g. `Llama-3.3-Nemotron-Super-49B-v1` (DeciLM) — failed at executor init:

```
Failed to initialize executor on rank 0: The repository ... contains custom code which
must be executed to correctly load the model ... Please pass the argument trust_remote_code=True.
-> ValueError -> Executor worker returned error -> run_tensorrt_llm.py subprocess exit 1
```

The `modelopt.deploy.llm.LLM` wrapper already accepts and forwards `trust_remote_code` (`modelopt/deploy/llm/generate.py:153`), and `scripts/huggingface_example.sh` already forwards `--trust_remote_code` to the script — only the call site dropped it.

The same omission exists in the sibling TRT-LLM deploy paths driven by the same launcher and the same checkpoints, so they are fixed together:

| File | Fix |
| --- | --- |
| `examples/hf_ptq/run_tensorrt_llm.py` | the reported bug |
| `examples/llm_eval/lm_eval_tensorrt_llm.py` | `LLM()` ignored the `trust_remote_code` that lm-eval injects into `model_args` |
| `examples/llm_eval/mmlu.py` | `LLM()` ignored it (the tokenizer already used it) |
| `examples/hf_ptq/scripts/huggingface_example.sh` | the `mmlu` stage never forwarded the flag at all |

All four propagate the **user-provided** flag; none hardcode `trust_remote_code=True` (per SECURITY.md).

### Usage

No API change. Existing flag now takes effect on the model load:

```bash
scripts/huggingface_example.sh --model <Llama-3.3-Nemotron-Super-49B-v1> \
    --quant fp8 --tasks quant --trust_remote_code
```

### Testing

- New CPU regression test `tests/examples/hf_ptq/test_run_tensorrt_llm.py` stubs the `tensorrt_llm`-dependent import and asserts both the tokenizer **and** the model load receive the flag, parametrized over `True`/`False`. Confirmed it fails without the fix (`KeyError: 'trust_remote_code'`) and passes with it.
- Verified against the real `fire` package that a bare `--trust_remote_code` maps to `True` in `mmlu.py`'s `**kwargs`, and is absent (defaulting to `False`) when not passed.
- Simulated the launcher's argument assembly both ways: with `TRUST_REMOTE_CODE=false` the emitted commands are byte-identical to before this change.
- `bash -n` on the launcher; full pre-commit clean.
- GPU deploy of the `fp8` DeciLM checkpoint was verified by the bug reporter on GB10 with this one-line change (model loaded, TRT engine built, generation succeeded, deploy exit 0). The `mmlu` / `lm_eval` stages are not GPU-verified here.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A <!-- examples-only bug fix -->
- Did you get Claude approval on this PR?: ❌ <!-- not yet run -->

### Additional Information

nvbug 6538278 / OMNIML-5659. Reported against modelopt 0.46.0rc0 on GB10 / DGX Spark (`tensorrt-llm/release:1.3.0rc22`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added consistent handling of the `trust_remote_code` setting across TensorRT-LLM inference and MMLU evaluation workflows.
  * Ensured tokenizer and model loading receive the configured remote-code behavior.
* **Tests**
  * Added coverage validating remote-code settings and preserving KV-cache behavior when context logits are requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->