### PR TITLE
specdec_bench: fix run provenance, add MLflow tracking

### DIFF
--- a/examples/specdec_bench/run.py
+++ b/examples/specdec_bench/run.py
@@ -18,6 +18,7 @@ import asyncio
 
 import yaml
 from specdec_bench import datasets, metrics, models, runners
+from specdec_bench.mlflow_tracking import add_mlflow_args, mlflow_run, resolve_mlflow_args
 from specdec_bench.utils import (
     decode_chat,
     dump_env,
@@ -402,6 +403,7 @@ if __name__ == "__main__":
         default=None,
         help="Directory to save the results",
     )
+    add_mlflow_args(parser)
     args = parser.parse_args()
 
     if args.runtime_params is not None:
@@ -425,4 +427,9 @@ if __name__ == "__main__":
             "Warning: Ignore EOS should only be used in certain cases, do no activate unless necessary"
         )
 
-    run_simple(args)
+    # Resolved after the dataset/algorithm defaults above, since the
+    # experiment name is derived from them.
+    resolve_mlflow_args(args, parser)
+
+    with mlflow_run(args):
+        run_simple(args)

--- a/examples/specdec_bench/specdec_bench/mlflow_tracking.py
+++ b/examples/specdec_bench/specdec_bench/mlflow_tracking.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Track a specdec_bench run on an MLflow server.
+
+A benchmark's results otherwise exist only as JSON under ``--save_dir``,
+which somebody has to upload before anyone else can see them. Logging to
+MLflow makes the run visible as soon as it finishes, with its acceptance
+length, throughput and full configuration queryable next to every other
+run, and the log and result files attached.
+
+Mirrors the flags ``examples/hf_ptq`` uses (``--mlflow``,
+``--mlflow_experiment``, ``--mlflow_run_name``), so a shell that already
+exports ``MLFLOW_TRACKING_URI`` opts in without changing the command.
+"""
+
+import argparse
+import json
+import os
+import warnings
+from contextlib import contextmanager
+from pathlib import Path
+
+from modelopt.torch.utils.mlflow import (
+    MlflowRunLogger,
+    default_experiment_name,
+    validate_tracking_uri,
+)
+
+# Result files each metric writes into --save_dir, keyed by the artifact
+# path they take on in MLflow. Missing entries are skipped by the logger,
+# so listing every metric's output here is safe regardless of which ran.
+_RESULT_FILES = {
+    "results/acceptance_rate.json": "acceptance_rate.json",
+    "results/specbench_results.json": "specbench_results.json",
+    "results/timing.json": "timing.json",
+    "results/aa_timing.json": "aa_timing.json",
+    "results/configuration.json": "configuration.json",
+    "results/acceptance_rate_analysis.png": "acceptance_rate_analysis.png",
+}
+
+# argparse fields that configure tracking itself rather than the benchmark.
+_NON_PARAM_ARGS = frozenset({"mlflow", "mlflow_experiment", "mlflow_required", "mlflow_run_name"})
+
+
+def add_mlflow_args(parser: argparse.ArgumentParser) -> None:
+    """Add the MLflow tracking flags."""
+    parser.add_argument(
+        "--mlflow",
+        default=None,
+        help=(
+            "Track this run on an MLflow server (e.g. https://<your-mlflow-server>/), "
+            "uploading the configuration, the acceptance/timing results and the run log. "
+            "MLflow's own $MLFLOW_TRACKING_URI enables tracking without this flag, which "
+            "overrides it. A URI taken from the environment is best-effort: if it is "
+            "unusable the run warns and continues untracked."
+        ),
+    )
+    parser.add_argument(
+        "--mlflow_experiment",
+        default=None,
+        help=(
+            "MLflow experiment name. Default: "
+            "$USER/specdec_bench/<model basename>-<speculative algorithm>."
+        ),
+    )
+    parser.add_argument(
+        "--mlflow_run_name",
+        default=None,
+        help="MLflow run name. Default: the UTC start time as YYYYmmdd-HHMMSS.",
+    )
+
+
+def resolve_mlflow_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    """Settle where tracking is configured from, and name the experiment."""
+    # MLflow's own variable enables tracking on its own; --mlflow overrides it.
+    # Only the flag is a deliberate request, so only the flag is fatal when the
+    # URI is unusable: the variable is commonly exported for unrelated tooling
+    # and must not fail a benchmark that is about to spend GPU hours.
+    args.mlflow_required = args.mlflow is not None
+    args.mlflow = args.mlflow or os.environ.get("MLFLOW_TRACKING_URI") or None
+    if not args.mlflow:
+        return
+    try:
+        args.mlflow = validate_tracking_uri(args.mlflow)
+    except ValueError as e:
+        if args.mlflow_required:
+            parser.error(f"--mlflow: {e}")
+        warnings.warn(f"Ignoring MLFLOW_TRACKING_URI, continuing untracked: {e}")
+        args.mlflow = None
+        return
+    args.mlflow_experiment = args.mlflow_experiment or default_experiment_name(
+        "specdec_bench",
+        args.model_dir or "unknown",
+        args.speculative_algorithm or "NONE",
+    )
+
+
+def _run_tags(args: argparse.Namespace) -> dict[str, str]:
+    """Identity of what ran, as searchable tags.
+
+    ``draft_model`` is what distinguishes two runs that share a verifier,
+    which is the comparison this benchmark exists to make. The published Hub
+    id is kept whole — the org is precisely what separates two drafters
+    trained for the same base model — and only a local path is shortened to
+    its leaf, since the leading directories say nothing about the drafter.
+    """
+    tags = {
+        "model": Path(args.model_dir).name if args.model_dir else "",
+        "algorithm": args.speculative_algorithm or "NONE",
+        "engine": args.engine or "",
+        "dataset": args.dataset or "",
+    }
+    hub_id = getattr(args, "draft_huggingface_model_id", None)
+    if hub_id:
+        tags["draft_model"] = str(hub_id)
+    elif args.draft_model_dir:
+        tags["draft_model"] = Path(args.draft_model_dir).name
+    return {k: v for k, v in tags.items() if v}
+
+
+def _headline_metrics(save_dir: str | None) -> dict[str, float]:
+    """Acceptance length and throughput, read back from the metric JSONs.
+
+    Read from disk rather than passed in because each metric owns its own
+    output format, and the file is what a later consumer sees anyway. A
+    missing or malformed file yields no metric rather than failing the run:
+    tracking must never be why a completed benchmark reports failure.
+    """
+    if not save_dir:
+        return {}
+    out: dict[str, float] = {}
+
+    def _first(path: Path):
+        try:
+            with path.open() as f:
+                payload = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+        if isinstance(payload, list):
+            return payload[0] if payload else None
+        return payload
+
+    directory = Path(save_dir)
+    acceptance = _first(directory / "acceptance_rate.json") or {}
+    for key in ("Average_AL", "Average_AR"):
+        if isinstance(acceptance.get(key), (int, float)):
+            out["avg_al"] = float(acceptance[key])
+            break
+    categories = acceptance.get("Category_AL") or acceptance.get("Category_AR") or {}
+    if isinstance(categories, dict):
+        for name, value in categories.items():
+            if isinstance(value, (int, float)):
+                out[f"category_al/{name}"] = float(value)
+
+    timing = _first(directory / "timing.json") or {}
+    for source, name in (("Output TPS", "output_tps"), ("Output TPS/gpu", "output_tps_per_gpu")):
+        if isinstance(timing.get(source), (int, float)):
+            out[name] = float(timing[source])
+    return out
+
+
+@contextmanager
+def mlflow_run(args: argparse.Namespace):
+    """Track this invocation for the duration of the block, or do nothing.
+
+    The benchmark's headline metrics don't exist until the run has finished
+    writing them, so unlike ``MlflowRunLogger.track`` this reads them out of
+    ``--save_dir`` on the way out. The result files themselves are named
+    upfront: the logger uploads only the ones the run actually wrote.
+    """
+    logger = MlflowRunLogger(
+        args.mlflow,
+        getattr(args, "mlflow_experiment", None) or "",
+        run_name=getattr(args, "mlflow_run_name", None),
+        enabled=bool(args.mlflow),
+        required=bool(getattr(args, "mlflow_required", False)),
+    )
+    if not logger.enabled:
+        yield None
+        return
+
+    params = {k: v for k, v in vars(args).items() if k not in _NON_PARAM_ARGS}
+    files = (
+        {artifact: Path(args.save_dir) / name for artifact, name in _RESULT_FILES.items()}
+        if args.save_dir
+        else {}
+    )
+
+    logger.start(params=params, tags=_run_tags(args))
+    status = "FAILED"
+    try:
+        yield logger
+        status = "FINISHED"
+    finally:
+        # Metrics are read here rather than passed to start(): the benchmark
+        # writes them during the block. A failed run still uploads whatever it
+        # managed to produce, which is usually the point of looking at it.
+        logger.finish(status, files=files, metrics=_headline_metrics(args.save_dir))

--- a/examples/specdec_bench/specdec_bench/mlflow_tracking.py
+++ b/examples/specdec_bench/specdec_bench/mlflow_tracking.py
@@ -39,6 +39,8 @@ from modelopt.torch.utils.mlflow import (
     validate_tracking_uri,
 )
 
+__all__ = ["add_mlflow_args", "mlflow_run", "resolve_mlflow_args"]
+
 # Result files each metric writes into --save_dir, keyed by the artifact
 # path they take on in MLflow. Missing entries are skipped by the logger,
 # so listing every metric's output here is safe regardless of which ran.
@@ -63,9 +65,9 @@ def add_mlflow_args(parser: argparse.ArgumentParser) -> None:
         help=(
             "Track this run on an MLflow server (e.g. https://<your-mlflow-server>/), "
             "uploading the configuration, the acceptance/timing results and the run log. "
-            "MLflow's own $MLFLOW_TRACKING_URI enables tracking without this flag, which "
-            "overrides it. A URI taken from the environment is best-effort: if it is "
-            "unusable the run warns and continues untracked."
+            "MLflow's own $MLFLOW_TRACKING_URI enables tracking without this flag; this "
+            "flag takes precedence when both are set. A URI taken from the environment "
+            "is best-effort: if it is unusable the run warns and continues untracked."
         ),
     )
     parser.add_argument(
@@ -95,10 +97,16 @@ def resolve_mlflow_args(args: argparse.Namespace, parser: argparse.ArgumentParse
         return
     try:
         args.mlflow = validate_tracking_uri(args.mlflow)
-    except ValueError as e:
+    except ValueError:
+        # Deliberately not echoing the URI or the exception text, which quotes
+        # it: a rejected URI may carry credentials in its userinfo or query,
+        # and this lands in terminals and CI logs. The caller supplied the
+        # value, so naming the source is enough to act on.
+        source = "--mlflow" if args.mlflow_required else "$MLFLOW_TRACKING_URI"
+        message = f"{source} is not a valid http(s) MLflow tracking URI"
         if args.mlflow_required:
-            parser.error(f"--mlflow: {e}")
-        warnings.warn(f"Ignoring MLFLOW_TRACKING_URI, continuing untracked: {e}")
+            parser.error(message)
+        warnings.warn(f"{message}; continuing untracked")
         args.mlflow = None
         return
     args.mlflow_experiment = args.mlflow_experiment or default_experiment_name(
@@ -143,29 +151,42 @@ def _headline_metrics(save_dir: str | None) -> dict[str, float]:
         return {}
     out: dict[str, float] = {}
 
-    def _first(path: Path):
+    def _first(path: Path) -> dict:
+        """The run's result object, or an empty one for anything unexpected.
+
+        A metric file is written by a separate process that may have died
+        mid-write, so its contents are not a given. Anything that is not a
+        mapping (or a list of them) yields {} rather than propagating: this
+        runs inside the caller's `finally`, where an exception would stop
+        the MLflow run from being closed at all.
+        """
         try:
             with path.open() as f:
                 payload = json.load(f)
         except (OSError, json.JSONDecodeError):
-            return None
+            return {}
         if isinstance(payload, list):
-            return payload[0] if payload else None
-        return payload
+            payload = payload[0] if payload else None
+        return payload if isinstance(payload, dict) else {}
 
     directory = Path(save_dir)
-    acceptance = _first(directory / "acceptance_rate.json") or {}
-    for key in ("Average_AL", "Average_AR"):
+    acceptance = _first(directory / "acceptance_rate.json")
+    # Pre-v1.0.0 specdec_bench names these _AR. The suffix records how the
+    # figure was computed, so it is kept in the metric name rather than
+    # folded into avg_al, which would silently mix the two definitions.
+    for key, metric in (("Average_AL", "avg_al"), ("Average_AR", "avg_ar")):
         if isinstance(acceptance.get(key), (int, float)):
-            out["avg_al"] = float(acceptance[key])
+            out[metric] = float(acceptance[key])
             break
-    categories = acceptance.get("Category_AL") or acceptance.get("Category_AR") or {}
-    if isinstance(categories, dict):
-        for name, value in categories.items():
-            if isinstance(value, (int, float)):
-                out[f"category_al/{name}"] = float(value)
+    for key, prefix in (("Category_AL", "category_al"), ("Category_AR", "category_ar")):
+        categories = acceptance.get(key)
+        if isinstance(categories, dict):
+            for name, value in categories.items():
+                if isinstance(value, (int, float)):
+                    out[f"{prefix}/{name}"] = float(value)
+            break
 
-    timing = _first(directory / "timing.json") or {}
+    timing = _first(directory / "timing.json")
     for source, name in (("Output TPS", "output_tps"), ("Output TPS/gpu", "output_tps_per_gpu")):
         if isinstance(timing.get(source), (int, float)):
             out[name] = float(timing[source])
@@ -199,7 +220,10 @@ def mlflow_run(args: argparse.Namespace):
         else {}
     )
 
-    logger.start(params=params, tags=_run_tags(args))
+    # files is named here as well as at finish(): start() stats each path so
+    # finish() can tell an output this run wrote from one left in --save_dir
+    # by a previous attempt, which is otherwise uploaded as if it were ours.
+    logger.start(params=params, tags=_run_tags(args), files=files)
     status = "FAILED"
     try:
         yield logger

--- a/examples/specdec_bench/specdec_bench/utils.py
+++ b/examples/specdec_bench/specdec_bench/utils.py
@@ -17,9 +17,11 @@ import datetime
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
+from warnings import warn as _warn
 
 from transformers import AutoTokenizer
 
@@ -32,13 +34,18 @@ _SENSITIVE_SUBSTRINGS = ("token", "key", "secret", "password")
 _SENSITIVE_KEY_ALLOWLIST = frozenset(
     {"tokenizer", "tokenizer_path", "tokenizer_mode", "tokenizer_revision"}
 )
-# A bare substring match over `token` also swallows engine config: the serving
-# config alone contributes num_speculative_tokens, max_num_batched_tokens,
+# Names that are credentials outright, whatever they hold. These redact on the
+# name alone: a numeric or boolean value is no proof of safety, and treating one
+# as such would persist e.g. an all-digit token.
+_ALWAYS_SENSITIVE_SUBSTRINGS = ("hf_token", "api_key", "access_key", "secret", "password")
+# The remaining substrings are ambiguous rather than damning: a bare match over
+# `token` also swallows engine config, where the serving config alone
+# contributes num_speculative_tokens, max_num_batched_tokens,
 # skip_tokenizer_init and a dozen similar knobs, none of them credentials.
-# Enumerating them doesn't hold — the set grows with every engine release — so
-# redact on VALUE SHAPE instead: a credential is a non-trivial string, whereas
-# these knobs are ints, bools, and None. `hf_token` still redacts because its
-# value is a string.
+# Enumerating those doesn't hold — the set grows with every engine release — so
+# for the ambiguous names only, a scalar value (int / bool / None) is taken as
+# evidence the field is a knob and kept. A string still redacts, because that is
+# the shape a credential takes.
 _NON_SECRET_VALUE_TYPES = (bool, int, float, type(None))
 
 
@@ -218,19 +225,44 @@ def _checkpoint_provenance(model_dir):
 
 _UNSET = object()
 
+# `<org>/<name>`, the shape of a Hub repo id. Deliberately excludes `:@?#` and
+# whitespace so a URL with embedded credentials (`https://user:tok@host/...`)
+# can't reach configuration.json through the environment.
+_HUB_MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*$")
+
+
+def _hub_model_id(env_var):
+    """Return `$env_var` if it looks like a Hub repo id, else None.
+
+    These ids are copied verbatim into configuration.json and published, so an
+    unset or malformed value is dropped rather than recorded. A rejected value
+    warns instead of raising: provenance metadata should never fail a benchmark
+    that has already run.
+    """
+    raw = (os.environ.get(env_var) or "").strip()
+    if not raw:
+        return None
+    if not _HUB_MODEL_ID_RE.match(raw):
+        _warn(f"{env_var} is not an <org>/<name> Hub id; omitting it from configuration.json")
+        return None
+    return raw
+
 
 def _is_sensitive_key(key, value=_UNSET):
     """Whether `key` names a secret.
 
