### PR TITLE
Fix Hparam configurability restoration after exceptions

### DIFF
--- a/modelopt/torch/opt/hparam.py
+++ b/modelopt/torch/opt/hparam.py
@@ -96,8 +96,10 @@ class Hparam:
         """Context manager to temporarily set hparam to be configurable."""
         original_value = self._is_configurable
         self._is_configurable = True
-        yield
-        self._is_configurable = original_value
+        try:
+            yield
+        finally:
+            self._is_configurable = original_value
 
     @property
     def is_sortable(self):

--- a/tests/unit/torch/opt/test_dynamic.py
+++ b/tests/unit/torch/opt/test_dynamic.py
@@ -26,6 +26,17 @@ from modelopt.torch.opt.dynamic import (
 )
 
 
+def test_force_configurable_restores_state_after_exception():
+    hp = Hparam([1, 2])
+    hp._is_configurable = False
+
+    with pytest.raises(RuntimeError, match="forced failure"), hp._force_configurable():
+        assert hp.is_configurable
+        raise RuntimeError("forced failure")
+
+    assert not hp.is_configurable
+
+
 def test_register_rejects_non_module_classes():
     """Registering a non-class (e.g. a factory function) must fail at the registration site."""
     registry = _DMRegistryCls(prefix="Test")


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

`Hparam._force_configurable()` restored `_is_configurable` only after a normal context-manager exit. If code inside the context raised, the restoration statement was skipped and a previously non-configurable `Hparam` remained permanently configurable.

Wrap the `yield` in `try`/`finally` so the original state is restored on both normal and exceptional exits. Add a regression test that raises inside the context and verifies the temporary configurable state does not leak.

### Usage

No call-site changes are required. Existing users of the context manager retain the same behavior, including when an operation inside the context fails:

```python
with hp._force_configurable():
    hp.choices = new_choices
```

### Testing

- Verified the new regression test fails against the pre-fix implementation because `hp.is_configurable` remains `True`.
- `.venv/bin/python -m pytest tests/unit/torch/opt/test_dynamic.py -q` (`3 passed`)
- `.venv/bin/python -m pytest tests/unit/torch/opt -q` (`66 passed, 2 skipped`)
- Relevant pre-commit hooks passed: file/merge/line-ending checks, Ruff check and format, mypy, license insertion check, Bandit.
- `git diff --check`

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A — this is a small, backward-compatible correctness fix rather than a critical bug fix.
- Did you get Claude approval on this PR?: N/A — not available to an external contributor before submission.

### Additional Information

Related prior work: #1913 was closed without merging and only tested the normal-exit path. This PR adds exception-path coverage together with the production fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling so temporary settings are reliably restored even when an error occurs.
  * Exceptions raised during configuration operations continue to be reported correctly.

* **Tests**
  * Added coverage for configuration restoration after a failed operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->