### PR TITLE
Give the EAGLE-3 cp_size=2 compile case a longer timeout

### DIFF
--- a/tests/examples/speculative_decoding/test_eagle.py
+++ b/tests/examples/speculative_decoding/test_eagle.py
@@ -116,7 +116,12 @@ def test_calibrate_draft_vocab(tiny_llama_path, tiny_daring_anteater_path, draft
 
 
 # fmt: off
-@pytest.mark.parametrize(("cp_size", "mix_hidden_states"), [(1, False), (2, False), (1, True), (2, True)])
+@pytest.mark.parametrize(("cp_size", "mix_hidden_states"), [
+    (1, False),
+    pytest.param(2, False, marks=pytest.mark.timeout(360)),
+    (1, True),
+    (2, True),
+])
 def test_llama_eagle3(tiny_llama_path,
                       tiny_daring_anteater_path,
                       eagle_output_dir,


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix (CI)

`test_llama_eagle3[2-False]` timed out at the 300s examples default in the [first nightly](https://github.com/NVIDIA/Model-Optimizer/actions/runs/31137639327) after #2086 re-enabled the `cp_size=2` cases. Those cases had never run in CI before — the old guard compared `Version("2.10.0a0")` against `Version("2.10.0")`, which is False on every NGC alpha build, so they had been silently skipped since February.

Measured on the 2-GPU runner:

| case | duration |
|---|---|
| `[2-False]` | **304s** — over the 300s default by 4s |
| `[1-False]` | 173s |
| `[2-True]` | 51s |
| `[1-True]` | 39s |

Only `[2-False]` exceeds the cap, and only barely: it pays context parallelism *plus* `torch.compile`, which `mix_hidden_states=False` enables. It is a margin problem, not a hang. The marker is scoped to that single param so the 300s cap keeps protecting every other example test.

Note 360s is roughly 18% headroom over a single sample on a shared runner. If it ever trips again the signal will be a duration just above 360s, which distinguishes normal variance from a real regression.

### Testing

Measured by temporarily running the spec-dec lane ungated on the 2-GPU runner in this PR (**those overrides have been reverted**; the diff is now one file). That run: **16 passed, 2 skipped** in 1016s, with `[2-False]` at 304.27s.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A — adjusts an existing test's timeout
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌ — not yet run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reformatted test parameter definitions for improved readability.
  * Preserved all existing test combinations and timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->