### PR TITLE
Make Puzzletron v2 CI visible and required

### DIFF
--- a/.github/workflows/_pr_gate.yml
+++ b/.github/workflows/_pr_gate.yml
@@ -7,21 +7,36 @@ on:
         description: "Newline-separated list of file patterns to watch for changes"
         required: true
         type: string
+      skip_puzzletron_only:
+        description: "Skip test jobs for Puzzletron-only PRs targeting feature/puzzletron_v2"
+        required: false
+        type: boolean
+        default: false
     outputs:
       any_changed:
         description: "Whether any relevant files changed"
         value: ${{ jobs.check-file-changes.outputs.any_changed }}
+      run_tests:
+        description: "Whether this workflow's test jobs should run"
+        value: ${{ jobs.check-file-changes.outputs.run_tests }}
+      puzzletron_only:
+        description: "Whether all test-relevant changes are Puzzletron-scoped in a Puzzletron v2 feature PR"
+        value: ${{ jobs.check-file-changes.outputs.puzzletron_only }}
 
 jobs:
   check-file-changes:
     runs-on: ubuntu-latest
     outputs:
       any_changed: ${{ steps.changed-tests.outputs.any_changed || steps.non-pr.outputs.any_changed }}
+      run_tests: ${{ steps.scope-pr.outputs.run_tests || steps.non-pr.outputs.any_changed }}
+      puzzletron_only: ${{ steps.scope-pr.outputs.puzzletron_only || steps.non-pr.outputs.puzzletron_only }}
     steps:
       # For non-PR triggers (schedule, workflow_dispatch), always run tests
       - id: non-pr
         if: "!startsWith(github.ref, 'refs/heads/pull-request/')"
-        run: echo "any_changed=true" >> $GITHUB_OUTPUT
+        run: |
+          echo "any_changed=true" >> "$GITHUB_OUTPUT"
+          echo "puzzletron_only=false" >> "$GITHUB_OUTPUT"
       - if: startsWith(github.ref, 'refs/heads/pull-request/')
         uses: actions/checkout@v6
         with:
@@ -37,6 +52,7 @@ jobs:
         run: |
           echo "head_sha=$(echo "$PR_INFO" | jq -r '.head.sha')" >> $GITHUB_OUTPUT
           echo "base_sha=$(echo "$PR_INFO" | jq -r '.base.sha')" >> $GITHUB_OUTPUT
+          echo "base_ref=$(echo "$PR_INFO" | jq -r '.base.ref')" >> $GITHUB_OUTPUT
       # Get commit from main branch that is present in the PR to use as base for changed files
       - if: startsWith(github.ref, 'refs/heads/pull-request/')
         id: calculate-merge-base
@@ -51,11 +67,53 @@ jobs:
           sha: ${{ steps.pr-shas.outputs.head_sha }}
           files: ${{ inputs.files }}
           fail_on_initial_diff_error: true
