### PR TITLE
Add PR review-feedback guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ These instructions apply to AI-assisted work in this repository.
 
 - **Judge each comment on its merits before acting.** Check it against the
   current code — reviewers comment on stale diffs, and bot findings (CodeRabbit,
-  Greptile) are claims to verify, not instructions. Weight CODEOWNERS reviewers
+  Claude) are claims to verify, not instructions. Weight CODEOWNERS reviewers
   above bots; if a reviewer reaffirms after your pushback, that settles it.
 - **Pick one outcome per thread:** address it in a commit, push back citing the
   code that shows the comment is wrong, or postpone it as out of scope. Report

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,17 @@ These instructions apply to AI-assisted work in this repository.
 - Before opening or marking a PR ready for review, read the
   [submitting your code](CONTRIBUTING.md#submitting-your-code) guidance.
 - Read `.github/PULL_REQUEST_TEMPLATE.md` and satisfy the checklist.
+
+## Responding to PR review feedback
+
+- **Judge each comment on its merits before acting.** Check it against the
+  current code — reviewers comment on stale diffs, and bot findings (CodeRabbit,
+  Greptile) are claims to verify, not instructions. Weight CODEOWNERS reviewers
+  above bots; if a reviewer reaffirms after your pushback, that settles it.
+- **Pick one outcome per thread:** address it in a commit, push back citing the
+  code that shows the comment is wrong, or postpone it as out of scope. Report
+  which threads got which when you ask for push approval.
+- **Reply in every thread the pushed commits addressed** — a sentence on what
+  changed and where. Those replies need no extra approval; pushback and postpone
+  replies do, since no commit backs them. Never resolve threads: that is the
+  reviewer's call.


### PR DESCRIPTION
### What does this PR do?

Type of change: documentation

Adds a `## Responding to PR review feedback` section to `AGENTS.md` (which `CLAUDE.md` symlinks to, so it covers both Claude Code and Codex). Today the agent instructions stop at "open the PR" — nothing says what to do with the review comments that come back, so agents either apply every suggestion reflexively (including stale or wrong bot findings) or fix things silently and leave reviewers guessing whether their comment landed.

The new section says to:

- **Triage before acting** — check each comment against the current code; CODEOWNERS reviewers outweigh bot reviewers (CodeRabbit, Claude), whose findings are claims to verify rather than instructions. A reviewer reaffirming after pushback settles it.
- **Pick one outcome per thread** — address in a commit, push back citing the code that shows the comment is wrong, or postpone as out of scope, and report which threads got which when asking for push approval.
- **Reply in the thread after pushing** — a sentence on what changed and where. Those replies ride on the approval to push; pushback and postpone replies need their own approval, since no commit backs them. The agent never resolves threads — that stays the reviewer's call.

### Usage

N/A — agent instructions only, no code change.

### Testing

`pre-commit run --files AGENTS.md` passes (markdownlint included).

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: N/A
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for responding to pull request review feedback.
  * Clarified how to validate comments, prioritize reviewers, report outcomes, and respond to addressed threads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->