### PR TITLE
feat(megatron-bridge): SFT-masked data support in distillation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changelog
 
 *Megatron Framework (M-LM / M-Bridge)*
 
+- Add SFT-masked data support to ``examples/megatron_bridge/distill.py``: ``--sft --sft_dataset_root <dir>`` distills on raw prompt-completion JSONL (``{"input", "output"}`` records) with the loss masked to the response tokens, using Megatron-Bridge's ``FinetuningDatasetConfig`` and the model's own HuggingFace tokenizer instead of the pretraining ``GPTDataset`` and ``NullTokenizer``.
 - Add per-expert weight quantization for Transformer Engine ``TEGroupedMLP`` (fused MoE experts): each expert now has its own ``weight_quantizer`` (a ``GroupedQuantizer`` holding one ``TensorQuantizer`` per expert) with an independent ``amax``, instead of a single shared ``amax`` across all experts. Applies to ``mtq.quantize`` calibration, HF / Megatron export, and QAD.
 - Add opt-in ``torch.compile`` execution for Transformer Engine grouped-linear per-expert weight quantizers while preserving their native checkpoint amax shapes. Set ``MODELOPT_TEGROUPED_COMPILE_WEIGHT_LOOP=1`` before quantized-module conversion; the default path remains eager.
 

--- a/examples/megatron_bridge/README.md
+++ b/examples/megatron_bridge/README.md
@@ -137,7 +137,12 @@ the model's own HuggingFace tokenizer. Both fields are tokenized **as written**,
 leading and trailing spaces on each field are stripped — no chat template is applied and no BOS
 token is prepended. So if your model expects role/turn markers or a BOS token, include them in the
 `"input"` field yourself, and express any significant separator as a newline rather than a trailing
-space. An EOS token is appended after the response.
+space. An EOS token is appended after the response. A record longer than `--seq_length` is
+truncated from the **start** of `"input"`, which drops any BOS, system prompt or opening role
+marker baked in there, so pre-filter or pre-truncate the corpus if that matters.
+
+Teacher and student must share a tokenizer — distillation scores the teacher on the student's
+token ids, and the KD losses compare the two models' logits elementwise over the vocab dimension.
 
 ### Distillation with Real Data
 

