### PR TITLE
Pin Accelerate below 1.14 for llm_qat

### DIFF
--- a/examples/llm_qat/requirements.txt
+++ b/examples/llm_qat/requirements.txt
@@ -1,5 +1,5 @@
 # Accelerate 1.14 regresses FSDP2 handling of shared parameters.
-accelerate<1.14
+accelerate>=1.0.0,<1.14
 flash-attn>=2.6.0
 liger-kernel>=0.5.0; platform_system != 'Darwin' and platform_system != 'Windows'
 py7zr

--- a/examples/llm_qat/requirements.txt
+++ b/examples/llm_qat/requirements.txt
@@ -1,3 +1,5 @@
+# Accelerate 1.14 regresses FSDP2 handling of shared parameters.
+accelerate<1.14
 flash-attn>=2.6.0
 liger-kernel>=0.5.0; platform_system != 'Darwin' and platform_system != 'Windows'
 py7zr


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Pins Accelerate below 1.14 for the `llm_qat` example. Accelerate 1.14 introduced an FSDP2 regression for models whose input embeddings and output head share a parameter; the shared weight can be assigned to two FSDP groups and training fails before the first step.

The pin is example-local. The project-wide Hugging Face dependency range and unrelated examples remain unchanged.

### Usage

No usage change. Installing the `llm_qat` requirements now resolves Accelerate to the existing supported range below 1.14.

### Testing

- Reproduced the duplicate shared-parameter FSDP2 failure with Accelerate 1.14.0 on two ranks.
- Verified Accelerate 1.13.0 completes a distillation training step with the otherwise-identical environment and a clean `main` source tree.
- Verified the combined requirements resolve to `accelerate>=1.0.0,<1.14` and select 1.13.0.
- `pre-commit run --files examples/llm_qat/requirements.txt`
- `git diff --check`

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A — dependency-only change validated by an exact two-rank A/B run.
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌ — draft PR; automated review is pending.

### Additional Information

This is a scoped compatibility pin while the upstream Accelerate regression remains unresolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Constrained the Accelerate dependency to versions below 1.14 to improve compatibility for the LLM question-answering example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->