### PR TITLE
Fix saving pruned Nemotron-3-Nano hybrid_override_pattern with MTP or Pipe symbols

### DIFF
--- a/examples/megatron_bridge/prune_minitron.py
+++ b/examples/megatron_bridge/prune_minitron.py
@@ -659,10 +659,10 @@ def main(args: argparse.Namespace):
                     "training/distillation instead of LM-only to recover vision quality."
                 )
         if isinstance(provider, _HYBRID_PROVIDER_TYPES) and hasattr(
-            hf_cfg, "hybrid_override_pattern"
+            text_cfg, "hybrid_override_pattern"
         ):
             # MCore's pattern can carry an MTP suffix (``/...``) and PP boundaries (``|``) which we need to remove
-            hf_cfg.hybrid_override_pattern = "".join(
+            text_cfg.hybrid_override_pattern = "".join(
                 parse_main_layer_chars(getattr(unwrapped_model, hybrid_key), mcore_cfg.num_layers)
             )
         text_cfg.num_hidden_layers = mcore_cfg.num_layers

--- a/examples/megatron_bridge/prune_minitron.py
+++ b/examples/megatron_bridge/prune_minitron.py
@@ -67,6 +67,7 @@ import modelopt.torch.opt as mto
 import modelopt.torch.prune as mtp
 import modelopt.torch.utils.distributed as dist
 from modelopt.torch.export import copy_hf_ckpt_remote_code
+from modelopt.torch.nas.plugins.megatron_model_stats import parse_main_layer_chars
 from modelopt.torch.utils import (
     get_supported_datasets,
     num2hrb,
@@ -660,7 +661,10 @@ def main(args: argparse.Namespace):
         if isinstance(provider, _HYBRID_PROVIDER_TYPES) and hasattr(
             hf_cfg, "hybrid_override_pattern"
         ):
-            hf_cfg.hybrid_override_pattern = getattr(unwrapped_model, hybrid_key)
+            # MCore's pattern can carry an MTP suffix (``/...``) and PP boundaries (``|``) which we need to remove
+            hf_cfg.hybrid_override_pattern = "".join(
+                parse_main_layer_chars(getattr(unwrapped_model, hybrid_key), mcore_cfg.num_layers)
+            )
         text_cfg.num_hidden_layers = mcore_cfg.num_layers
         # Mark MTP as disabled on the HF text config written after pruning
         for field in _MTP_HF_CONFIG_FIELDS:

--- a/tests/examples/megatron_bridge/test_prune_minitron.py
+++ b/tests/examples/megatron_bridge/test_prune_minitron.py
@@ -40,9 +40,15 @@ from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
         ),
         # NemotronH (nemotron-3-nano): Mamba + attention + MoE hybrid. Saved in Megatron checkpoint
         # format because HF export of a pruned NemotronH requires transformers<5.
+        # MTP heads are enabled so the run covers dropping them during calibration and the
+        # hybrid pattern MCore builds for them.
         pytest.param(
             lambda tmp_path, num_gpus: create_tiny_nemotron_h_dir(
-                tmp_path, with_tokenizer=True, return_model=True
+                tmp_path,
+                with_tokenizer=True,
+                return_model=True,
+                num_nextn_predict_layers=1,
+                mtp_hybrid_override_pattern="*E",
             ),
             True,
             id="nemotron_h",


### PR DESCRIPTION
Saving pruned Nemotron-3-Nano (with MTP) to HF format raised an assertion which is fixed here

Tested on nemo:26.04 with transformers 4.57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exported hybrid layer patterns for pruned models by removing MTP and pipeline-parallel markers.
  * Ensured exported configurations accurately represent the model’s main layers.

* **Tests**
  * Added coverage for pruning models with an MTP prediction layer and hybrid override patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->