--- a/examples/megatron_bridge/README.md
+++ b/examples/megatron_bridge/README.md
@@ -130,6 +130,13 @@ The distillation script expects pre-tokenized data in Megatron's binary format (
 See the **[Dataset Preparation README](../dataset/README.md#tokenizing-for-megatron-frameworks)**
 for full instructions on tokenizing JSONL files and Hugging Face datasets and get the list of output prefixes that you can use for `--data_paths` argument.
 
+Alternatively, pass `--sft --sft_dataset_root <dir>` to distill on **raw prompt-completion JSONL**
+with the loss masked to the completion. The directory must hold `training.jsonl` and
+`validation.jsonl` of `{"input": <prompt>, "output": <response>}` records, which are tokenized with
+the model's own HuggingFace tokenizer. Both fields are tokenized **verbatim** — no chat template is
+applied and no BOS token is prepended — so if your model expects role/turn markers or a BOS token,
+include them in the `"input"` field yourself.
+
 ### Distillation with Real Data
 
 Example usage to distill a 4B student (HF) from an 8B teacher (HF) on 8 GPUs (TP=8, PP=1):

--- a/examples/megatron_bridge/README.md
+++ b/examples/megatron_bridge/README.md
@@ -131,8 +131,8 @@ See the **[Dataset Preparation README](../dataset/README.md#tokenizing-for-megat
 for full instructions on tokenizing JSONL files and Hugging Face datasets and get the list of output prefixes that you can use for `--data_paths` argument.
 
 Alternatively, pass `--sft --sft_dataset_root <dir>` to distill on **raw prompt-completion JSONL**
-with the loss masked to the completion. The directory must hold `training.jsonl` and
-`validation.jsonl` of `{"input": <prompt>, "output": <response>}` records, which are tokenized with
+with the loss masked to the completion. The directory must hold `training.jsonl` (and
+`validation.jsonl` when `--eval_iters > 0`) of `{"input": <prompt>, "output": <response>}` records, which are tokenized with
 the model's own HuggingFace tokenizer. Both fields are tokenized **verbatim** — no chat template is
 applied and no BOS token is prepended — so if your model expects role/turn markers or a BOS token,
 include them in the `"input"` field yourself. An EOS token is appended after the response.

--- a/examples/megatron_bridge/README.md
+++ b/examples/megatron_bridge/README.md
@@ -135,7 +135,7 @@ with the loss masked to the completion. The directory must hold `training.jsonl`
 `validation.jsonl` of `{"input": <prompt>, "output": <response>}` records, which are tokenized with
 the model's own HuggingFace tokenizer. Both fields are tokenized **verbatim** — no chat template is
 applied and no BOS token is prepended — so if your model expects role/turn markers or a BOS token,
-include them in the `"input"` field yourself.
+include them in the `"input"` field yourself. An EOS token is appended after the response.
 
 ### Distillation with Real Data
 

--- a/examples/megatron_bridge/README.md
+++ b/examples/megatron_bridge/README.md
@@ -133,9 +133,11 @@ for full instructions on tokenizing JSONL files and Hugging Face datasets and ge
 Alternatively, pass `--sft --sft_dataset_root <dir>` to distill on **raw prompt-completion JSONL**
 with the loss masked to the completion. The directory must hold `training.jsonl` (and
 `validation.jsonl` when `--eval_iters > 0`) of `{"input": <prompt>, "output": <response>}` records, which are tokenized with
-the model's own HuggingFace tokenizer. Both fields are tokenized **verbatim** — no chat template is
-applied and no BOS token is prepended — so if your model expects role/turn markers or a BOS token,
-include them in the `"input"` field yourself. An EOS token is appended after the response.
+the model's own HuggingFace tokenizer. Both fields are tokenized **as written**, except that
+leading and trailing spaces on each field are stripped — no chat template is applied and no BOS
+token is prepended. So if your model expects role/turn markers or a BOS token, include them in the
+`"input"` field yourself, and express any significant separator as a newline rather than a trailing
+space. An EOS token is appended after the response.
 
 ### Distillation with Real Data
 

--- a/examples/megatron_bridge/README.md
+++ b/examples/megatron_bridge/README.md
@@ -134,12 +134,13 @@ Alternatively, pass `--sft --sft_dataset_root <dir>` to distill on **raw prompt-
 with the loss masked to the completion. The directory must hold `training.jsonl` (and
 `validation.jsonl` when `--eval_iters > 0`) of `{"input": <prompt>, "output": <response>}` records, which are tokenized with
 the model's own HuggingFace tokenizer. Both fields are tokenized **as written**, except that
-leading and trailing spaces on each field are stripped — no chat template is applied and no BOS
-token is prepended. So if your model expects role/turn markers or a BOS token, include them in the
-`"input"` field yourself, and express any significant separator as a newline rather than a trailing
-space. An EOS token is appended after the response. A record longer than `--seq_length` is
-truncated from the **start** of `"input"`, which drops any BOS, system prompt or opening role
-marker baked in there, so pre-filter or pre-truncate the corpus if that matters.
+leading and trailing spaces on each field are stripped — no chat template is applied. So if your
+model expects role/turn markers, include them in the `"input"` field yourself, and express any
+significant separator as a newline rather than a trailing space. A BOS token is prepended
+automatically when the tokenizer prepends one at inference, so do not add it yourself; an EOS
+token is appended after the response. A record longer than `--seq_length` is truncated from the
+**start** of `"input"`, which drops any system prompt or opening role marker baked in there, so
+pre-filter or pre-truncate the corpus if that matters.
 
 Teacher and student must share a tokenizer — distillation scores the teacher on the student's
 token ids, and the KD losses compare the two models' logits elementwise over the vocab dimension.

--- a/examples/megatron_bridge/distill.py
+++ b/examples/megatron_bridge/distill.py
@@ -139,7 +139,7 @@ def get_args():
         "--sft_dataset_root",
         type=str,
         default=None,
-        help="Directory holding training.jsonl / validation.jsonl of "
+        help="Directory holding training.jsonl (and validation.jsonl when --eval_iters > 0) of "
         '{"input": <prompt>, "output": <response>} records (used with --sft). Both fields are '
         "tokenized verbatim: no chat template is applied and no BOS is prepended, so if the model "
         "expects role/turn markers or a BOS token, bake them into the fields yourself. An EOS "
@@ -278,7 +278,8 @@ def get_args():
 
     if args.sft and not args.sft_dataset_root:
         raise ValueError(
-            "--sft requires --sft_dataset_root (a directory with training.jsonl / validation.jsonl)."
+            "--sft requires --sft_dataset_root (a directory with training.jsonl, plus "
+            "validation.jsonl when --eval_iters > 0)."
         )
     if args.sft and (args.data_paths or args.use_mock_data):
         raise ValueError(
@@ -297,9 +298,20 @@ def _warn_if_bos_missing(tokenizer, dataset_root: str) -> None:
     ``--sft`` tokenizes both fields verbatim, so the caller owns the BOS. Adding one here is not
     safe (their text may already have it, which would double it), but training without the BOS the
     model is served with is silent train/inference skew.
+
+    Bounded on purpose: it inspects only the first record of ``training.jsonl``, so a mixed corpus
+    whose first record happens to carry a BOS will not be flagged.
     """
     bos = getattr(tokenizer, "bos_token", None)
-    if not bos or not getattr(tokenizer, "add_bos_token", False):
+    if not bos:
+        return
+    try:
+        # Probe rather than trusting ``add_bos_token``: many fast tokenizers prepend BOS via the
+        # post-processor without exposing that attribute, and a missing warning is the worse
+        # failure here.
+        if tokenizer("x").input_ids[:1] != [tokenizer.bos_token_id]:
+            return
+    except Exception:
         return
     try:
         with open(os.path.join(dataset_root, "training.jsonl")) as f:
@@ -535,7 +547,15 @@ def main(args: argparse.Namespace):
             TokenizerConfig(
                 tokenizer_type="HuggingFaceTokenizer",
                 tokenizer_model=args.student_hf_path,
-                hf_tokenizer_kwargs={"trust_remote_code": args.trust_remote_code},
+                hf_tokenizer_kwargs={
+                    "trust_remote_code": args.trust_remote_code,
+                    # Enforce the verbatim contract here rather than relying on the dataset's
+                    # add_bos/add_eos: text_to_ids adds special tokens when this is left at its
+                    # default of True, and prompt_template tokenizes "{input}" and "{output}"
+                    # separately -- so a BOS-adding tokenizer would inject one at the answer
+                    # boundary, where answer_only_loss starts scoring.
+                    "include_special_tokens": False,
+                },
             )
             if args.sft
             else TokenizerConfig(

--- a/examples/megatron_bridge/distill.py
+++ b/examples/megatron_bridge/distill.py
@@ -141,7 +141,8 @@ def get_args():
         help="Directory holding training.jsonl / validation.jsonl of "
         '{"input": <prompt>, "output": <response>} records (used with --sft). Both fields are '
         "tokenized verbatim: no chat template is applied and no BOS is prepended, so if the model "
-        "expects role/turn markers or a BOS token, bake them into the fields yourself.",
+        "expects role/turn markers or a BOS token, bake them into the fields yourself. An EOS "
+        "token is appended after the response.",
     )
     # Training & Eval arguments
     parser.add_argument(
@@ -293,6 +294,29 @@ def main(args: argparse.Namespace):
     checkpoint_dir = os.path.join(args.output_dir, "checkpoints")
     tensorboard_dir = os.path.join(args.output_dir, "tb_logs")
 
+    if args.sft:
+        # SFT tokenizes raw text with the student's tokenizer and scores the teacher on those same
+        # ids, so both models must agree on what every id means. Equal vocabulary *sizes* are not
+        # enough -- Llama-2 and Mistral are both 32000 tokens with different mappings -- so compare
+        # the mappings. Checked before the providers are built so a mismatch costs seconds.
+        # The pretraining path is structurally immune: NullTokenizer plus pre-tokenized
+        # --data_paths means one tokenization feeds both models.
+        from transformers import AutoTokenizer
+
+        _tok = {"trust_remote_code": args.trust_remote_code}
+        student_vocab = AutoTokenizer.from_pretrained(args.student_hf_path, **_tok).get_vocab()
+        teacher_vocab = AutoTokenizer.from_pretrained(args.teacher_hf_path, **_tok).get_vocab()
+        if student_vocab != teacher_vocab:
+            detail = (
+                f"{len(student_vocab)} vs {len(teacher_vocab)} tokens"
+                if len(student_vocab) != len(teacher_vocab)
+                else f"both {len(student_vocab)} tokens, but different token->id mappings"
+            )
+            raise ValueError(
+                "--sft tokenizes with the student's tokenizer and scores the teacher on those "
+                f"same ids, so student and teacher must share a tokenizer ({detail})."
+            )
+
     # Build student and teacher model providers
     def _build_model_provider(hf_path, load_weights=True):
         bridge = AutoBridge.from_hf_pretrained(hf_path, trust_remote_code=args.trust_remote_code)
@@ -337,16 +361,6 @@ def main(args: argparse.Namespace):
         # before the model is built so the student's linear layers are constructed accordingly.
         student_provider.gradient_accumulation_fusion = False
     teacher_provider = _build_model_provider(args.teacher_hf_path)
-
-    if args.sft and student_provider.vocab_size != teacher_provider.vocab_size:
-        # The pretraining path is structurally immune to this: NullTokenizer plus pre-tokenized
-        # --data_paths means one tokenization feeds both models. SFT tokenizes raw text with the
-        # student's tokenizer, so a teacher from another family would score ids it never saw and
-        # silently produce a garbage KD target instead of an error.
-        raise ValueError(
-            "--sft tokenizes with the student's tokenizer, so student and teacher must share a "
-            f"vocabulary (got {student_provider.vocab_size} vs {teacher_provider.vocab_size})."
-        )
 
     kd_config = ModelOptDistillConfig(
         skip_lm_loss=not args.no_skip_lm_loss, kd_loss_scale=args.kd_loss_scale

--- a/examples/megatron_bridge/distill.py
+++ b/examples/megatron_bridge/distill.py
@@ -34,6 +34,7 @@ from megatron.bridge.recipes.utils.optimizer_utils import (
 from megatron.bridge.training.config import (
     CheckpointConfig,
     ConfigContainer,
+    FinetuningDatasetConfig,
     GPTDatasetConfig,
     LoggerConfig,
     MockGPTDatasetConfig,
@@ -124,6 +125,21 @@ def get_args():
     )
     parser.add_argument(
         "--use_mock_data", action="store_true", help="Use mock data instead of --data_paths"
+    )
+    parser.add_argument(
+        "--sft",
+        action="store_true",
+        help="SFT-masked distillation: read raw prompt-completion jsonl from --sft_dataset_root "
+        "and mask the loss to the completion (assistant response) tokens. Uses "
+        "FinetuningDatasetConfig and the real HuggingFace tokenizer instead of the pretraining "
+        "GPTDataset and NullTokenizer.",
+    )
+    parser.add_argument(
+        "--sft_dataset_root",
+        type=str,
+        default=None,
+        help="Directory holding training.jsonl / validation.jsonl of "
+        '{"input": <prompt>, "output": <response>} records (used with --sft).',
     )
     # Training & Eval arguments
     parser.add_argument(
@@ -256,6 +272,11 @@ def get_args():
     if args.validate_only and args.eval_iters == 0:
         raise ValueError("--validate_only requires --eval_iters > 0.")
 
+    if args.sft and not args.sft_dataset_root:
+        raise ValueError(
+            "--sft requires --sft_dataset_root (a directory with training.jsonl / validation.jsonl)."
+        )
+
     print_args(args)
 
     return args
@@ -279,6 +300,10 @@ def main(args: argparse.Namespace):
         provider.expert_model_parallel_size = args.ep_size
         provider.expert_tensor_parallel_size = 1  # Expert tensor parallelism is not supported
         provider.seq_length = args.seq_length
+        if args.sft:
+            # The SFT loss mask covers only the response tokens, so the reduction must be
+            # per-token for it to combine correctly across context-parallel ranks.
+            provider.calculate_per_token_loss = True
         if args.recompute_granularity is not None:
             provider.recompute_granularity = args.recompute_granularity
             provider.recompute_method = args.recompute_method
@@ -368,7 +393,30 @@ def main(args: argparse.Namespace):
         "dataloader_type": "single",
         "skip_getting_attention_mask_from_dataset": True,
     }
-    if args.use_mock_data:
+    if args.sft:
+        # SFT-masked distillation via Bridge's FinetuningDatasetConfig -> NeMo-style GPTSFTDataset.
+        # `dataset_root` holds training.jsonl / validation.jsonl of {"input", "output"} records.
+        # prompt_template="{input}{output}" tokenizes input+output verbatim (adjacent placeholders,
+        # no separator); label_key="output" with answer_only_loss=True masks the loss to the
+        # response only (answer_start_idx == len(context_ids)); truncation_field="input" truncates
+        # the context when the pair exceeds seq_length.
+        dataset_config = FinetuningDatasetConfig(
+            seq_length=args.seq_length,
+            dataset_root=args.sft_dataset_root,
+            seed=args.seed,
+            dataloader_type="batch",
+            do_validation=True,
+            do_test=False,
+            dataset_kwargs={
+                "prompt_template": "{input}{output}",
+                "label_key": "output",
+                "truncation_field": "input",
+                "answer_only_loss": True,
+                "add_bos": False,
+                "add_eos": True,
+            },
+        )
+    elif args.use_mock_data:
         dataset_config = MockGPTDatasetConfig(**dataset_kwargs)
     else:
         # Convert flat CLI list (e.g. ["1.0", "/path/data"]) to Megatron blend format
@@ -399,7 +447,7 @@ def main(args: argparse.Namespace):
             grad_reduce_in_fp32=True,
             overlap_grad_reduce=True,
             overlap_param_gather=True,
-            average_in_collective=True,
+            average_in_collective=not args.sft,  # per-token loss must not be pre-averaged
             use_distributed_optimizer=True,
         ),
         dataset=dataset_config,
@@ -412,8 +460,18 @@ def main(args: argparse.Namespace):
             wandb_entity=args.wandb_entity,  # optional
             wandb_exp_name=args.wandb_exp_name,
         ),
-        tokenizer=TokenizerConfig(
-            tokenizer_type="NullTokenizer", vocab_size=distill_provider.vocab_size
+        tokenizer=(
+            # SFT reads raw text, so it needs the model's real tokenizer; the pretraining path
+            # consumes pre-tokenized data and keeps NullTokenizer.
+            TokenizerConfig(
+                tokenizer_type="HuggingFaceTokenizer",
+                tokenizer_model=args.student_hf_path,
+                hf_tokenizer_kwargs={"trust_remote_code": args.trust_remote_code},
+            )
+            if args.sft
+            else TokenizerConfig(
+                tokenizer_type="NullTokenizer", vocab_size=distill_provider.vocab_size
+            )
         ),
         checkpoint=CheckpointConfig(
             save_interval=(

--- a/examples/megatron_bridge/distill.py
+++ b/examples/megatron_bridge/distill.py
@@ -288,6 +288,8 @@ def get_args():
             "--sft is mutually exclusive with --data_paths / --use_mock_data: the SFT branch wins "
             "the dataset selection, so those inputs would be silently ignored."
         )
+    if args.sft_dataset_root and not args.sft:
+        raise ValueError("--sft_dataset_root requires --sft; without it the SFT path is not used.")
 
     print_args(args)
 
@@ -344,8 +346,8 @@ def main(args: argparse.Namespace):
         student_tokenizer = AutoTokenizer.from_pretrained(args.student_hf_path, **_tok)
         student_vocab = student_tokenizer.get_vocab()
         teacher_vocab = AutoTokenizer.from_pretrained(args.teacher_hf_path, **_tok).get_vocab()
-        # Only student ids ever reach the teacher, so agreement on those is the invariant. A
-        # teacher vocabulary that is a strict superset (extra reserved tokens, say) is fine.
+        # Every student id must mean the same thing to the teacher. This is necessary but not
+        # sufficient: the KD losses also need equal logits width, checked on the providers below.
         conflicts = {t for t, i in student_vocab.items() if teacher_vocab.get(t, i) != i}
         missing = student_vocab.keys() - teacher_vocab.keys()
         if conflicts or missing:
@@ -354,11 +356,6 @@ def main(args: argparse.Namespace):
                 "same ids, so the teacher must map every student token to the same id: "
                 f"{len(conflicts)} conflicting id(s), {len(missing)} token(s) absent from the "
                 "teacher. Student and teacher must share a tokenizer."
-            )
-        if len(teacher_vocab) > len(student_vocab):
-            warn_rank_0(
-                f"Teacher vocabulary has {len(teacher_vocab) - len(student_vocab)} token(s) the "
-                "student lacks; ids agree on every student token, so distillation is well-defined."
             )
 
         _warn_if_bos_missing(student_tokenizer, args.sft_dataset_root)
@@ -407,6 +404,13 @@ def main(args: argparse.Namespace):
         # before the model is built so the student's linear layers are constructed accordingly.
         student_provider.gradient_accumulation_fusion = False
     teacher_provider = _build_model_provider(args.teacher_hf_path)
+
+    if args.sft and student_provider.vocab_size != teacher_provider.vocab_size:
+        # The KD losses compare logits directly, so the padded vocab dimensions must match.
+        raise ValueError(
+            "--sft distillation needs student and teacher logits of equal width, but their padded "
+            f"vocab sizes differ ({student_provider.vocab_size} vs {teacher_provider.vocab_size})."
+        )
 
     kd_config = ModelOptDistillConfig(
         skip_lm_loss=not args.no_skip_lm_loss, kd_loss_scale=args.kd_loss_scale

--- a/examples/megatron_bridge/distill.py
+++ b/examples/megatron_bridge/distill.py
@@ -278,6 +278,11 @@ def get_args():
         raise ValueError(
             "--sft requires --sft_dataset_root (a directory with training.jsonl / validation.jsonl)."
         )
+    if args.sft and (args.data_paths or args.use_mock_data):
+        raise ValueError(
+            "--sft is mutually exclusive with --data_paths / --use_mock_data: the SFT branch wins "
+            "the dataset selection, so those inputs would be silently ignored."
+        )
 
     print_args(args)
 
@@ -304,7 +309,11 @@ def main(args: argparse.Namespace):
         provider.seq_length = args.seq_length
         if args.sft:
             # The SFT loss mask covers only the response tokens, so the reduction must be
-            # per-token for it to combine correctly across context-parallel ranks.
+            # per-token for it to combine correctly across context-parallel ranks. This lands on
+            # both providers (harmless: the teacher's LM loss is zeroed in
+            # adjust_distillation_model_for_mcore) and must stay in sync with
+            # ``average_in_collective=not args.sft`` on the shared DistributedDataParallelConfig
+            # below -- a per-token loss must not be pre-averaged.
             provider.calculate_per_token_loss = True
         if args.recompute_granularity is not None:
             provider.recompute_granularity = args.recompute_granularity
@@ -328,6 +337,16 @@ def main(args: argparse.Namespace):
         # before the model is built so the student's linear layers are constructed accordingly.
         student_provider.gradient_accumulation_fusion = False
     teacher_provider = _build_model_provider(args.teacher_hf_path)
+
+    if args.sft and student_provider.vocab_size != teacher_provider.vocab_size:
+        # The pretraining path is structurally immune to this: NullTokenizer plus pre-tokenized
+        # --data_paths means one tokenization feeds both models. SFT tokenizes raw text with the
+        # student's tokenizer, so a teacher from another family would score ids it never saw and
+        # silently produce a garbage KD target instead of an error.
+        raise ValueError(
+            "--sft tokenizes with the student's tokenizer, so student and teacher must share a "
+            f"vocabulary (got {student_provider.vocab_size} vs {teacher_provider.vocab_size})."
+        )
 
     kd_config = ModelOptDistillConfig(
         skip_lm_loss=not args.no_skip_lm_loss, kd_loss_scale=args.kd_loss_scale
@@ -411,7 +430,9 @@ def main(args: argparse.Namespace):
             dataset_root=args.sft_dataset_root,
             seed=args.seed,
             dataloader_type="batch",
-            do_validation=True,
+            # Honour --eval_iters 0 so a training-only dataset_root does not have to carry a
+            # dummy validation.jsonl just to satisfy the builder.
+            do_validation=args.eval_iters > 0,
             do_test=False,
             dataset_kwargs={
                 "prompt_template": "{input}{output}",

--- a/examples/megatron_bridge/distill.py
+++ b/examples/megatron_bridge/distill.py
@@ -139,7 +139,9 @@ def get_args():
         type=str,
         default=None,
         help="Directory holding training.jsonl / validation.jsonl of "
-        '{"input": <prompt>, "output": <response>} records (used with --sft).',
+        '{"input": <prompt>, "output": <response>} records (used with --sft). Both fields are '
+        "tokenized verbatim: no chat template is applied and no BOS is prepended, so if the model "
+        "expects role/turn markers or a BOS token, bake them into the fields yourself.",
     )
     # Training & Eval arguments
     parser.add_argument(
@@ -262,7 +264,7 @@ def get_args():
     args = parser.parse_args()
 
     # Sanity checks
-    if not args.use_mock_data and not args.data_paths:
+    if not args.sft and not args.use_mock_data and not args.data_paths:
         raise ValueError("Must provide either --data_paths or set --use_mock_data.")
 
     if args.student_hf_model is None:
@@ -400,6 +402,10 @@ def main(args: argparse.Namespace):
         # no separator); label_key="output" with answer_only_loss=True masks the loss to the
         # response only (answer_start_idx == len(context_ids)); truncation_field="input" truncates
         # the context when the pair exceeds seq_length.
+        #
+        # add_bos=False plus the placeholder-only prompt_template means the records are tokenized
+        # exactly as written -- no chat template, no BOS, no role markers. Callers whose model
+        # expects those must bake them into the "input" field; see --sft_dataset_root help.
         dataset_config = FinetuningDatasetConfig(
             seq_length=args.seq_length,
             dataset_root=args.sft_dataset_root,

--- a/examples/megatron_bridge/distill.py
+++ b/examples/megatron_bridge/distill.py
@@ -22,7 +22,6 @@ See `README.md` in this directory for example usage and data preparation instruc
 
 import argparse
 import contextlib
-import json
 import os
 
 import torch
@@ -131,24 +130,16 @@ def get_args():
     parser.add_argument(
         "--sft",
         action="store_true",
-        help="SFT-masked distillation: read raw prompt-completion jsonl from --sft_dataset_root "
-        "and mask the loss to the completion (assistant response) tokens. Uses "
-        "FinetuningDatasetConfig and the real HuggingFace tokenizer instead of the pretraining "
-        "GPTDataset and NullTokenizer.",
+        help="Distill on prompt-completion jsonl from --sft_dataset_root with the loss masked to "
+        "the completion, instead of pre-tokenized --data_paths.",
     )
     parser.add_argument(
         "--sft_dataset_root",
         type=str,
         default=None,
         help="Directory holding training.jsonl (and validation.jsonl when --eval_iters > 0) of "
-        '{"input": <prompt>, "output": <response>} records (used with --sft). Both fields are '
-        "tokenized as written, except that leading and trailing spaces on each field are "
-        "stripped: no chat template is applied and no BOS is prepended, so if the model expects "
-        "role/turn markers or a BOS token, bake them into the fields yourself, and put any "
-        "significant separator inside the text as a newline rather than a space. An EOS token is "
-        "appended after the response. A record longer than --seq_length is truncated from the "
-        "START of 'input', which drops any BOS, system prompt or opening role marker baked in "
-        "there; pre-filter or pre-truncate the corpus if that matters.",
+        '{"input": <prompt>, "output": <response>} records (used with --sft). See the README for '
+        "how the fields are tokenized and truncated.",
     )
     # Training & Eval arguments
     parser.add_argument(
@@ -299,6 +290,8 @@ def get_args():
         absent = [f for f in required if not os.path.isfile(os.path.join(args.sft_dataset_root, f))]
         if absent:
             raise ValueError(f"--sft_dataset_root {args.sft_dataset_root} is missing: {absent}.")
+        # Decided once here so it reaches print_args and costs a single tokenizer load.
+        args.sft_add_bos = _tokenizer_prepends_bos(args)
 
     _check_shared_vocabulary(args)
 
@@ -308,20 +301,10 @@ def get_args():
 
 
 def _check_shared_vocabulary(args) -> None:
-    """Raise unless teacher and student use the same tokenizer.
-
-    Warns instead when a tokenizer cannot be loaded (some VLM repos ship only a processor).
-    """
+    """Raise unless teacher and student use the same tokenizer."""
     _tok = {"trust_remote_code": args.trust_remote_code}
-    try:
-        student_vocab = AutoTokenizer.from_pretrained(args.student_hf_path, **_tok).get_vocab()
-        teacher_vocab = AutoTokenizer.from_pretrained(args.teacher_hf_path, **_tok).get_vocab()
-    except Exception as e:
-        warn_rank_0(
-            f"Could not load both tokenizers to verify teacher and student share a vocabulary: {e}. "
-            "Distillation needs them to agree on every token id; check it yourself if in doubt."
-        )
-        return
+    student_vocab = AutoTokenizer.from_pretrained(args.student_hf_path, **_tok).get_vocab()
+    teacher_vocab = AutoTokenizer.from_pretrained(args.teacher_hf_path, **_tok).get_vocab()
     if student_vocab != teacher_vocab:
         raise ValueError(
             "Distillation scores the teacher on the student's token ids, so teacher and student "
@@ -329,49 +312,22 @@ def _check_shared_vocabulary(args) -> None:
         )
 
 
-def _warn_if_bos_missing(args) -> None:
-    """Warn when the tokenizer prepends a BOS at inference but the SFT records do not carry one.
+def _tokenizer_prepends_bos(args) -> bool:
+    """True when the student tokenizer prepends a BOS at inference.
 
-    Inspects only the first record of ``training.jsonl``.
+    Probes an encode: fast tokenizers prepend via a post-processor that exposes no attribute.
     """
-    dataset_root = args.sft_dataset_root
-    try:
-        tokenizer = AutoTokenizer.from_pretrained(
-            args.student_hf_path, trust_remote_code=args.trust_remote_code
-        )
-    except Exception:
-        return
-    bos = getattr(tokenizer, "bos_token", None)
-    if not bos:
-        return
-    try:
-        # Probe rather than trusting ``add_bos_token``: many fast tokenizers prepend BOS via the
-        # post-processor without exposing that attribute, and a missing warning is the worse
-        # failure here.
-        if tokenizer("x").input_ids[:1] != [tokenizer.bos_token_id]:
-            return
-    except Exception:
-        return
-    try:
-        with open(os.path.join(dataset_root, "training.jsonl")) as f:
-            first_input = str(json.loads(f.readline()).get("input", ""))
-    except Exception:
-        return  # a malformed or missing file is the dataset builder's error to report, not ours
-    if not first_input.startswith(bos):
-        warn_rank_0(
-            f"This tokenizer prepends {bos!r} at inference, but the first record in "
-            f"{dataset_root}/training.jsonl does not start with it. --sft tokenizes the fields "
-            f"verbatim, so the model would be trained without the BOS it is served with. Include "
-            f"{bos!r} at the start of the 'input' field."
-        )
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.student_hf_path, trust_remote_code=args.trust_remote_code
+    )
+    if not getattr(tokenizer, "bos_token", None):
+        return False
+    return tokenizer("x").input_ids[:1] == [tokenizer.bos_token_id]
 
 
 def main(args: argparse.Namespace):
     checkpoint_dir = os.path.join(args.output_dir, "checkpoints")
     tensorboard_dir = os.path.join(args.output_dir, "tb_logs")
-
-    if args.sft:
-        _warn_if_bos_missing(args)
 
     # Build student and teacher model providers
     def _build_model_provider(hf_path, load_weights=True):
@@ -513,7 +469,8 @@ def main(args: argparse.Namespace):
                 # boundary and then "output" itself, the only span the loss is computed on.
                 "truncation_method": "left",
                 "answer_only_loss": True,
-                "add_bos": False,
+                # Prepended after truncation, so it survives a record that had to be cut.
+                "add_bos": args.sft_add_bos,
                 "add_eos": True,
             },
         )

