### PR TITLE
Mark the MLflow test's fake credentials for TruffleHog

### DIFF
--- a/tests/unit/torch/utils/test_mlflow.py
+++ b/tests/unit/torch/utils/test_mlflow.py
@@ -33,6 +33,11 @@ from modelopt.torch.utils.mlflow import (
 )
 
 URI = "https://mlflow.example.com"
+# Fake credentials for the redaction tests. TruffleHog's URI detector flags any
+# scheme://user:pass@host, so the marker sits on the definitions; these tests exist
+# precisely to prove such credentials are masked.
+CREDS_URI = "https://user:tok@mlflow.example.com"  # trufflehog:ignore
+SHORT_CREDS_URI = "https://u:tok@host"  # trufflehog:ignore
 
 
 class FakeMlflow:
@@ -409,7 +414,7 @@ def test_unreachable_server_fails_before_the_work_starts(monkeypatch):
         (["--password", "hunter2", "--verbose"], ["--password", "***", "--verbose"]),
         # Credentials embedded in a URI are masked wherever they appear.
         (
-            ["--mlflow", "https://user:tok@mlflow.example.com"],
+            ["--mlflow", CREDS_URI],
             ["--mlflow", "https://***@mlflow.example.com"],
         ),
         # Ordinary arguments are untouched, including values that merely contain the word.
@@ -426,7 +431,7 @@ def test_redact_argv_masks_credentials(argv, expected):
 def test_command_artifact_carries_no_secrets(fake_mlflow, monkeypatch):
     """argv reaches the server as command.txt, so secrets in it must not."""
     monkeypatch.setattr(
-        sys, "argv", ["run.py", "--hf_token", "hf_abc123", "--mlflow", "https://u:tok@host"]
+        sys, "argv", ["run.py", "--hf_token", "hf_abc123", "--mlflow", SHORT_CREDS_URI]
     )
     logger = _logger()
 
@@ -444,9 +449,7 @@ def test_params_and_run_url_mask_credentials(monkeypatch):
     fake = FakeMlflow()
     monkeypatch.setitem(sys.modules, "mlflow", fake)
     monkeypatch.setattr(sys, "argv", ["run.py"])
-    logger = MlflowRunLogger(
-        "https://user:tok@mlflow.example.com", "tester/hf_ptq/m-nvfp4", run_name="masked"
-    )
+    logger = MlflowRunLogger(CREDS_URI, "tester/hf_ptq/m-nvfp4", run_name="masked")
 
     logger.start(params={"hf_token": "secret", "endpoint": "https://u:p@host", "qformat": "nvfp4"})
     url = logger.run_url
@@ -455,7 +458,7 @@ def test_params_and_run_url_mask_credentials(monkeypatch):
     assert fake.params == {"hf_token": "***", "endpoint": "https://***@host", "qformat": "nvfp4"}
     assert "tok" not in url and "https://***@mlflow.example.com" in url
     # The real URI is still what talks to the server.
-    assert fake.tracking_uri == "https://user:tok@mlflow.example.com"
+    assert fake.tracking_uri == CREDS_URI
 
 
 def test_failure_after_start_run_does_not_orphan_the_run(monkeypatch):


### PR DESCRIPTION
### What does this PR do?

Type of change: CI/CD bug fix

The nightly secret scan still fails ([run](https://github.com/NVIDIA/Model-Optimizer/actions/runs/31285393940)). The `lob` exclusion worked — verified findings went **63 → 0** — but two *unverified* URI results remain, and `--results=verified,unknown` fails the job on those as well:

```
{"chunks": 2869, "verified_secrets": 0, "unverified_secrets": 2}
Found unverified URI result  x2   ->  exit 183
```

Both come from `tests/unit/torch/utils/test_mlflow.py`, which embeds credentials in a URI **so the tests can assert they get masked**:

```python
(["--mlflow", "https://user:tok@mlflow.example.com"],
 ["--mlflow", "https://***@mlflow.example.com"]),
```

They arrived with #2023, which is why this is separate from the `lob` noise.

The fixtures are hoisted into two named constants so the `trufflehog:ignore` marker sits on one short line each. The marker only applies to the line containing the match, and a trailing comment on all four use sites would have blown the 100-character limit.

Deliberately narrow: unlike `lob` — irrelevant to this repo and reporting function names as *verified* — the URI detector is worth keeping. A real `scheme://user:pass@host` leak is plausible here, so the fixtures are annotated rather than the detector disabled.

### Testing

`tests/unit/torch/utils/test_mlflow.py`: **54 passed**, ruff check and format clean. A scan of all tracked files with the detector's own regex now reports **0 unmarked matches**.

Only tonight's nightly can confirm the job goes green: the scan is diff-scoped on `pull_request` and full-history on `schedule`, which is why this class of failure never appears on a PR.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A — annotates existing test fixtures
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: ❌ — not yet run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage setup for credential-bearing URI redaction scenarios.
  * Confirmed masked outputs and command artifact behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->