-    Pass `value` when it is available: a name that looks sensitive but holds an
-    int / bool / None is engine config, not a credential. Callers that only
-    have the name (e.g. argv scanning) omit it and get the name-only verdict.
+    Names in `_ALWAYS_SENSITIVE_SUBSTRINGS` redact unconditionally. For the
+    merely ambiguous ones, pass `value` when it is available: a scalar rules the
+    field an engine knob rather than a credential. Callers that only have the
+    name (e.g. argv scanning) omit it and every match redacts.
     """
     # Engine configs can carry non-string dict keys (e.g. int layer ids in a
     # serving_config); those are never sensitive field *names*, so skip them.
     if not isinstance(key, str):
         return False
     klow = key.lower()
+    if any(s in klow for s in _ALWAYS_SENSITIVE_SUBSTRINGS):
+        return True
     if klow in _SENSITIVE_KEY_ALLOWLIST:
         return False
     if not any(s in klow for s in _SENSITIVE_SUBSTRINGS):
@@ -304,14 +336,18 @@ def dump_env(args, save_dir, overrides=None):
     if overrides:
         config.update(_redact_config(overrides))
 
-    # Effective speculation width, resolved from whichever flag the algorithm
-    # uses. DFLASH takes --block_size (= draft_length + 1) and leaves
-    # --draft_length at its default, so recording the raw args makes a
-    # block_size=8 DFLASH run look like draft_length=3. Consumers should read
-    # this field rather than re-deriving it from the two flags.
+    # The speculation width the engine was actually given, resolved from
+    # whichever flag the algorithm reads. DFLASH is configured by --block_size
+    # and ignores --draft_length, which stays at its default, so recording the
+    # raw args makes a block_size=8 DFLASH run look like draft_length=3.
+    #
+    # The value is the engine's `num_speculative_tokens` verbatim, not the
+    # count of draft tokens: models/vllm.py passes block_size straight through
+    # for DFLASH, and draft_length straight through otherwise. Consumers should
+    # read this field rather than re-deriving it from the two flags.
     block_size = getattr(args, "block_size", None)
     config["num_speculative_tokens"] = (
-        block_size - 1 if block_size is not None else getattr(args, "draft_length", None)
+        block_size if block_size is not None else getattr(args, "draft_length", None)
     )
 
     config["engine_version"] = _get_engine_version(config.get("engine"))
@@ -348,13 +384,13 @@ def dump_env(args, save_dir, overrides=None):
     # runs. The harness sets JIRA_TICKET only after verifying the checkpoint
     # resolves on Hub; standalone runs leave both empty.
     config["jira_ticket"] = os.environ.get("JIRA_TICKET") or None
-    config["huggingface_model_id"] = os.environ.get("HUGGINGFACE_MODEL_ID") or None
+    config["huggingface_model_id"] = _hub_model_id("HUGGINGFACE_MODEL_ID")
     # Hub id of the external draft checkpoint, for algorithms that use one
     # (EAGLE3 / DRAFT_TARGET / DFLASH / DSPARK). `draft_model_dir` only records
     # a local path, which says nothing about which published drafter ran — two
     # drafters for the same verifier are otherwise indistinguishable. Empty for
     # in-model drafts (MTP heads).
-    config["draft_huggingface_model_id"] = os.environ.get("DRAFT_HUGGINGFACE_MODEL_ID") or None
+    config["draft_huggingface_model_id"] = _hub_model_id("DRAFT_HUGGINGFACE_MODEL_ID")
 
     os.makedirs(save_dir, exist_ok=True)
     with open(os.path.join(save_dir, "configuration.json"), "w") as f:

--- a/examples/specdec_bench/specdec_bench/utils.py
+++ b/examples/specdec_bench/specdec_bench/utils.py
@@ -23,6 +23,8 @@ import sys
 from pathlib import Path
 from warnings import warn as _warn
 
+from huggingface_hub.errors import HFValidationError
+from huggingface_hub.utils import validate_repo_id
 from transformers import AutoTokenizer
 
 from . import __version__ as specdec_bench_version
@@ -36,8 +38,9 @@ _SENSITIVE_KEY_ALLOWLIST = frozenset(
 )
 # Names that are credentials outright, whatever they hold. These redact on the
 # name alone: a numeric or boolean value is no proof of safety, and treating one
-# as such would persist e.g. an all-digit token.
-_ALWAYS_SENSITIVE_SUBSTRINGS = ("hf_token", "api_key", "access_key", "secret", "password")
+# as such would persist e.g. an all-digit token. Matched against the key with
+# separators stripped, so hf_token / hfToken / hf-token are all covered.
+_ALWAYS_SENSITIVE_SUBSTRINGS = ("hftoken", "apikey", "accesskey", "secret", "password")
 # The remaining substrings are ambiguous rather than damning: a bare match over
 # `token` also swallows engine config, where the serving config alone
 # contributes num_speculative_tokens, max_num_batched_tokens,
@@ -232,18 +235,30 @@ _HUB_MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*$")
 
 
 def _hub_model_id(env_var):
-    """Return `$env_var` if it looks like a Hub repo id, else None.
+    """Return `$env_var` if it is a well-formed Hub repo id, else None.
 
     These ids are copied verbatim into configuration.json and published, so an
     unset or malformed value is dropped rather than recorded. A rejected value
     warns instead of raising: provenance metadata should never fail a benchmark
     that has already run.
+
+    Both checks are needed. The local pattern is the security boundary: it
+    excludes `:@?#` and whitespace, so a URL carrying an embedded credential
+    cannot get through, whereas `validate_repo_id` alone would also accept a
+    single-component name. `validate_repo_id` then adds canonicality, rejecting
+    `foo..bar`, `foo--bar` and `foo.git`.
     """
     raw = (os.environ.get(env_var) or "").strip()
     if not raw:
         return None