--- a/examples/megatron_bridge/distill.py
+++ b/examples/megatron_bridge/distill.py
@@ -50,7 +50,7 @@ from megatron.bridge.training.post_training.distillation import ModelOptDistillC
 from megatron.core.datasets.utils import get_blend_from_list
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.utils import unwrap_model
-from transformers import AutoConfig
+from transformers import AutoConfig, AutoTokenizer
 
 import modelopt.torch.distill as mtd
 import modelopt.torch.utils.distributed as dist
@@ -141,9 +141,11 @@ def get_args():
         default=None,
         help="Directory holding training.jsonl (and validation.jsonl when --eval_iters > 0) of "
         '{"input": <prompt>, "output": <response>} records (used with --sft). Both fields are '
-        "tokenized verbatim: no chat template is applied and no BOS is prepended, so if the model "
-        "expects role/turn markers or a BOS token, bake them into the fields yourself. An EOS "
-        "token is appended after the response.",
+        "tokenized as written, except that leading and trailing spaces on each field are "
+        "stripped: no chat template is applied and no BOS is prepended, so if the model expects "
+        "role/turn markers or a BOS token, bake them into the fields yourself, and put any "
+        "significant separator inside the text as a newline rather than a space. An EOS token is "
+        "appended after the response.",
     )
     # Training & Eval arguments
     parser.add_argument(
@@ -338,21 +340,25 @@ def main(args: argparse.Namespace):
         # the mappings. Checked before the providers are built so a mismatch costs seconds.
         # The pretraining path is structurally immune: NullTokenizer plus pre-tokenized
         # --data_paths means one tokenization feeds both models.
-        from transformers import AutoTokenizer
-
         _tok = {"trust_remote_code": args.trust_remote_code}
         student_tokenizer = AutoTokenizer.from_pretrained(args.student_hf_path, **_tok)
         student_vocab = student_tokenizer.get_vocab()
         teacher_vocab = AutoTokenizer.from_pretrained(args.teacher_hf_path, **_tok).get_vocab()
-        if student_vocab != teacher_vocab:
-            detail = (
-                f"{len(student_vocab)} vs {len(teacher_vocab)} tokens"
-                if len(student_vocab) != len(teacher_vocab)
-                else f"both {len(student_vocab)} tokens, but different token->id mappings"
-            )
+        # Only student ids ever reach the teacher, so agreement on those is the invariant. A
+        # teacher vocabulary that is a strict superset (extra reserved tokens, say) is fine.
+        conflicts = {t for t, i in student_vocab.items() if teacher_vocab.get(t, i) != i}
+        missing = student_vocab.keys() - teacher_vocab.keys()
+        if conflicts or missing:
             raise ValueError(
                 "--sft tokenizes with the student's tokenizer and scores the teacher on those "
-                f"same ids, so student and teacher must share a tokenizer ({detail})."
+                "same ids, so the teacher must map every student token to the same id: "
+                f"{len(conflicts)} conflicting id(s), {len(missing)} token(s) absent from the "
+                "teacher. Student and teacher must share a tokenizer."
+            )
+        if len(teacher_vocab) > len(student_vocab):
+            warn_rank_0(
+                f"Teacher vocabulary has {len(teacher_vocab) - len(student_vocab)} token(s) the "
+                "student lacks; ids agree on every student token, so distillation is well-defined."
             )
 
         _warn_if_bos_missing(student_tokenizer, args.sft_dataset_root)
@@ -477,8 +483,10 @@ def main(args: argparse.Namespace):
         # the context when the pair exceeds seq_length.
         #
         # add_bos=False plus the placeholder-only prompt_template means the records are tokenized
-        # exactly as written -- no chat template, no BOS, no role markers. Callers whose model
-        # expects those must bake them into the "input" field; see --sft_dataset_root help.
+        # as written -- no chat template, no BOS, no role markers. One exception: GPTSFTDataset
+        # applies .strip(" ") to each field, so a significant trailing/leading SPACE is lost (a
+        # newline is not). Callers whose model expects markers must bake them into the "input"
+        # field; see --sft_dataset_root help.
         dataset_config = FinetuningDatasetConfig(
             seq_length=args.seq_length,
             dataset_root=args.sft_dataset_root,
@@ -492,6 +500,10 @@ def main(args: argparse.Namespace):
                 "prompt_template": "{input}{output}",
                 "label_key": "output",
                 "truncation_field": "input",
+                # GPTSFTDataset defaults to "right", which truncates the END of the prompt --
+                # the question and whatever turn marker the caller baked in, i.e. exactly the
+                # boundary answer_only_loss starts scoring at. Drop the oldest context instead.
+                "truncation_method": "left",
                 "answer_only_loss": True,
                 "add_bos": False,
                 "add_eos": True,

--- a/examples/megatron_bridge/distill.py
+++ b/examples/megatron_bridge/distill.py
@@ -47,6 +47,7 @@ from megatron.bridge.training.config import (
 from megatron.bridge.training.distill import distill
 from megatron.bridge.training.post_training.checkpointing import has_modelopt_state
 from megatron.bridge.training.post_training.distillation import ModelOptDistillConfig
+from megatron.bridge.utils.vocab_utils import calculate_padded_vocab_size
 from megatron.core.datasets.utils import get_blend_from_list
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.utils import unwrap_model
@@ -145,7 +146,9 @@ def get_args():
         "stripped: no chat template is applied and no BOS is prepended, so if the model expects "
         "role/turn markers or a BOS token, bake them into the fields yourself, and put any "
         "significant separator inside the text as a newline rather than a space. An EOS token is "
-        "appended after the response.",
+        "appended after the response. A record longer than --seq_length is truncated from the "
+        "START of 'input', which drops any BOS, system prompt or opening role marker baked in "
+        "there; pre-filter or pre-truncate the corpus if that matters.",
     )
     # Training & Eval arguments
     parser.add_argument(
@@ -290,13 +293,53 @@ def get_args():
         )
     if args.sft_dataset_root and not args.sft:
         raise ValueError("--sft_dataset_root requires --sft; without it the SFT path is not used.")
+    if args.sft:
+        # Fail on a mistyped root here rather than after both checkpoints have loaded onto GPUs.
+        required = ["training.jsonl"] + (["validation.jsonl"] if args.eval_iters > 0 else [])
+        absent = [f for f in required if not os.path.isfile(os.path.join(args.sft_dataset_root, f))]
+        if absent:
+            raise ValueError(f"--sft_dataset_root {args.sft_dataset_root} is missing: {absent}.")
+
+    _check_shared_vocabulary(args)
 
     print_args(args)
 
     return args
 
 
-def _warn_if_bos_missing(tokenizer, dataset_root: str) -> None:
+def _check_shared_vocabulary(args) -> None:
+    """Raise when teacher and student do not map every token to the same id.
+
+    The KD losses compare the two models' logits elementwise over the vocab dimension, so a token
+    must mean the same thing to both regardless of how the data reaches them. Equal vocabulary
+    *sizes* are not enough -- Llama-2 and Mistral are both 32000 tokens with different mappings --
+    so compare the mappings. Run before the providers are built so a mismatch costs seconds.
+
+    A tokenizer that cannot be loaded (some VLM repos ship only a processor) is warned about
+    rather than fatal: this guard is not worth failing a run that would otherwise work.
+    """
+    _tok = {"trust_remote_code": args.trust_remote_code}
+    try:
+        student_vocab = AutoTokenizer.from_pretrained(args.student_hf_path, **_tok).get_vocab()
+        teacher_vocab = AutoTokenizer.from_pretrained(args.teacher_hf_path, **_tok).get_vocab()
+    except Exception as e:
+        warn_rank_0(
+            f"Could not load both tokenizers to verify teacher and student share a vocabulary: {e}. "
+            "Distillation needs them to agree on every token id; check it yourself if in doubt."
+        )
+        return
+    conflicts = {t for t, i in student_vocab.items() if teacher_vocab.get(t, i) != i}
+    missing = student_vocab.keys() - teacher_vocab.keys()
+    if conflicts or missing:
+        raise ValueError(
+            "Distillation scores the teacher on the student's token ids, so the teacher must map "
+            f"every student token to the same id: {len(conflicts)} conflicting id(s), "
+            f"{len(missing)} token(s) absent from the teacher. Student and teacher must share a "
+            "tokenizer."
+        )
+
+
+def _warn_if_bos_missing(args) -> None:
     """Warn when the tokenizer prepends a BOS at inference but the SFT records do not carry one.
 
     ``--sft`` tokenizes both fields verbatim, so the caller owns the BOS. Adding one here is not
@@ -306,6 +349,13 @@ def _warn_if_bos_missing(tokenizer, dataset_root: str) -> None:
     Bounded on purpose: it inspects only the first record of ``training.jsonl``, so a mixed corpus
     whose first record happens to carry a BOS will not be flagged.
     """
+    dataset_root = args.sft_dataset_root
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(
+            args.student_hf_path, trust_remote_code=args.trust_remote_code
+        )
+    except Exception:
+        return
     bos = getattr(tokenizer, "bos_token", None)
     if not bos:
         return
@@ -336,29 +386,7 @@ def main(args: argparse.Namespace):
     tensorboard_dir = os.path.join(args.output_dir, "tb_logs")
 
     if args.sft:
-        # SFT tokenizes raw text with the student's tokenizer and scores the teacher on those same
-        # ids, so both models must agree on what every id means. Equal vocabulary *sizes* are not
-        # enough -- Llama-2 and Mistral are both 32000 tokens with different mappings -- so compare
-        # the mappings. Checked before the providers are built so a mismatch costs seconds.
-        # The pretraining path is structurally immune: NullTokenizer plus pre-tokenized
-        # --data_paths means one tokenization feeds both models.
-        _tok = {"trust_remote_code": args.trust_remote_code}
-        student_tokenizer = AutoTokenizer.from_pretrained(args.student_hf_path, **_tok)
-        student_vocab = student_tokenizer.get_vocab()
-        teacher_vocab = AutoTokenizer.from_pretrained(args.teacher_hf_path, **_tok).get_vocab()
-        # Every student id must mean the same thing to the teacher. This is necessary but not
-        # sufficient: the KD losses also need equal logits width, checked on the providers below.
-        conflicts = {t for t, i in student_vocab.items() if teacher_vocab.get(t, i) != i}
-        missing = student_vocab.keys() - teacher_vocab.keys()
-        if conflicts or missing:
-            raise ValueError(
-                "--sft tokenizes with the student's tokenizer and scores the teacher on those "
-                "same ids, so the teacher must map every student token to the same id: "
-                f"{len(conflicts)} conflicting id(s), {len(missing)} token(s) absent from the "
-                "teacher. Student and teacher must share a tokenizer."
-            )
-
-        _warn_if_bos_missing(student_tokenizer, args.sft_dataset_root)
+        _warn_if_bos_missing(args)
 
     # Build student and teacher model providers
     def _build_model_provider(hf_path, load_weights=True):
@@ -405,11 +433,22 @@ def main(args: argparse.Namespace):
         student_provider.gradient_accumulation_fusion = False
     teacher_provider = _build_model_provider(args.teacher_hf_path)
 
-    if args.sft and student_provider.vocab_size != teacher_provider.vocab_size:
-        # The KD losses compare logits directly, so the padded vocab dimensions must match.
+    # The KD losses compare logits elementwise over the vocab dimension, so the two output layers
+    # must have the same width. That width is the *padded* vocab size, which the providers derive
+    # from their own ``vocab_size`` and ``make_vocab_size_divisible_by``; a shared tokenizer does
+    # not imply it, because the two HF configs can declare different vocab sizes. Independent of
+    # the data path: the pretraining path feeds both models one tokenization, but says nothing
+    # about how wide their output layers are.
+    padded = {
+        name: calculate_padded_vocab_size(
+            p.vocab_size, p.make_vocab_size_divisible_by, p.tensor_model_parallel_size
+        )
+        for name, p in (("student", student_provider), ("teacher", teacher_provider))
+    }
+    if padded["student"] != padded["teacher"]:
         raise ValueError(
-            "--sft distillation needs student and teacher logits of equal width, but their padded "
-            f"vocab sizes differ ({student_provider.vocab_size} vs {teacher_provider.vocab_size})."
+            "Distillation needs student and teacher logits of equal width, but their padded vocab "
+            f"sizes differ ({padded['student']} vs {padded['teacher']})."
         )
 
     kd_config = ModelOptDistillConfig(
@@ -504,9 +543,14 @@ def main(args: argparse.Namespace):
                 "prompt_template": "{input}{output}",
                 "label_key": "output",
                 "truncation_field": "input",
-                # GPTSFTDataset defaults to "right", which truncates the END of the prompt --
-                # the question and whatever turn marker the caller baked in, i.e. exactly the
-                # boundary answer_only_loss starts scoring at. Drop the oldest context instead.
+                # GPTSFTDataset defaults to "right", which is wrong here twice over: within
+                # "input" it drops the END of the prompt -- the question tail and whatever turn
+                # marker the caller baked in, i.e. exactly the boundary answer_only_loss starts
+                # scoring at -- and once the prompt alone cannot absorb the overflow it walks the
+                # template back-to-front and eats "output", the only span the loss is computed on.
+                # "left" drops the oldest context instead. The cost is that a record over
+                # seq_length loses the head of "input", including any BOS baked in there; see
+                # --sft_dataset_root help.
                 "truncation_method": "left",
                 "answer_only_loss": True,
                 "add_bos": False,
@@ -569,7 +613,9 @@ def main(args: argparse.Namespace):
                     # add_bos/add_eos: text_to_ids adds special tokens when this is left at its
                     # default of True, and prompt_template tokenizes "{input}" and "{output}"
                     # separately -- so a BOS-adding tokenizer would inject one at the answer
-                    # boundary, where answer_only_loss starts scoring.
+                    # boundary, where answer_only_loss starts scoring. Consumed by Bridge in
+                    # training/tokenizers/config.py, which reads it out of hf_tokenizer_kwargs;
+                    # it is not forwarded blindly to AutoTokenizer.
                     "include_special_tokens": False,
                 },
             )

--- a/examples/megatron_bridge/distill.py
+++ b/examples/megatron_bridge/distill.py
@@ -308,15 +308,9 @@ def get_args():
 
 
 def _check_shared_vocabulary(args) -> None:
-    """Raise when teacher and student do not map every token to the same id.
+    """Raise unless teacher and student use the same tokenizer.
 
-    The KD losses compare the two models' logits elementwise over the vocab dimension, so a token
-    must mean the same thing to both regardless of how the data reaches them. Equal vocabulary
-    *sizes* are not enough -- Llama-2 and Mistral are both 32000 tokens with different mappings --
-    so compare the mappings. Run before the providers are built so a mismatch costs seconds.
-
-    A tokenizer that cannot be loaded (some VLM repos ship only a processor) is warned about
-    rather than fatal: this guard is not worth failing a run that would otherwise work.
+    Warns instead when a tokenizer cannot be loaded (some VLM repos ship only a processor).
     """
     _tok = {"trust_remote_code": args.trust_remote_code}
     try:
@@ -328,26 +322,17 @@ def _check_shared_vocabulary(args) -> None:
             "Distillation needs them to agree on every token id; check it yourself if in doubt."
         )
         return
-    conflicts = {t for t, i in student_vocab.items() if teacher_vocab.get(t, i) != i}
-    missing = student_vocab.keys() - teacher_vocab.keys()
-    if conflicts or missing:
+    if student_vocab != teacher_vocab:
         raise ValueError(
-            "Distillation scores the teacher on the student's token ids, so the teacher must map "
-            f"every student token to the same id: {len(conflicts)} conflicting id(s), "
-            f"{len(missing)} token(s) absent from the teacher. Student and teacher must share a "
-            "tokenizer."
+            "Distillation scores the teacher on the student's token ids, so teacher and student "
+            "must use the same tokenizer."
         )
 
 
 def _warn_if_bos_missing(args) -> None:
     """Warn when the tokenizer prepends a BOS at inference but the SFT records do not carry one.
 
-    ``--sft`` tokenizes both fields verbatim, so the caller owns the BOS. Adding one here is not
-    safe (their text may already have it, which would double it), but training without the BOS the
-    model is served with is silent train/inference skew.
-
-    Bounded on purpose: it inspects only the first record of ``training.jsonl``, so a mixed corpus
-    whose first record happens to carry a BOS will not be flagged.
+    Inspects only the first record of ``training.jsonl``.
     """
     dataset_root = args.sft_dataset_root
     try:
@@ -403,12 +388,8 @@ def main(args: argparse.Namespace):
         provider.expert_tensor_parallel_size = 1  # Expert tensor parallelism is not supported
         provider.seq_length = args.seq_length
         if args.sft:
-            # The SFT loss mask covers only the response tokens, so the reduction must be
-            # per-token for it to combine correctly across context-parallel ranks. This lands on
-            # both providers (harmless: the teacher's LM loss is zeroed in
-            # adjust_distillation_model_for_mcore) and must stay in sync with
-            # ``average_in_collective=not args.sft`` on the shared DistributedDataParallelConfig
-            # below -- a per-token loss must not be pre-averaged.
+            # A response-only loss mask needs per-token reduction to combine across CP ranks.
+            # Must stay in sync with ``average_in_collective=not args.sft`` on the DDP config.
             provider.calculate_per_token_loss = True
         if args.recompute_granularity is not None:
             provider.recompute_granularity = args.recompute_granularity
@@ -433,12 +414,8 @@ def main(args: argparse.Namespace):
         student_provider.gradient_accumulation_fusion = False
     teacher_provider = _build_model_provider(args.teacher_hf_path)
 
-    # The KD losses compare logits elementwise over the vocab dimension, so the two output layers
-    # must have the same width. That width is the *padded* vocab size, which the providers derive
-    # from their own ``vocab_size`` and ``make_vocab_size_divisible_by``; a shared tokenizer does
-    # not imply it, because the two HF configs can declare different vocab sizes. Independent of
-    # the data path: the pretraining path feeds both models one tokenization, but says nothing
-    # about how wide their output layers are.
+    # The KD losses compare logits elementwise over the vocab dim, so both output layers must have
+    # the same padded width. A shared tokenizer does not imply it: the HF configs can disagree.
     padded = {
         name: calculate_padded_vocab_size(
             p.vocab_size, p.make_vocab_size_divisible_by, p.tensor_model_parallel_size
@@ -455,10 +432,8 @@ def main(args: argparse.Namespace):
         skip_lm_loss=not args.no_skip_lm_loss, kd_loss_scale=args.kd_loss_scale
     )
 
-    # VLM detection convention: HF VLM configs expose a ``vision_config``, and Megatron-Bridge nests
-    # the text model under the ``language_model`` submodule (used as ``distill_submodule`` below). If a
-    # future model breaks either convention, the ``getattr(model, "language_model")`` in the provider
-    # will error loudly rather than silently distilling the wrong module.
+    # HF VLM configs expose ``vision_config``; Megatron-Bridge nests the text model under
+    # ``language_model`` (used as ``distill_submodule`` below).
     is_vlm = hasattr(
         AutoConfig.from_pretrained(args.student_hf_path, trust_remote_code=args.trust_remote_code),
         "vision_config",
@@ -518,18 +493,9 @@ def main(args: argparse.Namespace):
         "skip_getting_attention_mask_from_dataset": True,
     }
     if args.sft:
-        # SFT-masked distillation via Bridge's FinetuningDatasetConfig -> NeMo-style GPTSFTDataset.
-        # `dataset_root` holds training.jsonl / validation.jsonl of {"input", "output"} records.
-        # prompt_template="{input}{output}" tokenizes input+output verbatim (adjacent placeholders,
-        # no separator); label_key="output" with answer_only_loss=True masks the loss to the
-        # response only (answer_start_idx == len(context_ids)); truncation_field="input" truncates
-        # the context when the pair exceeds seq_length.
-        #
-        # add_bos=False plus the placeholder-only prompt_template means the records are tokenized
-        # as written -- no chat template, no BOS, no role markers. One exception: GPTSFTDataset
-        # applies .strip(" ") to each field, so a significant trailing/leading SPACE is lost (a
-        # newline is not). Callers whose model expects markers must bake them into the "input"
-        # field; see --sft_dataset_root help.
+        # SFT-masked distillation via Bridge's FinetuningDatasetConfig -> NeMo-style GPTSFTDataset,
+        # reading {"input", "output"} jsonl. Fields are tokenized as written except that each is
+        # ``.strip(" ")``-ed; see --sft_dataset_root help.
         dataset_config = FinetuningDatasetConfig(
             seq_length=args.seq_length,
             dataset_root=args.sft_dataset_root,
@@ -543,14 +509,8 @@ def main(args: argparse.Namespace):
                 "prompt_template": "{input}{output}",
                 "label_key": "output",
                 "truncation_field": "input",
-                # GPTSFTDataset defaults to "right", which is wrong here twice over: within
-                # "input" it drops the END of the prompt -- the question tail and whatever turn
-                # marker the caller baked in, i.e. exactly the boundary answer_only_loss starts
-                # scoring at -- and once the prompt alone cannot absorb the overflow it walks the
-                # template back-to-front and eats "output", the only span the loss is computed on.
-                # "left" drops the oldest context instead. The cost is that a record over
-                # seq_length loses the head of "input", including any BOS baked in there; see
-                # --sft_dataset_root help.
+                # Drop the oldest context. The default "right" would cut the prompt/answer
+                # boundary and then "output" itself, the only span the loss is computed on.
                 "truncation_method": "left",
                 "answer_only_loss": True,
                 "add_bos": False,
@@ -609,13 +569,9 @@ def main(args: argparse.Namespace):
                 tokenizer_model=args.student_hf_path,
                 hf_tokenizer_kwargs={
                     "trust_remote_code": args.trust_remote_code,
-                    # Enforce the verbatim contract here rather than relying on the dataset's
-                    # add_bos/add_eos: text_to_ids adds special tokens when this is left at its
-                    # default of True, and prompt_template tokenizes "{input}" and "{output}"
-                    # separately -- so a BOS-adding tokenizer would inject one at the answer
-                    # boundary, where answer_only_loss starts scoring. Consumed by Bridge in
-                    # training/tokenizers/config.py, which reads it out of hf_tokenizer_kwargs;
-                    # it is not forwarded blindly to AutoTokenizer.
+                    # Default True would make text_to_ids inject a BOS at the answer boundary,
+                    # since "{input}" and "{output}" are tokenized separately. Consumed by Bridge
+                    # in training/tokenizers/config.py.
                     "include_special_tokens": False,
                 },
             )

--- a/examples/megatron_bridge/distill.py
+++ b/examples/megatron_bridge/distill.py
@@ -22,6 +22,7 @@ See `README.md` in this directory for example usage and data preparation instruc
 
 import argparse
 import contextlib
+import json
 import os
 
 import torch
@@ -290,6 +291,30 @@ def get_args():
     return args
 
 
+def _warn_if_bos_missing(tokenizer, dataset_root: str) -> None:
+    """Warn when the tokenizer prepends a BOS at inference but the SFT records do not carry one.
+
+    ``--sft`` tokenizes both fields verbatim, so the caller owns the BOS. Adding one here is not
+    safe (their text may already have it, which would double it), but training without the BOS the
+    model is served with is silent train/inference skew.
+    """
+    bos = getattr(tokenizer, "bos_token", None)
+    if not bos or not getattr(tokenizer, "add_bos_token", False):
+        return
+    try:
+        with open(os.path.join(dataset_root, "training.jsonl")) as f:
+            first_input = str(json.loads(f.readline()).get("input", ""))
+    except Exception:
+        return  # a malformed or missing file is the dataset builder's error to report, not ours
+    if not first_input.startswith(bos):
+        warn_rank_0(
+            f"This tokenizer prepends {bos!r} at inference, but the first record in "
+            f"{dataset_root}/training.jsonl does not start with it. --sft tokenizes the fields "
+            f"verbatim, so the model would be trained without the BOS it is served with. Include "
+            f"{bos!r} at the start of the 'input' field."
+        )
+
+
 def main(args: argparse.Namespace):
     checkpoint_dir = os.path.join(args.output_dir, "checkpoints")
     tensorboard_dir = os.path.join(args.output_dir, "tb_logs")
@@ -304,7 +329,8 @@ def main(args: argparse.Namespace):
         from transformers import AutoTokenizer
 
         _tok = {"trust_remote_code": args.trust_remote_code}
-        student_vocab = AutoTokenizer.from_pretrained(args.student_hf_path, **_tok).get_vocab()
+        student_tokenizer = AutoTokenizer.from_pretrained(args.student_hf_path, **_tok)
+        student_vocab = student_tokenizer.get_vocab()
         teacher_vocab = AutoTokenizer.from_pretrained(args.teacher_hf_path, **_tok).get_vocab()
         if student_vocab != teacher_vocab:
             detail = (
@@ -316,6 +342,8 @@ def main(args: argparse.Namespace):
                 "--sft tokenizes with the student's tokenizer and scores the teacher on those "
                 f"same ids, so student and teacher must share a tokenizer ({detail})."
             )
+
+        _warn_if_bos_missing(student_tokenizer, args.sft_dataset_root)
 
     # Build student and teacher model providers
     def _build_model_provider(hf_path, load_weights=True):

--- a/tests/examples/megatron_bridge/test_distill.py
+++ b/tests/examples/megatron_bridge/test_distill.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Tests for prune_minitron.py and distill.py scripts."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -56,6 +57,43 @@ def test_distill_llm(tmp_path, num_gpus):
 
     assert (distill_output_dir / f"checkpoints/iter_{train_iters:07d}").exists()
     assert (distilled_hf_path / "config.json").exists()
+
+
+def test_distill_llm_sft(tmp_path, num_gpus):
+    """--sft distills from prompt-completion jsonl instead of pre-tokenized --data_paths."""
+    teacher_hf_path = create_tiny_qwen3_dir(tmp_path, with_tokenizer=True)
+    train_iters = 2
+    gbs = 4
+    dataset_root = tmp_path / "sft_data"
+    dataset_root.mkdir()
+    # More records than train_iters * gbs so the sampler does not run dry.
+    records = [{"input": f"Q: what follows {i}?\nA:", "output": f" {i + 1}"} for i in range(64)]
+    for split in ("training", "validation"):
+        (dataset_root / f"{split}.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n"
+        )
+
+    distill_output_dir = tmp_path / "distill_output"
+    distill_cmd_parts = extend_cmd_parts(
+        ["torchrun", f"--nproc_per_node={num_gpus}", "distill.py", "--sft"],
+        student_hf_path=teacher_hf_path,
+        teacher_hf_path=teacher_hf_path,
+        sft_dataset_root=dataset_root,
+        output_dir=distill_output_dir,
+        tp_size=num_gpus,
+        pp_size=1,
+        seq_length=64,
+        mbs=1,
+        gbs=gbs,
+        train_iters=train_iters,
+        lr_warmup_iters=1,
+        eval_interval=train_iters,
+        eval_iters=1,
+        log_interval=1,
+    )
+    run_example_command(distill_cmd_parts, example_path="megatron_bridge")
+
+    assert (distill_output_dir / f"checkpoints/iter_{train_iters:07d}").exists()
 
 
 def test_distill_validate_only(tmp_path, num_gpus):


### PR DESCRIPTION
## What does this PR do ?

**Type of change:** New feature

**Overview:** Adds SFT-masked data support to the Megatron-Bridge distillation example, so a
model can be distilled on prompt/response pairs with the loss masked to the response.

Today `examples/megatron_bridge/distill.py` only consumes pretraining-style data — `GPTDataset`
over pre-tokenized blends with `NullTokenizer` — so the loss is computed over every token. When
distilling an instruction-tuned model it is usually preferable to train on prompt/response pairs
and mask the loss to the response, matching how the model was fine-tuned.

## Usage

```bash
python examples/megatron_bridge/distill.py \
  --teacher_hf_path <teacher> --student_hf_path <student> \
  --sft --sft_dataset_root /path/to/data \
  ...
```

where `/path/to/data` holds `training.jsonl` / `validation.jsonl` of records:

```json
{"input": "<prompt>", "output": "<response>"}
```

## How it works

Switches the data path to Bridge's `FinetuningDatasetConfig` (NeMo-style `GPTSFTDataset`):

* `prompt_template="{input}{output}"` tokenizes input+output verbatim — adjacent placeholders,
  no separator — so the text is fed exactly as provided
* `label_key="output"` with `answer_only_loss=True` masks the loss to the response
  (`answer_start_idx == len(context_ids)`)
* `truncation_field="input"` truncates the context when a pair exceeds `seq_length`

Two supporting changes, both scoped to `--sft`:

* **Tokenizer.** SFT reads raw text, so it uses the model's real HuggingFace tokenizer. The
  pretraining path consumes pre-tokenized data and keeps `NullTokenizer`.
* **Loss reduction.** A response-only mask requires per-token loss to combine correctly across
  context-parallel ranks, so `calculate_per_token_loss` is enabled and `average_in_collective`
  is disabled. Both are untouched on the pretraining path.

## Testing

Used for quantization-aware distillation of Nemotron-Nano-3 (W4A16 NVFP4) at `seq_length=32768`
with CP>1: 200 iterations, logits-distillation loss `3.37e-2 -> 1.91e-2` monotonically, router
`seq_load_balancing_loss` steady, and the resulting checkpoint exports and serves correctly.

Opt-in: without `--sft` the existing mock/blend data path is unchanged.

## Before your PR is "Ready for review"

- **Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md)** and your commits are signed.
- **Is this change backward compatible?**: Yes — purely additive and opt-in behind `--sft`.
- **Did you write any new necessary tests?**: No
- **Did you add or update any necessary documentation?**: No
- **Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?**: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added supervised fine-tuning (SFT) support for distillation workflows.
  * Added configuration and validation for SFT dataset locations and supported inputs.
  * Added raw prompt/completion JSONL datasets with response-only loss masking.
  * Added truncation, end-of-sequence handling, and student-tokenizer support without automatic chat templates or BOS tokens.
  * Added matching student and teacher vocabulary validation.
  * Preserved existing mock and GPT dataset modes for non-SFT runs.

* **Documentation**
  * Documented required filenames, record format, tokenizer behavior, and completion-only loss masking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->