### PR TITLE
[6562078]: fix calibration for vLLM 0.26.0

### DIFF
--- a/examples/vllm_serve/Dockerfile
+++ b/examples/vllm_serve/Dockerfile
@@ -28,8 +28,10 @@ RUN pip install flash-attn==2.7.4.post1 --no-build-isolation
 # Pre-compile CUDA extensions to avoid compilation time during runtime
 RUN python3 -c "import modelopt.torch.quantization.extensions as ext; ext.precompile()" || true
 
-# Allow users to run without root
+# Allow the non-root vllm user to access the workspace
 RUN chmod -R 777 /workspace
+
+USER vllm
 
 # Override the ENTRYPOINT from the base image to allow flexible usage
 ENTRYPOINT []

--- a/examples/vllm_serve/Dockerfile
+++ b/examples/vllm_serve/Dockerfile
@@ -1,4 +1,4 @@
-FROM vllm/vllm-openai:v0.20.0
+FROM vllm/vllm-openai:v0.26.0
 
 # Set environment variables
 ENV PIP_NO_CACHE_DIR=off \

--- a/examples/vllm_serve/README.md
+++ b/examples/vllm_serve/README.md
@@ -7,8 +7,8 @@ Compared with realquant, fakequant is 2-5x slower, but doesn't require dedicated
 The general fakequant example is tested with vLLM 0.9.0, 0.19.1, and 0.26.0. The compact
 NVFP4 attention worker documented below requires vLLM 0.15.0 or newer.
 
-> **Note:** When using KV cache quantization (`KV_QUANT_CFG`), NaN errors during calibration can
-> occur. If you encounter this, try reducing `--max-num-batched-tokens` or increasing tensor parallelism.
+> **Note:** On some models with hybrid Mamba+Attention layers (e.g. NemotronH) NaN errors may occur
+> during calibration at low tensor parallelism. Set `CLAMP_MAMBA_NAN=1` to enable a workaround.
 
 ## Prepare environment
 
@@ -33,6 +33,7 @@ You can either edit the `quant_config` dictionary in `vllm_serve_fakequant.py`, 
 | MODELOPT_STATE_PATH | Optional path to exported `vllm_fq_modelopt_state.pth` (restores quantizer state and parameters) | None |
 | CALIB_BATCH_SIZE | Calibration batch size                           | 1                  |
 | RECIPE_PATH      | Optional path to a ModelOpt PTQ recipe YAML  | None |
+| CLAMP_MAMBA_NAN  | Clamp NaN in MambaMixer2 layers during calibration (for hybrid Mamba+Attention models) | 0 |
 
 Set these variables in your shell or Docker environment as needed to customize calibration.
 

--- a/examples/vllm_serve/README.md
+++ b/examples/vllm_serve/README.md
@@ -4,8 +4,11 @@ This is a simple example to demonstrate calibrating and serving ModelOpt fakequa
 
 Compared with realquant, fakequant is 2-5x slower, but doesn't require dedicated kernel support and facilitates research.
 
-The general fakequant example is tested with vLLM 0.9.0 and 0.19.1. The compact
+The general fakequant example is tested with vLLM 0.9.0, 0.19.1, and 0.26.0. The compact
 NVFP4 attention worker documented below requires vLLM 0.15.0 or newer.
+
+> **Note:** When using KV cache quantization (`KV_QUANT_CFG`), NaN errors during calibration can
+> occur. If you encounter this, try reducing `--max-num-batched-tokens` or increasing tensor parallelism.
 
 ## Prepare environment
 

--- a/examples/vllm_serve/fakequant_worker.py
+++ b/examples/vllm_serve/fakequant_worker.py
@@ -131,8 +131,7 @@ def _fakequant_run_prolog_worker(self) -> None:
         except AssertionError as e:
             if "nan" in str(e).lower() and "amax" in str(e).lower():
                 print_rank_0(
-                    "NaN detected in calibration amax. "
-                    "Try reducing --max-num-batched-tokens (e.g. to 2048)."
+                    "NaN detected in calibration amax. Try reducing --max-num-batched-tokens."
                 )
             raise
 