-    if not _HUB_MODEL_ID_RE.match(raw):
-        _warn(f"{env_var} is not an <org>/<name> Hub id; omitting it from configuration.json")
+    rejected = not _HUB_MODEL_ID_RE.match(raw)
+    if not rejected:
+        try:
+            validate_repo_id(raw)
+        except HFValidationError:
+            rejected = True
+    if rejected:
+        _warn(f"{env_var} is not a valid <org>/<name> Hub id; omitting it from configuration.json")
         return None
     return raw
 
@@ -261,7 +276,7 @@ def _is_sensitive_key(key, value=_UNSET):
     if not isinstance(key, str):
         return False
     klow = key.lower()
-    if any(s in klow for s in _ALWAYS_SENSITIVE_SUBSTRINGS):
+    if any(s in klow.replace("_", "").replace("-", "") for s in _ALWAYS_SENSITIVE_SUBSTRINGS):
         return True
     if klow in _SENSITIVE_KEY_ALLOWLIST:
         return False

--- a/examples/specdec_bench/specdec_bench/utils.py
+++ b/examples/specdec_bench/specdec_bench/utils.py
@@ -32,6 +32,14 @@ _SENSITIVE_SUBSTRINGS = ("token", "key", "secret", "password")
 _SENSITIVE_KEY_ALLOWLIST = frozenset(
     {"tokenizer", "tokenizer_path", "tokenizer_mode", "tokenizer_revision"}
 )
