### PR TITLE
nemotron_model_support

### DIFF
--- a/examples/hf_ptq/example_utils.py
+++ b/examples/hf_ptq/example_utils.py
@@ -260,9 +260,10 @@ def create_vlm_calibration_loop(full_model, calib_dataloader):
                 # Remove None values
                 call_kwargs = {k: v for k, v in call_kwargs.items() if v is not None}
 
-                # Use safe_nemotron_vl_forward for Nemotron Nano VL (embedding-injection style)
-                # For other VLMs (like Nemotron-Parse), use standard forward
-                if hasattr(full_model, "img_context_token_id"):
+                # Use safe_nemotron_vl_forward for Nemotron Nano VL (embedding-injection style, which
+                # exposes `extract_feature`). Newer Nemotron omni models do the vision merge inside
+                # their own (device-safe) `forward` and have no `extract_feature` — call it directly.
+                if hasattr(full_model, "img_context_token_id") and hasattr(full_model, "extract_feature"):
                     safe_nemotron_vl_forward(full_model, call_kwargs)
                 else:
                     full_model(**call_kwargs)

--- a/examples/hf_ptq/example_utils.py
+++ b/examples/hf_ptq/example_utils.py
@@ -728,11 +728,19 @@ def get_model(
         hf_config = AutoConfig.from_pretrained(ckpt_path, **config_kwargs)
 
         if is_nemotron_vl(hf_config):
-            print(
-                "Detected Nemotron VL model from config. "
-                "Disabling automatic device mapping for compatibility."
-            )
-            device_map = None
+            # By default Nemotron-VL loads single-device ("for compatibility"), but that OOMs for
+            # very large VLMs (whole model on one GPU). Allow an env override to shard across GPUs
+            # (accelerate model-parallel, NOT FSDP), e.g. MODELOPT_VL_DEVICE_MAP=auto|sequential.
+            _vl_dm = os.environ.get("MODELOPT_VL_DEVICE_MAP", "").strip()
+            if _vl_dm:
+                print(f"Detected Nemotron VL model from config. Using device_map='{_vl_dm}' (override).")
+                device_map = _vl_dm
+            else:
+                print(
+                    "Detected Nemotron VL model from config. "
+                    "Disabling automatic device mapping for compatibility."
+                )
+                device_map = None
     except Exception as e:
         print(f"Error: Could not load config from {ckpt_path}: {e}")
         raise RuntimeError(f"Failed to load model configuration from {ckpt_path}") from e


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Two small changes in `examples/hf_ptq/example_utils.py` so `hf_ptq` runs on the NemotronH Omni/VL (120B-A12B) checkpoint, quantizing the language model only:

1. **VL calibration routing** - call `safe_nemotron_vl_forward` only when the model exposes both `img_context_token_id` and `extract_feature`; otherwise fall back to `full_model(**call_kwargs)`. This model does not define `extract_feature`, so the previous unconditional path raised `AttributeError: ... has no attribute 'extract_feature'`.
2. **Optional VL sharding** - new opt-in env var `MODELOPT_VL_DEVICE_MAP` to override the VL `device_map` (e.g. `auto`) so very large VL models can be sharded across GPUs during calibration. Default behavior is unchanged when the var is unset.

### Usage

```bash
MODELOPT_VL_DEVICE_MAP=auto python examples/hf_ptq/hf_ptq.py \
    --pyt_ckpt_path <nemotronh-omni> \
    --recipe general/ptq/nvfp4_experts_only-kv_fp8_cast \
    --calib_with_images --calib_size 512 --batch_size 1 --trust_remote_code \
    --export_path <out>
```

### Testing

- NVFP4 experts-only, 512-image calibration, 8xGPU sharded: export OK. Verify -> quant_algo NVFP4, group_size 16, KV FP8, 40,960 weight-scales all of which are expert scales (experts-only scope exact; attn/Mamba/shared/vision untouched). Per-GPU peak 66-89 GB -> no OOM.
- FP8 full-LM run exercised the same VL pathway.
- Without the sharding override, single-GPU calibration OOMs (~255 GiB in use) - expected; with `MODELOPT_VL_DEVICE_MAP=auto` it fits.

- Is this change backward compatible?: YES (default path unchanged; new behavior is conditional/opt-in)
- New PIP dependency: N/A
- Did you write any new necessary tests?: NO (example-script change; behavior gated by model attributes / env var)
- Did you update Changelog?: N/A
