### PR TITLE
Apply the docs-only ignore to the example lane groups

### DIFF
--- a/.github/workflows/_pr_gate.yml
+++ b/.github/workflows/_pr_gate.yml
@@ -12,10 +12,10 @@ on:
         required: false
         type: string
         default: |
-          **.ipynb
-          **.md
-          **.png
-          **.rst
+          **/*.ipynb
+          **/*.md
+          **/*.png
+          **/*.rst
     outputs:
       any_changed:
         description: "Whether any relevant files changed"

--- a/.github/workflows/example_tests.yml
+++ b/.github/workflows/example_tests.yml
@@ -45,11 +45,6 @@ jobs:
           base_sha: ${{ steps.base.outputs.merge_base }}
           sha: ${{ steps.base.outputs.head_sha }}
           fail_on_initial_diff_error: true
-          files_ignore: |
-            **.ipynb
-            **.md
-            **.png
-            **.rst
           # `common` runs every lane. Each lane lists the example directories it covers, plus any
           # extra directory those tests reach into (e.g. hf_ptq's script runs lm_eval from
           # ../llm_eval, and the speculative_decoding test drives hf_ptq).
@@ -64,18 +59,23 @@ jobs:
               - tests/_test_utils/**
               - tests/conftest.py
               - tests/examples/conftest.py
+              - "!**/*.{md,rst,png,ipynb}"
             torch:
               - "{examples,tests/examples}/{llm_distill,llm_qat,llm_sparsity,specdec_bench,speculative_decoding}/**"
               - examples/dataset/** # data prep for llm_qat and speculative_decoding
               - examples/hf_ptq/** # the speculative_decoding test drives hf_ptq
+              - "!**/*.{md,rst,png,ipynb}"
             trtllm:
               - "{examples,tests/examples}/{gpt-oss,hf_ptq,llm_eval}/**"
               - examples/dataset/** # data prep for gpt-oss
+              - "!**/*.{md,rst,png,ipynb}"
             megatron:
               - "{examples,tests/examples}/megatron_bridge/**"
+              - "!**/*.{md,rst,png,ipynb}"
             onnx:
               - "{examples,tests/examples}/{diffusers,torch_onnx,torch_trt}/**"
               - examples/onnx_ptq/** # torch_trt reuses onnx_ptq
+              - "!**/*.{md,rst,png,ipynb}"
       - id: lanes
         env:
           # Nightly and on-demand runs have no diff to inspect, so they run everything.


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix (CI)

Follow-up to #2090. `files_ignore` does not apply to `files_yaml` groups — the action keys ignores separately through `files_ignore_yaml`. Docs-only PRs therefore still matched a lane: a change to `examples/diffusers/README.md` alone started the onnx lane's three GPU jobs.

```yaml
files_ignore_yaml: |
  common: &docs
    - "**.ipynb"
    - "**.md"
    - "**.png"
    - "**.rst"
  torch: *docs
  trtllm: *docs
  megatron: *docs
  onnx: *docs
```

Only `example_tests.yml` is affected. `gpu_tests`, `regression_tests` and `unit_tests` go through `_pr_gate.yml`, which uses the plain `files` + `files_ignore` pair where the ignore does apply.

### Testing

Found by a probe PR opened against merged main (a README-only change), which showed `onnx` running when nothing should have. The same probe is re-run against this branch to confirm the fix — see the linked draft PR.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A — CI configuration
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌ — not yet run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated example-test workflow filtering to consistently ignore documentation, image, and notebook-only changes across all test lanes.
  * Improved pull request gate file matching by using recursive patterns for Markdown, reStructuredText, PNG, and notebook files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->