+# A bare substring match over `token` also swallows engine config: the serving
+# config alone contributes num_speculative_tokens, max_num_batched_tokens,
+# skip_tokenizer_init and a dozen similar knobs, none of them credentials.
+# Enumerating them doesn't hold — the set grows with every engine release — so
+# redact on VALUE SHAPE instead: a credential is a non-trivial string, whereas
+# these knobs are ints, bools, and None. `hf_token` still redacts because its
+# value is a string.
+_NON_SECRET_VALUE_TYPES = (bool, int, float, type(None))
 
 
 def get_tokenizer(path, trust_remote_code=False):
@@ -208,7 +216,16 @@ def _checkpoint_provenance(model_dir):
         return {"path": str(model_dir)}
 
 
-def _is_sensitive_key(key):
+_UNSET = object()
+
+
+def _is_sensitive_key(key, value=_UNSET):
+    """Whether `key` names a secret.
+
+    Pass `value` when it is available: a name that looks sensitive but holds an
+    int / bool / None is engine config, not a credential. Callers that only
+    have the name (e.g. argv scanning) omit it and get the name-only verdict.
+    """
     # Engine configs can carry non-string dict keys (e.g. int layer ids in a
     # serving_config); those are never sensitive field *names*, so skip them.
     if not isinstance(key, str):
@@ -216,7 +233,11 @@ def _is_sensitive_key(key):
     klow = key.lower()
     if klow in _SENSITIVE_KEY_ALLOWLIST:
         return False
-    return any(s in klow for s in _SENSITIVE_SUBSTRINGS)
+    if not any(s in klow for s in _SENSITIVE_SUBSTRINGS):
+        return False
+    if value is _UNSET:
+        return True
+    return not isinstance(value, _NON_SECRET_VALUE_TYPES)
 
 
 def _redact_value(value):
