### PR TITLE
Document the Puzzletron v2 campaign workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Model Optimizer is also integrated with [NVIDIA Megatron-Bridge](https://github.
 ## Latest News
 
 - [2026/05/27] [**End-to-end optimization tutorial for Nemotron-3-Nano-30B-A3B**](./examples/megatron_bridge/tutorials/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16): Pruning + distillation (with long context extension) + FP8 quantization achieving 2.6× vLLM throughput and 2.6× memory reduction.
-- [2026/05/13] [**Puzzletron**](./examples/puzzletron): A new algorithm for heterogeneous pruning & NAS of LLM and VLM models.
+- [2026/05/13] [**Puzzletron v2**](./examples/puzzletron): A campaign workflow for heterogeneous pruning and NAS, with a campaign report catalog that records retained reports and their explicit reproduction and support status.
 - [2026/04/15] Customer story: [Domyn compresses Colosseum-355B → 260B using ModelOpt's Minitron pruning + distillation](https://www.domyn.com/blog/domyn-large-the-journey-of-a-european-sovereign-ai-model-for-regulated-industries)
 - [2026/03/17] Customer story: [Bielik.AI builds Bielik Minitron 7B (33% smaller, 50% faster, 90% quality retained) using ModelOpt's Minitron pruning + distillation](https://bielik.ai/en/nvidia-gtc-bielik-minitron-premiere/)
 - [2026/03/11] Model Optimizer quantized Nemotron-3-Super checkpoints are available on Hugging Face for download: [FP8](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8), [NVFP4](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4). Learn more in the [Nemotron 3 Super release blog](https://blogs.nvidia.com/blog/nemotron-3-super-agentic-ai/). Check out how to quantize Nemotron 3 models for deployment acceleration [here](./examples/llm_ptq/README.md)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Model Optimizer is also integrated with [NVIDIA Megatron-Bridge](https://github.
 ## Latest News
 
 - [2026/05/27] [**End-to-end optimization tutorial for Nemotron-3-Nano-30B-A3B**](./examples/megatron_bridge/tutorials/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16): Pruning + distillation (with long context extension) + FP8 quantization achieving 2.6× vLLM throughput and 2.6× memory reduction.
-- [2026/05/13] [**Puzzletron v2**](./examples/puzzletron): A campaign workflow for heterogeneous pruning and NAS, with a campaign report catalog that records retained reports and their explicit reproduction and support status.
+- [2026/05/13] [**Puzzletron v2**](./examples/puzzletron): A guided, resumable workflow for heterogeneous pruning campaigns, candidate evaluation, and optional distillation.
 - [2026/04/15] Customer story: [Domyn compresses Colosseum-355B → 260B using ModelOpt's Minitron pruning + distillation](https://www.domyn.com/blog/domyn-large-the-journey-of-a-european-sovereign-ai-model-for-regulated-industries)
 - [2026/03/17] Customer story: [Bielik.AI builds Bielik Minitron 7B (33% smaller, 50% faster, 90% quality retained) using ModelOpt's Minitron pruning + distillation](https://bielik.ai/en/nvidia-gtc-bielik-minitron-premiere/)
 - [2026/03/11] Model Optimizer quantized Nemotron-3-Super checkpoints are available on Hugging Face for download: [FP8](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8), [NVFP4](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4). Learn more in the [Nemotron 3 Super release blog](https://blogs.nvidia.com/blog/nemotron-3-super-agentic-ai/). Check out how to quantize Nemotron 3 models for deployment acceleration [here](./examples/llm_ptq/README.md)

--- a/docs/source/guides/3_pruning.rst
+++ b/docs/source/guides/3_pruning.rst
@@ -5,11 +5,7 @@ Pruning
 .. tip::
 
     Checkout `Megatron-Bridge Minitron Pruning & Distillation <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/megatron_bridge>`_ and
-    `Puzzletron v2 <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/puzzletron>`_ for heterogeneous pruning campaigns, or the
-    `ResNet20 on CIFAR-10 Notebook <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/pruning/cifar_resnet.ipynb>`_
-    for a dated, end-to-end computer-vision example. The notebook uses the still-supported ``fastnas`` mode,
-    but its long-running workflow is not covered by automated notebook execution tests. Treat its environment setup,
-    runtime estimate, and recorded metrics as illustrative unless you revalidate them with the current release.
+    `Puzzletron v2 <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/puzzletron>`_ for heterogeneous pruning campaigns.
     Retained Puzzletron campaign reports and their reproduction status are summarized in the
     `campaign report catalog <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/puzzletron/docs/campaign_reports.md>`_.
 
@@ -74,6 +70,13 @@ Prerequisites
 
 Below we show an example using :class:`"fastnas" <modelopt.torch.prune.fastnas.FastNASModeDescriptor>`.
 For Minitron pruning, please refer to the `example snippet <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/pruning#getting-started>`_ in the pruning readme.
+
+.. note::
+
+    The `ResNet20 on CIFAR-10 notebook <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/pruning/cifar_resnet.ipynb>`_
+    is a dated, end-to-end FastNAS example. It uses the still-supported ``fastnas`` mode, but its long-running
+    workflow is not covered by automated notebook execution tests. Treat its environment setup, runtime estimate,
+    and recorded metrics as illustrative unless you revalidate them with the current release.
 
 Perform pruning
 ---------------

--- a/docs/source/guides/3_pruning.rst
+++ b/docs/source/guides/3_pruning.rst
@@ -2,16 +2,18 @@
 Pruning
 =======
 
-.. tip::
+ModelOpt provides three pruning workflows:
 
-    Checkout `Megatron-Bridge Minitron Pruning & Distillation <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/megatron_bridge>`_ and
-    `Puzzletron v2 <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/puzzletron>`_ for heterogeneous pruning campaigns.
-    Retained Puzzletron campaign reports and their reproduction status are summarized in the
-    `campaign report catalog <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/puzzletron/docs/campaign_reports.md>`_.
+* `Puzzletron v2 <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/puzzletron>`_
+  for guided, resumable heterogeneous pruning campaigns.
+* `Minitron <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/pruning#minitron>`_
+  for structured pruning of large language models.
+* `FastNAS <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/pruning#fastnas-pruning-for-pytorch-computer-vision-models>`_
+  for computer vision subnet search.
 
-ModelOpt provides Minitron and FastNAS pruning modes through the unified
-:meth:`mtp.prune <modelopt.torch.prune.pruning.prune>`. Given a model,
-these methods find the subnet which meets the given deployment constraints (e.g. FLOPs, parameters)
+Minitron and FastNAS are available through the unified
+:meth:`mtp.prune <modelopt.torch.prune.pruning.prune>` API. Given a model,
+these modes find the subnet which meets the given deployment constraints (e.g. FLOPs, parameters)
 from your provided base model with little to no accuracy degradation (depending on how aggressive the pruning is).
 These pruning methods support pruning the convolutional and linear layers, and
 attention heads of the model. More details on these pruning modes are as follows:
@@ -24,15 +26,8 @@ attention heads of the model. More details on these pruning modes are as follows
 #.  ``fastnas``: A pruning method recommended for Computer Vision models. Given a pretrained model,
     FastNAS finds the subnet which maximizes the score function while meeting the given constraints.
 
-For heterogeneous model pruning, use the separate `Puzzletron v2 campaign workflow
-<https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/puzzletron>`_. It combines
-model-aware setup, measured serving costs, Mixed Integer Programming (MIP) based NAS,
-candidate evaluation, optional global distillation, and resumable reporting. Puzzletron
-v2 is not driven by the unified ``mtp.prune`` example below. Consult the
-`Puzzletron campaign report catalog <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/puzzletron/docs/campaign_reports.md>`_
-for retained report metadata, relationships to current configurations,
-unresolved slicing findings, and why the listed reports do not establish
-current model support.
+The remainder of this guide covers the unified Minitron and FastNAS API.
+Puzzletron v2 instead uses its setup wizard and campaign runner.
 
 Follow the steps described below to obtain the optimal model satisfying your
 requirements using :mod:`mtp<modelopt.torch.prune>`:
@@ -70,13 +65,9 @@ Prerequisites
 
 Below we show an example using :class:`"fastnas" <modelopt.torch.prune.fastnas.FastNASModeDescriptor>`.
 For Minitron pruning, please refer to the `example snippet <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/pruning#getting-started>`_ in the pruning readme.
-
-.. note::
-
-    The `ResNet20 on CIFAR-10 notebook <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/pruning/cifar_resnet.ipynb>`_
-    is a dated, end-to-end FastNAS example. It uses the still-supported ``fastnas`` mode, but its long-running
-    workflow is not covered by automated notebook execution tests. Treat its environment setup, runtime estimate,
-    and recorded metrics as illustrative unless you revalidate them with the current release.
+For an end-to-end FastNAS walkthrough, see the
+`ResNet20 on CIFAR-10 notebook <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/pruning/cifar_resnet.ipynb>`_
+(a dated example; revalidate its environment and results with the current release).
 
 Perform pruning
 ---------------

--- a/docs/source/guides/3_pruning.rst
+++ b/docs/source/guides/3_pruning.rst
@@ -7,7 +7,9 @@ Pruning
     Checkout `Megatron-Bridge Minitron Pruning & Distillation <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/megatron_bridge>`_ and
     `Puzzletron v2 <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/puzzletron>`_ for heterogeneous pruning campaigns, or the
     `ResNet20 on CIFAR-10 Notebook <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/pruning/cifar_resnet.ipynb>`_
-    for an end-to-end computer-vision example.
+    for a dated, end-to-end computer-vision example. The notebook uses the still-supported ``fastnas`` mode,
+    but its long-running workflow is not covered by automated notebook execution tests. Treat its environment setup,
+    runtime estimate, and recorded metrics as illustrative unless you revalidate them with the current release.
     Retained Puzzletron campaign reports and their reproduction status are summarized in the
     `campaign report catalog <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/puzzletron/docs/campaign_reports.md>`_.
 

--- a/docs/source/guides/3_pruning.rst
+++ b/docs/source/guides/3_pruning.rst
@@ -5,24 +5,36 @@ Pruning
 .. tip::
 
     Checkout `Megatron-Bridge Minitron Pruning & Distillation <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/megatron_bridge>`_ and
+    `Puzzletron v2 <https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/puzzletron>`_ for heterogeneous pruning campaigns, or the
     `ResNet20 on CIFAR-10 Notebook <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/pruning/cifar_resnet.ipynb>`_
-    for an end-to-end example of pruning.
+    for an end-to-end computer-vision example.
+    Retained Puzzletron campaign reports and their reproduction status are summarized in the
+    `campaign report catalog <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/puzzletron/docs/campaign_reports.md>`_.
 
-ModelOpt provides three main pruning methods (aka ``mode``) - Minitron, Puzzletron, and FastNAS - via a unified API
+ModelOpt provides Minitron and FastNAS pruning modes through the unified
 :meth:`mtp.prune <modelopt.torch.prune.pruning.prune>`. Given a model,
-these methods finds the subnet which meets the given deployment constraints (e.g. FLOPs, parameters)
-from your provided base model with little to no accuracy degradation (depending on how aggressive is the pruning).
+these methods find the subnet which meets the given deployment constraints (e.g. FLOPs, parameters)
+from your provided base model with little to no accuracy degradation (depending on how aggressive the pruning is).
 These pruning methods support pruning the convolutional and linear layers, and
-attention heads of the model. More details on these pruning modes is as follows:
+attention heads of the model. More details on these pruning modes are as follows:
 
 #.  ``mcore_minitron``: A pruning method developed by NVIDIA Research for pruning GPT, Mamba and Hybrid
     Transformer Mamba models in NVIDIA Megatron-Bridge or Megatron-LM framework. It uses the activation magnitudes to prune
     the embedding hidden size, mlp ffn hidden size, transformer attention heads, GQA query groups,
     mamba heads and head dimension, and number of layers of the model.
     Checkout more details of the algorithm in the `paper <https://arxiv.org/abs/2408.11796>`_.
-#.  ``puzzletron``: An advanced LLM/VLM pruning method by NVIDIA using Mixed Integer Programming (MIP) based NAS search algorithm.
 #.  ``fastnas``: A pruning method recommended for Computer Vision models. Given a pretrained model,
     FastNAS finds the subnet which maximizes the score function while meeting the given constraints.
+
+For heterogeneous model pruning, use the separate `Puzzletron v2 campaign workflow
+<https://github.com/NVIDIA/Model-Optimizer/tree/main/examples/puzzletron>`_. It combines
+model-aware setup, measured serving costs, Mixed Integer Programming (MIP) based NAS,
+candidate evaluation, optional global distillation, and resumable reporting. Puzzletron
+v2 is not driven by the unified ``mtp.prune`` example below. Consult the
+`Puzzletron campaign report catalog <https://github.com/NVIDIA/Model-Optimizer/blob/main/examples/puzzletron/docs/campaign_reports.md>`_
+for retained report metadata, relationships to current configurations,
+unresolved slicing findings, and why the listed reports do not establish
+current model support.
 
 Follow the steps described below to obtain the optimal model satisfying your
 requirements using :mod:`mtp<modelopt.torch.prune>`:

--- a/docs/source/guides/3_pruning.rst
+++ b/docs/source/guides/3_pruning.rst
@@ -12,9 +12,11 @@ ModelOpt provides three pruning workflows:
   for computer vision subnet search.
 
 Minitron and FastNAS are available through the unified
-:meth:`mtp.prune <modelopt.torch.prune.pruning.prune>` API. Given a model,
-these modes find the subnet which meets the given deployment constraints (e.g. FLOPs, parameters)
-from your provided base model with little to no accuracy degradation (depending on how aggressive the pruning is).
+:meth:`mtp.prune <modelopt.torch.prune.pruning.prune>` API. FastNAS and
+Minitron auto pruning find a subnet that meets the given deployment constraints
+(e.g. FLOPs or parameters). Manual Minitron pruning instead applies explicitly
+configured target dimensions. Depending on how aggressive the pruning is, the
+resulting model may have little to no accuracy degradation from the base model.
 These pruning methods support pruning the convolutional and linear layers, and
 attention heads of the model. More details on these pruning modes are as follows:
 

--- a/examples/megatron_bridge/README.md
+++ b/examples/megatron_bridge/README.md
@@ -227,10 +227,8 @@ For more details, see the [Megatron-Bridge conversion README](https://github.com
 
 ### Distillation Results
 
-See [examples/pruning/](../pruning/README.md#tutorials--results) for Minitron
-tutorials and retained Puzzletron v2 campaign reports. Puzzletron report status,
-configuration relationships, and known gaps are summarized in its
-[campaign report catalog](../puzzletron/docs/campaign_reports.md).
+See [examples/pruning/](../pruning/README.md#tutorials--results) for current
+Minitron tutorials and results.
 
 ## Pruning
 

--- a/examples/megatron_bridge/README.md
+++ b/examples/megatron_bridge/README.md
@@ -63,7 +63,7 @@ This section shows how to quantize a HuggingFace model using ModelOpt in the Meg
 
 `quantize.py` supports the following formats via `--quant_cfg` (e.g. `fp8`, `nvfp4`, `int8_sq`, `int4_awq`, `w4a8_awq`, ...). You can also pass any full config name exposed by ModelOpt (e.g. `NVFP4_DEFAULT_CFG`) or a YAML `--recipe` (e.g. `general/ptq/nvfp4_default-kv_fp8`, authoritative for quant_cfg + algorithm + KV-cache). KV-cache quantization can be enabled on top via `--kv_cache_quant` (e.g. `fp8`, `nvfp4`).
 
-**Step 1 — quantize** Qwen3-8B to NVFP4 on 2 GPUs (Tensor Parallelism = 2) using 1024 samples from default dataset (Mix of [`cnn_dailymail`](https://huggingface.co/datasets/abisee/cnn_dailymail) and [`nemotron-post-training-dataset-v2`](https://huggingface.co/datasets/nvidia/Nemotron-Post-Training-Dataset-v2)) for calibration (sequence length = 4096):
+**Step 1, quantize** Qwen3-8B to NVFP4 on 2 GPUs (Tensor Parallelism = 2) using 1024 samples from default dataset (Mix of [`cnn_dailymail`](https://huggingface.co/datasets/abisee/cnn_dailymail) and [`nemotron-post-training-dataset-v2`](https://huggingface.co/datasets/nvidia/Nemotron-Post-Training-Dataset-v2)) for calibration (sequence length = 4096):
 
 ```bash
 torchrun --nproc_per_node 2 quantize.py \
@@ -75,7 +75,7 @@ torchrun --nproc_per_node 2 quantize.py \
     --export_megatron_path /tmp/Qwen3-8B-NVFP4-megatron
 ```
 
-**Step 2 — export** the Megatron checkpoint to a deployable HuggingFace checkpoint:
+**Step 2, export** the Megatron checkpoint to a deployable HuggingFace checkpoint:
 
 ```bash
 torchrun --nproc_per_node 2 export.py \
@@ -111,7 +111,7 @@ This can be used stand-alone or after [Pruning](#pruning) / [Post-Training Quant
 
 The [distill.py](distill.py) script supports both standard HuggingFace checkpoints and [Puzzletron AnyModel](../puzzletron/README.md) checkpoints as student/teacher inputs. Just pass the checkpoint path via `--student_hf_path` / `--teacher_hf_path`. The distilled model is saved to `<output_dir>/checkpoints` in Megatron distributed checkpoint format.
 
-To distill a student whose weights live in a **Megatron checkpoint** (e.g. a quantized checkpoint from [quantize.py](quantize.py) for [Quantization Aware Distillation](#quantization-aware-distillation-qad), or a pruned checkpoint), additionally pass `--student_megatron_path` — `--student_hf_path` is still required to build the student architecture.
+To distill a student whose weights live in a **Megatron checkpoint** (e.g. a quantized checkpoint from [quantize.py](quantize.py) for [Quantization Aware Distillation](#quantization-aware-distillation-qad), or a pruned checkpoint), additionally pass `--student_megatron_path`; `--student_hf_path` is still required to build the student architecture.
 
 ### Data Preparation
 
@@ -227,7 +227,10 @@ For more details, see the [Megatron-Bridge conversion README](https://github.com
 
 ### Distillation Results
 
-See [examples/pruning/](../pruning/README.md#tutorials--results) for distillation experiment results covering Minitron and Puzzletron pruning algorithms.
+See [examples/pruning/](../pruning/README.md#tutorials--results) for Minitron
+tutorials and retained Puzzletron v2 campaign reports. Puzzletron report status,
+configuration relationships, and known gaps are summarized in its
+[campaign report catalog](../puzzletron/docs/campaign_reports.md).
 
 ## Pruning
 
@@ -242,9 +245,9 @@ The script supports three NAS-based pruning targets and one manual export mode:
 | NAS | `--prune_target_memory_mb` | Prune to a target memory footprint in MB (weights + KV-cache) for a given batch size and sequence length assuming BF16 precision |
 | Manual | `--prune_export_config` | Prune directly to a specified architecture config (no NAS). Useful if you want to take top K candidates and do a short knowledge distillation before selecting the best model. |
 
-Multiple NAS targets can be combined — e.g. `--prune_target_params 6e9 --prune_target_memory_mb 12288` finds the best model with under 6B params and under 12GB memory footprint at (default) batch size 1 and sequence length 4096 assuming BF16 precision.
+Multiple NAS targets can be combined, e.g. `--prune_target_params 6e9 --prune_target_memory_mb 12288` finds the best model with under 6B params and under 12GB memory footprint at (default) batch size 1 and sequence length 4096 assuming BF16 precision.
 
-**Prune by total parameter count** — prune Qwen3-8B to 6B on 2-GPUs (Pipeline Parallelism = 2) while skipping pruning of `num_attention_heads` using following defaults:
+**Prune by total parameter count**, prune Qwen3-8B to 6B on 2-GPUs (Pipeline Parallelism = 2) while skipping pruning of `num_attention_heads` using following defaults:
     1024 samples from [`nemotron-post-training-dataset-v2`](https://huggingface.co/datasets/nvidia/Nemotron-Post-Training-Dataset-v2) for calibration,
     at-most 20% depth (`num_layers`) and 40% width is pruned per prunable hparam (`hidden_size`, `ffn_hidden_size`, ...),
     top-10 candidates are evaluated for MMLU score (5% sampled data) to select the best model.
@@ -258,7 +261,7 @@ torchrun --nproc_per_node 2 prune_minitron.py \
     --output_hf_path /tmp/Qwen3-8B-Pruned-6B
 ```
 
-**Prune by active parameter count** — useful for MoE models where most experts are inactive per token (e.g. prune Nemotron-3-Nano-30B-A3B-BF16 (3.6B active params) to 3B active params):
+**Prune by active parameter count**, useful for MoE models where most experts are inactive per token (e.g. prune Nemotron-3-Nano-30B-A3B-BF16 (3.6B active params) to 3B active params):
 
 ```bash
 torchrun --nproc_per_node 2 prune_minitron.py \
@@ -268,7 +271,7 @@ torchrun --nproc_per_node 2 prune_minitron.py \
     --output_hf_path /tmp/Nemotron-3-Nano-30B-A3B-BF16-Pruned-3B-Active
 ```
 
-**Prune by memory footprint** — prune to fit a target GPU memory budget (weights + KV-cache at the given sequence length and batch size, assuming BF16):
+**Prune by memory footprint**, prune to fit a target GPU memory budget (weights + KV-cache at the given sequence length and batch size, assuming BF16):
 
 ```bash
 torchrun --nproc_per_node 2 prune_minitron.py \
@@ -280,7 +283,7 @@ torchrun --nproc_per_node 2 prune_minitron.py \
     --output_hf_path /tmp/Qwen3-8B-Pruned-12GB
 ```
 
-**Manual pruning** — prune directly to a specified architecture (no NAS, no score evaluation):
+**Manual pruning**, prune directly to a specified architecture (no NAS, no score evaluation):
 
 ```bash
 torchrun --nproc_per_node 2 prune_minitron.py \

--- a/examples/megatron_bridge/README.md
+++ b/examples/megatron_bridge/README.md
@@ -243,7 +243,7 @@ The script supports three NAS-based pruning targets and one manual export mode:
 | NAS | `--prune_target_memory_mb` | Prune to a target memory footprint in MB (weights + KV-cache) for a given batch size and sequence length assuming BF16 precision |
 | Manual | `--prune_export_config` | Prune directly to a specified architecture config (no NAS). Useful if you want to take top K candidates and do a short knowledge distillation before selecting the best model. |
 
-Multiple NAS targets can be combined, e.g. `--prune_target_params 6e9 --prune_target_memory_mb 12288` finds the best model with under 6B params and under 12GB memory footprint at (default) batch size 1 and sequence length 4096 assuming BF16 precision.
+Multiple NAS targets can be combined, e.g., `--prune_target_params 6e9 --prune_target_memory_mb 12288`, to find the best model with under 6B params and under 12GB memory footprint at (default) batch size 1 and sequence length 4096, assuming BF16 precision.
 
 **Prune by total parameter count**, prune Qwen3-8B to 6B on 2-GPUs (Pipeline Parallelism = 2) while skipping pruning of `num_attention_heads` using following defaults:
     1024 samples from [`nemotron-post-training-dataset-v2`](https://huggingface.co/datasets/nvidia/Nemotron-Post-Training-Dataset-v2) for calibration,

--- a/examples/pruning/README.md
+++ b/examples/pruning/README.md
@@ -7,7 +7,7 @@ Pruning can involve removal (prune) of Linear and Conv layers; and Transformer a
 This section focuses on applying Model Optimizer's state-of-the-art complementary pruning modes to enable you to search for the best subnet architecture from your provided base model:
 
 1. [Minitron](https://arxiv.org/pdf/2408.11796): A pruning method developed by NVIDIA Research for pruning GPT (and later extended to Mamba, MoE, and Hybrid Transformer Mamba) models in NVIDIA Megatron-LM (M-LM) or Megatron-Bridge (M-Bridge) framework. It uses the activation magnitudes to prune the embedding hidden size; mlp ffn hidden size; transformer attention heads; mamba heads and head dimension; MoE number of experts, ffn hidden size, and shared expert intermediate size; and number of layers of the model.
-1. [Puzzletron](../puzzletron/README.md): An advanced pruning method by NVIDIA using Mixed Integer Programming (MIP) based NAS search algorithm.
+1. [Puzzletron v2](../puzzletron/README.md): A heterogeneous pruning campaign workflow that uses measured serving costs and Mixed Integer Programming (MIP) based NAS. Retained reports and their evidence status are summarized in its [campaign report catalog](../puzzletron/docs/campaign_reports.md).
 1. FastNAS: A pruning method recommended for Computer Vision models. Given a pretrained model, FastNAS finds the subnet which maximizes the score function while meeting the given constraints.
 
 <div align="center">
@@ -19,7 +19,7 @@ This section focuses on applying Model Optimizer's state-of-the-art complementar
 | Support Matrix | View the support matrix to see available pruning algorithms and their compatibility with different models and frameworks | \[[Link](#support-matrix)\] | |
 | Examples | Examples of different pruning methods | \[[Link](#examples)\] | |
 | Pruning Guidelines | Guidelines for choosing how and how much to prune for best results | \[[Link](#pruning-guidelines)\] | |
-| Tutorials / Results | End-to-end tutorials for Minitron and Puzzletron pruning | \[[Link](#tutorials--results)\] | |
+| Tutorials / Results | Minitron tutorials and Puzzletron campaign reports | \[[Link](#tutorials--results)\] | |
 | Resources | Extra links to relevant resources | \[[Link](#resources)\] | |
 
 </div>
@@ -28,13 +28,18 @@ This section focuses on applying Model Optimizer's state-of-the-art complementar
 
 For Minitron pruning for Megatron-Bridge / Megatron-LM models, use the NeMo container (e.g., `nvcr.io/nvidia/nemo:26.04`) which has all the dependencies installed.
 
+For Puzzletron v2, follow its dedicated [installation and campaign setup guide](../puzzletron/README.md#installation).
+
 For FastNAS pruning for PyTorch Computer Vision models, no additional dependencies are required.
 
 ## Getting Started
 
-As part of the pruning process, you will need to set up the training and/or validation data loaders, and optionally define a validation score function (Minitron, FastNAS) and specify the desired pruning constraints (See [Support Matrix](#support-matrix) for available pruning constraints).
+As part of the Minitron or FastNAS pruning process, you will need to set up the training and/or validation data loaders, optionally define a validation score function, and specify the desired pruning constraints (See [Support Matrix](#support-matrix) for available pruning constraints).
 
-To prune your model, you can simply call the `mtp.prune` API and save the pruned model. If the model is pruned using Minitron, you can use your standard saving and loading functions since it is a homogeneous pruning; while for FastNAS, you need to use `mto.save` and `mto.restore` to save and restore the heterogeneous pruned model.
+For these two modes, call the `mtp.prune` API and save the pruned model. If the model is pruned using Minitron, you can use your standard saving and loading functions since it is a homogeneous pruning; while for FastNAS, you need to use `mto.save` and `mto.restore` to save and restore the heterogeneous pruned model.
+
+Puzzletron v2 uses its dedicated campaign configuration and runner instead of
+the unified `mtp.prune` flow. Start with the [Puzzletron v2 setup wizard](../puzzletron/README.md#setup-wizard).
 
 ### Minitron
 
@@ -193,15 +198,18 @@ Some of the official models pruned using Minitron method followed by distillatio
 
 See [minitron/](minitron/README.md) for end-to-end tutorials and results.
 
-### Puzzletron Pruning for LLMs (e.g. Llama, Qwen, Nemotron)
+### Puzzletron v2 Heterogeneous Pruning Campaigns
 
-Checkout the [Puzzletron README](../puzzletron/README.md) which showcases MIP-based NAS pruning that produces heterogeneous model architectures — varying FFN intermediate sizes per layer and selectively removing attention layers — to meet a target parameter count or memory budget.
+The [Puzzletron v2 guide](../puzzletron/README.md) covers the complete campaign:
+model-aware setup, importance collection, heterogeneous search, candidate
+evaluation, optional global distillation, and reporting.
 
-Supported models include Llama-3.1-8B-Instruct, Qwen3-8B, Qwen2.5-7B-Instruct, Nemotron-Nano-12B-v2, Mistral-Small-24B-Instruct-2501, and others via the [configs](../puzzletron/configs/) directory. See the [Puzzletron README](../puzzletron/README.md) for more details.
-
-After compression, use [Megatron-Bridge distillation](../megatron_bridge/README.md#distillation) to recover accuracy.
-
-See [puzzletron/](puzzletron/README.md) for distillation results on Puzzletron-compressed models.
+The checked-in v2 migration or reconstruction entry points are
+[Nemotron-3 Nano 30B-A3B](../puzzletron/configs/families/nemotron3/nano_30b_a3b_bf16/runs/default.yaml)
+and [Qwen3.5-9B](../puzzletron/configs/families/qwen3_5/qwen3p5_9b/runs/default.yaml).
+See the [campaign report catalog](../puzzletron/docs/campaign_reports.md) for the
+retained reports, current-configuration relationships, unresolved warnings, and
+reproduction status.
 
 ### FastNAS Pruning for PyTorch Computer Vision Models
 
@@ -292,11 +300,11 @@ After pruning, distillation is required to recover model accuracy. Below are rec
 
 ## Tutorials / Results
 
-End-to-end distillation results with Megatron-Bridge after Minitron and Puzzletron pruning:
+Current pruning guides and campaign reports:
 
-- **[Minitron — Nemotron-3-Nano-30B-A3B-BF16](../megatron_bridge/tutorials/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/README.md)** ⭐ *recommended — newer and most comprehensive*: End-to-end tutorial of structured pruning for Nemotron-3-Nano-30B-A3B-BF16 (31.6B/A3.6B) to 22B/A3.0B active parameters followed by two-phase knowledge distillation (80B tokens @ 8K seq length + 20B tokens @ 32K seq length = 100B tokens total), quantization, and vLLM deployment. Covers MoE + Mamba-Transformer hybrid, tool-calling data, and a long-context fine-tuning phase. Achieves near-parity with the official 30B model across popular pretraining and reasoning benchmarks while delivering up to 2.6× throughput speedup and 2.6× memory reduction when combined with FP8 quantization.
-- **[Minitron — Nemotron-Nano-9B-v2](minitron/NVIDIA-Nemotron-Nano-9B-v2/README.md)**: Earlier end-to-end tutorial covering structured pruning of the dense Mamba-Transformer Nemotron-Nano-9B-v2 to 7B followed by knowledge distillation up to 80B tokens, quantization, and vLLM deployment. Simpler architecture, single-phase 8K seq length distillation, no tool-calling or long-context phase.
-- **[Puzzletron — Qwen3-8B and Llama-3.1-8B-Instruct](puzzletron/Llama-3.1-8B-Instruct.md)**: MIP-based compression followed by short distillation runs on WikiText-103. Shows MMLU recovery and illustrates the importance of using larger datasets to avoid overfitting.
+- **[Minitron, Nemotron-3-Nano-30B-A3B-BF16](../megatron_bridge/tutorials/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/README.md)** ⭐ *recommended, newer and most comprehensive*: End-to-end tutorial of structured pruning for Nemotron-3-Nano-30B-A3B-BF16 (31.6B/A3.6B) to 22B/A3.0B active parameters followed by two-phase knowledge distillation (80B tokens @ 8K seq length + 20B tokens @ 32K seq length = 100B tokens total), quantization, and vLLM deployment. Covers MoE + Mamba-Transformer hybrid, tool-calling data, and a long-context fine-tuning phase. Achieves near-parity with the official 30B model across popular pretraining and reasoning benchmarks while delivering up to 2.6× throughput speedup and 2.6× memory reduction when combined with FP8 quantization.
+- **[Minitron, Nemotron-Nano-9B-v2](minitron/NVIDIA-Nemotron-Nano-9B-v2/README.md)**: Earlier end-to-end tutorial covering structured pruning of the dense Mamba-Transformer Nemotron-Nano-9B-v2 to 7B followed by knowledge distillation up to 80B tokens, quantization, and vLLM deployment. Simpler architecture, single-phase 8K seq length distillation, no tool-calling or long-context phase.
+- **[Puzzletron v2 campaign reports](../puzzletron/README.md)**: Retained reports related to current migration or reconstruction configs. They are marked as not reproduced and do not establish current model support. See the [campaign report catalog](../puzzletron/docs/campaign_reports.md) for report metadata, unresolved findings, and requirements for future support evidence.
 
 ## Resources
 

--- a/examples/pruning/README.md
+++ b/examples/pruning/README.md
@@ -4,11 +4,13 @@ Model pruning is a technique that removes redundant or less important parameters
 
 Pruning can involve removal (prune) of Linear and Conv layers; and Transformer attention, MLP, MoE, Mamba, and depth of the model.
 
-This section focuses on applying Model Optimizer's state-of-the-art complementary pruning modes to enable you to search for the best subnet architecture from your provided base model:
+Model Optimizer provides three complementary pruning workflows for finding smaller, more efficient variants of a base model:
 
-1. [Minitron](https://arxiv.org/pdf/2408.11796): A pruning method developed by NVIDIA Research for pruning GPT (and later extended to Mamba, MoE, and Hybrid Transformer Mamba) models in NVIDIA Megatron-LM (M-LM) or Megatron-Bridge (M-Bridge) framework. It uses the activation magnitudes to prune the embedding hidden size; mlp ffn hidden size; transformer attention heads; mamba heads and head dimension; MoE number of experts, ffn hidden size, and shared expert intermediate size; and number of layers of the model.
-1. [Puzzletron v2](../puzzletron/README.md): A heterogeneous pruning campaign workflow that uses measured serving costs and Mixed Integer Programming (MIP) based NAS. Retained reports and their evidence status are summarized in its [campaign report catalog](../puzzletron/docs/campaign_reports.md).
-1. FastNAS: A pruning method recommended for Computer Vision models. Given a pretrained model, FastNAS finds the subnet which maximizes the score function while meeting the given constraints.
+| Workflow | Use when | Interface | Start here |
+|---|---|---|---|
+| [Puzzletron v2](../puzzletron/README.md) | You want a guided, resumable heterogeneous pruning campaign that compares candidates and can optionally distill the selected model. | Setup wizard and campaign runner | [Setup wizard](../puzzletron/README.md#setup-wizard) |
+| Minitron | You want structured pruning for GPT, Mamba, MoE, or hybrid language models in Megatron-LM or Megatron-Bridge. | Unified `mtp.prune` API | [Minitron](#minitron) |
+| FastNAS | You want subnet search for a PyTorch computer vision model under deployment constraints. | Unified `mtp.prune` API | [FastNAS](#fastnas-pruning-for-pytorch-computer-vision-models) |
 
 <div align="center">
 
@@ -19,7 +21,7 @@ This section focuses on applying Model Optimizer's state-of-the-art complementar
 | Support Matrix | View the support matrix to see available pruning algorithms and their compatibility with different models and frameworks | \[[Link](#support-matrix)\] | |
 | Examples | Examples of different pruning methods | \[[Link](#examples)\] | |
 | Pruning Guidelines | Guidelines for choosing how and how much to prune for best results | \[[Link](#pruning-guidelines)\] | |
-| Tutorials / Results | Minitron tutorials and Puzzletron campaign reports | \[[Link](#tutorials--results)\] | |
+| Tutorials / Results | End-to-end pruning tutorials and results | \[[Link](#tutorials--results)\] | |
 | Resources | Extra links to relevant resources | \[[Link](#resources)\] | |
 
 </div>
@@ -28,7 +30,8 @@ This section focuses on applying Model Optimizer's state-of-the-art complementar
 
 For Minitron pruning for Megatron-Bridge / Megatron-LM models, use the NeMo container (e.g., `nvcr.io/nvidia/nemo:26.04`) which has all the dependencies installed.
 
-For Puzzletron v2, follow its dedicated [installation and campaign setup guide](../puzzletron/README.md#installation).
+For Puzzletron v2, start with the [setup wizard](../puzzletron/README.md#setup-wizard). Complete the
+[installation steps](../puzzletron/README.md#installation) before launching the generated GPU campaign.
 
 For FastNAS pruning for PyTorch Computer Vision models, no additional dependencies are required.
 
@@ -37,9 +40,6 @@ For FastNAS pruning for PyTorch Computer Vision models, no additional dependenci
 As part of the Minitron or FastNAS pruning process, you will need to set up the training and/or validation data loaders, optionally define a validation score function, and specify the desired pruning constraints (See [Support Matrix](#support-matrix) for available pruning constraints).
 
 For these two modes, call the `mtp.prune` API and save the pruned model. If the model is pruned using Minitron, you can use your standard saving and loading functions since it is a homogeneous pruning; while for FastNAS, you need to use `mto.save` and `mto.restore` to save and restore the heterogeneous pruned model.
-
-Puzzletron v2 uses its dedicated campaign configuration and runner instead of
-the unified `mtp.prune` flow. Start with the [Puzzletron v2 setup wizard](../puzzletron/README.md#setup-wizard).
 
 ### Minitron
 
@@ -200,23 +200,19 @@ See [minitron/](minitron/README.md) for end-to-end tutorials and results.
 
 ### Puzzletron v2 Heterogeneous Pruning Campaigns
 
-The [Puzzletron v2 guide](../puzzletron/README.md) covers the complete campaign:
-model-aware setup, importance collection, heterogeneous search, candidate
-evaluation, optional global distillation, and reporting.
-
-The checked-in v2 migration or reconstruction entry points are
-[Nemotron-3 Nano 30B-A3B](../puzzletron/configs/families/nemotron3/nano_30b_a3b_bf16/runs/default.yaml)
-and [Qwen3.5-9B](../puzzletron/configs/families/qwen3_5/qwen3p5_9b/runs/default.yaml).
-See the [campaign report catalog](../puzzletron/docs/campaign_reports.md) for the
-retained reports, current-configuration relationships, unresolved warnings, and
-reproduction status.
+Use [Puzzletron v2](../puzzletron/README.md) when you want a guided, resumable
+workflow for exploring different model shapes, comparing candidates against
+deployment goals, and optionally distilling the selected model. Start with the
+[setup wizard](../puzzletron/README.md#setup-wizard), then use the generated
+campaign bundle with the Puzzletron runner.
 
 ### FastNAS Pruning for PyTorch Computer Vision Models
 
 Check out the FastNAS pruning example usage in the [documentation](https://nvidia.github.io/Model-Optimizer/guides/3_pruning.html#pruning-and-subnet-search).
 
-You can also take a look at FastNAS pruning interactive notebook [cifar_resnet](./cifar_resnet.ipynb) in this directory
-which showcases the usage of FastNAS for pruning a ResNet 20 model for the CIFAR-10 dataset. The notebook
+The [CIFAR-10 ResNet20 notebook](./cifar_resnet.ipynb) (dated; revalidate its
+environment and results with the current release) demonstrates an end-to-end
+FastNAS workflow. The notebook
 also shows how to profile the model to understand the search space of possible pruning options and demonstrates
 how to save and restore pruned models.
 
@@ -300,11 +296,10 @@ After pruning, distillation is required to recover model accuracy. Below are rec
 
 ## Tutorials / Results
 
-Current pruning guides and campaign reports:
+Current pruning tutorials and results:
 
 - **[Minitron, Nemotron-3-Nano-30B-A3B-BF16](../megatron_bridge/tutorials/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/README.md)** ⭐ *recommended, newer and most comprehensive*: End-to-end tutorial of structured pruning for Nemotron-3-Nano-30B-A3B-BF16 (31.6B/A3.6B) to 22B/A3.0B active parameters followed by two-phase knowledge distillation (80B tokens @ 8K seq length + 20B tokens @ 32K seq length = 100B tokens total), quantization, and vLLM deployment. Covers MoE + Mamba-Transformer hybrid, tool-calling data, and a long-context fine-tuning phase. Achieves near-parity with the official 30B model across popular pretraining and reasoning benchmarks while delivering up to 2.6× throughput speedup and 2.6× memory reduction when combined with FP8 quantization.
 - **[Minitron, Nemotron-Nano-9B-v2](minitron/NVIDIA-Nemotron-Nano-9B-v2/README.md)**: Earlier end-to-end tutorial covering structured pruning of the dense Mamba-Transformer Nemotron-Nano-9B-v2 to 7B followed by knowledge distillation up to 80B tokens, quantization, and vLLM deployment. Simpler architecture, single-phase 8K seq length distillation, no tool-calling or long-context phase.
-- **[Puzzletron v2 campaign reports](../puzzletron/README.md)**: Retained reports related to current migration or reconstruction configs. They are marked as not reproduced and do not establish current model support. See the [campaign report catalog](../puzzletron/docs/campaign_reports.md) for report metadata, unresolved findings, and requirements for future support evidence.
 
 ## Resources
 

--- a/examples/pruning/minitron/README.md
+++ b/examples/pruning/minitron/README.md
@@ -8,4 +8,4 @@ Each subdirectory covers a specific source model and target size, including the 
 
 - [Minitron pruning instructions](../../megatron_bridge/README.md#pruning) and [Megatron-Bridge distillation instructions](../../megatron_bridge/README.md#distillation)
 - [Megatron dataset tokenization](../../dataset/MEGATRON_DATA_PREP.md)
-- [Puzzletron v2 campaign workflow](../../puzzletron/README.md) and [campaign report catalog](../../puzzletron/docs/campaign_reports.md)
+- Other pruning workflows: [Puzzletron v2](../../puzzletron/README.md)

--- a/examples/pruning/minitron/README.md
+++ b/examples/pruning/minitron/README.md
@@ -1,4 +1,4 @@
-# Minitron Pruning — End-to-End Tutorials
+# Minitron Pruning, End-to-End Tutorials
 
 End-to-end tutorials for [Minitron](https://arxiv.org/abs/2407.14679) structured pruning followed by knowledge distillation, quantization, evaluation,and vLLM deployment.
 
@@ -8,4 +8,4 @@ Each subdirectory covers a specific source model and target size, including the 
 
 - [Minitron pruning instructions](../../megatron_bridge/README.md#pruning) and [Megatron-Bridge distillation instructions](../../megatron_bridge/README.md#distillation)
 - [Megatron dataset tokenization](../../dataset/MEGATRON_DATA_PREP.md)
-- [Puzzletron pruning algorithm](../../puzzletron/README.md)
+- [Puzzletron v2 campaign workflow](../../puzzletron/README.md) and [campaign report catalog](../../puzzletron/docs/campaign_reports.md)

--- a/examples/puzzletron/README.md
+++ b/examples/puzzletron/README.md
@@ -1,14 +1,13 @@
 # Puzzletron v2
 
-Puzzletron searches for smaller and faster variants of a pretrained model by
-combining width and depth importance, physical slicing, measured serving costs,
-mixed-integer search, evaluation, and optional knowledge distillation. Each
-stage writes resumable artifacts and contributes to one self-contained HTML
-campaign report.
+Puzzletron v2 helps you explore model shapes and select a smaller, faster
+variant against your quality and deployment goals. Its guided setup creates a
+reproducible, resumable campaign that compares candidates and can optionally
+distill the selected model.
 
 ## Table of Contents
 
-- [Campaign reports](#campaign-reports)
+- [Start here](#start-here)
 - [Setup wizard](#setup-wizard)
 - [Installation](#installation)
 - [Run with an agent](#run-with-an-agent)
@@ -17,22 +16,16 @@ campaign report.
 - [Campaign stages](#campaign-stages)
 - [Reports](#reports)
 
-## Campaign reports
+## Start here
 
-The [campaign report catalog](docs/campaign_reports.md) records each report's
-producer state, reproduction and support status, metadata origin, relationship
-to current configuration files, and known limitations. An entry marked as not
-reproduced is not a current model-support claim. Detailed run facts remain in
-the retained reports.
-
-Each report is a self-contained HTML file that embeds sanity-check outputs,
-stage manifests, and evaluation results; it can be 100s of MB. Download it to
-disk and open it locally rather than previewing it in a browser tab.
-
-Each report's **Zero-shot Evaluation** section compares the pruned candidate
-solutions directly against the full teacher model across multiple benchmarks.
-Interpret those results together with the reproduction status and unresolved
-correctness findings recorded in the campaign report catalog.
+- **New campaign:** use the [setup wizard](#setup-wizard) to generate validated
+  smoke and production bundles.
+- **Generated campaign:** complete the [installation](#installation), then
+  [run the campaign](#run-a-campaign) with its generated bundle.
+- **Agent-assisted campaign:** follow [Run with an agent](#run-with-an-agent)
+  with your model, data, compute environment, and deployment goals.
+- **Existing results:** see [Reports](#reports) to regenerate a campaign report
+  or inspect the retained examples.
 
 ## Setup wizard
 
@@ -61,23 +54,16 @@ accepted answer and the exact navigation frame are saved in
 python examples/puzzletron/puzzletron_setup_v2.py --resume /path/to/campaign
 ```
 
-The wizard supports reusable named parallel profiles, canonical per-stage execution
-strategies, independent instance counts, scheduling-compatible effective batches,
-multiple named vLLM workload/topology measurements, independent MIP goals with
-internal constraints/variants/matrices, and editable post-MIP flow DAGs. The
-recommended flow begins with online evaluation and uses LM loss for filtering;
-it does not include Initial Filter. PTQ and downstream evaluation are shown as
-reserved but unavailable.
+The wizard supports reusable execution profiles, multiple deployment
+measurements, independent optimization goals, and editable downstream flows.
+The defaults keep the common path concise while preserving detailed controls
+for advanced campaigns. See [Configuration](#configuration) for the generated
+bundle structure and extension points.
 
 The final review writes `resolved_defaults.yaml`, `README.md`, and validated
 `smoke/` and `production/` bundles transactionally. Both bundles are validated
 and dry-run, but neither is submitted and production is not gated on smoke. The
 wizard never launches the orchestrator.
-
-Wizard discovery and schema generation do not establish model or axis support.
-The [campaign report catalog](docs/campaign_reports.md) records retained
-reports, their evidence status, and the requirements for a future support
-claim.
 
 ## Installation
 
@@ -310,10 +296,7 @@ export PUZZLETRON_RUN_ROOT=/shared/puzzle_runs/my_campaign
 Independent runs, variants, solution pools, resource constraints, and
 homogeneous search are documented in [MIP runs](docs/mip_profiles.md). Configure
 candidate evaluation, filtering, materialization, and distillation with
-[post-MIP pipelines](docs/post_mip_pipeline.md). The
-[campaign report catalog](docs/campaign_reports.md) records retained reports and
-their evidence status; it is not a current model or pruning-axis support
-matrix.
+[post-MIP pipelines](docs/post_mip_pipeline.md).
 
 ## Run a campaign
 
@@ -339,32 +322,28 @@ python -m pip install -r examples/puzzletron/requirements-orchestrator.txt
 The login-node environment must expose `sbatch`, `squeue`, and `sacct`. It does
 not need PyTorch, Hydra, ModelOpt installation, CUDA, or the worker container.
 
-Each stage reads its AutoModel mesh from the experiment config
-(`tp`, `cp`, `pp`, `ep`, `dp_shard`, `dp_replicate`). The orchestrator derives
-`gpus_per_instance = PP × DP_REPLICATE × DP_SHARD × CP × TP` (EP overlays
-`dp_shard`) and packs `instances` independent model copies onto nodes. For
-example, sixteen one-GPU `vllm_stats` shards on an eight-GPU node type allocate
-two nodes and dispatch sixteen shard commands.
-
-Example single-stage dry-run:
-
-```bash
-PUZZLETRON_EXPERIMENT=examples/puzzletron/configs/families/nemotron3/nano_30b_a3b_bf16/runs/default.yaml
-PUZZLETRON_RUNNER=examples/puzzletron/configs/orchestration/runner.slurm.example.yaml
-PUZZLETRON_EXECUTION=examples/puzzletron/configs/orchestration/execution.example.yaml
-
-python examples/puzzletron/orchestrate.py \
-  --experiment "$PUZZLETRON_EXPERIMENT" \
-  --runner "$PUZZLETRON_RUNNER" \
-  --execution "$PUZZLETRON_EXECUTION" \
-  --stage mip \
-  --dry-run
-```
+### Generated v2 campaign
 
 Setup-v2-generated bundles encode evaluation, filtering, materialization,
-AIPerf, and distillation in `post_mip.flows`. Run their generated experiment,
-runner, and execution configs with `--stage full`; the orchestrator schedules
-the dynamic `post.*` nodes as part of the campaign DAG.
+AIPerf, and distillation in one campaign DAG. Run the generated smoke bundle
+first to validate the environment and campaign wiring:
+
+```bash
+PUZZLETRON_BUNDLE=/path/to/generated/campaign/smoke
+
+python examples/puzzletron/orchestrate.py \
+  --experiment "$PUZZLETRON_BUNDLE/experiment.yaml" \
+  --runner "$PUZZLETRON_BUNDLE/runner.yaml" \
+  --execution "$PUZZLETRON_BUNDLE/execution.yaml" \
+  --stage full
+```
+
+After the smoke campaign succeeds, replace `smoke` with `production` and run
+the same command for the full campaign. Add `--dry-run` to inspect either plan
+without submitting work, or select one stage while iterating, for example
+`--stage mip --dry-run`.
+
+### Legacy checked-in Nano campaign
 
 The checked-in Nano experiment uses the legacy `zero_shot_evaluation`,
 `aiperf`, and global distillation stages. Its online-solution path still needs
@@ -458,6 +437,8 @@ verified completed stages. Do not use it as the initial command for legacy
 configs with `mode: online_solutions`; setup-v2-generated bundles use their
 dynamic `post.*` DAG instead.
 
+### Monitor and resume
+
 The launch command is a blocking foreground controller: it submits every
 dependency-ready branch concurrently, polls scheduler state, and exits when the
 selected plan completes or fails. Progress is colorized automatically on a TTY.
@@ -495,7 +476,10 @@ python examples/puzzletron/orchestrate.py \
   --stage width_importance
 ```
 
-The dependency-free [`StageSpec` registry](../../modelopt/torch/puzzletron/stages/graph.py) is the authoritative contract for every public stage's identity, dependencies, enablement, semantic config sections, and static completion artifacts. Add or change those properties there. Default execution strategies remain scheduler-specific and live in the [orchestration compiler](../../modelopt/torch/puzzletron/orchestration/compiler.py); handlers, scheduler adapters, mesh resolution, and heavyweight artifact validators remain separate runtime concerns.
+The [`StageSpec` registry](../../modelopt/torch/puzzletron/stages/graph.py)
+defines stage dependencies and enablement. See the
+[v2 architecture](docs/v2_architecture.md) for orchestration internals and
+maintainer guidance.
 
 | Stage | Purpose |
 |---|---|
@@ -568,3 +552,17 @@ fingerprints are cached under
 are reused and only affected sections rebuild. Use `--rebuild-section aiperf`
 (repeatable) for selected sections, or `--no-cache` for an intentional full
 rebuild.
+
+### Retained campaign reports
+
+The [campaign report catalog](docs/campaign_reports.md) records each retained
+report's producer state, reproduction and support status, metadata origin,
+relationship to current configuration files, and known limitations. An entry
+marked as not reproduced is not a current model-support claim. Detailed run
+facts remain in the reports.
+
+Each retained report is a self-contained HTML file that embeds sanity-check
+outputs, stage manifests, and evaluation results; it can be hundreds of MB.
+Download it to disk and open it locally rather than previewing it in a browser
+tab. Interpret its evaluation results together with the reproduction status
+and unresolved findings in the catalog.

--- a/examples/puzzletron/README.md
+++ b/examples/puzzletron/README.md
@@ -1,4 +1,4 @@
-# Puzzletron
+# Puzzletron v2
 
 Puzzletron searches for smaller and faster variants of a pretrained model by
 combining width and depth importance, physical slicing, measured serving costs,
@@ -13,14 +13,12 @@ campaign report.
 - [Installation](#installation)
 - [Run with an agent](#run-with-an-agent)
 - [Configuration](#configuration)
-- [Run the complete pipeline manually](#run-the-complete-pipeline-manually)
-- [Run step by step](#run-step-by-step)
-- [Online evaluation and downstream stages](#online-evaluation-and-downstream-stages)
+- [Run a campaign](#run-a-campaign)
+- [Campaign stages](#campaign-stages)
 - [Reports](#reports)
 
 ## Campaign reports
 
-The reports below retain their original run data from development snapshots.
 The [campaign report catalog](docs/campaign_reports.md) records each report's
 producer state, reproduction and support status, metadata origin, relationship
 to current configuration files, and known limitations. An entry marked as not
@@ -36,54 +34,18 @@ solutions directly against the full teacher model across multiple benchmarks.
 Interpret those results together with the reproduction status and unresolved
 correctness findings recorded in the campaign report catalog.
 
-| Model | Hugging Face model | Current configuration reference | Campaign report |
-|---|---|---|---|
-| Nemotron-3 Nano 30B-A3B | `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` | [default.yaml](configs/families/nemotron3/nano_30b_a3b_bf16/runs/default.yaml) | [HTML report](reports/nemotron3_nano_30b_a3b.html) |
-| Qwen3.5-9B | `Qwen/Qwen3.5-9B` | [default.yaml](configs/families/qwen3_5/qwen3p5_9b/runs/default.yaml) | [HTML report](reports/qwen3p5_9b.html) |
-
 ## Setup wizard
 
-The setup wizard inspects a local checkpoint config or Hugging Face model config
-and generates self-contained smoke and production experiment, runner, and
-execution bundles. Its setup environment does not require PyTorch or model
-weights:
+The schema-driven Puzzletron v2 setup wizard inspects a local checkpoint or
+Hugging Face model configuration and generates self-contained smoke and
+production experiment, runner, and execution bundles. Its setup environment
+does not require PyTorch or model weights.
+
+Install the setup dependencies, then start the guided flow with the current v2
+defaults profile:
 
 ```bash
 python -m pip install -r examples/puzzletron/requirements-setup.txt
-python examples/puzzletron/puzzletron_setup.py
-```
-
-Normal mode asks the model, data, pruning axes, MIP objectives/runs, and cluster
-details while accepting defaults for lower-level tuning. Detailed mode also
-exposes solver controls, extra constraints, custom post-MIP nodes, and resource
-overrides:
-
-```bash
-python examples/puzzletron/puzzletron_setup.py --detailed
-```
-
-Every answer is saved atomically. A new invocation starts fresh; resume is always
-explicit:
-
-```bash
-python examples/puzzletron/puzzletron_setup.py --resume /path/to/campaign
-```
-
-The initial profiles support Nemotron 3 and Qwen 3.5/3.6 dense, MoE, text, and
-multimodal configurations. Unsupported configs exit with detected metadata and
-point to `.agents/skills/running-puzzletron/SKILL.md` for descriptor onboarding.
-
-Each campaign contains independent `smoke/` and `production/` bundles. Both are
-validated and dry-run, but neither is submitted and production is not gated on
-smoke. Slurm and SSH bare-metal runners are supported; use the bare-metal runner
-with `localhost` for a single local host.
-
-### Setup wizard v2
-
-The new schema-driven wizard keeps the existing entry point unchanged and adds
-local defaults-versus-customize decisions at every section:
-
-```bash
 python examples/puzzletron/puzzletron_setup_v2.py \
   --defaults examples/puzzletron/configs/setup/defaults.example.yaml
 ```
@@ -99,7 +61,7 @@ accepted answer and the exact navigation frame are saved in
 python examples/puzzletron/puzzletron_setup_v2.py --resume /path/to/campaign
 ```
 
-V2 supports reusable named parallel profiles, canonical per-stage execution
+The wizard supports reusable named parallel profiles, canonical per-stage execution
 strategies, independent instance counts, scheduling-compatible effective batches,
 multiple named vLLM workload/topology measurements, independent MIP goals with
 internal constraints/variants/matrices, and editable post-MIP flow DAGs. The
@@ -108,8 +70,14 @@ it does not include Initial Filter. PTQ and downstream evaluation are shown as
 reserved but unavailable.
 
 The final review writes `resolved_defaults.yaml`, `README.md`, and validated
-`smoke/` and `production/` bundles transactionally. The wizard never launches
-the orchestrator.
+`smoke/` and `production/` bundles transactionally. Both bundles are validated
+and dry-run, but neither is submitted and production is not gated on smoke. The
+wizard never launches the orchestrator.
+
+Wizard discovery and schema generation do not establish model or axis support.
+The [campaign report catalog](docs/campaign_reports.md) records retained
+reports, their evidence status, and the requirements for a future support
+claim.
 
 ## Installation
 
@@ -330,7 +298,7 @@ examples/puzzletron/configs/
         ├── family.yaml               # descriptors, hooks, and family axes
         └── <model>/
             ├── model.yaml            # checkpoint metadata and legal domains
-            └── runs/default.yaml     # exact end-to-end experiment
+            └── runs/default.yaml     # current campaign replay/reconstruction
 ```
 
 Site-specific paths can be overridden without editing the checked-in config:
@@ -342,41 +310,12 @@ export PUZZLETRON_RUN_ROOT=/shared/puzzle_runs/my_campaign
 Independent runs, variants, solution pools, resource constraints, and
 homogeneous search are documented in [MIP runs](docs/mip_profiles.md). Configure
 candidate evaluation, filtering, materialization, and distillation with
-[post-MIP pipelines](docs/post_mip_pipeline.md).
+[post-MIP pipelines](docs/post_mip_pipeline.md). The
+[campaign report catalog](docs/campaign_reports.md) records retained reports and
+their evidence status; it is not a current model or pruning-axis support
+matrix.
 
-## Run the complete pipeline manually
-
-Choose one tested entry config:
-
-```bash
-export CONFIG=examples/puzzletron/configs/families/nemotron3/nano_30b_a3b_bf16/runs/default.yaml
-source .venv/bin/activate
-python examples/puzzletron/main.py \
-  --config "$CONFIG" \
-  --stage full \
-  --gpus-per-node 8
-```
-
-`--stage full` executes every enabled stage in dependency order. Completed
-stages with valid manifests and acceptance markers are skipped; use `--force`
-only when intentionally invalidating and rerunning the selected work.
-
-There is one current orchestration boundary to understand before using
-`--stage full`. The canonical `zero_shot_evaluation` handler evaluates realized
-checkpoints, while the Nano experiment uses `mode: online_solutions` to score
-MIP architectures from one resident sorted teacher without materializing every
-candidate. The canonical AIPerf handler also runs one topology, while the tested
-Nano campaign uses a topology matrix. Until these paths are integrated into
-`main.py`, run through `mip`, use the profile commands below, and then invoke
-the canonical KD stages individually. A teacher-only canonical evaluation is
-not completion of an online MIP profile.
-
-On a scheduler, run the same command inside the site's container and launch
-distributed stages with the topology declared by that stage's
-`automodel.parallel` section. Do not assume one parallel recipe is valid for
-all stages.
-
-## Campaign orchestrator (v2)
+## Run a campaign
 
 The v2 orchestrator lives in
 [`modelopt/torch/puzzletron/orchestration/`](../../modelopt/torch/puzzletron/orchestration/)
@@ -407,25 +346,117 @@ Each stage reads its AutoModel mesh from the experiment config
 example, sixteen one-GPU `vllm_stats` shards on an eight-GPU node type allocate
 two nodes and dispatch sixteen shard commands.
 
-Example dry-run:
+Example single-stage dry-run:
 
 ```bash
+PUZZLETRON_EXPERIMENT=examples/puzzletron/configs/families/nemotron3/nano_30b_a3b_bf16/runs/default.yaml
+PUZZLETRON_RUNNER=examples/puzzletron/configs/orchestration/runner.slurm.example.yaml
+PUZZLETRON_EXECUTION=examples/puzzletron/configs/orchestration/execution.example.yaml
+
 python examples/puzzletron/orchestrate.py \
-  --experiment examples/puzzletron/configs/families/nemotron3/nano_30b_a3b_bf16/runs/default.yaml \
-  --runner examples/puzzletron/configs/orchestration/runner.slurm.example.yaml \
-  --execution examples/puzzletron/configs/orchestration/execution.example.yaml \
+  --experiment "$PUZZLETRON_EXPERIMENT" \
+  --runner "$PUZZLETRON_RUNNER" \
+  --execution "$PUZZLETRON_EXECUTION" \
+  --stage mip \
   --dry-run
 ```
 
-Submit on Slurm or bare metal:
+Setup-v2-generated bundles encode evaluation, filtering, materialization,
+AIPerf, and distillation in `post_mip.flows`. Run their generated experiment,
+runner, and execution configs with `--stage full`; the orchestrator schedules
+the dynamic `post.*` nodes as part of the campaign DAG.
+
+The checked-in Nano experiment uses the legacy `zero_shot_evaluation`,
+`aiperf`, and global distillation stages. Its online-solution path still needs
+two explicit preparation steps because the orchestrator runs and aggregates
+the shards but does not create the online evaluation plan or materialize the
+selected finalists. Use site-specific runner and execution configs, then run
+the prerequisite DAG through MIP by temporarily disabling the downstream
+stages:
 
 ```bash
+PUZZLETRON_EXPERIMENT=examples/puzzletron/configs/families/nemotron3/nano_30b_a3b_bf16/runs/default.yaml
+PUZZLETRON_RUNNER=/path/to/runner.yaml
+PUZZLETRON_EXECUTION=/path/to/execution.yaml
+export PUZZLETRON_RUN_ROOT=/shared/puzzle_runs/my_campaign
+
 python examples/puzzletron/orchestrate.py \
-  --experiment "$CONFIG" \
-  --runner "$RUNNER" \
-  --execution "$EXECUTION" \
+  --experiment "$PUZZLETRON_EXPERIMENT" \
+  --runner "$PUZZLETRON_RUNNER" \
+  --execution "$PUZZLETRON_EXECUTION" \
+  --stage full \
+  --override zero_shot_evaluation.enabled=false \
+  --override aiperf.enabled=false \
+  --override global_distillation_sanity.enabled=false \
+  --override global_distillation.enabled=false \
+  --override post_distillation_evaluation.enabled=false
+```
+
+Prepare the online evaluation plan, then run and aggregate its shards. The
+profile IDs below match the Nano example; for another legacy experiment using
+this path, pass every entry from its `zero_shot_evaluation.profile_ids` list.
+
+```bash
+python examples/puzzletron/run_profile_online_evaluation.py \
+  --puzzle-dir "$PUZZLETRON_RUN_ROOT" \
+  --profile-id params-075 \
+  --profile-id runtime-075 \
+  --profile-id memory-075 \
+  --profile-id params-075-num-experts-only \
+  --profile-id params-075-expert-dim-only \
+  --profile-id params-075-num-experts-and-expert-dim \
+  --prepare
+
+python examples/puzzletron/orchestrate.py \
+  --experiment "$PUZZLETRON_EXPERIMENT" \
+  --runner "$PUZZLETRON_RUNNER" \
+  --execution "$PUZZLETRON_EXECUTION" \
+  --stage zero_shot_evaluation
+```
+
+Materialize the evaluated finalists for the Nano example's configured AIPerf
+profile before running AIPerf and the remaining enabled stages. This helper
+loads ModelOpt and Safetensors, so run it in the full worker environment from
+the installation steps above, not in the dependency-light controller
+environment. If the runner uses a container, enter it with the same mounts
+before activating the worker venv. For another legacy experiment using this
+path, use its `aiperf.profile_id` value.
+
+```bash
+# On the worker host or in the worker container:
+cd /path/to/modelopt
+source /path/to/full-modelopt-venv/bin/activate
+export PUZZLETRON_RUN_ROOT=/shared/puzzle_runs/my_campaign
+
+python examples/puzzletron/prepare_online_profile_finalists.py \
+  --puzzle-dir "$PUZZLETRON_RUN_ROOT" \
+  --config examples/puzzletron/configs/families/nemotron3/nano_30b_a3b_bf16/runs/default.yaml \
+  --profile-id runtime-075 \
+  --count 1
+```
+
+Return to the login node before launching the controller. The login node must
+provide the scheduler commands listed above.
+
+```bash
+cd /path/to/modelopt
+source .venv-orchestrator/bin/activate
+PUZZLETRON_EXPERIMENT=examples/puzzletron/configs/families/nemotron3/nano_30b_a3b_bf16/runs/default.yaml
+PUZZLETRON_RUNNER=/path/to/runner.yaml
+PUZZLETRON_EXECUTION=/path/to/execution.yaml
+export PUZZLETRON_RUN_ROOT=/shared/puzzle_runs/my_campaign
+
+python examples/puzzletron/orchestrate.py \
+  --experiment "$PUZZLETRON_EXPERIMENT" \
+  --runner "$PUZZLETRON_RUNNER" \
+  --execution "$PUZZLETRON_EXECUTION" \
   --stage full
 ```
+
+For the legacy Nano experiment, the final `--stage full` resumes from the
+verified completed stages. Do not use it as the initial command for legacy
+configs with `mode: online_solutions`; setup-v2-generated bundles use their
+dynamic `post.*` DAG instead.
 
 The launch command is a blocking foreground controller: it submits every
 dependency-ready branch concurrently, polls scheduler state, and exits when the
@@ -450,15 +481,18 @@ validation through WorkAdapters. See
 [`configs/orchestration/`](configs/orchestration/) for starter runner and
 execution files.
 
-## Run step by step
+## Campaign stages
 
-Run one stage with the same entry config:
+Select one stage with the same v2 experiment, runner, and execution configs:
 
 ```bash
-python examples/puzzletron/main.py \
-  --config "$CONFIG" \
-  --stage width_importance \
-  --gpus-per-node 8
+PUZZLETRON_BUNDLE=/path/to/generated/campaign/production
+
+python examples/puzzletron/orchestrate.py \
+  --experiment "$PUZZLETRON_BUNDLE/experiment.yaml" \
+  --runner "$PUZZLETRON_BUNDLE/runner.yaml" \
+  --execution "$PUZZLETRON_BUNDLE/execution.yaml" \
+  --stage width_importance
 ```
 
 The dependency-free [`StageSpec` registry](../../modelopt/torch/puzzletron/stages/graph.py) is the authoritative contract for every public stage's identity, dependencies, enablement, semantic config sections, and static completion artifacts. Add or change those properties there. Default execution strategies remain scheduler-specific and live in the [orchestration compiler](../../modelopt/torch/puzzletron/orchestration/compiler.py); handlers, scheduler adapters, mesh resolution, and heavyweight artifact validators remain separate runtime concerns.
@@ -510,122 +544,13 @@ Independent DAG branches may run concurrently when they have disjoint writers.
 Long-running stages should resume their durable checkpoints or immutable shards
 rather than restarting completed work.
 
-## Online evaluation and downstream stages
-
-Set the config and campaign directory explicitly so standalone tools and Hydra
-resolve the same artifacts:
-
-```bash
-export CONFIG=examples/puzzletron/configs/families/nemotron3/nano_30b_a3b_bf16/runs/default.yaml
-export PUZZLETRON_RUN_ROOT=/shared/puzzle_runs/nemotron3-nano
-export PUZZLE_DIR="$PUZZLETRON_RUN_ROOT"
-export PROFILE=runtime-075
-```
-
-After `mip`, prepare one deduplicated online-evaluation plan. Repeat
-`--profile-id` for every configured profile; aliases ensure that an identical
-architecture is evaluated once while remaining visible in every profile.
-
-```bash
-python examples/puzzletron/run_profile_online_evaluation.py \
-  --puzzle-dir "$PUZZLE_DIR" --prepare \
-  --profile-id params-075 \
-  --profile-id runtime-075 \
-  --profile-id memory-075 \
-  --profile-id params-075-num-experts-only \
-  --profile-id params-075-expert-dim-only \
-  --profile-id params-075-num-experts-and-expert-dim
-```
-
-Run every width in the plan. One command is one resident model instance;
-independent instances use distinct shard indices, and each receives the entire
-stage-local AutoModel GPU mesh:
-
-```bash
-torchrun --standalone --nproc-per-node=8 \
-  examples/puzzletron/run_profile_online_evaluation.py \
-  --puzzle-dir "$PUZZLE_DIR" --config "$CONFIG" --run-shard \
-  --width 2688 --shard-index 0 --shard-count 1 \
-  --eval-samples 128 --block-size 8192 --micro-batch-size 4
-```
-
-After every width/shard pair finishes, merge the durable results:
-
-```bash
-python examples/puzzletron/run_profile_online_evaluation.py \
-  --puzzle-dir "$PUZZLE_DIR" --merge \
-  --eval-samples 128 --block-size 8192
-```
-
-Experiments using realized checkpoints instead call the canonical evaluator:
-
-```bash
-python examples/puzzletron/main.py \
-  --config "$CONFIG" --stage zero_shot_evaluation --gpus-per-node 8
-```
-
-Materialize only the best online candidate needed by AIPerf and KD. This verifies
-its physical parameter count and writes a registry containing the candidate and
-teacher:
-
-```bash
-python examples/puzzletron/prepare_online_profile_finalists.py \
-  --puzzle-dir "$PUZZLE_DIR" --config "$CONFIG" \
-  --profile-id "$PROFILE" --count 1
-```
-
-The official AIPerf package installed above provides the default `aiperf`
-executable; set `AIPERF_EXECUTABLE` only to select a different installation.
-
-For one topology, call the canonical AIPerf stage:
-
-```bash
-python examples/puzzletron/main.py \
-  --config "$CONFIG" --stage aiperf --gpus-per-node 8
-```
-
-For the tested all-eight-GPU topology matrix, launch one profile worker per node.
-Under Slurm, each task must see all eight GPUs and derives its shard identity
-from `SLURM_PROCID` and `SLURM_NTASKS`. Merge once after every worker exits:
-
-```bash
-srun --nodes="$NODES" --ntasks="$NODES" --ntasks-per-node=1 \
-  python examples/puzzletron/run_profile_aiperf_worker.py \
-  --puzzle-dir "$PUZZLE_DIR" --profile-id "$PROFILE" \
-  --input-tokens 8192 --output-tokens 1024
-
-python examples/puzzletron/run_profile_aiperf_worker.py \
-  --puzzle-dir "$PUZZLE_DIR" --profile-id "$PROFILE" \
-  --input-tokens 8192 --output-tokens 1024 --merge
-```
-
-Use the same selected registry for KD. Run the frozen-minibatch overfit gate
-before production distillation; use `run_multinode_stage.sh` with these stage
-names when the configured stage mesh spans multiple nodes:
-
-```bash
-python examples/puzzletron/main.py \
-  --config "$CONFIG" --stage global_distillation_sanity --gpus-per-node 8
-
-python examples/puzzletron/main.py \
-  --config "$CONFIG" --stage global_distillation --gpus-per-node 8
-```
-
-Finally evaluate the consolidated global-KD checkpoint:
-
-```bash
-python examples/puzzletron/main.py \
-  --config "$CONFIG" --stage post_distillation_evaluation --gpus-per-node 8
-```
-
 ## Reports
 
-`main.py` refreshes the report before and after each stage and records the
-currently running stage. Standalone profile workers do not own the DAG, so
-regenerate after online-evaluation merge, finalist realization, AIPerf merge,
-or any other manual artifact publication. The generator is read-only with
-respect to model artifacts and includes valid partial results without marking
-their stage complete.
+After the selected plan completes cleanly, the v2 orchestrator generates the
+final campaign report through the configured runner. Reporting is nonfatal to
+the completed campaign, but a failed report attempt is recorded in the
+controller result. The generator is read-only with respect to model artifacts
+and includes valid partial results without marking their stage complete.
 
 Regenerate without rerunning model work:
 

--- a/examples/puzzletron/README.md
+++ b/examples/puzzletron/README.md
@@ -61,9 +61,10 @@ for advanced campaigns. See [Configuration](#configuration) for the generated
 bundle structure and extension points.
 
 The final review writes `resolved_defaults.yaml`, `README.md`, and validated
-`smoke/` and `production/` bundles transactionally. Both bundles are validated
-and dry-run, but neither is submitted and production is not gated on smoke. The
-wizard never launches the orchestrator.
+`smoke/` and `production/` bundles transactionally. The wizard validates both
+bundles and writes a `dry-run-plan.txt` file in each, but neither bundle is
+submitted and production is not gated on smoke. The wizard never launches the
+orchestrator.
 
 ## Installation
 

--- a/examples/puzzletron/docs/v2_architecture.md
+++ b/examples/puzzletron/docs/v2_architecture.md
@@ -1,8 +1,9 @@
 # Puzzletron v2 Architecture
 
-> **Scope:** This document maps the Puzzletron v2 design to the current working
-> branch as of July 23, 2026. The post-MIP node framework is implemented but
-> still evolving; explicitly future work is separated near the end.
+> **Scope:** This document maps the Puzzletron v2 design to the checked-in
+> implementation. Architecture components and schema capabilities are not model
+> support claims. See the [campaign report catalog](campaign_reports.md) for
+> retained observations and their reproduction status.
 
 ## Executive summary
 
@@ -153,9 +154,9 @@ relative to the repository root.
 ```mermaid
 flowchart TB
     subgraph entry["Campaign authoring"]
-        setup["Setup wizard<br/>puzzletron_setup/<br/>examples/puzzletron/puzzletron_setup.py"]
-        config["Config and bundle generation<br/>examples/puzzletron/configs/<br/>puzzletron_setup/bundle.py"]
-        public["Public entry points<br/>examples/puzzletron/orchestrate.py<br/>examples/puzzletron/main.py"]
+        setup["Setup wizard<br/>puzzletron_setup/v2/<br/>examples/puzzletron/puzzletron_setup_v2.py"]
+        config["Config and bundle generation<br/>examples/puzzletron/configs/<br/>puzzletron_setup/v2/bundle.py"]
+        public["Campaign entry boundary<br/>Public: examples/puzzletron/orchestrate.py<br/>Internal stage worker: examples/puzzletron/main.py"]
     end
 
     subgraph cp["Scheduler-neutral control plane"]
@@ -251,7 +252,7 @@ flowchart TB
 
 | Component | Primary code | Responsibility |
 |---|---|---|
-| Setup and campaign contracts | `puzzletron_setup/`, `examples/puzzletron/configs/` | Inspect model capabilities, ask relevant questions, and emit validated smoke/production experiment, runner, and execution bundles |
+| Setup and campaign contracts | `puzzletron_setup/v2/`, `examples/puzzletron/configs/` | Inspect model capabilities, ask relevant questions, and emit validated smoke/production experiment, runner, and execution bundles |
 | Stage contract | `modelopt/torch/puzzletron/stages/graph.py` | Define canonical stages, dependencies, completion artifacts, enablement, and distributed behavior |
 | Orchestrator | `modelopt/torch/puzzletron/orchestration/` exposed through `puzzletron_orchestrator/` | Compile the DAG, validate meshes, pack instances, execute work, persist state, retry, resume, and monitor |
 | Model abstraction | `modelopt/torch/puzzletron/anymodel/` | Describe model structure, supported axes, tensor bindings, export behavior, and HF versus AutoModel-native implementations |
@@ -387,6 +388,12 @@ slicing mental model, and a worked example.
 
 ## Current implementation versus design direction
 
+The list below describes implementation components. It does not imply that every
+component, model, axis, modality, or topology combination is end-to-end
+demonstrated. Current support requires new reproduced evidence; the
+[campaign report catalog](campaign_reports.md) records retained observations
+and their evidence status.
+
 ### Implemented in the current v2 code
 
 - A canonical stage registry and dependency graph.
@@ -416,7 +423,7 @@ slicing mental model, and a worked example.
 - Improve embedding-width search so ranking, replacement scoring, and bypass do
   not require a full independent sweep for every embedding size.
 - Systematically exercise valid parallelism, input-layout, and modality
-  combinations for every supported model.
+  combinations, then promote only the campaign slices with documented evidence.
 
 ## Manager takeaway
 


### PR DESCRIPTION
### What does this PR do?

Type of change: documentation.

The pruning entry points mixed Puzzletron v2 campaign guidance with the unified Minitron and FastNAS API, and the Puzzletron README emphasized implementation and retained-report details before the normal user workflow.

This PR:

- presents Puzzletron v2, Minitron, and FastNAS as distinct workflow choices;
- points Minitron and FastNAS users to the unified `mtp.prune` API;
- reorganizes the Puzzletron guide around setup, generated smoke-to-production campaigns, and a clearly separated legacy Nano path;
- keeps retained campaign-report context in the Puzzletron Reports section; and
- keeps the dated CIFAR-10 FastNAS notebook next to the FastNAS guidance with an inline revalidation caveat.

The change affects documentation and navigation only. It does not modify pruning APIs, runtime behavior, campaign configurations, retained reports, or the CIFAR-10 notebook.

### Usage

Use the Puzzletron v2 setup wizard and generated campaign runner for guided, resumable heterogeneous pruning campaigns. Use `mtp.prune` for Minitron and FastNAS. Validate a generated Puzzletron smoke bundle before switching to production.

### Testing

Existing documentation checks and focused Puzzletron tests cover the affected links, generated campaign flow, online evaluation planning, and finalist preparation. The full CIFAR-10 notebook was not run because its training workflow takes one to three hours.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pruning guidance for Puzzletron v2, Minitron, and FastNAS workflows.
  * Added Puzzletron v2 instructions for guided setup, resumable campaigns, monitoring, reporting, replay, and finalist preparation.
  * Clarified model saving and restoration, campaign configuration, generated workflow bundles, and supported workflow boundaries.
  * Refreshed pruning, distillation, and quantization examples with current tutorials, links, and a FastNAS notebook reference.
  * Documented architecture mappings, implementation coverage, evidence status, and handling of partial or cached reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->