--- a/examples/vllm_serve/fakequant_worker.py
+++ b/examples/vllm_serve/fakequant_worker.py
@@ -124,10 +124,17 @@ def _fakequant_run_prolog_worker(self) -> None:
         calibrate_loop = calibrate_fun(calib_dataloader, self)
 
         quant_cfg = get_quant_config(quant_config, model)
-
-        with disable_compilation(model):
-            print("Quantizing model...")
-            mtq.quantize(model, quant_cfg, forward_loop=calibrate_loop)
+        try:
+            with disable_compilation(model):
+                print("Quantizing model...")
+                mtq.quantize(model, quant_cfg, forward_loop=calibrate_loop)
+        except Exception as e:
+            if "nan" in str(e).lower():
+                print(
+                    f"NaN detected during quantization: {e}\n"
+                    f"Consider downgrading vLLM version or reduce --max-num-batched-tokens to 2048"
+                )
+            raise
 
         quantizer_file_path = quant_config["quant_file_path"]
         if quantizer_file_path:

--- a/examples/vllm_serve/fakequant_worker.py
+++ b/examples/vllm_serve/fakequant_worker.py
@@ -36,7 +36,7 @@ from modelopt.torch.quantization.plugins.vllm import (
     disable_compilation,
     post_restore_vllm_parallel_linears,
 )
-from modelopt.torch.utils import print_rank_0, safe_load
+from modelopt.torch.utils import safe_load
 from modelopt.torch.utils.dataset_utils import get_dataset_dataloader
 
 quant_config: dict[str, Any] = {
@@ -48,6 +48,7 @@ quant_config: dict[str, Any] = {
     "modelopt_state_path": os.environ.get("MODELOPT_STATE_PATH", None),
     "calib_batch_size": int(os.environ.get("CALIB_BATCH_SIZE", 1)),
     "recipe_path": os.environ.get("RECIPE_PATH", None),
+    "clamp_mamba_nan": os.environ.get("CLAMP_MAMBA_NAN", "0") == "1",
 }
 
 
@@ -121,19 +122,14 @@ def _fakequant_run_prolog_worker(self) -> None:
             device=self.device,
         )
 
-        calibrate_loop = calibrate_fun(calib_dataloader, self)
+        calibrate_loop = calibrate_fun(
+            calib_dataloader, self, clamp_mamba_nan=quant_config["clamp_mamba_nan"]
+        )
 
         quant_cfg = get_quant_config(quant_config, model)
-        try:
-            with disable_compilation(model):
-                print("Quantizing model...")
-                mtq.quantize(model, quant_cfg, forward_loop=calibrate_loop)
-        except AssertionError as e:
-            if "nan" in str(e).lower() and "amax" in str(e).lower():
-                print_rank_0(
-                    "NaN detected in calibration amax. Try reducing --max-num-batched-tokens."
-                )
-            raise
+        with disable_compilation(model):
+            print("Quantizing model...")
+            mtq.quantize(model, quant_cfg, forward_loop=calibrate_loop)
 
         quantizer_file_path = quant_config["quant_file_path"]
         if quantizer_file_path:

--- a/examples/vllm_serve/fakequant_worker.py
+++ b/examples/vllm_serve/fakequant_worker.py
@@ -36,7 +36,7 @@ from modelopt.torch.quantization.plugins.vllm import (
     disable_compilation,
     post_restore_vllm_parallel_linears,
 )