+      - if: >-
+          startsWith(github.ref, 'refs/heads/pull-request/') &&
+          inputs.skip_puzzletron_only
+        name: Check for non-Puzzletron changes in test-relevant directories
+        id: changed-generic-tests
+        uses: step-security/changed-files@v46.0.5
+        with:
+          base_sha: ${{ steps.calculate-merge-base.outputs.merge-base }}
+          sha: ${{ steps.pr-shas.outputs.head_sha }}
+          files: ${{ inputs.files }}
+          files_ignore: |
+            examples/puzzletron/**
+            modelopt/torch/puzzletron/**
+            puzzletron_orchestrator/**
+            puzzletron_setup/**
+            tests/_test_utils/torch/puzzletron/**
+            tests/gpu/torch/puzzletron/**
+            tests/gpu_vllm/torch/puzzletron/**
+            tests/unit/torch/puzzletron/**
+          fail_on_initial_diff_error: true
+      - if: startsWith(github.ref, 'refs/heads/pull-request/')
+        name: Scope Puzzletron v2 feature PR tests
+        id: scope-pr
+        env:
+          ANY_CHANGED: ${{ steps.changed-tests.outputs.any_changed }}
+          BASE_REF: ${{ steps.pr-shas.outputs.base_ref }}
+          GENERIC_CHANGED: ${{ steps.changed-generic-tests.outputs.any_changed }}
+          SKIP_PUZZLETRON_ONLY: ${{ inputs.skip_puzzletron_only }}
+        run: |
+          run_tests="$ANY_CHANGED"
+          puzzletron_only=false
+
+          if [[ "$SKIP_PUZZLETRON_ONLY" == "true" &&
+                "$BASE_REF" == "feature/puzzletron_v2" &&
+                "$ANY_CHANGED" == "true" &&
+                "$GENERIC_CHANGED" != "true" ]]; then
+            run_tests=false
+            puzzletron_only=true
+          fi
+
+          echo "run_tests=$run_tests" >> "$GITHUB_OUTPUT"
+          echo "puzzletron_only=$puzzletron_only" >> "$GITHUB_OUTPUT"
   wait-checks:
     needs: [check-file-changes]
     if: >-
       startsWith(github.ref, 'refs/heads/pull-request/') &&
-      needs.check-file-changes.outputs.any_changed == 'true'
+      needs.check-file-changes.outputs.run_tests == 'true'
     uses: ./.github/workflows/_wait_for_checks.yml
     permissions:
       checks: read

--- a/.github/workflows/example_tests.yml
+++ b/.github/workflows/example_tests.yml
@@ -22,16 +22,18 @@ jobs:
     secrets: inherit
     with:
       files: |
+        .github/workflows/_pr_gate.yml
         .github/workflows/example_tests.yml
         examples/**
         modelopt/**
         pyproject.toml
         tests/examples/**
+      skip_puzzletron_only: true
 
   ##### PyTorch Example Tests (speculative_decoding requires 26.01 image) #####
   torch:
     needs: [pr-gate]
-    if: needs.pr-gate.outputs.any_changed == 'true'
+    if: needs.pr-gate.outputs.run_tests == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +53,7 @@ jobs:
   ##### TensorRT-LLM Example Tests (pr/non-pr split: non-pr runs extra autodeploy+eval examples) #####
   trtllm-pr:
     needs: [pr-gate]
-    if: startsWith(github.ref, 'refs/heads/pull-request/') && needs.pr-gate.outputs.any_changed == 'true'
+    if: startsWith(github.ref, 'refs/heads/pull-request/') && needs.pr-gate.outputs.run_tests == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -81,7 +83,7 @@ jobs:
   ##### Megatron Example Tests #####
   megatron:
     needs: [pr-gate]
-    if: needs.pr-gate.outputs.any_changed == 'true'
+    if: needs.pr-gate.outputs.run_tests == 'true'
     uses: ./.github/workflows/_example_tests_runner.yml
     secrets: inherit
     with:
@@ -94,7 +96,7 @@ jobs:
   ##### ONNX/TensorRT Example Tests #####
   onnx:
     needs: [pr-gate]
-    if: needs.pr-gate.outputs.any_changed == 'true'
+    if: needs.pr-gate.outputs.run_tests == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -115,10 +117,17 @@ jobs:
     needs: [pr-gate, torch, trtllm-pr, megatron, onnx]
     runs-on: ubuntu-latest
     steps:
+      - name: Report intentionally scoped example tests
+        if: needs.pr-gate.outputs.puzzletron_only == 'true'
+        run: |
+          echo "## Generic example tests were not required" >> "$GITHUB_STEP_SUMMARY"
+          echo >> "$GITHUB_STEP_SUMMARY"
+          echo "This pull request targets \`feature/puzzletron_v2\`, and its test-relevant changes are limited to Puzzletron-scoped paths." >> "$GITHUB_STEP_SUMMARY"
+          echo "The standalone Puzzletron v2 CPU check remains required." >> "$GITHUB_STEP_SUMMARY"
       - name: Required example tests did not succeed
         if: |
           needs.pr-gate.result != 'success' ||
-          (needs.pr-gate.outputs.any_changed == 'true' && (
+          (needs.pr-gate.outputs.run_tests == 'true' && (
             needs.torch.result != 'success' ||
             needs.trtllm-pr.result != 'success' ||
             needs.megatron.result != 'success' ||

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -22,6 +22,7 @@ jobs:
     secrets: inherit
     with:
       files: |
+        .github/workflows/_pr_gate.yml
         .github/workflows/gpu_tests.yml
         modelopt/**
         noxfile.py
@@ -30,10 +31,11 @@ jobs:
         tests/gpu_megatron/**
         tests/gpu_trtllm/**
         tests/gpu_vllm/**
+      skip_puzzletron_only: true
 
   gpu-tests:
     needs: [pr-gate]
-    if: needs.pr-gate.outputs.any_changed == 'true'
+    if: needs.pr-gate.outputs.run_tests == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -94,6 +96,13 @@ jobs:
     needs: [pr-gate, gpu-tests]
     runs-on: ubuntu-latest
     steps:
+      - name: Report intentionally scoped GPU tests
+        if: needs.pr-gate.outputs.puzzletron_only == 'true'
+        run: |
+          echo "## Generic GPU tests were not required" >> "$GITHUB_STEP_SUMMARY"
+          echo >> "$GITHUB_STEP_SUMMARY"
+          echo "This pull request targets \`feature/puzzletron_v2\`, and its test-relevant changes are limited to Puzzletron-scoped paths." >> "$GITHUB_STEP_SUMMARY"
+          echo "Dedicated Puzzletron GPU coverage is tracked separately." >> "$GITHUB_STEP_SUMMARY"
       - name: Required GPU tests did not succeed
-        if: ${{ needs.pr-gate.result != 'success' || (needs.pr-gate.outputs.any_changed == 'true' && needs.gpu-tests.result != 'success') }}
+        if: ${{ needs.pr-gate.result != 'success' || (needs.pr-gate.outputs.run_tests == 'true' && needs.gpu-tests.result != 'success') }}
         run: exit 1

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -169,10 +169,32 @@ jobs:
         with:
           python-version: "3.12"
       - name: Run tests against the pinned Puzzletron runtime
+        id: puzzletron_tests
         env:
           COVERAGE_PROCESS_START: ${{ github.workspace }}/pyproject.toml
           COVERAGE_FILE: ${{ github.workspace }}/.coverage
         run: pip install nox uv && nox -s puzzletron_v2
+      - name: Publish Puzzletron v2 test summary
+        if: ${{ always() }}
+        env:
+          TEST_RESULT: ${{ steps.puzzletron_tests.outcome }}
+        run: |
+          if [[ "$TEST_RESULT" == "success" ]]; then
+            heading="Puzzletron v2 CPU CI passed"
+            detail="All CPU-eligible Puzzletron v2 unit tests passed against the pinned runtime."
+          else
+            heading="Puzzletron v2 CPU CI did not pass"
+            detail="The pinned-runtime Puzzletron v2 unit-test session needs attention."
+          fi
+
+          {
+            echo "## $heading"
+            echo
+            echo "$detail"
+            echo
+            echo "The job also verifies dependency consistency and the exact versions recorded in \`examples/puzzletron/ci_environment.json\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice title=$heading::$detail"
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -181,6 +203,49 @@ jobs:
           fail_ci_if_error: true
           skip_validation: true
           verbose: true
+  puzzletron_v2_pr_required_check:
+    name: Puzzletron v2 CI / required check
+    if: ${{ github.event_name == 'pull_request' && always() }}
+    needs: [check-file-changes, puzzletron_v2]
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish required-check result
+        env:
+          CHANGE_DETECTION_RESULT: ${{ needs.check-file-changes.result }}
+          PUZZLETRON_CHANGED: ${{ needs.check-file-changes.outputs.puzzletron_changed }}
+          PUZZLETRON_TEST_RESULT: ${{ needs.puzzletron_v2.result }}
+        run: |
+          if [[ "$CHANGE_DETECTION_RESULT" != "success" ]]; then
+            heading="Puzzletron v2 CI could not determine applicability"
+            detail="Change detection did not succeed, so this check cannot safely pass."
+            conclusion="failure"
+          elif [[ "$PUZZLETRON_CHANGED" != "true" ]]; then
+            heading="Puzzletron v2 CPU CI was not required"
+            detail="This pull request does not change a Puzzletron v2 CI dependency path."
+            conclusion="success"
+          elif [[ "$PUZZLETRON_TEST_RESULT" == "success" ]]; then
+            heading="Puzzletron v2 CPU CI passed"
+            detail="All CPU-eligible Puzzletron v2 tests passed against the pinned runtime."
+            conclusion="success"
+          else
+            heading="Puzzletron v2 CPU CI failed"
+            detail="The dedicated pinned-runtime job concluded with: $PUZZLETRON_TEST_RESULT."
+            conclusion="failure"
+          fi
+
+          {
+            echo "## $heading"
+            echo
+            echo "$detail"
+            echo
+            echo "This stable aggregate is suitable for branch rules that require Puzzletron v2 CPU validation."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice title=$heading::$detail"
+
+          if [[ "$conclusion" == "failure" ]]; then
+            exit 1
+          fi
   launcher:
     if: needs.check-file-changes.outputs.any_changed == 'true'
     needs: [linux, check-file-changes]
@@ -218,7 +283,7 @@ jobs:
   unit-pr-required-check:
     # Run even if some jobs are skipped
     if: ${{ github.event_name == 'pull_request' && always() }}
-    needs: [check-file-changes, linux, windows, multi-version, partial-install, puzzletron_v2, launcher, skills]
+    needs: [check-file-changes, linux, windows, multi-version, partial-install, puzzletron_v2_pr_required_check, launcher, skills]
     runs-on: ubuntu-latest
     steps:
       - name: Required unit tests did not succeed
@@ -230,6 +295,5 @@ jobs:
             needs.partial-install.result != 'success' ||
             needs.launcher.result != 'success' ||
             needs.skills.result != 'success'
-          )) || (needs.check-file-changes.outputs.puzzletron_changed == 'true' &&
-            needs.puzzletron_v2.result != 'success') }}
+          )) || needs.puzzletron_v2_pr_required_check.result != 'success' }}
         run: exit 1

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,9 +7,12 @@ on:
     branches: [main, release/*, feature/*]
     paths:
       - ".github/workflows/unit_tests.yml"
+      - "examples/puzzletron/**"
       - "modelopt/**"
       - "noxfile.py"
       - "pyproject.toml"
+      - "puzzletron_orchestrator/**"
+      - "puzzletron_setup/**"
       - "tests/unit/**"
       - "tools/launcher/**"
       - ".agents/skills/**"
@@ -38,11 +41,22 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       any_changed: ${{ steps.changed.outputs.any_changed || steps.non-pr.outputs.any_changed }}
-      puzzletron_changed: ${{ steps.puzzletron_changed.outputs.any_changed || steps.non-pr.outputs.any_changed }}
+      puzzletron_changed: >-
+        ${{ steps.puzzletron_base.outputs.any_changed ||
+          steps.puzzletron_changed.outputs.any_changed ||
+          steps.puzzletron_non_pr.outputs.any_changed }}
     steps:
       - id: non-pr
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        run: echo "any_changed=true" >> $GITHUB_OUTPUT
+        if: github.event_name != 'pull_request'
+        run: echo "any_changed=true" >> "$GITHUB_OUTPUT"
+      - id: puzzletron_non_pr
+        if: >-
+          github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'push' && github.ref == 'refs/heads/feature/puzzletron_v2')
+        run: echo "any_changed=true" >> "$GITHUB_OUTPUT"
+      - id: puzzletron_base
+        if: github.event_name == 'pull_request' && github.base_ref == 'feature/puzzletron_v2'
+        run: echo "any_changed=true" >> "$GITHUB_OUTPUT"
       - if: github.event_name == 'pull_request'
         uses: actions/checkout@v6
         with:
@@ -79,6 +93,103 @@ jobs:
             puzzletron_orchestrator/**
             puzzletron_setup/**
             tests/unit/torch/puzzletron/**
+  puzzletron_v2:
+    name: Puzzletron v2 CPU tests
+    if: needs.check-file-changes.outputs.puzzletron_changed == 'true'
+    needs: [check-dco, check-file-changes]
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/ubuntu-setup
+        with:
+          python-version: "3.12"
+      - name: Run the dedicated Puzzletron v2 CPU suite
+        id: puzzletron_tests
+        env:
+          COVERAGE_PROCESS_START: ${{ github.workspace }}/pyproject.toml
+          COVERAGE_FILE: ${{ github.workspace }}/.coverage
+        run: pip install nox uv && nox -s puzzletron_v2
+      - name: Publish Puzzletron v2 test summary
+        if: ${{ always() }}
+        env:
+          TEST_RESULT: ${{ steps.puzzletron_tests.outcome }}
+        run: |
+          if [[ "$TEST_RESULT" == "success" ]]; then
+            heading="Puzzletron v2 CPU CI passed"
+            detail="The dedicated tests/unit/torch/puzzletron suite passed against the pinned runtime."
+          else
+            heading="Puzzletron v2 CPU CI did not pass"
+            detail="The dedicated tests/unit/torch/puzzletron session needs attention."
+          fi
+
+          {
+            echo "## $heading"
+            echo
+            echo "$detail"
+            echo
+            echo "This lane runs only \`tests/unit/torch/puzzletron\`; the regular unit matrix continues to run all other \`tests/unit\` tests."
+            echo
+            echo "The job also verifies dependency consistency and the exact versions recorded in \`examples/puzzletron/ci_environment.json\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice title=$heading::$detail"
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: puzzletron
+          fail_ci_if_error: true
+          skip_validation: true
+          verbose: true
+  puzzletron_v2_pr_required_check:
+    name: Puzzletron v2 CI / required check
+    if: ${{ github.event_name == 'pull_request' && always() }}
+    needs: [check-file-changes, puzzletron_v2]
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish required-check result
+        env:
+          CHANGE_DETECTION_RESULT: ${{ needs.check-file-changes.result }}
+          PUZZLETRON_CHANGED: ${{ needs.check-file-changes.outputs.puzzletron_changed }}
+          PUZZLETRON_TEST_RESULT: ${{ needs.puzzletron_v2.result }}
+        run: |
+          if [[ "$CHANGE_DETECTION_RESULT" != "success" ]]; then
+            heading="Puzzletron v2 CI could not determine applicability"
+            detail="Change detection did not succeed, so this check cannot safely pass."
+            conclusion="failure"
+          elif [[ "$PUZZLETRON_CHANGED" != "true" ]]; then
+            heading="Puzzletron v2 CPU CI was not required"
+            detail="This pull request neither targets feature/puzzletron_v2 nor changes a Puzzletron v2 CI dependency path."
+            conclusion="success"
+          elif [[ "$PUZZLETRON_TEST_RESULT" == "success" ]]; then
+            heading="Puzzletron v2 CPU CI passed"
+            detail="The dedicated tests/unit/torch/puzzletron suite passed against the pinned runtime."
+            conclusion="success"
+          else
+            heading="Puzzletron v2 CPU CI failed"
+            detail="The dedicated tests/unit/torch/puzzletron job concluded with: $PUZZLETRON_TEST_RESULT."
+            conclusion="failure"
+          fi
+
+          {
+            echo "## $heading"
+            echo
+            echo "$detail"
+            echo
+            echo "This stable check runs the dedicated Puzzletron v2 suite for every pull request into \`feature/puzzletron_v2\`; other branches retain path-aware applicability."
+            echo "The regular unit matrix continues to cover all other unit tests."
+            echo "The existing unit aggregate also observes this lane until branch protection explicitly adopts this standalone check."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::notice title=$heading::$detail"
+
+          if [[ "$conclusion" == "failure" ]]; then
+            exit 1
+          fi
   linux:
     needs: [check-dco]
     runs-on: ubuntu-latest
@@ -153,99 +264,6 @@ jobs:
       - uses: ./.github/actions/ubuntu-setup
       - name: Run unit tests
         run: pip install nox uv && nox -s "partial_unit(subset='${{ matrix.test-env }}')"
-  puzzletron_v2:
-    name: Puzzletron v2 CPU tests
-    if: needs.check-file-changes.outputs.puzzletron_changed == 'true'
-    needs: [check-dco, check-file-changes]
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/ubuntu-setup
-        with:
-          python-version: "3.12"
-      - name: Run tests against the pinned Puzzletron runtime
-        id: puzzletron_tests
-        env:
-          COVERAGE_PROCESS_START: ${{ github.workspace }}/pyproject.toml
-          COVERAGE_FILE: ${{ github.workspace }}/.coverage
-        run: pip install nox uv && nox -s puzzletron_v2
-      - name: Publish Puzzletron v2 test summary
-        if: ${{ always() }}
-        env:
-          TEST_RESULT: ${{ steps.puzzletron_tests.outcome }}
-        run: |
-          if [[ "$TEST_RESULT" == "success" ]]; then
-            heading="Puzzletron v2 CPU CI passed"
-            detail="All CPU-eligible Puzzletron v2 unit tests passed against the pinned runtime."
-          else
-            heading="Puzzletron v2 CPU CI did not pass"
-            detail="The pinned-runtime Puzzletron v2 unit-test session needs attention."
-          fi
-
-          {
-            echo "## $heading"
-            echo
-            echo "$detail"
-            echo
-            echo "The job also verifies dependency consistency and the exact versions recorded in \`examples/puzzletron/ci_environment.json\`."
-          } >> "$GITHUB_STEP_SUMMARY"
-          echo "::notice title=$heading::$detail"
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: puzzletron
-          fail_ci_if_error: true
-          skip_validation: true
-          verbose: true
-  puzzletron_v2_pr_required_check:
-    name: Puzzletron v2 CI / required check
-    if: ${{ github.event_name == 'pull_request' && always() }}
-    needs: [check-file-changes, puzzletron_v2]
-    permissions: {}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Publish required-check result
-        env:
-          CHANGE_DETECTION_RESULT: ${{ needs.check-file-changes.result }}
-          PUZZLETRON_CHANGED: ${{ needs.check-file-changes.outputs.puzzletron_changed }}
-          PUZZLETRON_TEST_RESULT: ${{ needs.puzzletron_v2.result }}
-        run: |
-          if [[ "$CHANGE_DETECTION_RESULT" != "success" ]]; then
-            heading="Puzzletron v2 CI could not determine applicability"
-            detail="Change detection did not succeed, so this check cannot safely pass."
-            conclusion="failure"
-          elif [[ "$PUZZLETRON_CHANGED" != "true" ]]; then
-            heading="Puzzletron v2 CPU CI was not required"
-            detail="This pull request does not change a Puzzletron v2 CI dependency path."
-            conclusion="success"
-          elif [[ "$PUZZLETRON_TEST_RESULT" == "success" ]]; then
-            heading="Puzzletron v2 CPU CI passed"
-            detail="All CPU-eligible Puzzletron v2 tests passed against the pinned runtime."
-            conclusion="success"
-          else
-            heading="Puzzletron v2 CPU CI failed"
-            detail="The dedicated pinned-runtime job concluded with: $PUZZLETRON_TEST_RESULT."
-            conclusion="failure"
-          fi
-
-          {
-            echo "## $heading"
-            echo
-            echo "$detail"
-            echo
-            echo "This stable aggregate is suitable for branch rules that require Puzzletron v2 CPU validation."
-          } >> "$GITHUB_STEP_SUMMARY"
-          echo "::notice title=$heading::$detail"
-
-          if [[ "$conclusion" == "failure" ]]; then
-            exit 1
-          fi
   launcher:
     if: needs.check-file-changes.outputs.any_changed == 'true'
     needs: [linux, check-file-changes]
@@ -283,7 +301,7 @@ jobs:
   unit-pr-required-check:
     # Run even if some jobs are skipped
     if: ${{ github.event_name == 'pull_request' && always() }}
-    needs: [check-file-changes, linux, windows, multi-version, partial-install, puzzletron_v2_pr_required_check, launcher, skills]
+    needs: [check-file-changes, linux, windows, multi-version, partial-install, puzzletron_v2, launcher, skills]
     runs-on: ubuntu-latest
     steps:
       - name: Required unit tests did not succeed
@@ -295,5 +313,6 @@ jobs:
             needs.partial-install.result != 'success' ||
             needs.launcher.result != 'success' ||
             needs.skills.result != 'success'
-          )) || needs.puzzletron_v2_pr_required_check.result != 'success' }}
+          )) || (needs.check-file-changes.outputs.puzzletron_changed == 'true' &&
+            needs.puzzletron_v2.result != 'success') }}
         run: exit 1


### PR DESCRIPTION
### What does this PR do?

Type of change: new tests

Puzzletron v2 pull requests need a stable, visible CPU signal without forcing unrelated generic suites to run for Puzzletron-only changes. This PR:

- runs the dedicated Puzzletron v2 CPU suite for every pull request targeting `feature/puzzletron_v2` and for Puzzletron-relevant changes on other targets;
- adds a stable required-check job that reports whether the suite applies and propagates its result;
- publishes clear workflow summaries for passed, failed, and intentionally scoped checks; and
- lets the generic example and GPU workflows skip Puzzletron-only changes targeting `feature/puzzletron_v2` while keeping their aggregate checks conclusive.

Other target branches retain their existing path-based CI applicability. The existing unit-test aggregate observes the new Puzzletron lane until branch protection adopts the standalone check. Dedicated Puzzletron GPU coverage and branch-protection configuration are outside this PR.

### Testing

GitHub Actions will exercise the dedicated Puzzletron v2 CPU lane, the required-check aggregation, and the generic example and GPU routing changed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added targeted test handling for Puzzletron-only changes.
  * Added clear required-check summaries when tests are intentionally skipped or required.
  * Added dedicated CPU test reporting with coverage uploads.
* **Bug Fixes**
  * Improved test gating for pull requests and non-pull-request events.
  * Ensured GPU, example, and unit tests run only when relevant changes require them.
  * Expanded change detection to include workflow and Puzzletron-related updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->