### PR TITLE
[TEST - DO NOT MERGE] changed-files v47 gating probe: one example

### DIFF
--- a/examples/diffusers/quantization/config.py
+++ b/examples/diffusers/quantization/config.py
@@ -89,3 +89,6 @@ def reset_set_int8_config(quant_config, percentile, n_steps, collect_method, bac
                     },
                 }
             )
+
+
+# v47 probe


### PR DESCRIPTION
Temporary draft PR verifying that lane gating still works under `step-security/changed-files@v47.0.5` (#2103). Based on that branch so the diff is only the probe file while the workflow under test carries v47. **Do not review or merge.**

**Expected:** onnx lane only — verifies files_yaml group selectivity still works under v47