### PR TITLE
docs(diffusers): clarify --calib-size is samples/prompts, not steps

### DIFF
--- a/examples/diffusers/quantization/quantize.py
+++ b/examples/diffusers/quantization/quantize.py
@@ -563,7 +563,14 @@ def create_argument_parser() -> argparse.ArgumentParser:
     calib_group = parser.add_argument_group("Calibration Configuration")
     calib_group.add_argument("--batch-size", type=int, default=2, help="Batch size for calibration")
     calib_group.add_argument(
-        "--calib-size", type=int, default=128, help="Total number of calibration samples"
+        "--calib-size",
+        type=int,
+        default=128,
+        help=(
+            "Number of calibration samples/prompts to run (not denoising steps). "
+            "Total prompts used ≈ ceil(calib_size / batch_size) * batch_size. "
+            "For denoising steps, use --n-steps."
+        ),
     )
     calib_group.add_argument("--n-steps", type=int, default=30, help="Number of denoising steps")
     calib_group.add_argument(

--- a/examples/diffusers/quantization/quantize.py
+++ b/examples/diffusers/quantization/quantize.py
@@ -564,12 +564,14 @@ def create_argument_parser() -> argparse.ArgumentParser:
     calib_group.add_argument("--batch-size", type=int, default=2, help="Batch size for calibration")
     calib_group.add_argument(
         "--calib-size",
+        "--calib-samples",
+        dest="calib_size",
         type=int,
         default=128,
         help=(
             "Number of calibration samples/prompts to run (not denoising steps). "
-            "Total prompts used ≈ ceil(calib_size / batch_size) * batch_size. "
-            "For denoising steps, use --n-steps."
+            "Total prompts used ~ ceil(calib_size / batch_size) * batch_size. "
+            "Alias: --calib-samples. For denoising steps, use --n-steps."
         ),
     )
     calib_group.add_argument("--n-steps", type=int, default=30, help="Number of denoising steps")


### PR DESCRIPTION
## Summary
Clarifies `--calib-size` help in `examples/diffusers/quantization/quantize.py` so it is not confused with denoising steps.

## Changes
- Help text: number of calibration samples/prompts
- Notes ceil batching vs `--batch-size`
- Points users to `--n-steps` for denoising steps

Fixes #247

## Test plan
- [ ] `python quantize.py --help` shows the new help string

## Summary by CodeRabbit
* **Documentation**
  * Clarified the `--calib-size` option to explain calibration sample and prompt counts.
  * Documented batch-size rounding behavior.
  * Distinguished calibration size from denoising steps configured with `--n-steps`.

---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `--calib-samples` as an alternative to `--calib-size`.
  * Clarified calibration prompts, sample handling, batch-size rounding, and denoising-step configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->