@@ -229,7 +250,7 @@ def _redact_value(value):
     """
     if isinstance(value, dict):
         return {
-            k: ("***REDACTED***" if _is_sensitive_key(k) else _redact_value(v))
+            k: ("***REDACTED***" if _is_sensitive_key(k, v) else _redact_value(v))
             for k, v in value.items()
         }
     if isinstance(value, list):
@@ -283,6 +304,16 @@ def dump_env(args, save_dir, overrides=None):
     if overrides:
         config.update(_redact_config(overrides))
 
+    # Effective speculation width, resolved from whichever flag the algorithm
+    # uses. DFLASH takes --block_size (= draft_length + 1) and leaves
+    # --draft_length at its default, so recording the raw args makes a
+    # block_size=8 DFLASH run look like draft_length=3. Consumers should read
+    # this field rather than re-deriving it from the two flags.
+    block_size = getattr(args, "block_size", None)
+    config["num_speculative_tokens"] = (
+        block_size - 1 if block_size is not None else getattr(args, "draft_length", None)
+    )
+
     config["engine_version"] = _get_engine_version(config.get("engine"))
     config["gpu"] = _get_gpu_name()
     config["python_version"] = sys.version
@@ -318,6 +349,12 @@ def dump_env(args, save_dir, overrides=None):
     # resolves on Hub; standalone runs leave both empty.
     config["jira_ticket"] = os.environ.get("JIRA_TICKET") or None
     config["huggingface_model_id"] = os.environ.get("HUGGINGFACE_MODEL_ID") or None
+    # Hub id of the external draft checkpoint, for algorithms that use one
+    # (EAGLE3 / DRAFT_TARGET / DFLASH / DSPARK). `draft_model_dir` only records
+    # a local path, which says nothing about which published drafter ran — two
+    # drafters for the same verifier are otherwise indistinguishable. Empty for
+    # in-model drafts (MTP heads).
+    config["draft_huggingface_model_id"] = os.environ.get("DRAFT_HUGGINGFACE_MODEL_ID") or None
 
     os.makedirs(save_dir, exist_ok=True)
     with open(os.path.join(save_dir, "configuration.json"), "w") as f:

--- a/examples/specdec_bench/specdec_bench/utils.py
+++ b/examples/specdec_bench/specdec_bench/utils.py
@@ -269,7 +269,20 @@ def _is_sensitive_key(key, value=_UNSET):
         return False
     if value is _UNSET:
         return True
-    return not isinstance(value, _NON_SECRET_VALUE_TYPES)
+    return not _is_non_secret_value(value)
+
+
+def _is_non_secret_value(value):
+    """Whether `value`'s shape rules out a credential.
+
+    Engine knobs are scalars or containers of them (a token-budget list is
+    `[256, 512]`). A credential is a non-trivial string, so a container is only
+    cleared when every leaf is itself non-secret; an empty one has nothing to
+    leak.
+    """
+    if isinstance(value, (list, tuple, set)):
+        return all(_is_non_secret_value(v) for v in value)
+    return isinstance(value, _NON_SECRET_VALUE_TYPES)
 
 
 def _redact_value(value):
@@ -336,19 +349,24 @@ def dump_env(args, save_dir, overrides=None):
     if overrides:
         config.update(_redact_config(overrides))
 
-    # The speculation width the engine was actually given, resolved from
-    # whichever flag the algorithm reads. DFLASH is configured by --block_size
-    # and ignores --draft_length, which stays at its default, so recording the
-    # raw args makes a block_size=8 DFLASH run look like draft_length=3.
+    # The speculation width the engine was actually given. Which flag carries
+    # it depends on the algorithm: DFLASH is configured by --block_size and
+    # ignores --draft_length (which stays at its default), so recording the raw
+    # args makes a block_size=8 DFLASH run look like draft_length=3.
     #
-    # The value is the engine's `num_speculative_tokens` verbatim, not the
-    # count of draft tokens: models/vllm.py passes block_size straight through
-    # for DFLASH, and draft_length straight through otherwise. Consumers should
-    # read this field rather than re-deriving it from the two flags.
-    block_size = getattr(args, "block_size", None)
-    config["num_speculative_tokens"] = (
-        block_size if block_size is not None else getattr(args, "draft_length", None)
-    )
+    # Keyed on the algorithm rather than on flag precedence so this stays in
+    # step with the engine branches in models/vllm.py, which forward exactly
+    # one flag per algorithm. The value is the engine's `num_speculative_tokens`
+    # verbatim. Consumers should read this field rather than re-deriving it.
+    algorithm = getattr(args, "speculative_algorithm", None)
+    if algorithm == "NONE":
+        # Measured with speculation off. 0 rather than None, which means the
+        # harness never passed a width at all.
+        config["num_speculative_tokens"] = 0
+    elif algorithm == "DFLASH":
+        config["num_speculative_tokens"] = getattr(args, "block_size", None)
+    else:
+        config["num_speculative_tokens"] = getattr(args, "draft_length", None)
 
     config["engine_version"] = _get_engine_version(config.get("engine"))
     config["gpu"] = _get_gpu_name()

--- a/modelopt/torch/utils/mlflow.py
+++ b/modelopt/torch/utils/mlflow.py
@@ -54,6 +54,12 @@ _UNSAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]+")
 # Anything uploaded or printed passes through _redact first: a tracking URI may carry
 # ``user:token@`` and a caller's own flags may carry a secret.
 _SECRET_NAME = re.compile(r"token|api[-_]?key|password|passwd|secret|credential", re.IGNORECASE)
+# Names that are credentials outright, whatever they hold, so that an
+# all-digit token is not mistaken for configuration. Matched with separators
+# stripped, covering hf_token / hfToken / hf-token alike.
+_EXPLICIT_SECRET_NAME = re.compile(
+    r"hftoken|apikey|accesskey|password|passwd|secret|credential", re.IGNORECASE
+)
 _URI_USERINFO = re.compile(r"(?<=://)[^/\s@]+(?=@)")
 _MASK = "***"
 
@@ -70,6 +76,24 @@ def _stat_key(path: Path) -> tuple[int, int] | None:
 def _redact(value: Any) -> Any:
     """Mask credentials embedded in a URI, leaving non-strings untouched."""
     return _URI_USERINFO.sub(_MASK, value) if isinstance(value, str) else value
+
+
+def _is_secret_param(name: str, value: Any) -> bool:
+    """Whether a param named *name* holding *value* is a credential.
+
+    ``token`` matches plenty of configuration that is not a secret — a
+    speculative-decoding run reports ``num_speculative_tokens``, and engines
+    expose ``max_num_batched_tokens`` and friends — and masking those loses
+    the very numbers a run is recorded for. A credential is a non-trivial
+    string, so a name that merely looks sensitive is kept when its value is
+    an int, float, bool or None. An explicit ``*token``/``*key`` name still
+    masks whatever it holds.
+    """
+    if not _SECRET_NAME.search(name):
+        return False
+    if _EXPLICIT_SECRET_NAME.search(name.replace("_", "").replace("-", "")):
+        return True
+    return not isinstance(value, (bool, int, float, type(None)))
 
 
 def _redact_argv(argv: list[str]) -> list[str]:
@@ -417,7 +441,7 @@ class MlflowRunLogger:
     def _log_inputs(self, params, tags, texts) -> None:
         if params:
             self._mlflow.log_params(
-                {k: _MASK if _SECRET_NAME.search(k) else _redact(v) for k, v in params.items()}
+                {k: _MASK if _is_secret_param(k, v) else _redact(v) for k, v in params.items()}
             )
         self._mlflow.set_tags(
             {

--- a/tests/examples/specdec_bench/test_dump_env.py
+++ b/tests/examples/specdec_bench/test_dump_env.py
@@ -117,6 +117,11 @@ class TestHubModelIdValidation:
             "not-an-id",  # no org
             "org/model/extra",  # too many segments
             "org / model",  # whitespace
+            # Non-canonical repo names: harmless, but validate_repo_id rejects
+            # them, so they should not be recorded as if they resolved.
+            "org/foo..bar",
+            "org/foo--bar",
+            "org/foo.git",
         ],
     )
     @pytest.mark.parametrize("env_var", ["DRAFT_HUGGINGFACE_MODEL_ID", "HUGGINGFACE_MODEL_ID"])

--- a/tests/examples/specdec_bench/test_dump_env.py
+++ b/tests/examples/specdec_bench/test_dump_env.py
@@ -32,6 +32,7 @@ def _args(**kw):
     base = {
         "engine": "VLLM",
         "model_dir": None,
+        "speculative_algorithm": "EAGLE3",
         "draft_length": 3,
         "block_size": None,
     }
@@ -46,9 +47,11 @@ def _dump(tmp_path, **kw):
 
 
 class TestNumSpeculativeTokens:
-    def test_draft_length_path(self, tmp_path):
-        """Algorithms that take --draft_length record it directly."""
-        assert _dump(tmp_path, draft_length=7)["num_speculative_tokens"] == 7
+    @pytest.mark.parametrize("algorithm", ["EAGLE3", "EAGLE", "MTP", "DRAFT_TARGET"])
+    def test_draft_length_path(self, tmp_path, algorithm):
+        """Algorithms configured by --draft_length record it directly."""
+        cfg = _dump(tmp_path, speculative_algorithm=algorithm, draft_length=7)
+        assert cfg["num_speculative_tokens"] == 7
 
     def test_block_size_path(self, tmp_path):
         """DFLASH takes --block_size and leaves --draft_length at its default,
