### PR TITLE
Bump codecov-action to v7, the last Node 20 warning

### DIFF
--- a/.github/workflows/_example_tests_runner.yml
+++ b/.github/workflows/_example_tests_runner.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           echo "::warning title=Allowed example failure::'${{ inputs.example }}' failed but is in the allow-failure list (vars.ALLOW_FAILURE_EXAMPLE_TESTS); not blocking. Remove it from the variable once fixed."
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -94,7 +94,7 @@ jobs:
           # Use `python3` (the vllm image has no `python` on PATH)
           python3 -m pip install nox && nox -s ${{ matrix.example }}
       - name: Upload GPU coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml

--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -62,7 +62,7 @@ jobs:
           COVERAGE_FILE: ${{ github.workspace }}/.coverage
         run: python -m pip install nox && nox -s regression
       - name: Upload regression coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -67,7 +67,7 @@ jobs:
           COVERAGE_FILE: ${{ github.workspace }}/.coverage
         run: pip install nox uv && nox -s "unit-3.12(torch_213, tf_latest)"
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit


### PR DESCRIPTION
### What does this PR do?

Type of change: CI/CD maintenance

#2102 and #2103 bumped every action this repo references *directly*, but Node 20 annotations still appear — e.g. [this run on #2103](https://github.com/NVIDIA/Model-Optimizer/actions/runs/31170982088?pr=2103):

> The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea`

We never reference `github-script`. It comes in transitively through `codecov/codecov-action`:

| codecov-action | bundled github-script | runtime |
|---|---|---|
| `@v5` (= v5.5.5) | `60a0d830…` | **node20** |
| `@v6.0.2` / `@v7.0.0` | `ed597411…` | node24 |

Bumps all four call sites (`unit_tests`, `gpu_tests`, `regression_tests`, `_example_tests_runner`) to `@v7`.

Checked: v6's notes call out node24 support as the only breaking aspect — the same pattern as the bumps in #2102 — and our runners report 2.336.0. The inputs used here (`token`, `files`, `flags`, `fail_ci_if_error`, `verbose`) all still exist in v7. A scan of every referenced action, direct and one level transitive, now finds no node20 runtimes left.

### Testing

Coverage upload runs in every unit, gpu, regression and example job, so CI exercises this broadly. Worth checking that coverage still lands in Codecov rather than only that the step is green — `fail_ci_if_error: false` means an upload failure would not turn the job red.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A — CI configuration
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌ — not yet run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated test workflows to use the latest coverage reporting action.
  * Improved compatibility and reliability of coverage report uploads across example, GPU, regression, and unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->