-from modelopt.torch.utils import safe_load
+from modelopt.torch.utils import print_rank_0, safe_load
 from modelopt.torch.utils.dataset_utils import get_dataset_dataloader
 
 quant_config: dict[str, Any] = {
@@ -128,11 +128,11 @@ def _fakequant_run_prolog_worker(self) -> None:
             with disable_compilation(model):
                 print("Quantizing model...")
                 mtq.quantize(model, quant_cfg, forward_loop=calibrate_loop)
-        except Exception as e:
-            if "nan" in str(e).lower():
-                print(
-                    f"NaN detected during quantization: {e}\n"
-                    f"Consider downgrading vLLM version or reduce --max-num-batched-tokens to 2048"
+        except AssertionError as e:
+            if "nan" in str(e).lower() and "amax" in str(e).lower():
+                print_rank_0(
+                    "NaN detected in calibration amax. "
+                    "Try reducing --max-num-batched-tokens (e.g. to 2048)."
                 )
             raise
 

--- a/examples/vllm_serve/vllm_ptq_utils.py
+++ b/examples/vllm_serve/vllm_ptq_utils.py
@@ -66,6 +66,7 @@ def calibrate_fun(calib_dataloader: DataLoader, self: Any) -> Callable[[Any], No
                     NewRequestData,
                     req_id=req_id,
                     prompt_token_ids=input_ids_list,
+                    prefill_token_ids=input_ids_list,
                     mm_kwargs=[],
                     mm_hashes=[],
                     mm_positions=[],
@@ -99,6 +100,26 @@ def calibrate_fun(calib_dataloader: DataLoader, self: Any) -> Callable[[Any], No
             if hasattr(self, "sample_tokens"):
                 if output is None:  # TODO: make this default when vllm <= 0.11 is outdated
                     self.sample_tokens(None)
+
+            # finish_requests runs before add_requests inside execute_model, so
+            # req IDs aren't registered yet at that point — call it directly after.
+            if hasattr(self.model_runner, "finish_requests"):
+                cleanup_output = _create_new_data_cls(
+                    SchedulerOutput,
+                    scheduled_new_reqs=[],
+                    scheduled_cached_reqs=CachedRequestData.make_empty(),
+                    num_scheduled_tokens={},
+                    total_num_scheduled_tokens=0,
+                    scheduled_spec_decode_tokens={},
+                    scheduled_encoder_inputs={},
+                    num_common_prefix_blocks=[0] * num_groups,
+                    finished_req_ids=set(num_scheduled_tokens.keys()),
+                    free_encoder_mm_hashes=[],
+                    kv_connector_metadata=None,
+                    structured_output_request_ids={},
+                    grammar_bitmask=None,
+                )
+                self.model_runner.finish_requests(cleanup_output)
 
     return calibrate_loop
 

--- a/examples/vllm_serve/vllm_ptq_utils.py
+++ b/examples/vllm_serve/vllm_ptq_utils.py
@@ -105,19 +105,23 @@ def calibrate_fun(calib_dataloader: DataLoader, self: Any) -> Callable[[Any], No
             finally:
                 # finish_requests runs before add_requests inside execute_model, so
                 # req IDs aren't registered yet at that point — call it directly after.
-                if hasattr(self.model_runner, "finish_requests"):
-                    cleanup_output = dataclasses.replace(
-                        scheduler_output,
-                        scheduled_new_reqs=[],
-                        num_scheduled_tokens={},
-                        total_num_scheduled_tokens=0,
-                        finished_req_ids=set(num_scheduled_tokens.keys()),
-                    )
-                    self.model_runner.finish_requests(cleanup_output)
-                else:
-                    warnings.warn(
-                        "model_runner.finish_requests not found; request state may leak during calibration."
-                    )
+                # Wrap in try/except so a cleanup error never masks the original exception.
+                try:
+                    if hasattr(self.model_runner, "finish_requests"):
+                        cleanup_output = dataclasses.replace(
+                            scheduler_output,
+                            scheduled_new_reqs=[],
+                            num_scheduled_tokens={},
+                            total_num_scheduled_tokens=0,
+                            finished_req_ids=set(num_scheduled_tokens.keys()),
+                        )
+                        self.model_runner.finish_requests(cleanup_output)
+                    else:
+                        warnings.warn(
+                            "model_runner.finish_requests not found; request state may leak during calibration."
+                        )
+                except Exception as cleanup_err:
+                    warnings.warn(f"Failed to clean up request state: {cleanup_err}")
 
     return calibrate_loop
 

--- a/examples/vllm_serve/vllm_ptq_utils.py
+++ b/examples/vllm_serve/vllm_ptq_utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import dataclasses
+import warnings
 from collections.abc import Callable
 from typing import Any
 
@@ -96,30 +97,27 @@ def calibrate_fun(calib_dataloader: DataLoader, self: Any) -> Callable[[Any], No
                 structured_output_request_ids={},
                 grammar_bitmask=None,
             )
-            output = self.execute_model(scheduler_output)
-            if hasattr(self, "sample_tokens"):
-                if output is None:  # TODO: make this default when vllm <= 0.11 is outdated
-                    self.sample_tokens(None)
-
-            # finish_requests runs before add_requests inside execute_model, so
-            # req IDs aren't registered yet at that point — call it directly after.
-            if hasattr(self.model_runner, "finish_requests"):
-                cleanup_output = _create_new_data_cls(
-                    SchedulerOutput,
-                    scheduled_new_reqs=[],
-                    scheduled_cached_reqs=CachedRequestData.make_empty(),
-                    num_scheduled_tokens={},
-                    total_num_scheduled_tokens=0,
-                    scheduled_spec_decode_tokens={},
-                    scheduled_encoder_inputs={},
-                    num_common_prefix_blocks=[0] * num_groups,
-                    finished_req_ids=set(num_scheduled_tokens.keys()),
-                    free_encoder_mm_hashes=[],
-                    kv_connector_metadata=None,
-                    structured_output_request_ids={},
-                    grammar_bitmask=None,
-                )
-                self.model_runner.finish_requests(cleanup_output)
+            try:
+                output = self.execute_model(scheduler_output)
+                if hasattr(self, "sample_tokens"):
+                    if output is None:  # TODO: make this default when vllm <= 0.11 is outdated
+                        self.sample_tokens(None)
+            finally:
+                # finish_requests runs before add_requests inside execute_model, so
+                # req IDs aren't registered yet at that point — call it directly after.
+                if hasattr(self.model_runner, "finish_requests"):
+                    cleanup_output = dataclasses.replace(
+                        scheduler_output,
+                        scheduled_new_reqs=[],
+                        num_scheduled_tokens={},
+                        total_num_scheduled_tokens=0,
+                        finished_req_ids=set(num_scheduled_tokens.keys()),
+                    )
+                    self.model_runner.finish_requests(cleanup_output)
+                else:
+                    warnings.warn(
+                        "model_runner.finish_requests not found; request state may leak during calibration."
+                    )
 
     return calibrate_loop
 

--- a/examples/vllm_serve/vllm_ptq_utils.py
+++ b/examples/vllm_serve/vllm_ptq_utils.py
@@ -36,7 +36,45 @@ def _create_new_data_cls(data_cls, **kwargs):
     return data_cls(**filtered_kwargs)
 
 
-def calibrate_fun(calib_dataloader: DataLoader, self: Any) -> Callable[[Any], None]:
+def _patch_mamba_mixer2(model: Any) -> None:
+    """Clamp NaN in MambaMixer2 and causal_conv1d_fn for hybrid Mamba+Attention models.
+
+    Enable via CLAMP_MAMBA_NAN=1 when calibration produces NaN on models with
+    MambaMixer2 layers (e.g. NemotronH at low TP).
+    """
+    mamba_cls = next(
+        (type(m) for _, m in model.named_modules() if "MambaMixer2" in type(m).__name__),
+        None,
+    )
+    if mamba_cls is None:
+        return
+
+    class PatchedMambaMixer2(mamba_cls):  # type: ignore[misc,valid-type]
+        def forward(self, *args, **kwargs):
+            return torch.nan_to_num(super().forward(*args, **kwargs), nan=0.0)
+
+    for _, parent in model.named_modules():
+        for _, child in list(parent.named_children()):
+            if type(child) is mamba_cls:
+                child.__class__ = PatchedMambaMixer2
+
+    try:
+        import vllm.model_executor.layers.mamba.mamba_mixer2 as _mm2
+
+        _orig_conv = _mm2.causal_conv1d_fn
+        _mm2.causal_conv1d_fn = lambda x, w, b=None, *a, **kw: torch.nan_to_num(
+            _orig_conv(x, w, b, *a, **kw), nan=0.0
+        )
+    except Exception as e:
+        warnings.warn(f"causal_conv1d_fn patch failed: {e}")
+
+
+def calibrate_fun(
+    calib_dataloader: DataLoader, self: Any, clamp_mamba_nan: bool = False
+) -> Callable[[Any], None]:
+    if clamp_mamba_nan:
+        _patch_mamba_mixer2(self.model_runner.model)
+
     def calibrate_loop(model: Any) -> None:
         for batch_idx, batch in tqdm(enumerate(calib_dataloader)):
             input_ids_batch = batch["input_ids"]
@@ -56,7 +94,7 @@ def calibrate_fun(calib_dataloader: DataLoader, self: Any) -> Callable[[Any], No
                     input_ids_list_batch = [input_ids_list_batch]
 
             num_groups = len(self.model_runner.kv_cache_config.kv_cache_groups)
-            empty_block_ids = tuple([] for _ in range(num_groups))
+            calib_block_ids = tuple([batch_idx] for _ in range(num_groups))
 
             scheduled_new_reqs = []
             num_scheduled_tokens = {}
@@ -74,7 +112,7 @@ def calibrate_fun(calib_dataloader: DataLoader, self: Any) -> Callable[[Any], No
                     mm_features=[],
                     sampling_params=SamplingParams(max_tokens=1),
                     pooling_params=None,
-                    block_ids=empty_block_ids,
+                    block_ids=calib_block_ids,
                     num_computed_tokens=0,
                     lora_request=None,
                 )
@@ -91,7 +129,7 @@ def calibrate_fun(calib_dataloader: DataLoader, self: Any) -> Callable[[Any], No
                 scheduled_spec_decode_tokens={},
                 scheduled_encoder_inputs={},
                 num_common_prefix_blocks=[0] * num_groups,
-                finished_req_ids=set(),
+                finished_req_ids=set(num_scheduled_tokens),
                 free_encoder_mm_hashes=[],
                 kv_connector_metadata=None,
                 structured_output_request_ids={},

--- a/examples/vllm_serve/vllm_serve_fakequant.py
+++ b/examples/vllm_serve/vllm_serve_fakequant.py
@@ -78,6 +78,7 @@ additional_env_vars = {
     "CALIB_BATCH_SIZE",
     "RECIPE_PATH",
     "TRUST_REMOTE_CODE",
+    "CLAMP_MAMBA_NAN",
 }
 
 try:


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Fixes calibration failures when running fake-quantization with vLLM 0.26.0.

**Core vLLM 0.26.0 API fixes:**

1. **`finish_requests` must be called explicitly after `add_requests`.**
   In vLLM 0.26.0 the scheduler calls `finish_requests` *before* `add_requests`
   inside `execute_model`, so request IDs are not registered yet and cleanup
   never runs. The calibration loop now calls `finish_requests` directly after
   each batch using `dataclasses.replace`. Wrapped in `try/finally` with an inner
   `try/except` so it always runs and never masks the original exception.

2. **`NewRequestData` gained a `prefill_token_ids` field.**
   vLLM 0.26.0 added this required argument; the calibration helper now passes it.

**NaN workaround for hybrid Mamba+Attention models (e.g. NemotronH):**

On some hybrid Mamba+Attention models, `causal_conv1d_fn` (a fused BF16 Triton
kernel) produces NaN during calibration at low tensor parallelism despite valid
inputs. Root cause is undiagnosed in the kernel itself. A temporary workaround
is available via `CLAMP_MAMBA_NAN=1` which patches `MambaMixer2` and
`causal_conv1d_fn` to clamp NaN outputs to 0 during calibration.

**Additional improvements:**
- `else: warnings.warn(...)` when `finish_requests` is absent — silent no-op becomes a warning.
- Dockerfile updated to vLLM 0.26.0 with `USER vllm` (non-root).
- README updated with vLLM 0.26.0 support, `CLAMP_MAMBA_NAN` env var, and NaN note.
- `CLAMP_MAMBA_NAN` added to `additional_env_vars` for Ray/multinode propagation.

### Usage

```bash
cd examples/vllm_serve
QUANT_CFG=FP8_DEFAULT_CFG QUANT_CALIB_SIZE=8 CALIB_BATCH_SIZE=1 \
  python vllm_serve_fakequant.py Qwen/Qwen1.5-MoE-A2.7B-Chat -tp 1 \
  --host 0.0.0.0 --port 8000
```

For models with hybrid Mamba+Attention layers that produce NaN during calibration:

```bash
CLAMP_MAMBA_NAN=1 KV_QUANT_CFG=NVFP4_KV_CFG \
  python vllm_serve_fakequant.py <model> -tp 1 --host 0.0.0.0 --port 8000
```

### Testing

Tested end-to-end FQ calibration with vLLM 0.26.0 using the Docker image built
from `examples/vllm_serve/Dockerfile` on a single GPU and multiple GPU with nemetron3-nano model and Qwen1.5-MoE-A2.7B-Chat

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A (examples change only)
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information

Changes are confined to `examples/vllm_serve/` and do not affect the core library.