@@ -56,15 +59,25 @@ class TestNumSpeculativeTokens:
 
         The recorded value matches what the engine receives: models/vllm.py
         passes block_size through as num_speculative_tokens unchanged."""
-        cfg = _dump(tmp_path, draft_length=3, block_size=8)
+        cfg = _dump(tmp_path, speculative_algorithm="DFLASH", draft_length=3, block_size=8)
         assert cfg["num_speculative_tokens"] == 8
         # The raw flags stay for provenance; only the derived field is
         # authoritative.
         assert cfg["draft_length"] == 3
         assert cfg["block_size"] == 8
 
-    def test_block_size_wins_over_draft_length(self, tmp_path):
-        assert _dump(tmp_path, draft_length=3, block_size=4)["num_speculative_tokens"] == 4
+    def test_none_algorithm_records_zero(self, tmp_path):
+        """--speculative_algorithm NONE speculates nothing, but --draft_length
+        still defaults to 3. Baselines are the rows most often joined against
+        specdec rows, so a phantom width there is worse than no width."""
+        cfg = _dump(tmp_path, speculative_algorithm="NONE", draft_length=3)
+        assert cfg["num_speculative_tokens"] == 0
+
+    def test_block_size_ignored_for_non_dflash(self, tmp_path):
+        """Only the DFLASH branches consume block_size as the width. Passing it
+        alongside EAGLE3 must not override the flag the engine actually read."""
+        cfg = _dump(tmp_path, speculative_algorithm="EAGLE3", draft_length=5, block_size=8)
+        assert cfg["num_speculative_tokens"] == 5
 
     def test_missing_attrs_do_not_raise(self, tmp_path):
         """dump_env is called from harnesses that build their own namespace."""
@@ -74,19 +87,20 @@ class TestNumSpeculativeTokens:
 
 
 class TestDraftHuggingfaceModelId:
-    def test_absent_by_default(self, tmp_path):
+    def test_absent_by_default(self, tmp_path, monkeypatch):
+        # Cleared explicitly: exporting this var is the documented way to run a
+        # benchmark, so reading the ambient environment would fail for anyone
+        # who does.
+        monkeypatch.delenv("DRAFT_HUGGINGFACE_MODEL_ID", raising=False)
         assert _dump(tmp_path)["draft_huggingface_model_id"] is None
 
     def test_read_from_env(self, tmp_path, monkeypatch):
         monkeypatch.setenv("DRAFT_HUGGINGFACE_MODEL_ID", "org/Drafter-A")
         assert _dump(tmp_path)["draft_huggingface_model_id"] == "org/Drafter-A"
 
-    @pytest.mark.parametrize("value", ["", None, "   "])
+    @pytest.mark.parametrize("value", ["", "   "])
     def test_blank_normalizes_to_none(self, tmp_path, monkeypatch, value):
-        if value is None:
-            monkeypatch.delenv("DRAFT_HUGGINGFACE_MODEL_ID", raising=False)
-        else:
-            monkeypatch.setenv("DRAFT_HUGGINGFACE_MODEL_ID", value)
+        monkeypatch.setenv("DRAFT_HUGGINGFACE_MODEL_ID", value)
         assert _dump(tmp_path)["draft_huggingface_model_id"] is None
 
 

--- a/tests/examples/specdec_bench/test_dump_env.py
+++ b/tests/examples/specdec_bench/test_dump_env.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the derived provenance fields dump_env writes.
+
+configuration.json is the only record of how a benchmark ran once the job is
+gone, and downstream tooling reads it verbatim. These fields exist because the
+raw argparse namespace is ambiguous about what the engine actually did.
+"""
+
+import argparse
+import json
+
+import pytest
+from specdec_bench.utils import dump_env
+
+
+def _args(**kw):
+    """An argparse namespace with the fields dump_env reaches for."""
+    base = {
+        "engine": "VLLM",
+        "model_dir": None,
+        "draft_length": 3,
+        "block_size": None,
+    }
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def _dump(tmp_path, **kw):
+    dump_env(_args(**kw), str(tmp_path))
+    with open(tmp_path / "configuration.json") as f:
+        return json.load(f)
+
+
+class TestNumSpeculativeTokens:
+    def test_draft_length_path(self, tmp_path):
+        """Algorithms that take --draft_length record it directly."""
+        assert _dump(tmp_path, draft_length=7)["num_speculative_tokens"] == 7
+
+    def test_block_size_path(self, tmp_path):
+        """DFLASH takes --block_size and leaves --draft_length at its default,
+        so reading draft_length would report 3 for a block_size=8 run."""
+        cfg = _dump(tmp_path, draft_length=3, block_size=8)
+        assert cfg["num_speculative_tokens"] == 7
+        # The raw flags stay for provenance; only the derived field is
+        # authoritative.
+        assert cfg["draft_length"] == 3
+        assert cfg["block_size"] == 8
+
+    def test_block_size_wins_over_draft_length(self, tmp_path):
+        assert _dump(tmp_path, draft_length=3, block_size=4)["num_speculative_tokens"] == 3
+
+    def test_missing_attrs_do_not_raise(self, tmp_path):
+        """dump_env is called from harnesses that build their own namespace."""
+        dump_env(argparse.Namespace(engine="VLLM", model_dir=None), str(tmp_path))
+        with open(tmp_path / "configuration.json") as f:
+            assert json.load(f)["num_speculative_tokens"] is None
+
+
+class TestDraftHuggingfaceModelId:
+    def test_absent_by_default(self, tmp_path):
+        assert _dump(tmp_path)["draft_huggingface_model_id"] is None
+
+    def test_read_from_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DRAFT_HUGGINGFACE_MODEL_ID", "org/Drafter-A")
+        assert _dump(tmp_path)["draft_huggingface_model_id"] == "org/Drafter-A"
+
+    @pytest.mark.parametrize("value", ["", None])
+    def test_blank_normalizes_to_none(self, tmp_path, monkeypatch, value):
+        if value is None:
+            monkeypatch.delenv("DRAFT_HUGGINGFACE_MODEL_ID", raising=False)
+        else:
+            monkeypatch.setenv("DRAFT_HUGGINGFACE_MODEL_ID", value)
+        assert _dump(tmp_path)["draft_huggingface_model_id"] is None

