### PR TITLE
Fix AA-next OpenHands timeout guidance

### DIFF
--- a/.agents/skills/evaluation/recipes/examples/example_eval_next.yaml
+++ b/.agents/skills/evaluation/recipes/examples/example_eval_next.yaml
@@ -72,7 +72,7 @@ cluster:
   account: ???
   walltime: "04:00:00"               # auto_resume chains across windows
   shards: 1                          # N = N nodes (each redeploys vLLM)
-  eval_image: ${NEL_NEXT_EVAL_IMAGE}  # from eval-config (TB2.1 needs ≥0.3.1.1-harbor, multi-arch; enroot creds per SKILL Step 7.5)
+  eval_image: ${NEL_NEXT_EVAL_IMAGE}  # from eval-config (current AA-next source of truth: 0.5.0.1-harbor, multi-arch; enroot creds per SKILL Step 7.5)
   sbatch_comment: '{"OccupiedIdleGPUsJobReaper":{"exemptIdleTimeMins":"480","reason":"benchmarking","description":"nel-next agentic eval"}}'
   sbatch_extra_flags: {switches: 1, exclusive: true}
   container_env:                     # AWS creds reach the eval container ONLY via here

--- a/.agents/skills/evaluation/recipes/tasks/aa_next/swebench_verified.md
+++ b/.agents/skills/evaluation/recipes/tasks/aa_next/swebench_verified.md
@@ -5,7 +5,8 @@ run flow). Same harbor/ECS-Fargate flow as Terminal-Bench; the deltas are the
 **OpenHands agent**, a larger problem set, longer timeouts, and a different
 ECR/region. Start from `recipes/examples/example_eval_next.yaml`.
 
-> **Source of truth:** `configs/benchmarks/nel_next/swebench_verified/bench.yaml`
+> **Source of truth:** `configs/benchmarks/swe-bench-verified/bench.yaml` and
+> `configs/shared/nel_next_containers.yaml`
 > in nvidia-eval-factory-benchmarking — match its values for a reference run.
 
 ## Task-specific values (canonical `bench.yaml`)
@@ -19,7 +20,7 @@ ECR/region. Start from `recipes/examples/example_eval_next.yaml`.
 | `solver` | `timeout_strategy: max`, `run_timeout: 10800` (3h), `agent_kwargs.llm_kwargs.timeout: 3600` |
 | `sandbox.region` | `us-east-2` |
 | `sandbox.ecr_repository` | `${HARBOR_SWEBENCH_ECR_REPOSITORY}` (dedicated `harbor-swebench` repo, **us-west-2**, regardless of sandbox region) |
-| `cluster.eval_image` | `${NEL_NEXT_EVAL_IMAGE}` (needs **≥ `0.3.1.1-harbor`** — FEP-1085 reasoning fix) |
+| `cluster.eval_image` | `${NEL_NEXT_EVAL_IMAGE}` (current internal source of truth: **`0.5.0.1-harbor`**) |
 | `cluster.container_env.AWS_DEFAULT_REGION` | `us-east-2` (match `sandbox.region`) |
 | `instruction_template` | **must be MOUNTED** — the harbor image doesn't bundle the built-in (gotcha below) |
 
@@ -40,6 +41,17 @@ benchmarks:
       concurrency: 15
       log_stream_prefix: swebench-verified-<model>-<cluster>
 ```
+
+### Canary gate — verify the OpenHands request timeout
+
+`0.3.1.1-harbor` accepts the `llm_kwargs.timeout` field above but does not pass
+it to the OpenHands `LLM` client, which silently retains its 300-second default.
+Use an eval image containing
+[NVIDIA-NeMo/Evaluator#1083](https://github.com/NVIDIA-NeMo/Evaluator/pull/1083)
+(`0.5.0.1-harbor` in the current internal source of truth). After the first
+canary task starts, inspect the OpenHands startup/agent log and require an
+active timeout of `3600`; treat `timeout: 300` as an infrastructure failure and
+do not launch the scored run.
 
 ### Gotcha — mount the instruction template
 

--- a/.agents/skills/evaluation/recipes/tasks/aa_next/terminal_bench_2_1.md
+++ b/.agents/skills/evaluation/recipes/tasks/aa_next/terminal_bench_2_1.md
@@ -24,10 +24,11 @@ pinned via a vendored registry override in nemo-evaluator-next.
 | `cluster.container_env.AWS_DEFAULT_REGION` | match `sandbox.region` |
 | `max_concurrent` / `sandbox.concurrency` | `50` (canonical bench.yaml) |
 | timeout_strategy | `max` (canonical bench.yaml) + `agent_kwargs.llm_kwargs.timeout: 3600`; use `task` for leaderboard-comparable |
-| `cluster.eval_image` requirement | **≥ `0.3.1.1-harbor`** — TB 2.1's task set is pinned via a vendored registry override in that image (`${NEL_NEXT_EVAL_IMAGE}`, multi-arch) |
+| `cluster.eval_image` requirement | current internal source of truth: **`0.5.0.1-harbor`** (`${NEL_NEXT_EVAL_IMAGE}`, multi-arch) |
 
 These values mirror the canonical TB2.1 config — re-check it before a scored run:
-`configs/benchmarks/nel_next/terminal_bench_21/bench.yaml` in
+`configs/benchmarks/terminal-bench-2.1/bench.yaml` and
+`configs/shared/nel_next_containers.yaml` in
 nvidia-eval-factory-benchmarking (see `references/nel-next.md` + the eval-config
 "source of truth" note). The `benchmarks:` block (drop into the example template):
 
@@ -50,7 +51,8 @@ benchmarks:
       log_stream_prefix: terminalbench21-<model>-<cluster>
 ```
 
