### PR TITLE
Bump the Node 20 actions that have no behavior change

### DIFF
--- a/.github/actions/cache-extensions/action.yml
+++ b/.github/actions/cache-extensions/action.yml
@@ -12,7 +12,7 @@ runs:
     - shell: bash
       run: echo "TORCH_EXTENSIONS_DIR=/root/.cache/torch_extensions" >> "$GITHUB_ENV"
     - id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: /root/.cache/torch_extensions
         key: torch-ext-${{ inputs.cache-key }}-${{ hashFiles('modelopt/torch/kernels/quantization/**', 'modelopt/torch/quantization/extensions.py', 'modelopt/torch/utils/cpp_extension.py')

--- a/.github/workflows/_pr_gate.yml
+++ b/.github/workflows/_pr_gate.yml
@@ -57,7 +57,7 @@ jobs:
     permissions:
       checks: read
     steps:
-      - uses: poseidon/wait-for-status-checks@v0.6.0
+      - uses: poseidon/wait-for-status-checks@v0.7.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           match_pattern: "^linux$" # Wait for Unit tests / linux

--- a/.github/workflows/example_tests.yml
+++ b/.github/workflows/example_tests.yml
@@ -99,7 +99,7 @@ jobs:
           echo "any_changed=$any" | tee --append "$GITHUB_OUTPUT"
       - name: Wait for unit tests before spending GPU runners
         if: ${{ steps.lanes.outputs.any_changed == 'true' && startsWith(github.ref, 'refs/heads/pull-request/') }}
-        uses: poseidon/wait-for-status-checks@v0.6.0
+        uses: poseidon/wait-for-status-checks@v0.7.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           match_pattern: "^linux$" # Wait for Unit tests / linux

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build docs
         run: pip install nox uv && nox -s docs
       - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs-html
           path: docs/build/html
@@ -44,7 +44,7 @@ jobs:
     outputs:
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Download docs artifact
         if: github.event.action != 'closed'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docs-html
           path: docs/build/html
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download docs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docs-html
           path: docs/build/html


### PR DESCRIPTION
### What does this PR do?

Type of change: CI/CD maintenance

Clears the [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) warnings. The runner already forces these onto Node 24, so this changes what the actions *declare*, not how they run.

| action | bump | why it is safe |
|---|---|---|
| `actions/cache` | v4 → v6 | v5 requires runner >= 2.327.1; our self-hosted GPU runners report **2.336.0** |
| `actions/download-artifact` | v4 → v8 | v5's breaking change affects downloads **by artifact ID**; `pages.yml` downloads by `name: docs-html` |
| `actions/upload-artifact` | v4 → v7 | node24 runtime only |
| `dorny/paths-filter` | v3 → v4 | node24 runtime only |
| `poseidon/wait-for-status-checks` | v0.6.0 → v0.7.0 | node24 runtime only |

`step-security/changed-files` stays at v46.0.5 and is bumped in a separate PR: the lane gating depends on its `files_yaml` group outputs and `any_modified` semantics, and v47 ships no release notes covering them. Splitting keeps a gating regression attributable.

### Testing

`actions/cache` is exercised by every GPU job through `cache-extensions`; the `pages.yml` three are exercised by the docs build. Worth watching on this PR: cache **hit rate** rather than just success, since a silent cache-key change costs build time without failing.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A — CI configuration
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌ — not yet run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated caching and build workflow actions to newer versions.
  * Improved pull request status-check handling.
  * Updated artifact upload, download, and path-filtering actions used by page deployments and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->