### PR TITLE
Add Inkling attention support to vLLM runtime

### DIFF
--- a/modelopt/torch/kernels/common/attention/triton_fa.py
+++ b/modelopt/torch/kernels/common/attention/triton_fa.py
@@ -77,6 +77,7 @@ _V_QDQ_MODES = {None: 0, "nvfp4": 2}
 
 
 LOG2E: float = 1.44269504088896
+_LOG2E = tl.constexpr(1.44269504088896)
 
 # ---------------------------------------------------------------------------
 # Autotune configs for forward kernel
@@ -217,6 +218,24 @@ def _apply_mask(
 
 
 @triton.jit
+def _apply_left_window(
+    scores,
+    q_pos,
+    kv_pos,
+    seq_len_q,
+    seq_len_kv,
+    kv_start,
+    WINDOW_LEFT: tl.constexpr,
+):
+    """Mask keys older than the causal query-relative left window."""
+    if WINDOW_LEFT >= 0:
+        q_abs_pos = q_pos[:, None] + seq_len_kv - seq_len_q
+        kv_abs_pos = kv_start + kv_pos[None, :]
+        scores += tl.where(kv_abs_pos >= q_abs_pos - WINDOW_LEFT, 0, float("-inf"))
+    return scores
+
+
+@triton.jit
 def _apply_sparse_nm_with_dense_tokens(
     scores,
     kv_start,
@@ -308,6 +327,11 @@ def _attn_fwd(
     stride_vc_head=0,
     PAGE_SIZE: tl.constexpr = 16,
     max_blocks_per_seq=0,
+    Rel_logits=None,  # [total_q, num_q_heads, rel_extent]
+    stride_rel_tok=0,
+    stride_rel_head=0,
+    REL_EXTENT: tl.constexpr = 0,
+    WINDOW_LEFT: tl.constexpr = -1,
 ):
     # --- Grid: (batch, num_q_heads, num_q_tiles) ---
     # Example: batch=2, num_q_heads=32, seq_len=256, BLOCK_M=128
@@ -356,7 +380,13 @@ def _attn_fwd(
     v_quantized_boundary = (seq_len_kv // 16) * 16
 
     # --- Main loop: iterate over KV tiles ---
-    for kv_start in range(0, kv_bound, BLOCK_N):
+    kv_lower = 0
+    if WINDOW_LEFT >= 0:
+        first_q_abs = causal_offset + tile_q * BLOCK_M
+        kv_lower = tl.maximum(0, first_q_abs - WINDOW_LEFT)
+        kv_lower = (kv_lower // BLOCK_N) * BLOCK_N
+
+    for kv_start in range(kv_lower, kv_bound, BLOCK_N):
         kv_start = tl.multiple_of(kv_start, BLOCK_N)  # Compiler hint for alignment
 
         # Load K^T [BLOCK_D, BLOCK_N] (transposed layout for Q @ K^T matmul)
@@ -392,7 +422,31 @@ def _attn_fwd(
             scores = tl.dot(q, k.to(tl.float32), input_precision="ieee") * qk_scale
         else:
             scores = tl.dot(q, k) * qk_scale
+
+        if REL_EXTENT > 0:
+            q_abs_pos = q_pos[:, None] + causal_offset
+            kv_abs_pos = kv_start + kv_pos[None, :]
+            rel_dist = q_abs_pos - kv_abs_pos
+            rel_idx = tl.minimum(tl.maximum(rel_dist, 0), REL_EXTENT - 1)
+            rel_valid = (
+                (q_pos[:, None] < seq_len_q) & (kv_abs_pos < seq_len_kv) & (rel_dist == rel_idx)
+            )
+            rel_ptrs = (
+                (q_offset + q_pos[:, None]) * stride_rel_tok + head_idx * stride_rel_head + rel_idx
+            )
+            rel_bias = tl.load(Rel_logits + rel_ptrs, mask=rel_valid, other=0.0)
+            scores += rel_bias.to(tl.float32) * _LOG2E
+
         scores = _apply_mask(scores, q_pos, kv_pos, seq_len_q, seq_len_kv, kv_start, IS_CAUSAL)
+        scores = _apply_left_window(
+            scores,
+            q_pos,
+            kv_pos,
+            seq_len_q,
+            seq_len_kv,
+            kv_start,
+            WINDOW_LEFT,
+        )
 
         # --- Optional N:M sparse softmax ---
         if SPARSITY_N > 0:
@@ -899,6 +953,8 @@ class _Attention(torch.autograd.Function):
         v_cache,
         block_table,
         page_size,
+        rel_logits,
+        window_left,
     ):
         HEAD_DIM = q.shape[2]
         num_q_heads = q.shape[1]
@@ -915,6 +971,12 @@ class _Attention(torch.autograd.Function):
         if is_paged and (q.requires_grad or k.requires_grad or v.requires_grad):
             raise NotImplementedError(
                 "Paged KV cache path is forward-only; backward is not implemented."
+            )
+        if (rel_logits is not None or window_left is not None) and any(
+            tensor.requires_grad for tensor in (q, k, v)
+        ):
+            raise NotImplementedError(
+                "Relative-bias and sliding-window attention are forward-only."
             )
 
         # Prefill: Q/K/V are the same packed tensor, reuse Q offsets for K/V.
@@ -1018,6 +1080,11 @@ class _Attention(torch.autograd.Function):
             "stride_vc_head": v_cache.stride(2) if is_paged else 0,
             "PAGE_SIZE": page_size,
             "max_blocks_per_seq": block_table.shape[1] if is_paged else 0,
+            "Rel_logits": rel_logits,
+            "stride_rel_tok": rel_logits.stride(0) if rel_logits is not None else 0,
+            "stride_rel_head": rel_logits.stride(1) if rel_logits is not None else 0,
+            "REL_EXTENT": rel_logits.shape[2] if rel_logits is not None else 0,
+            "WINDOW_LEFT": -1 if window_left is None else window_left,
         }
 
         # Grid: (batch, q_heads, q_tiles). Uses a function because BLOCK_M is autotuned.
@@ -1215,6 +1282,8 @@ class _Attention(torch.autograd.Function):
             None,  # v_cache
             None,  # block_table
             None,  # page_size
+            None,  # rel_logits
+            None,  # window_left
         )
 
 
@@ -1246,6 +1315,8 @@ def attention(
     v_cache: torch.Tensor | None = None,
     block_table: torch.Tensor | None = None,
     page_size: int = 16,
+    rel_logits: torch.Tensor | None = None,
+    window_left: int | None = None,
 ) -> torch.Tensor:
     """Variable-length flash attention with GQA, autograd, optional sparsity, and paged KV.
 
@@ -1312,6 +1383,11 @@ def attention(
         block_table: Page table [batch, max_blocks_per_seq] mapping sequence
             block indices to global page IDs.
         page_size: Number of tokens per page in the KV cache.
+        rel_logits: Optional additive relative-position logits with shape
+            ``[total_q_tokens, num_q_heads, rel_extent]``. Distances outside
+            ``[0, rel_extent)`` receive no bias.
+        window_left: Optional number of preceding tokens visible to each query.
+            The current token is always included by causal attention.
 
     Returns:
         Output tensor [total_q_tokens, num_q_heads, head_dim].
@@ -1359,6 +1435,19 @@ def attention(
         raise ValueError("v_cache_quantized requires v_qdq='nvfp4'")
     if v_cache_quantized and any(x is None for x in (k_cache, v_cache, block_table)):
         raise ValueError("v_cache_quantized requires a paged KV cache")
+    if rel_logits is not None:
+        expected = (q.shape[0], q.shape[1])
+        if rel_logits.ndim != 3 or rel_logits.shape[:2] != expected:
+            raise ValueError(
+                "rel_logits must have shape [total_q_tokens, num_q_heads, rel_extent], "
+                f"got {tuple(rel_logits.shape)} for Q shape {tuple(q.shape)}"
+            )
+        if rel_logits.shape[2] < 1:
+            raise ValueError("rel_logits rel_extent must be positive")
+        if rel_logits.device != q.device:
+            raise ValueError("rel_logits and Q must be on the same device")
+    if window_left is not None and (not isinstance(window_left, int) or window_left < 0):
+        raise ValueError(f"window_left must be a nonnegative integer or None, got {window_left!r}")
     sm_scale = 1.0 / (q.shape[2] ** 0.5) if softmax_scale is None else softmax_scale
     return _Attention.apply(
         q,
@@ -1387,6 +1476,8 @@ def attention(
         v_cache,
         block_table,
         page_size,
+        rel_logits,
+        window_left,
     )
 
 

--- a/modelopt/torch/kernels/quantization/attention/bmm1_qdq.py
+++ b/modelopt/torch/kernels/quantization/attention/bmm1_qdq.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NVFP4 QDQ helpers for attention BMM1 operands."""
+
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from modelopt.torch.kernels.quantization.common.nvfp4_quant import nvfp4_scalar_qdq
+
+__all__ = ["fake_quant_k_onwrite"]
+
+
+@triton.jit
+def _fake_quant_k_onwrite_kernel(
+    K_cache,
+    Slot_mapping,
+    num_tokens,
+    stride_kc_block,
+    stride_kc_pos,
+    stride_kc_head,
+    page_size,
+    global_scale,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    token = tl.program_id(0)
+    head = tl.program_id(1)
+    dims = tl.arange(0, BLOCK_D)
+    slot = tl.load(Slot_mapping + token, mask=token < num_tokens, other=-1).to(tl.int64)
+    valid = (token < num_tokens) & (slot >= 0)
+    block = tl.maximum(slot, 0) // page_size
+    offset = tl.maximum(slot, 0) % page_size
+    ptrs = K_cache + block * stride_kc_block + offset * stride_kc_pos + head * stride_kc_head + dims
+    values = tl.load(ptrs, mask=valid & (dims < HEAD_DIM), other=0.0).to(tl.float32)
+    grouped = tl.reshape(values, (BLOCK_D // 16, 16))
+    block_amax = tl.expand_dims(tl.max(tl.abs(grouped), axis=1), 1)
+    quantized = tl.reshape(nvfp4_scalar_qdq(grouped, block_amax, global_scale, 16), (BLOCK_D,))
+    tl.store(ptrs, quantized.to(K_cache.dtype.element_ty), mask=valid & (dims < HEAD_DIM))
+
+
+def fake_quant_k_onwrite(
+    k_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    *,
+    k_qdq_scale: float = 1.0,
+) -> None:
+    """NVFP4 fake-quantize newly written paged-cache K rows in place.
+
+    K uses block-16 groups along head dimension, the contraction dimension of
+    BMM1. ``slot_mapping`` is vLLM's flattened physical cache slot for each new
+    token; negative slots are ignored.
+    """
+    if k_cache.ndim != 4:
+        raise ValueError("k_cache must have shape [num_blocks, page_size, num_kv_heads, head_dim]")
+    if slot_mapping.ndim != 1:
+        raise ValueError("slot_mapping must be one-dimensional")
+    if not (math.isfinite(k_qdq_scale) and k_qdq_scale > 0):
+        raise ValueError(f"k_qdq_scale must be finite and positive, got {k_qdq_scale}")
+    if slot_mapping.numel() == 0:
+        return
+
+    num_kv_heads, head_dim = k_cache.shape[2:]
+    if head_dim % 16:
+        raise ValueError(f"head_dim={head_dim} cannot be grouped into block-16 NVFP4")
+    block_d = triton.next_power_of_2(head_dim)
+
+    with torch.cuda.device(k_cache.device):
+        _fake_quant_k_onwrite_kernel[(slot_mapping.numel(), num_kv_heads)](
+            k_cache,
+            slot_mapping,
+            slot_mapping.numel(),
+            k_cache.stride(0),
+            k_cache.stride(1),
+            k_cache.stride(2),
+            k_cache.shape[1],
+            k_qdq_scale,
+            HEAD_DIM=head_dim,
+            BLOCK_D=block_d,
+            num_warps=4,
+        )

--- a/modelopt/torch/quantization/plugins/vllm.py
+++ b/modelopt/torch/quantization/plugins/vllm.py
@@ -102,6 +102,11 @@ def _import_attention_module():
 
 vllm_attention = _import_attention_module()
 
+try:
+    from vllm.models.inkling.nvidia.attention import InklingAttention as VllmInklingAttention
+except ImportError:
+    VllmInklingAttention = None
+
 # Try multiple import paths for vLLM compatibility across versions
 vllm_shared_fused_moe_layer = None
 for module_path in [
@@ -198,7 +203,13 @@ except (AttributeError, ImportError):
 
 _ATTENTION_TYPES = tuple(
     t
-    for t in [vllm_attention.Attention, CrossAttention, EncoderOnlyAttention, VllmMLAAttention]
+    for t in [
+        vllm_attention.Attention,
+        CrossAttention,
+        EncoderOnlyAttention,
+        VllmMLAAttention,
+        VllmInklingAttention,
+    ]
     if t is not None
 )
 
@@ -378,15 +389,28 @@ def configure_vllm_nvfp4_attention_quantizers(
     Returns:
         The supplied module, converted in place to ``_QuantVLLMAttention``.
     """
-    if not isinstance(module, vllm_attention.Attention):
-        raise TypeError(f"Expected vLLM Attention, got {type(module).__name__}")
+    is_regular_attention = isinstance(module, vllm_attention.Attention)
+    is_inkling_attention = VllmInklingAttention is not None and isinstance(
+        module, VllmInklingAttention
+    )
+    if not (is_regular_attention or is_inkling_attention):
+        raise TypeError(f"Expected a supported vLLM attention module, got {type(module).__name__}")
     if not isinstance(dtype, torch.dtype):
         raise TypeError(f"Expected torch.dtype, got {type(dtype).__name__}")
 
     device = torch.device(device)
     module.device, module.dtype = device, dtype
-    if not isinstance(module, _QuantVLLMAttention):
+    if is_regular_attention and not isinstance(module, _QuantVLLMAttention):
         module = QuantModuleRegistry.convert(module)
+    elif is_inkling_attention and not hasattr(module, "q_bmm_quantizer"):
+        # Inkling is not a vLLM Attention subclass: its Q/K/V preparation and
+        # relative-attention launch are fused in model-specific kernels. The
+        # runtime adapter consumes these quantizers without replacing the
+        # model class.
+        module.q_bmm_quantizer = TensorQuantizer()
+        module.k_bmm_quantizer = TensorQuantizer()
+        module.v_bmm_quantizer = TensorQuantizer()
+        module.parallel_state = create_parallel_state()
     if not hasattr(module, "p_bmm_quantizer"):
         module.p_bmm_quantizer = TensorQuantizer()
 

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm.py
@@ -32,6 +32,7 @@ import inspect
 import math
 import warnings
 from dataclasses import dataclass
+from types import MethodType
 
 import torch
 from vllm.v1.attention.backends.flash_attn import (
@@ -44,7 +45,20 @@ from modelopt.torch.kernels.common.attention.decode_attention import (
     attention_decode as triton_decode_attention,
 )
 from modelopt.torch.kernels.common.attention.triton_fa import attention as triton_attention
+from modelopt.torch.kernels.quantization.attention.bmm1_qdq import fake_quant_k_onwrite
 from modelopt.torch.kernels.quantization.attention.bmm2_qdq import fake_quant_v_onwrite
+
+try:
+    from vllm.compilation.breakable_cudagraph import eager_break_during_capture
+    from vllm.forward_context import get_forward_context
+    from vllm.models.inkling.nvidia.attention import InklingAttention
+except ImportError:
+    InklingAttention = None
+    get_forward_context = None
+
+    def eager_break_during_capture(fn):
+        """Return ``fn`` unchanged on vLLM releases without graph-break support."""
+        return fn
 
 
 def _target_sparse_ratio_for_phase(target_sparse_ratio, phase: str) -> float:
@@ -154,6 +168,129 @@ def _p_qdq_from_layer(layer) -> tuple[str | None, float]:
 
 def _v_qdq_from_layer(layer) -> tuple[str | None, float | None]:
     return _bmm_qdq_from_layer(layer, "v_bmm_quantizer", None)
+
+
+def is_inkling_attention(module) -> bool:
+    """Return whether ``module`` is vLLM's model-specific Inkling attention."""
+    return InklingAttention is not None and isinstance(module, InklingAttention)
+
+
+def _nvfp4_scale(amax: float | None) -> float:
+    return 1.0 if amax is None else amax / (6.0 * 448.0)
+
+
+@eager_break_during_capture
+def _inkling_attention_forward(
+    layer,
+    q: torch.Tensor,
+    rel_logits: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    """Run ModelOpt attention after Inkling's fused Q/K/V preparation."""
+    adapter = layer._modelopt_inkling_attention_adapter
+    attn_metadata = get_forward_context().attn_metadata
+    if not isinstance(attn_metadata, dict):
+        output.zero_()
+        return
+
+    md = attn_metadata[layer.prefix]
+    nt = md.num_actual_tokens
+    q = q[:nt].contiguous()
+    rel_logits = rel_logits[:nt].contiguous()
+    key_cache, value_cache = layer._split_kv_cache()
+
+    quant_kw = adapter.quant_kw
+    if quant_kw is not None:
+        q = layer.q_bmm_quantizer(q.float())
+        fake_quant_k_onwrite(
+            key_cache,
+            md.slot_mapping[:nt],
+            k_qdq_scale=_nvfp4_scale(quant_kw["k_qdq_amax"]),
+        )
+
+    query_lens = md.query_start_loc[1:] - md.query_start_loc[:-1]
+    sparse_kw = dict(adapter.sparse_kw)
+    _resolve_skip_softmax_calibration(
+        sparse_kw,
+        is_prefill=md.max_query_len > 1,
+        max_seq_len=md.max_seq_len,
+    )
+    if md.max_query_len <= 1:
+        # Match the regular vLLM adapter: N:M sparse softmax is prefill-only.
+        for name in ("sparsity_n", "sparsity_m", "dense_sink_tokens", "dense_recent_tokens"):
+            sparse_kw.pop(name, None)
+
+    p_qdq = v_qdq = None
+    p_qdq_amax = 1.0
+    v_qdq_amax = None
+    v_cache_quantized = False
+    if quant_kw is not None:
+        p_qdq = quant_kw["p_qdq"]
+        p_qdq_amax = quant_kw["p_qdq_amax"]
+        v_qdq = quant_kw["v_qdq"]
+        v_qdq_amax = quant_kw["v_qdq_amax"]
+        if v_qdq == "nvfp4":
+            fake_quant_v_onwrite(
+                value_cache,
+                md.block_table,
+                ((md.seq_lens - query_lens) // 16) * 16,
+                (md.seq_lens // 16) * 16,
+                max_new_tokens=md.max_query_len,
+                page_size=value_cache.shape[1],
+                v_qdq_scale=_nvfp4_scale(v_qdq_amax),
+            )
+            v_cache_quantized = True
+
+    k_dummy = torch.empty(
+        0,
+        layer.num_kv_heads,
+        layer.head_dim,
+        dtype=key_cache.dtype,
+        device=q.device,
+    )
+    window_left = layer.window_size[0] if layer.window_size[0] >= 0 else None
+    result = triton_attention(
+        q,
+        k_dummy,
+        k_dummy,
+        md.query_start_loc[:-1],
+        query_lens,
+        md.max_query_len,
+        is_causal=True,
+        softmax_scale=layer.scaling,
+        b_start_loc_k=None,
+        b_seq_len_k=md.seq_lens,
+        max_input_len_k=md.max_seq_len,
+        p_qdq=p_qdq,
+        p_qdq_amax=p_qdq_amax,
+        v_qdq=v_qdq,
+        v_qdq_amax=v_qdq_amax,
+        v_cache_quantized=v_cache_quantized,
+        k_cache=key_cache,
+        v_cache=value_cache,
+        block_table=md.block_table,
+        page_size=key_cache.shape[1],
+        rel_logits=rel_logits,
+        window_left=window_left,
+        **sparse_kw,
+    )
+    output[:nt].copy_(result.to(output.dtype))
+
+
+@dataclass
+class ModelOptInklingAttentionAdapter:
+    """Per-layer state for vLLM Inkling's ModelOpt attention path."""
+
+    sparse_kw: dict | None = None
+    quant_kw: dict | None = None
+
+    def install(self, module) -> None:
+        """Replace one Inkling layer's private attention launch in place."""
+        if not is_inkling_attention(module):
+            raise TypeError(f"Expected InklingAttention, got {type(module).__name__}")
+        self.sparse_kw = dict(self.sparse_kw or {})
+        module._modelopt_inkling_attention_adapter = self
+        module._attention = MethodType(_inkling_attention_forward, module)
 
 
 def _quant_kw_from_impl(impl, layer):

--- a/modelopt/torch/sparsity/attention_sparsity/plugins/vllm_runtime.py
+++ b/modelopt/torch/sparsity/attention_sparsity/plugins/vllm_runtime.py
@@ -80,6 +80,7 @@ class VllmAttentionInstallReport:
 @dataclass(frozen=True, slots=True)
 class _AttentionPlan:
     name: str
+    kind: str
     module: torch.nn.Module
     new_impl: Any
     sparse_kw: dict[str, Any]
@@ -233,6 +234,24 @@ def _layer_errors(module) -> list[str]:
     return errors
 
 
+def _inkling_layer_errors(module, *, quantize: bool, formats: tuple[str, ...]) -> list[str]:
+    errors = []
+    if getattr(module, "head_dim", None) != 128:
+        errors.append(f"Inkling head_dim={getattr(module, 'head_dim', None)!r} must be 128")
+    if getattr(module, "d_rel", None) != 16:
+        errors.append(f"Inkling d_rel={getattr(module, 'd_rel', None)!r} must be 16")
+    window_size = getattr(module, "window_size", None)
+    if not isinstance(window_size, tuple) or len(window_size) != 2 or window_size[1] not in (-1, 0):
+        errors.append(f"Inkling window_size={window_size!r} is unsupported")
+    if str(getattr(module, "kv_cache_dtype", "")).startswith("fp8"):
+        errors.append("Inkling FP8 KV cache is unsupported")
+    if not callable(getattr(module, "_split_kv_cache", None)):
+        errors.append("Inkling paged K/V cache accessor is unavailable")
+    if quantize and any(fmt != "nvfp4" for fmt in formats):
+        errors.append("Inkling currently supports NVFP4 Q/K/P/V formats only")
+    return errors
+
+
 def _device_capability_error(device) -> str | None:
     if device is None:
         return None
@@ -334,12 +353,16 @@ def _plan_vllm_attention(
     candidates = []
     attention_count = 0
     for name, module in model.named_modules():
-        if not isinstance(module, _VLLM_ATTENTION):
+        if isinstance(module, _VLLM_ATTENTION):
+            kind = "regular"
+        elif attention_plugin.is_inkling_attention(module):
+            kind = "inkling"
+        else:
             continue
         attention_count += 1
         sparse_kw = _sparse_kwargs(name, resolved_sparse_cfg)
         if quantize or sparse_kw:
-            candidates.append((name, module, sparse_kw))
+            candidates.append((name, kind, module, sparse_kw))
 
     if not candidates and not quantize:
         return _InstallPlan(
@@ -351,8 +374,13 @@ def _plan_vllm_attention(
     mode = _cudagraph_mode(model_runner) if quantize else None
     quant_plugin: Any = _load_quant_plugin() if quantize else None
     plans = []
-    for name, module, sparse_kw in candidates:
-        reasons = _layer_errors(module)
+    formats = (q_format, k_format, p_format, v_format)
+    for name, kind, module, sparse_kw in candidates:
+        reasons = (
+            _layer_errors(module)
+            if kind == "regular"
+            else _inkling_layer_errors(module, quantize=quantize, formats=formats)
+        )
         device = dtype = None
         if quantize:
             device, dtype = quant_plugin._get_device_dtype(module)
@@ -368,15 +396,20 @@ def _plan_vllm_attention(
         if quantize:
             if graph_error := _sparse_graph_error(sparse_kw, mode):
                 reasons.append(graph_error)
-        new_impl, requires_flashinfer_patch, backend_error = _select_new_impl(module)
-        if backend_error:
-            reasons.append(backend_error)
+        if kind == "regular":
+            new_impl, requires_flashinfer_patch, backend_error = _select_new_impl(module)
+            if backend_error:
+                reasons.append(backend_error)
+        else:
+            new_impl = attention_plugin.ModelOptInklingAttentionAdapter()
+            requires_flashinfer_patch = False
         if reasons:
             errors.extend(f"{name or '<root>'}: {reason}" for reason in reasons)
             continue
         plans.append(
             _AttentionPlan(
                 name,
+                kind,
                 module,
                 new_impl,
                 sparse_kw,
@@ -386,7 +419,7 @@ def _plan_vllm_attention(
             )
         )
     if quantize and attention_count == 0:
-        errors.append("no regular attention layers were found")
+        errors.append("no supported attention layers were found")
     _raise_unsupported(errors, "NVFP4 attention" if quantize else "sparse attention")
     return _InstallPlan(
         model_runner,
@@ -465,6 +498,13 @@ def _apply_vllm_attention_plans(plan: _InstallPlan) -> VllmAttentionInstallRepor
                 "v_qdq": v_qdq,
                 "v_qdq_amax": v_qdq_amax,
             }
+            if layer.kind == "inkling":
+                k_qdq, k_qdq_amax = attention_plugin._bmm_qdq_from_layer(
+                    layer.module, "k_bmm_quantizer", 6.0 * 448.0
+                )
+                if k_qdq != "nvfp4":
+                    raise RuntimeError("Inkling K must use dynamic block-16 NVFP4")
+                layer.new_impl.quant_kw.update({"k_qdq": k_qdq, "k_qdq_amax": k_qdq_amax})
 
         missing = object()
         old_query_flag = getattr(layer.module, "_query_quant_in_kernel", missing)
@@ -475,6 +515,9 @@ def _apply_vllm_attention_plans(plan: _InstallPlan) -> VllmAttentionInstallRepor
             layer.module._query_quant_in_kernel = plan.q_format != "fp8"
             layer.module._value_quant_in_kernel = plan.v_format != "fp8"
         try:
+            if layer.kind == "inkling":
+                layer.new_impl.install(layer.module)
+                continue
             # Publish the adapter last so a native impl never runs with in-kernel
             # quantization flags that only the ModelOpt adapter understands.
             layer.module.impl = layer.new_impl

--- a/tests/gpu/torch/kernels/common/attention/test_triton_fa.py
+++ b/tests/gpu/torch/kernels/common/attention/test_triton_fa.py
@@ -107,6 +107,51 @@ class TestForward:
             ref = F.scaled_dot_product_attention(qb, kb, vb, is_causal=False).squeeze(2)
             torch.testing.assert_close(out[i : i + 1], ref, rtol=1e-3, atol=1e-3)
 
+    def test_relative_bias_gqa_sliding_window_matches_reference(self):
+        """Inkling-style relative logits compose with GQA and a causal window."""
+        seq_len, num_heads, num_kv_heads, head_dim = 17, 4, 2, 32
+        rel_extent, window_left = 8, 5
+        scale = 1.0 / head_dim
+
+        torch.manual_seed(104)
+        q, k, v = make_qkv(seq_len, num_heads, num_kv_heads, head_dim, dtype=torch.float32)
+        rel_logits = torch.randn(seq_len, num_heads, rel_extent, device="cuda", dtype=torch.float32)
+        locs, lens = make_varlen_meta([seq_len])
+
+        out = attention(
+            q,
+            k,
+            v,
+            locs,
+            lens,
+            seq_len,
+            softmax_scale=scale,
+            rel_logits=rel_logits,
+            window_left=window_left,
+        )
+
+        repeat = num_heads // num_kv_heads
+        k_heads = k.repeat_interleave(repeat, dim=1).permute(1, 0, 2)
+        v_heads = v.repeat_interleave(repeat, dim=1).permute(1, 0, 2)
+        q_heads = q.permute(1, 0, 2)
+        scores = torch.matmul(q_heads, k_heads.transpose(1, 2)) * scale
+        distance = (
+            torch.arange(seq_len, device="cuda")[:, None]
+            - torch.arange(seq_len, device="cuda")[None, :]
+        )
+        rel_idx = distance.clamp(0, rel_extent - 1)
+        bias = torch.gather(
+            rel_logits.permute(1, 0, 2),
+            2,
+            rel_idx.expand(num_heads, -1, -1),
+        )
+        bias = bias.masked_fill(~((distance >= 0) & (distance < rel_extent)), 0.0)
+        valid = (distance >= 0) & (distance <= window_left)
+        probs = torch.softmax((scores + bias).masked_fill(~valid, float("-inf")), dim=-1)
+        ref = torch.matmul(probs, v_heads).permute(1, 0, 2)
+
+        torch.testing.assert_close(out, ref, rtol=2e-3, atol=2e-3)
+
 
 # ---------------------------------------------------------------------------
 # Backward correctness (dense)

--- a/tests/gpu/torch/kernels/common/attention/test_triton_fa_paged.py
+++ b/tests/gpu/torch/kernels/common/attention/test_triton_fa_paged.py
@@ -27,6 +27,7 @@ from modelopt.torch.quantization.qtensor.nvfp4_tensor import NVFP4QTensor
 
 if TRITON_KERNEL_AVAILABLE:
     from modelopt.torch.kernels.common.attention import attention, triton_fa
+    from modelopt.torch.kernels.quantization.attention.bmm1_qdq import fake_quant_k_onwrite
     from modelopt.torch.kernels.quantization.attention.bmm2_qdq import fake_quant_v_onwrite
 
 NATIVE_E4M3_AVAILABLE = TRITON_KERNEL_AVAILABLE and torch.cuda.get_device_capability() >= (8, 9)
@@ -129,6 +130,47 @@ def _suffix_causal_reference(q, k, v, q_lens, kv_lens, num_heads, num_kv_heads, 
 @pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
 class TestPagedKV:
     """Paged KV cache mode tests — verify paged output matches contiguous."""
+
+    @requires_native_e4m3
+    def test_k_onwrite_matches_nvfp4_oracle_and_preserves_unmapped_slots(self):
+        """K-cache on-write QDQ uses block-16 groups along head dimension."""
+        page_size, num_kv_heads, head_dim = 16, 2, 128
+        torch.manual_seed(76)
+        cache = torch.randn(
+            2,
+            page_size,
+            num_kv_heads,
+            head_dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        before = cache.clone()
+        slot_mapping = torch.tensor([0, page_size + 1, -1], device="cuda")
+
+        fake_quant_k_onwrite(cache, slot_mapping)
+
+        selected = torch.stack((before[0, 0], before[1, 1]))
+        q, scale, double_scale = NVFP4QTensor.quantize(
+            selected,
+            16,
+            weights_scaling_factor_2=torch.tensor(1.0, device="cuda"),
+            try_tensorrt=False,
+        )
+        expected = q.dequantize(
+            dtype=cache.dtype,
+            scale=scale,
+            double_scale=double_scale,
+            block_sizes={-1: 16},
+        )
+        torch.testing.assert_close(cache[0, 0], expected[0], rtol=0, atol=0)
+        torch.testing.assert_close(cache[1, 1], expected[1], rtol=0, atol=0)
+        torch.testing.assert_close(cache[0, 1], before[0, 1], rtol=0, atol=0)
+
+    def test_k_onwrite_rejects_non_block_aligned_head_dim(self):
+        cache = torch.empty(1, 16, 1, 126, device="cuda")
+        slots = torch.zeros(1, device="cuda", dtype=torch.int64)
+        with pytest.raises(ValueError, match="head_dim=126"):
+            fake_quant_k_onwrite(cache, slots)
 
     @pytest.mark.parametrize(
         ("page_size", "v_qdq_scale", "match"),
@@ -241,6 +283,56 @@ class TestPagedKV:
         )
 
         torch.testing.assert_close(out_paged, out_contig, rtol=1e-2, atol=1e-2)
+
+    def test_paged_relative_bias_gqa_sliding_window_matches_contiguous(self):
+        """Inkling relative logits and local window work with paged GQA."""
+        seq_len, num_heads, num_kv_heads, head_dim = 17, 4, 2, 128
+        rel_extent, window_left, page_size = 16, 5, 16
+        scale = 1.0 / head_dim
+
+        torch.manual_seed(78)
+        q, k, v = make_qkv(
+            seq_len,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            dtype=torch.bfloat16,
+        )
+        rel_logits = torch.randn(
+            seq_len,
+            num_heads,
+            rel_extent,
+            device="cuda",
+            dtype=torch.bfloat16,
+        )
+        locs, lens = make_varlen_meta([seq_len])
+        common = {
+            "softmax_scale": scale,
+            "rel_logits": rel_logits,
+            "window_left": window_left,
+        }
+        contiguous = attention(q, k, v, locs, lens, seq_len, **common)
+        k_cache, v_cache, block_table = _scatter_to_paged_cache(
+            k, v, locs, lens, num_kv_heads, head_dim, page_size
+        )
+        dummy = torch.empty(0, num_kv_heads, head_dim, device="cuda", dtype=k.dtype)
+        paged = attention(
+            q,
+            dummy,
+            dummy,
+            locs,
+            lens,
+            seq_len,
+            b_seq_len_k=lens,
+            max_input_len_k=seq_len,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            block_table=block_table,
+            page_size=page_size,
+            **common,
+        )
+
+        torch.testing.assert_close(paged, contiguous, rtol=2e-2, atol=2e-2)
 
     @pytest.mark.parametrize("page_size", [16, 32, 64])
     def test_paged_different_page_sizes(self, page_size):

--- a/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_plugin.py
+++ b/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_plugin.py
@@ -33,6 +33,7 @@ import torch
 from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
 
 from modelopt.torch.kernels.common.attention import IS_AVAILABLE as TRITON_KERNEL_AVAILABLE
+from modelopt.torch.sparsity.attention_sparsity.plugins import vllm as vllm_plugin
 from modelopt.torch.sparsity.attention_sparsity.plugins.vllm import ModelOptSparseAttentionImpl
 
 if TRITON_KERNEL_AVAILABLE:
@@ -371,3 +372,204 @@ class TestModelOptSparseAttentionImpl:
             output=output,
         )
         torch.testing.assert_close(out_paged, out_ref, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
+def test_inkling_forward_matches_contiguous_reference(monkeypatch):
+    """Inkling metadata translation preserves relative-window paged GQA."""
+    seq_len, num_heads, num_kv_heads, head_dim = 17, 4, 2, 128
+    rel_extent, window_left, page_size = 16, 5, 16
+    scale = 1.0 / head_dim
+
+    torch.manual_seed(3)
+    q = torch.randn(seq_len, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(seq_len, num_kv_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    rel_logits = torch.randn(
+        seq_len,
+        num_heads,
+        rel_extent,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    query_start_loc = torch.tensor([0, seq_len], device="cuda", dtype=torch.int32)
+    seq_lens = torch.tensor([seq_len], device="cuda", dtype=torch.int32)
+    kv_cache, block_table = _make_paged_cache(
+        k,
+        v,
+        query_start_loc[:-1],
+        seq_lens,
+        num_kv_heads,
+        head_dim,
+        page_size,
+    )
+    metadata = SimpleNamespace(
+        num_actual_tokens=seq_len,
+        max_query_len=seq_len,
+        max_seq_len=seq_len,
+        query_start_loc=query_start_loc,
+        seq_lens=seq_lens,
+        block_table=block_table,
+    )
+    prefix = "model.layers.0.attn"
+    monkeypatch.setattr(
+        vllm_plugin,
+        "get_forward_context",
+        lambda: SimpleNamespace(attn_metadata={prefix: metadata}),
+    )
+    layer = SimpleNamespace(
+        prefix=prefix,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        scaling=scale,
+        window_size=(window_left, 0),
+        _modelopt_inkling_attention_adapter=SimpleNamespace(sparse_kw={}, quant_kw=None),
+        _split_kv_cache=lambda: kv_cache.unbind(0),
+    )
+    output = torch.empty_like(q)
+
+    vllm_plugin._inkling_attention_forward(layer, q, rel_logits, output)
+    reference = triton_attention(
+        q,
+        k,
+        v,
+        query_start_loc[:-1],
+        seq_lens,
+        seq_len,
+        softmax_scale=scale,
+        rel_logits=rel_logits,
+        window_left=window_left,
+    )
+
+    torch.testing.assert_close(output, reference, rtol=2e-2, atol=2e-2)
+
+
+def test_inkling_decode_drops_prefill_only_nm_sparsity(monkeypatch):
+    """Inkling decode preserves the established prefill-only N:M contract."""
+    prefix = "model.layers.0.attn"
+    metadata = SimpleNamespace(
+        num_actual_tokens=1,
+        max_query_len=1,
+        max_seq_len=4,
+        query_start_loc=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=torch.tensor([4], dtype=torch.int32),
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+    )
+    monkeypatch.setattr(
+        vllm_plugin,
+        "get_forward_context",
+        lambda: SimpleNamespace(attn_metadata={prefix: metadata}),
+    )
+    captured = {}
+
+    def fake_attention(q, _k, _v, *_args, **kwargs):
+        captured.update(kwargs)
+        return torch.zeros_like(q)
+
+    monkeypatch.setattr(vllm_plugin, "triton_attention", fake_attention)
+    cache = torch.zeros(1, 16, 1, 128)
+    layer = SimpleNamespace(
+        prefix=prefix,
+        num_kv_heads=1,
+        head_dim=128,
+        scaling=1.0 / 128,
+        window_size=(-1, -1),
+        _modelopt_inkling_attention_adapter=SimpleNamespace(
+            sparse_kw={
+                "sparsity_n": 2,
+                "sparsity_m": 4,
+                "dense_sink_tokens": 0,
+                "dense_recent_tokens": 0,
+            },
+            quant_kw=None,
+        ),
+        _split_kv_cache=lambda: (cache, cache),
+    )
+
+    vllm_plugin._inkling_attention_forward(
+        layer,
+        torch.zeros(1, 1, 128),
+        torch.zeros(1, 1, 16),
+        torch.empty(1, 1, 128),
+    )
+
+    for name in ("sparsity_n", "sparsity_m", "dense_sink_tokens", "dense_recent_tokens"):
+        assert name not in captured
+
+
+@pytest.mark.skipif(not TRITON_KERNEL_AVAILABLE, reason="Need CUDA + triton")
+def test_quantized_sparse_inkling_forward_is_finite(monkeypatch):
+    """Inkling adapter composes paged Q/K/P/V NVFP4 with active 2:4."""
+    seq_len, num_heads, num_kv_heads, head_dim = 17, 4, 2, 128
+    rel_extent, page_size = 16, 16
+    torch.manual_seed(4)
+    q = torch.randn(seq_len, num_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(seq_len, num_kv_heads, head_dim, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    rel_logits = torch.randn(
+        seq_len,
+        num_heads,
+        rel_extent,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    query_start_loc = torch.tensor([0, seq_len], device="cuda", dtype=torch.int32)
+    seq_lens = torch.tensor([seq_len], device="cuda", dtype=torch.int32)
+    kv_cache, block_table = _make_paged_cache(
+        k,
+        v,
+        query_start_loc[:-1],
+        seq_lens,
+        num_kv_heads,
+        head_dim,
+        page_size,
+    )
+    cache_before = kv_cache.clone()
+    metadata = SimpleNamespace(
+        num_actual_tokens=seq_len,
+        max_query_len=seq_len,
+        max_seq_len=seq_len,
+        query_start_loc=query_start_loc,
+        seq_lens=seq_lens,
+        block_table=block_table,
+        slot_mapping=torch.arange(seq_len, device="cuda", dtype=torch.int64),
+    )
+    prefix = "model.layers.0.attn"
+    monkeypatch.setattr(
+        vllm_plugin,
+        "get_forward_context",
+        lambda: SimpleNamespace(attn_metadata={prefix: metadata}),
+    )
+    q_inputs = []
+
+    def quantize_q(value):
+        q_inputs.append(value)
+        return value
+
+    layer = SimpleNamespace(
+        prefix=prefix,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        scaling=1.0 / head_dim,
+        window_size=(5, 0),
+        q_bmm_quantizer=quantize_q,
+        _modelopt_inkling_attention_adapter=SimpleNamespace(
+            sparse_kw={"sparsity_n": 2, "sparsity_m": 4, "dense_recent_tokens": 0},
+            quant_kw={
+                "k_qdq_amax": 6.0 * 448.0,
+                "p_qdq": "nvfp4",
+                "p_qdq_amax": 1.0,
+                "v_qdq": "nvfp4",
+                "v_qdq_amax": 6.0 * 448.0,
+            },
+        ),
+        _split_kv_cache=lambda: kv_cache.unbind(0),
+    )
+    output = torch.empty_like(q)
+
+    vllm_plugin._inkling_attention_forward(layer, q, rel_logits, output)
+
+    assert len(q_inputs) == 1 and q_inputs[0].dtype == torch.float32
+    assert torch.isfinite(output).all()
+    assert not torch.equal(kv_cache[0], cache_before[0])
+    assert not torch.equal(kv_cache[1, 0], cache_before[1, 0])

--- a/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_runtime.py
+++ b/tests/gpu_vllm/torch/sparsity/attention_sparsity/test_vllm_runtime.py
@@ -46,6 +46,22 @@ def _bare_attention(impl_cls=FlashAttentionImpl, module_cls=None):
     return module
 
 
+def _bare_inkling_attention():
+    if vllm_runtime.attention_plugin.InklingAttention is None:
+        pytest.skip("vLLM does not provide InklingAttention")
+    module = object.__new__(vllm_runtime.attention_plugin.InklingAttention)
+    nn.Module.__init__(module)
+    module.prefix = "model.layers.0.attn"
+    module.head_dim = 128
+    module.d_rel = 16
+    module.num_kv_heads = 8
+    module.window_size = (-1, -1)
+    module.kv_cache_dtype = "auto"
+    module.device = torch.device("cpu")
+    module.dtype = torch.bfloat16
+    return module
+
+
 def _sparse_metadata():
     return {
         "config_groups": {
@@ -273,6 +289,48 @@ def test_nvfp4_validation_of_all_layers_precedes_mutation(monkeypatch):
     assert invalid.impl is invalid_impl
     assert not hasattr(valid, "_query_quant_in_kernel")
     assert runner.cascade_attn_enabled is True
+
+
+def test_nvfp4_install_supports_inkling_attention(monkeypatch):
+    attention = _bare_inkling_attention()
+    runner = _model_runner(nn.ModuleDict({"inkling_attn": attention}))
+    runner.model_config.dtype = torch.bfloat16
+    runner.vllm_config.model_config.dtype = torch.bfloat16
+    monkeypatch.setattr(
+        quant_plugin,
+        "create_parallel_state",
+        lambda: quant_plugin.ParallelState(data_parallel_group=None),
+    )
+
+    report = vllm_runtime.install_vllm_nvfp4_attention(
+        runner,
+        sparse_cfg={
+            "*attn*": {
+                "enable": True,
+                "sparsity_n": 2,
+                "sparsity_m": 4,
+            }
+        },
+    )
+
+    assert report.installed_layers == ("inkling_attn",)
+    assert report.quantized_layers == ("inkling_attn",)
+    assert report.sparse_layers == ("inkling_attn",)
+    assert report.backend_counts == {"ModelOptInklingAttentionAdapter": 1}
+    assert isinstance(
+        attention._modelopt_inkling_attention_adapter,
+        vllm_runtime.attention_plugin.ModelOptInklingAttentionAdapter,
+    )
+    for name in ("q", "k", "p", "v"):
+        assert getattr(attention, f"{name}_bmm_quantizer").is_nvfp4_dynamic
+
+
+def test_inkling_install_rejects_non_nvfp4_formats():
+    attention = _bare_inkling_attention()
+    runner = _model_runner(nn.ModuleDict({"inkling_attn": attention}))
+
+    with pytest.raises(NotImplementedError, match="NVFP4 Q/K/P/V formats only"):
+        vllm_runtime.install_vllm_nvfp4_attention(runner, p_format="fp8")
 
 
 def test_apply_failure_does_not_leave_configured_layer_on_native_impl(monkeypatch):

--- a/tools/launcher/common/smoke/inkling_attention.py
+++ b/tools/launcher/common/smoke/inkling_attention.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Small GPU sanity checks for the experimental Inkling attention adapter."""
+
+import torch
+
+from modelopt.torch.kernels.common.attention.triton_fa import attention
+from modelopt.torch.kernels.quantization.attention.bmm1_qdq import fake_quant_k_onwrite
+from modelopt.torch.sparsity.attention_sparsity.plugins import vllm as vllm_plugin
+
+
+def _reference(q, k, v, rel_logits, scale, window_left):
+    num_heads = q.shape[1]
+    repeat = num_heads // k.shape[1]
+    q_heads = q.float().permute(1, 0, 2)
+    k_heads = k.float().repeat_interleave(repeat, dim=1).permute(1, 0, 2)
+    v_heads = v.float().repeat_interleave(repeat, dim=1).permute(1, 0, 2)
+    scores = torch.matmul(q_heads, k_heads.transpose(1, 2)) * scale
+    seq_len = q.shape[0]
+    distance = (
+        torch.arange(seq_len, device=q.device)[:, None]
+        - torch.arange(seq_len, device=q.device)[None, :]
+    )
+    rel_extent = rel_logits.shape[2]
+    rel_idx = distance.clamp(0, rel_extent - 1)
+    bias = torch.gather(
+        rel_logits.float().permute(1, 0, 2),
+        2,
+        rel_idx.expand(num_heads, -1, -1),
+    )
+    bias.masked_fill_(~((distance >= 0) & (distance < rel_extent)), 0.0)
+    valid = (distance >= 0) & (distance <= window_left)
+    probs = torch.softmax((scores + bias).masked_fill(~valid, float("-inf")), dim=-1)
+    return torch.matmul(probs, v_heads).permute(1, 0, 2)
+
+
+def main() -> None:
+    """Exercise the Inkling-specific ModelOpt kernel contracts on one GPU."""
+    import vllm
+
+    assert vllm.__version__ == "0.26.0", vllm.__version__
+    assert getattr(vllm_plugin, "InklingAttention", None) is not None
+    torch.manual_seed(123)
+    device = torch.device("cuda")
+    seq_len, num_heads, num_kv_heads, head_dim = 17, 4, 2, 128
+    rel_extent, window_left = 16, 5
+    scale = 1.0 / head_dim
+    q = torch.randn(seq_len, num_heads, head_dim, device=device, dtype=torch.bfloat16)
+    k = torch.randn(seq_len, num_kv_heads, head_dim, device=device, dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    rel_logits = torch.randn(seq_len, num_heads, rel_extent, device=device, dtype=torch.bfloat16)
+    starts = torch.tensor([0], device=device, dtype=torch.int32)
+    lengths = torch.tensor([seq_len], device=device, dtype=torch.int32)
+
+    out = attention(
+        q,
+        k,
+        v,
+        starts,
+        lengths,
+        seq_len,
+        softmax_scale=scale,
+        rel_logits=rel_logits,
+        window_left=window_left,
+    )
+    ref = _reference(q, k, v, rel_logits, scale, window_left)
+    torch.testing.assert_close(out.float(), ref, rtol=2e-2, atol=2e-2)
+
+    page_size = 16
+    k_cache = torch.zeros(2, page_size, num_kv_heads, head_dim, device=device, dtype=k.dtype)
+    v_cache = torch.zeros_like(k_cache)
+    k_cache.view(-1, num_kv_heads, head_dim)[:seq_len].copy_(k)
+    v_cache.view(-1, num_kv_heads, head_dim)[:seq_len].copy_(v)
+    block_table = torch.tensor([[0, 1]], device=device, dtype=torch.int32)
+    dummy = torch.empty(0, num_kv_heads, head_dim, device=device, dtype=k.dtype)
+    paged = attention(
+        q,
+        dummy,
+        dummy,
+        starts,
+        lengths,
+        seq_len,
+        softmax_scale=scale,
+        b_seq_len_k=lengths,
+        max_input_len_k=seq_len,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        block_table=block_table,
+        page_size=page_size,
+        rel_logits=rel_logits,
+        window_left=window_left,
+    )
+    torch.testing.assert_close(paged.float(), ref, rtol=2e-2, atol=2e-2)
+
+    transformed = attention(
+        q,
+        k,
+        v,
+        starts,
+        lengths,
+        seq_len,
+        softmax_scale=scale,
+        sparsity_n=2,
+        sparsity_m=4,
+        dense_recent_tokens=0,
+        p_qdq="nvfp4",
+        v_qdq="nvfp4",
+        rel_logits=rel_logits,
+        window_left=window_left,
+    )
+    assert torch.isfinite(transformed).all()
+
+    cache = torch.randn(2, 16, num_kv_heads, head_dim, device=device, dtype=torch.bfloat16)
+    before = cache.clone()
+    slots = torch.tensor([0, 17, -1], device=device, dtype=torch.int64)
+    fake_quant_k_onwrite(cache, slots)
+    assert not torch.equal(cache[0, 0], before[0, 0])
+    assert not torch.equal(cache[1, 1], before[1, 1])
+    assert torch.equal(cache[0, 1], before[0, 1])
+    assert torch.isfinite(cache).all()
+    print("INKLING_ATTENTION_SANITY_OK", vllm.__version__, torch.cuda.get_device_name())
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/launcher/examples/smoke/inkling_attention.yaml
+++ b/tools/launcher/examples/smoke/inkling_attention.yaml
@@ -1,0 +1,22 @@
+job_name: inkling_attention_sanity
+pipeline:
+  skip: false
+  allow_to_fail: false
+  note: "Inkling ModelOpt relative-bias, window, 2:4, and Q/K/P/V kernel sanity"
+
+  task_0:
+    inline: >-
+      python3 -m pip install --no-cache-dir -e modules/Model-Optimizer &&
+      python3 common/smoke/inkling_attention.py
+    environment:
+      - PYTHONPATH: modules/Model-Optimizer
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      time: "00:20:00"
+      container: vllm/vllm-openai:v0.26.0-aarch64
+      container_mounts: []
+      srun_args:
+        - --no-container-mount-home

--- a/tools/launcher/launch.py
+++ b/tools/launcher/launch.py
@@ -107,6 +107,8 @@ if _has_modelopt_src:
     _add_package_path(os.path.join(LAUNCHER_DIR, "modules/Model-Optimizer/modelopt"))
     _add_package_path(os.path.join(LAUNCHER_DIR, "modules/Model-Optimizer/modelopt_recipes"))
     _add_package_path(os.path.join(LAUNCHER_DIR, "modules/Model-Optimizer/examples"))
+    _add_package_path(os.path.join(LAUNCHER_DIR, "modules/Model-Optimizer/pyproject.toml"))
+    _add_package_path(os.path.join(LAUNCHER_DIR, "modules/Model-Optimizer/LICENSE_HEADER"))
 
 packager = run.PatternPackager(
     include_pattern=_include_pattern,


### PR DESCRIPTION
### What does this PR do?

Type of change: new feature

Adds ModelOpt attention support for vLLM 0.26's model-specific `InklingAttention` path:

- extends the Triton attention kernel with Inkling relative-position logits and causal left-window masking while preserving GQA and paged KV-cache support;
- adds block-16 NVFP4 K-cache on-write fake quantization and wires Inkling Q/K/P/V attention quantizers into the vLLM runtime adapter;
- composes NVFP4 attention with 2:4 prefill sparsity, while keeping N:M sparsity disabled during decode to match the existing vLLM contract;
- adds focused GPU/runtime tests and a launcher smoke configuration;
- packages the project metadata needed for editable installation inside launcher jobs.

The root cause was that Inkling uses a model-specific module rather than vLLM's regular `Attention` subclass. It also performs fused Q/K/V preparation and calls a private relative-attention implementation, so the existing ModelOpt discovery and adapter paths could not install attention quantization or sparsity.

### Usage

```python
from modelopt.torch.sparsity.attention_sparsity.plugins.vllm_runtime import (
    install_vllm_nvfp4_attention,
)

report = install_vllm_nvfp4_attention(model_runner, sparse_cfg="checkpoint")
```

A standalone GPU smoke workload is available at
`tools/launcher/examples/smoke/inkling_attention.yaml`.

### Testing

Validated with vLLM 0.26.0 on NVIDIA GB300:

- 29 Triton attention kernel tests passed.
- 28 vLLM plugin/runtime tests passed.
- Published Inkling 64Q/8KV global and 64Q/16KV local GQA geometries matched a PyTorch reference.
- Dense relative-bias/window attention, paged KV, NVFP4 K/P/V QDQ, Q quantizer integration, and active 2:4 prefill sparsity were exercised.
- Smoke result: `INKLING_ATTENTION_SANITY_OK 0.26.0 NVIDIA GB300`.
- All pre-commit hooks passed.

Full 66-layer Inkling checkpoint serving and benchmark evaluation have not yet been run; this PR is intentionally a draft.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update Changelog?: ❌ Pending before ready for review.
- Did you get Claude approval on this PR?: N/A

### Additional Information

Branch commit: `9c56d882de1c9f1a2686e3d6d44446d8bf0229e7`.