-`cluster.eval_image: ${NEL_NEXT_EVAL_IMAGE}` (≥ `0.3.1.1-harbor`) and the AWS creds
+`cluster.eval_image: ${NEL_NEXT_EVAL_IMAGE}` (`0.5.0.1-harbor` in the current
+internal source of truth) and the AWS creds
 come from `modelopttools:eval-config` (run it first) + the workspace `.env`.
 
 ## Score Extraction

--- a/.agents/skills/evaluation/references/nel-next.md
+++ b/.agents/skills/evaluation/references/nel-next.md
@@ -131,9 +131,14 @@ with its own `run_id`, copying the shared `services:` block.
 
 ## Rules & gotchas
 
-- **`eval_image`** = `${NEL_NEXT_EVAL_IMAGE}`. `0.3.1.1-harbor` is multi-arch and is
-  the minimum for **TB 2.1**; older `0.17.x/0.18.x-harbor-<arch>` are arch-suffixed.
-  Private gitlab-master image → cluster needs enroot creds (SKILL Step 7.5).
+- **`eval_image`** = `${NEL_NEXT_EVAL_IMAGE}`. The current internal source of
+  truth pins `0.5.0.1-harbor` (multi-arch) for TB 2.1 and SWE-bench. Do not use
+  `0.3.1.1-harbor` for OpenHands: although it accepts
+  `agent_kwargs.llm_kwargs.timeout`, the client still uses its 300-second
+  default. The runtime must include
+  [NVIDIA-NeMo/Evaluator#1083](https://github.com/NVIDIA-NeMo/Evaluator/pull/1083),
+  which propagates that setting into OpenHands. Private gitlab-master images
+  need enroot creds (SKILL Step 7.5).
 - **Mount sources must pre-exist** — pyxis won't create the host side of a bind
   mount (invisible to `--dry-run`, fails at canary). `ssh <login> 'mkdir -p
   <lustre>/<user>/.cache/{vllm,huggingface}'`.
@@ -159,6 +164,11 @@ $NEL eval run <cfg>.yaml --submit                                   # full
 $NEL eval {status|logs -f|report -f markdown|merge} -r <run_id>     # lifecycle
 $NEL mlflow-push -r <run_id> -c <cfg>.yaml                          # post-run: push merged bundle(s) to MLflow
 ```
+
+For a SWE-bench canary, inspect the OpenHands startup/agent log before scaling
+out. The configured `agent_kwargs.llm_kwargs.timeout` must appear as the active
+LLM timeout (for the recipe below, `3600`); `timeout: 300` means the eval image
+does not contain the propagation fix and the canary is invalid.
 
 `eval run` on a slurm cluster scp's the sbatch + redacted `.secrets.env` and
 submits via SSH; a built-in afternotok chain auto-resumes across walltime windows;


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Updates the AA-next evaluation runbook to require the current
`0.5.0.1-harbor` runtime for Terminal-Bench 2.1 and SWE-bench, and adds a
SWE-bench canary gate that rejects an active OpenHands `timeout: 300`.

The prior `0.3.1.1-harbor` guidance accepted
`solver.agent_kwargs.llm_kwargs.timeout: 3600`, but that runtime did not pass
the value to the OpenHands LLM client. OpenHands therefore retained its
300-second default and failed slow model generations with `LLMTimeoutError`.
NVIDIA-NeMo/Evaluator#1083 fixed the propagation path; `0.5.0.1-harbor` is the
current internal benchmark source of truth and includes that fix.

The source paths in the benchmark recipes are also updated to the current
`nvidia-eval-factory-benchmarking` layout.

Companion internal config-writer MR:
https://gitlab-master.nvidia.com/omniml/Model-Optimizer-Internal/-/merge_requests/111

### Usage

Keep `agent_kwargs.llm_kwargs.timeout: 3600` in the SWE-bench solver config and
use the `NEL_NEXT_EVAL_IMAGE` written by the current `modelopttools:eval-config`
skill. During the first canary, confirm the OpenHands agent reports an active
timeout of `3600`; do not scale out a canary that reports `timeout: 300`.

### Testing

- `pre-commit run --files` on all four changed files
- `git diff --check`
- Cross-checked the image against
  `configs/shared/nel_next_containers.yaml` in the internal benchmark source of
  truth

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A — documentation/runbook fix; pre-commit validation covers the changed files
- Did you update Changelog?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information

Upstream propagation fix:
https://github.com/NVIDIA-NeMo/Evaluator/pull/1083


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated evaluation guidance to use image version `0.5.0.1-harbor`.
  * Refreshed SWE-bench Verified and Terminal-Bench 2.1 configuration references.
  * Added validation guidance for confirming the 3600-second request timeout and rejecting the default 300-second timeout.
  * Documented timeout verification in startup logs and retained private-image credential requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->