### PR TITLE
Give each example lane its own Codecov flag

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,9 @@
-# Flags partition coverage by test suite. carryforward ensures that if GPU tests are skipped
-# on a PR (no relevant file changes), their coverage from the last nightly run is reused so
-# the comparison is not penalized for the missing upload.
+# Flags partition coverage by test suite, and the example lanes carry one flag each
+# (examples-<name>) since they are gated independently. carryforward reuses the last run's
+# coverage for any flag with no upload on this commit, so a PR that skips a suite or a single
+# example lane is not penalized for the missing upload. A flag shared across independently
+# gated jobs would defeat this: the flag would be present but partial, and carryforward only
+# applies when a flag is absent.
 flag_management:
   default_rules:
     carryforward: true

--- a/.github/workflows/_example_tests_runner.yml
+++ b/.github/workflows/_example_tests_runner.yml
@@ -92,6 +92,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-          flags: examples
+          # One flag per example, not a shared `examples`: carryforward only applies to a flag
+          # with no upload, so a shared flag would replace every lane's coverage with the subset
+          # that ran once lanes are gated independently.
+          flags: examples-${{ inputs.example }}
           fail_ci_if_error: false # test may be skipped if relevant file changes are not detected
           verbose: true


### PR DESCRIPTION
### What does this PR do?

Type of change: CI/CD bug fix

Every example lane uploaded coverage under one shared `examples` flag. That was correct while all lanes ran on every PR, but #2090 gates them independently, and **Codecov carryforward only applies to a flag with no upload on the commit**.

| scenario | `examples` flag | outcome |
|---|---|---|
| no lanes run (docs-only) | absent | ✅ carried forward |
| all lanes run | complete | ✅ correct |
| **one lane runs** (now common) | **present but partial** | ❌ carryforward skipped; full coverage replaced by that lane's subset |

The third row is what gating made routine: a PR touching only `examples/diffusers/**` runs the onnx lane, uploads `examples` containing onnx coverage alone, and Codecov reports a drop for code the PR never touched.

One flag per example (`examples-<name>`, 12 flags) restores the intent already documented in `.github/codecov.yml`: a skipped lane has no upload for its flag and is carried forward; a lane that ran replaces only its own slice. The config comment is updated to explain why a shared flag defeats carryforward, so this isn't re-introduced.

`gpu_tests` deliberately keeps a single `gpu` flag — its five suites are gated at workflow level, so they upload together or not at all. It would need the same change if per-suite gating is ever added.

### Testing

Not directly observable on this PR: it changes workflow files, which are in the gate's `common` group, so **all twelve lanes run** and every flag is uploaded — the healthy case either way. The behavior it fixes appears on the next PR that touches a single example, where `codecov/project` should now stay accurate instead of reporting a drop.

Worth noting the symptom was never blocking: `codecov/project` is not a required check and the threshold allows a 2% drop. This is about the coverage data being right.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ — flags are new names; historical data under `examples` is unaffected
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A — CI configuration
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌ — not yet run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved coverage reporting by tracking results separately for each test example.
  * Clarified coverage configuration and documented how skipped uploads are carried forward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->