--- a/tests/examples/specdec_bench/test_dump_env.py
+++ b/tests/examples/specdec_bench/test_dump_env.py
@@ -52,16 +52,19 @@ class TestNumSpeculativeTokens:
 
     def test_block_size_path(self, tmp_path):
         """DFLASH takes --block_size and leaves --draft_length at its default,
-        so reading draft_length would report 3 for a block_size=8 run."""
+        so reading draft_length would report 3 for a block_size=8 run.
+
+        The recorded value matches what the engine receives: models/vllm.py
+        passes block_size through as num_speculative_tokens unchanged."""
         cfg = _dump(tmp_path, draft_length=3, block_size=8)
-        assert cfg["num_speculative_tokens"] == 7
+        assert cfg["num_speculative_tokens"] == 8
         # The raw flags stay for provenance; only the derived field is
         # authoritative.
         assert cfg["draft_length"] == 3
         assert cfg["block_size"] == 8
 
     def test_block_size_wins_over_draft_length(self, tmp_path):
-        assert _dump(tmp_path, draft_length=3, block_size=4)["num_speculative_tokens"] == 3
+        assert _dump(tmp_path, draft_length=3, block_size=4)["num_speculative_tokens"] == 4
 
     def test_missing_attrs_do_not_raise(self, tmp_path):
         """dump_env is called from harnesses that build their own namespace."""
@@ -78,10 +81,40 @@ class TestDraftHuggingfaceModelId:
         monkeypatch.setenv("DRAFT_HUGGINGFACE_MODEL_ID", "org/Drafter-A")
         assert _dump(tmp_path)["draft_huggingface_model_id"] == "org/Drafter-A"
 
-    @pytest.mark.parametrize("value", ["", None])
+    @pytest.mark.parametrize("value", ["", None, "   "])
     def test_blank_normalizes_to_none(self, tmp_path, monkeypatch, value):
         if value is None:
             monkeypatch.delenv("DRAFT_HUGGINGFACE_MODEL_ID", raising=False)
         else:
             monkeypatch.setenv("DRAFT_HUGGINGFACE_MODEL_ID", value)
         assert _dump(tmp_path)["draft_huggingface_model_id"] is None
+
+
+class TestHubModelIdValidation:
+    """These ids are copied verbatim into a published configuration.json, so a
+    malformed environment value is dropped rather than recorded."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "https://user:hf_secret@huggingface.co/org/model",  # embedded credential
+            "org/model?token=hf_secret",
+            "org/model#hf_secret",
+            "not-an-id",  # no org
+            "org/model/extra",  # too many segments
+            "org / model",  # whitespace
+        ],
+    )
+    @pytest.mark.parametrize("env_var", ["DRAFT_HUGGINGFACE_MODEL_ID", "HUGGINGFACE_MODEL_ID"])
+    def test_malformed_is_dropped_with_warning(self, tmp_path, monkeypatch, env_var, value):
+        monkeypatch.setenv(env_var, value)
+        with pytest.warns(UserWarning, match=env_var):
+            cfg = _dump(tmp_path)
+        assert cfg[env_var.lower()] is None
+
+    @pytest.mark.parametrize(
+        "value", ["org/model", "nvidia/Kimi-K3-DSpark", "some-org/some.model-v1_2"]
+    )
+    def test_wellformed_ids_pass_through(self, tmp_path, monkeypatch, value):
+        monkeypatch.setenv("DRAFT_HUGGINGFACE_MODEL_ID", value)
+        assert _dump(tmp_path)["draft_huggingface_model_id"] == value

--- a/tests/examples/specdec_bench/test_redaction.py
+++ b/tests/examples/specdec_bench/test_redaction.py
@@ -56,7 +56,10 @@ class TestIsSensitiveKey:
             ("max_num_batched_tokens", 8192),
             ("dbo_decode_token_threshold", 32),
             ("skip_tokenizer_init", False),
-            ("encoder_cudagraph_token_budgets", None),
+            ("spec_tokens", None),
+            # Real vLLM configs hold a list here, not a scalar.
+            ("encoder_cudagraph_token_budgets", [256, 512]),
+            ("encoder_cudagraph_token_budgets", []),
         ],
     )
     def test_engine_knobs_survive(self, key, value):
@@ -142,6 +145,16 @@ class TestRedactValue:
         assert spec["num_speculative_tokens"] == 8
         assert spec["target_model_config"]["skip_tokenizer_init"] is False
         assert spec["target_model_config"]["hf_token"] == REDACTED
+
+    def test_list_valued_knob_survives(self):
+        """A sensitive-key hit replaces the whole subtree, so a knob holding a
+        list of ints has to clear on its contents or it never recurses."""
+        out = _redact_value({"encoder_cudagraph_token_budgets": [256, 512]})
+        assert out["encoder_cudagraph_token_budgets"] == [256, 512]
+
+    def test_list_of_strings_under_credential_name_redacts(self):
+        out = _redact_value({"hf_token": ["abc", "def"]})
+        assert out["hf_token"] == REDACTED
 
 
 class TestRedactArgv:

--- a/tests/examples/specdec_bench/test_redaction.py
+++ b/tests/examples/specdec_bench/test_redaction.py
@@ -81,6 +81,12 @@ class TestIsSensitiveKey:
             ("aws_secret_access_key", 0),
             ("password", True),
             ("hf_token", None),
+            # Separator-free and hyphenated spellings of the same names.
+            ("hfToken", 1234),
+            ("apiKey", 99),
+            ("accessKey", 0),
+            ("hf-token", 1234),
+            ("api-key", 99),
         ],
     )
     def test_credential_names_ignore_value_shape(self, key, value):

--- a/tests/examples/specdec_bench/test_redaction.py
+++ b/tests/examples/specdec_bench/test_redaction.py
@@ -70,6 +70,21 @@ class TestIsSensitiveKey:
     def test_string_and_container_values_still_redact(self, value):
         assert _is_sensitive_key("hf_token", value) is True
 
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("hf_token", 1234),
+            ("api_key", 99),
+            ("aws_secret_access_key", 0),
+            ("password", True),
+            ("hf_token", None),
+        ],
+    )
+    def test_credential_names_ignore_value_shape(self, key, value):
+        """An all-digit token is still a token. The scalar exception applies
+        only to names that are ambiguous, never to outright credentials."""
+        assert _is_sensitive_key(key, value) is True
+
     def test_name_only_call_keeps_legacy_verdict(self):
         """Callers with no value in hand (argv scanning) must still redact."""
         assert _is_sensitive_key("hf_token") is True

--- a/tests/examples/specdec_bench/test_redaction.py
+++ b/tests/examples/specdec_bench/test_redaction.py
@@ -49,6 +49,31 @@ class TestIsSensitiveKey:
     def test_non_sensitive_names_pass(self, key):
         assert _is_sensitive_key(key) is False
 
