### PR TITLE
[TEST - DO NOT MERGE] changed-files v47 gating probe: docs only

### DIFF
--- a/examples/diffusers/README.md
+++ b/examples/diffusers/README.md
@@ -485,3 +485,5 @@ Stable Diffusion pipelines rely heavily on random sampling operations, which inc
 - 💡 [Release Notes](https://nvidia.github.io/Model-Optimizer/reference/0_changelog.html)
 - 🐛 [File a bug](https://github.com/NVIDIA/Model-Optimizer/issues/new?template=1_bug_report.md)
 - ✨ [File a Feature Request](https://github.com/NVIDIA/Model-Optimizer/issues/new?template=2_feature_request.md)
+
+<!-- v47 probe -->


### PR DESCRIPTION
Temporary draft PR verifying that lane gating still works under `step-security/changed-files@v47.0.5` (#2103). Based on that branch so the diff is only the probe file while the workflow under test carries v47. **Do not review or merge.**

**Expected:** no lanes at all — verifies the per-group docs negation still filters under v47