+    @pytest.mark.parametrize(
+        ("key", "value"),
+        [
+            ("num_speculative_tokens", 8),
+            ("max_num_batched_tokens", 8192),
+            ("dbo_decode_token_threshold", 32),
+            ("skip_tokenizer_init", False),
+            ("encoder_cudagraph_token_budgets", None),
+        ],
+    )
+    def test_engine_knobs_survive(self, key, value):
+        """Engine config whose name trips the substring match but whose value
+        can't hold a credential. A serving_config contributes a dozen of these
+        and the list grows with each engine release, so the value's type — not
+        an enumerated allowlist — is what keeps them."""
+        assert _is_sensitive_key(key, value) is False
+
+    @pytest.mark.parametrize("value", ["hf_abc123", ["a", "b"], {"k": "v"}])
+    def test_string_and_container_values_still_redact(self, value):
+        assert _is_sensitive_key("hf_token", value) is True
+
+    def test_name_only_call_keeps_legacy_verdict(self):
+        """Callers with no value in hand (argv scanning) must still redact."""
+        assert _is_sensitive_key("hf_token") is True
+
 
 class TestRedactValue:
     def test_top_level_secret(self):
@@ -81,6 +106,27 @@ class TestRedactValue:
     def test_primitive_passthrough(self):
         for v in [None, 0, 1.5, "plain-string", True]:
             assert _redact_value(v) == v
+
+    def test_speculative_config_survives_beside_secret(self):
+        """The engine's own num_speculative_tokens is the cross-check on the
+        recorded speculation width, so it has to reach configuration.json —
+        while a real credential in the same subtree still does not."""
+        cfg = {
+            "serving_config": {
+                "speculative_config": {
+                    "method": "dflash",
+                    "num_speculative_tokens": 8,
+                    "target_model_config": {
+                        "hf_token": "supersecret",
+                        "skip_tokenizer_init": False,
+                    },
+                }
+            }
+        }
+        spec = _redact_value(cfg)["serving_config"]["speculative_config"]
+        assert spec["num_speculative_tokens"] == 8
+        assert spec["target_model_config"]["skip_tokenizer_init"] is False
+        assert spec["target_model_config"]["hf_token"] == REDACTED
 
 
 class TestRedactArgv:

--- a/tests/unit/torch/utils/test_mlflow.py
+++ b/tests/unit/torch/utils/test_mlflow.py
@@ -27,6 +27,7 @@ from modelopt.torch.utils.logging import TeeStream
 from modelopt.torch.utils.mlflow import (
     MlflowRunLogger,
     _git_sha,
+    _is_secret_param,
     _redact_argv,
     default_experiment_name,
     validate_tracking_uri,
@@ -421,6 +422,46 @@ def test_unreachable_server_fails_before_the_work_starts(monkeypatch):
 )
 def test_redact_argv_masks_credentials(argv, expected):
     assert _redact_argv(argv) == expected
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("hf_token", "hf_abc123"),
+        # A credential name masks whatever it holds: an all-digit token is
+        # still a token, so the value's type is no proof of safety.
+        ("hf_token", 1234),
+        ("hfToken", 1),
+        ("hf-token", 0),
+        ("api_key", 99),
+        ("aws_secret_access_key", 0),
+        ("password", True),
+        # An ambiguous name holding a string is masked, since that is the
+        # shape a credential takes.
+        ("some_token", "sk-live-abc"),
+    ],
+)
+def test_secret_params_are_masked(name, value):
+    assert _is_secret_param(name, value) is True
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        # Engine and algorithm configuration whose names merely contain
+        # "token". Masking these loses the numbers the run is recorded for.
+        ("num_speculative_tokens", 7),
+        ("max_num_batched_tokens", 8192),
+        ("dbo_decode_token_threshold", 32),
+        ("skip_tokenizer_init", False),
+        ("spec_tokens", None),
+        # Names that never matched in the first place.
+        ("draft_length", 7),
+        ("model_dir", "/models/Qwen3-0.6B"),
+    ],
+)
+def test_config_params_keep_their_value(name, value):
+    assert _is_secret_param(name, value) is False
 
 
 def test_command_artifact_carries_no_secrets(fake_mlflow, monkeypatch):


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix + new feature

**Fix what `configuration.json` records.** It is the only record of how a benchmark ran once the job is gone, and three fields were wrong or missing:

- **`num_speculative_tokens`** (new). DFLASH is configured by `--block_size` and ignores `--draft_length`, so a `block_size=8` run was recorded as `draft_length: 3`. Resolved by algorithm, matching the engine branches in `models/vllm.py`; `NONE` records `0` instead of inheriting a default.
- **`draft_huggingface_model_id`** (new, via env var). `draft_model_dir` is a local path, so two drafters benchmarked against the same verifier were indistinguishable afterwards. Validated as an `<org>/<name>` Hub id.
- **Redaction no longer eats engine config.** Matching any key containing `token` masked twelve `serving_config` knobs, including the engine's own speculation width. Value shape now decides: credentials are strings, these knobs are ints/bools/`None`. Explicit names (`hf_token`, `api_key`, …) still mask anything, `hfToken` and `hf-token` included.

**Add MLflow tracking.** Results otherwise sit in `--save_dir` until someone uploads them. `--mlflow` (plus `--mlflow_experiment` / `--mlflow_run_name`, mirroring `examples/hf_ptq`) logs acceptance length, per-category AL and throughput as metrics, the configuration as params, and the result JSONs and log as artifacts. `MLFLOW_TRACKING_URI` opts in without changing the command.

This also fixes the same redaction bug in `MlflowRunLogger`, which masked the `num_speculative_tokens` added above — and `max_num_batched_tokens` and similar for any caller.

### Usage

```bash
export DRAFT_HUGGINGFACE_MODEL_ID=org/My-Drafter   # optional

python3 run.py --model_dir ... --speculative_algorithm DFLASH --block_size 8 \
    --mlflow https://<your-mlflow-server>/ ...
```

```json
{
  "draft_length": 3,
  "block_size": 8,
  "num_speculative_tokens": 8,
  "draft_huggingface_model_id": "org/My-Drafter",
  "serving_config": { "speculative_config": { "num_speculative_tokens": 8 } }
}
```

The raw flags stay for provenance; `num_speculative_tokens` is what consumers should read, and the nested one is the engine's own value for cross-checking.

### Testing

`test_dump_env.py` (new) covers each algorithm's width path, `NONE`, absent attributes and Hub-id validation. `test_redaction.py` and `test_mlflow.py` gain engine knobs (including list-valued), credential names under scalar values, and separator-free spellings.

The provenance tests were verified to fail against the pre-fix code. The redaction change was replayed over real `configuration.json` files from the results bucket — knobs return, `hf_token` stays masked. MLflow tracking was exercised end-to-end against a live server.

69 unit + 83 example tests pass; `pre-commit` clean.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ — additive fields and opt-in flags. Consumers reading `draft_length` keep working but should move to `num_speculative_tokens`. Already-uploaded files keep their redacted cells until re-uploaded.
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A — `mlflow` is already optional, imported only when tracking is on.
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A — example-level change.
- Did you get Claude approval on this PR?: ❌ — not yet run.

### Additional Information

Found while reconciling results on the SpecDec visualizer: DFLASH rows showed `draft_length 3` against a histogram topping out at 9, and rows sharing a verifier could not be told apart. The MLflow half is the other end of the same problem — logged runs let the dashboard read the tracking server instead of requiring an upload per result.
