### PR TITLE
Simplify tied-weight export dedup

### DIFF
--- a/modelopt/torch/export/hf_export_handlers.py
+++ b/modelopt/torch/export/hf_export_handlers.py
@@ -45,7 +45,7 @@ def _export_weight(
     # install the built-in handlers while retaining this legacy helper's import path.
     from .unified_export_hf import _export_quantized_weight
 
-    _export_quantized_weight(module, ctx.dtype, weight_name, _tied_cache=ctx.tied_cache)
+    _export_quantized_weight(module, ctx.dtype, weight_name)
 
 
 # Preparation handlers are registered in the same precedence as the legacy MoE prepass.
@@ -130,12 +130,7 @@ def _export_moe_linear(name: str, module: nn.Module, ctx: ExportContext) -> None
 def _export_fused_experts_module(name: str, module: nn.Module, ctx: ExportContext) -> None:
     """Split and quantize a fused-experts module with plural weight quantizers."""
     with fsdp2_aware_weight_update(ctx.model, module, reshard=False):
-        _export_fused_experts(
-            module,
-            ctx.dtype,
-            _moe_tied_cache=ctx.moe_tied_cache,
-            _tied_cache=ctx.tied_cache,
-        )
+        _export_fused_experts(module, ctx.dtype)
 
 
 @ExportModuleRegistry.register(predicate=is_quantlinear)

--- a/modelopt/torch/export/model_utils.py
+++ b/modelopt/torch/export/model_utils.py
@@ -15,6 +15,7 @@
 """Utility functions for model type detection and classification."""
 
 import re
+from collections import defaultdict
 
 import torch.nn as nn
 
@@ -149,82 +150,63 @@ def get_language_model_from_vl(model) -> list[nn.Module] | None:
     return None
 
 
-def _collect_canonical_tied_patterns(
-    model: nn.Module,
-) -> tuple[list[re.Pattern], list[str]]:
-    """Walk the model and collect canonical-side tied-weight matchers.
+def _build_tied_weight_map(model: nn.Module) -> dict[str, str]:
+    """Map tied parameter aliases to a canonical name before export mutates the model.
 
-    Patterns are submodule-prefixed regexes from each module's
-    ``_tied_weights_keys`` dict-style declaration (the prefix matters
-    for nested models where the dict lives on an inner submodule).
-    Side substrings are dot-separated tokens that appear only on the
-    canonical side of those declarations — needed because modelopt's
-    per-expert unpacking creates post-export keys (e.g.
-    ``…experts.Y.gate_proj.input_scale``) that HF's regexes never knew
-    about. List-style (legacy) declarations are skipped.
+    Ties come only from groups that share the same live :class:`nn.Parameter` object.
+    ``_tied_weights_keys`` and ``tie_word_embeddings`` choose which name to retain; they
+    never create a tie by themselves.
     """
-    patterns: list[re.Pattern] = []
-    alias_token_set: set[str] = set()
-    canonical_token_set: set[str] = set()
+    groups: dict[int, list[str]] = defaultdict(list)
+    for name, parameter in model.named_parameters(remove_duplicate=False):
+        groups[id(parameter)].append(name)
 
-    def _tokens(s: str) -> set[str]:
-        """Identifiers in a regex string, with regex specials as separators."""
-        return {tok for tok in re.split(r"[^A-Za-z0-9_]+", s) if tok}
-
-    for name, submodule in model.named_modules():
-        tied = getattr(submodule, "_tied_weights_keys", None)
-        if not isinstance(tied, dict) or not tied:
+    declared_aliases: set[str] = set()
+    for module_name, module in model.named_modules():
+        tied = getattr(module, "_tied_weights_keys", None)
+        if not isinstance(tied, dict):
             continue
-        prefix = f"{name}." if name else ""
-        for alias_pat, canonical_pat in tied.items():
-            patterns.append(re.compile(prefix + canonical_pat))
-            alias_token_set.update(_tokens(prefix + alias_pat))
-            canonical_token_set.update(_tokens(prefix + canonical_pat))
+        prefix = f"{module_name}." if module_name else ""
+        for pattern in tied:
+            try:
+                alias_pattern = re.compile(pattern)
+            except re.error:
+                continue
+            for names in groups.values():
+                for name in names:
+                    if name.startswith(prefix) and alias_pattern.search(name[len(prefix) :]):
+                        declared_aliases.add(name)
 
-    # Tokens unique to the canonical side become substring matchers.
-    side_substrings = sorted(canonical_token_set - alias_token_set)
-    return patterns, side_substrings
+    embedding_canonical: dict[int, str] = {}
+    if getattr(getattr(model, "config", None), "tie_word_embeddings", False):
+        try:
+            input_embeddings = model.get_input_embeddings()
+            output_embeddings = model.get_output_embeddings()
+        except (AttributeError, NotImplementedError):
+            input_embeddings = output_embeddings = None
+        if (
+            input_embeddings is not None
+            and output_embeddings is not None
+            and getattr(input_embeddings, "weight", None)
+            is getattr(output_embeddings, "weight", object())
+        ):
+            parameter = input_embeddings.weight
+            for name in groups.get(id(parameter), []):
+                owner_name = name.rsplit(".", 1)[0] if "." in name else ""
+                try:
+                    owner = model.get_submodule(owner_name) if owner_name else model
+                except AttributeError:
+                    continue
+                if owner is input_embeddings:
+                    embedding_canonical[id(parameter)] = name
+                    break
 
-
-def _reorder_canonical_first(state_dict: dict, model: nn.Module) -> dict:
-    r"""Reorder ``state_dict`` so canonical-side tied keys iterate first.
-
-    Lets the downstream first-wins data_ptr dedup keep canonical names.
-    Uses both regex patterns and substring matchers from
-    :func:`_collect_canonical_tied_patterns`. Gated on the model class
-    name to scope the reorder to DiffusionGemma; other tied
-    encoder-decoder models that ship dict-style ``_tied_weights_keys``
-    can be added to the allowlist here. Mirrors the ``model_type``
-    dispatch used for the Whisper and Nemotron-VL branches elsewhere
-    in ``unified_export_hf.py``.
-    """
-    model_type = type(model).__name__.lower()
-    if "diffusiongemma" not in model_type and "diffusion_gemma" not in model_type:
-        return state_dict
-
-    canonical_patterns, side_substrings = _collect_canonical_tied_patterns(model)
-    if not canonical_patterns and not side_substrings:
-        return state_dict
-
-    def _has_side_substring(key: str) -> bool:
-        # Require the token to appear as a proper dot-separated path
-        # component, not just as a substring of an unrelated identifier.
-        for tok in side_substrings:
-            if (
-                f".{tok}." in key
-                or key.startswith(f"{tok}.")
-                or key.endswith(f".{tok}")
-                or key == tok
-            ):
-                return True
-        return False
-
-    head: dict = {}
-    tail: dict = {}
-    for k, v in state_dict.items():
-        if any(p.search(k) for p in canonical_patterns) or _has_side_substring(k):
-            head[k] = v
-        else:
-            tail[k] = v
-    head.update(tail)
-    return head
+    tied_weight_map: dict[str, str] = {}
+    for parameter_id, names in groups.items():
+        if len(names) < 2:
+            continue
+        canonical = embedding_canonical.get(parameter_id)
+        if canonical is None:
+            canonical = next((name for name in names if name not in declared_aliases), names[0])
+        tied_weight_map.update({name: canonical for name in names if name != canonical})
+    return tied_weight_map

--- a/modelopt/torch/export/moe_utils.py
+++ b/modelopt/torch/export/moe_utils.py
@@ -23,35 +23,6 @@ import torch
 import torch.nn as nn
 
 
-def _alias_per_expert_subtree_from_prior(module: nn.Module, prior: nn.Module, n: int) -> None:
-    """Build per-expert subtree on ``module`` by aliasing ``prior``'s packed buffers.
-
-    For each expert ``idx`` in ``0..n-1``, creates ``module.{idx}.{gate,up,down}_proj``
-    sub-modules whose ``weight`` / ``weight_scale`` / ``weight_scale_2`` /
-    ``input_scale`` are aliased to the prior side's already-packed tensors.
-    data_ptr equality is preserved so the downstream
-    ``postprocess_state_dict`` dedup collapses the duplicates at write time.
-    Called by ``_export_fused_experts`` on the tied-experts cache-hit fast path.
-    """
-    for _idx in range(n):
-        _prior_expert = getattr(prior, str(_idx), None)
-        if _prior_expert is None:
-            continue
-        _cur_expert = nn.Module()
-        for _proj_name in ("gate_proj", "up_proj", "down_proj"):
-            _prior_proj = getattr(_prior_expert, _proj_name, None)
-            if _prior_proj is None:
-                continue
-            _cur_proj = nn.Module()
-            if hasattr(_prior_proj, "weight"):
-                _cur_proj.weight = _prior_proj.weight
-            for _attr in ("weight_scale", "weight_scale_2", "input_scale"):
-                if hasattr(_prior_proj, _attr):
-                    _cur_proj.register_buffer(_attr, getattr(_prior_proj, _attr))
-            _cur_expert.add_module(_proj_name, _cur_proj)
-        module.add_module(str(_idx), _cur_expert)
-
-
 def _delete_fused_moe_source_attrs(module: nn.Module) -> None:
     """Remove the 3-D fused source params and per-expert quantizer ModuleLists.
 
@@ -77,8 +48,6 @@ def _delete_fused_moe_source_attrs(module: nn.Module) -> None:
 def _export_fused_experts(
     module: nn.Module,
     dtype: torch.dtype,
-    _moe_tied_cache: dict[tuple[int, int], nn.Module] | None = None,
-    _tied_cache: dict[int, nn.Module] | None = None,
 ) -> None:
     """Split fused MoE expert weights and export per-expert quantization scales.
 
@@ -100,19 +69,6 @@ def _export_fused_experts(
            {E}.up_proj.weight, {E}.up_proj.weight_scale, ...
            {E}.down_proj.weight, {E}.down_proj.weight_scale, ...
 
-    Tied-experts dedup is opt-in via ``_moe_tied_cache``: when multiple
-    fused-expert modules share their 3-D source params via HF
-    ``_tied_weights_keys``, the unpacking creates fresh per-expert tensors
-    that break the tie. With ``_moe_tied_cache`` provided (tuple-keyed by
-    ``(<first_proj>.data_ptr(), down_proj.data_ptr())``), the alias step
-    at the end re-points the per-expert ``weight`` / ``weight_scale`` /
-    ``weight_scale_2`` / ``input_scale`` buffers at a previously-processed
-    module sharing the same source memory. ``_tied_cache`` (int-keyed) is
-    threaded through to the per-projection ``_export_quantized_weight``
-    calls so wrapper-level dedup uses the same scope as standalone Linears.
-    Both caches are owned by the caller (typically
-    ``_export_transformers_checkpoint``) and scoped to one export
-    invocation; when ``None`` the corresponding alias step is skipped.
     """
     from modelopt.torch.export.unified_export_hf import _export_quantized_weight
     from modelopt.torch.quantization.plugins.huggingface import _get_fused_expert_intermediate_dim
@@ -123,25 +79,6 @@ def _export_fused_experts(
     first_proj_attr = getattr(module, "_first_proj_attr", "gate_up_proj")
     # Only the gated split needs the per-expert intermediate dim (gate|up boundary).
     expert_dim = _get_fused_expert_intermediate_dim(module) if is_gated else None
-
-    # Capture source tensor identities BEFORE unpacking (the source
-    # attrs are deleted at the end of this function).
-    _source_key = (
-        getattr(module, first_proj_attr).data_ptr(),
-        module.down_proj.data_ptr(),
-    )
-
-    # Tied-experts fast path: if this exact (first_proj, down) source-tensor pair
-    # has been processed before, alias all per-expert buffers directly from the
-    # prior module — no unpacking, no per-expert packing, no transient buffers
-    # thrown away. Cache miss falls through to the full unpack/pack below and
-    # registers this module as the prior for any later tied module.
-    if _moe_tied_cache is not None:
-        _prior = _moe_tied_cache.get(_source_key)
-        if _prior is not None and _prior is not module:
-            _alias_per_expert_subtree_from_prior(module, _prior, n)
-            _delete_fused_moe_source_attrs(module)
-            return
 
     # 1. Shared input quantizers — one per projection type, shared across all experts.
     first_proj_input_q = getattr(module, f"{first_proj_attr}_input_quantizer")
@@ -271,7 +208,7 @@ def _export_fused_experts(
             wrapper.weight_quantizer = w_quantizer
             wrapper.input_quantizer = i_quantizer
 
-            _export_quantized_weight(wrapper, dtype, _tied_cache=_tied_cache)
+            _export_quantized_weight(wrapper, dtype)
 
             proj = nn.Module()
             proj.weight = wrapper.weight
@@ -285,13 +222,6 @@ def _export_fused_experts(
 
     # 4. Remove fused params and quantizer lists — replaced by per-expert submodules
     _delete_fused_moe_source_attrs(module)
-
-    # 5. Register this module in the dedup cache so any later tied module
-    # (same source data_ptr pair) takes the fast path at the top of this
-    # function. Reached only on cache miss; cache-hit modules early-exited
-    # above before any unpack work.
-    if _moe_tied_cache is not None:
-        _moe_tied_cache[_source_key] = module
 
 
 def save_expert_token_count_table(model: nn.Module, output_dir: str | Path | None = None):

--- a/modelopt/torch/export/quant_utils.py
+++ b/modelopt/torch/export/quant_utils.py
@@ -1052,6 +1052,7 @@ def postprocess_state_dict(
     maxbound: float,
     quantization: str | None,
     is_modelopt_qlora: bool = False,
+    tied_weight_map: dict[str, str] | None = None,
 ) -> dict:
     """Filters out keys related to weight quantizers and updates KV cache related keys.
 
@@ -1060,6 +1061,7 @@ def postprocess_state_dict(
         maxbound: The maximum bound value for the output quantizer.
         quantization: The KV cache quantization format.
         is_modelopt_qlora: Whether the model is a modelopt-trained QLoRA model.
+        tied_weight_map: Parameter aliases mapped to the canonical name captured before export.
 
     Returns:
         The filtered state_dict without unnecessary keys like '_amax' and non KV cache output quantizers.
@@ -1104,39 +1106,54 @@ def postprocess_state_dict(
     post_state_dict = {k: _maybe_squeeze_scale(k, v) for k, v in post_state_dict.items()}
 
     # remove real quant parameters from the state dict
-    keys_to_delete = []
+    keys_to_delete = set()
     for key, value in post_state_dict.items():
         if any(
             key.endswith("weight_quantizer." + q_key)
             for q_key in RealQuantLinear.list_of_scale_tensors
         ):
-            keys_to_delete.append(key)
+            keys_to_delete.add(key)
 
     # remove LoRA adapters from state dict
     if is_modelopt_qlora:
         for key in post_state_dict:
             if "lora" in key and key not in keys_to_delete:
-                keys_to_delete.append(key)
-    # Check for tied weights and remove duplicates
-    seen_tensors = {}
+                keys_to_delete.add(key)
 
-    # Remove any tied weights if found.
-    for key, value in post_state_dict.items():
-        if isinstance(value, torch.Tensor):
-            # Use tensor data pointer to identify tied weights
-            tensor_id = value.data_ptr()
-            if tensor_id in seen_tensors:
-                # This is a tied weight, mark for deletion and warn
-                keys_to_delete.append(key)
-                logger.warning(
-                    f"Found tied weight: '{key}' is tied to '{seen_tensors[tensor_id]}'. "
-                    f"Removing duplicate '{key}' from the exported state dict."
-                )
-            else:
-                seen_tensors[tensor_id] = key
+    tied_groups: dict[str, list[tuple[str, str]]] = {}
+    expanded_prefixes: dict[tuple[str, str], set[str]] = {}
+    for alias, canonical in (tied_weight_map or {}).items():
+        alias_prefix, _, alias_name = alias.rpartition(".")
+        canonical_prefix, _, canonical_name = canonical.rpartition(".")
+        members = tied_groups.setdefault(alias, [])
+
+        if alias_name == canonical_name == "weight":
+            for suffix in ("weight", "weight_scale", "weight_scale_2", "input_scale"):
+                alias_key = f"{alias_prefix}.{suffix}" if alias_prefix else suffix
+                canonical_key = f"{canonical_prefix}.{suffix}" if canonical_prefix else suffix
+                if alias_key in post_state_dict:
+                    members.append((alias_key, canonical_key))
+        elif alias in post_state_dict:
+            members.append((alias, canonical))
+
+        if alias_name == canonical_name and alias_name in {"gate_up_proj", "up_proj", "down_proj"}:
+            expanded_prefixes.setdefault((alias_prefix, canonical_prefix), set()).add(alias_name)
+
+    for (alias_prefix, canonical_prefix), source_names in expanded_prefixes.items():
+        if "down_proj" not in source_names or not source_names & {"gate_up_proj", "up_proj"}:
+            continue
+        members = tied_groups.setdefault(alias_prefix, [])
+        prefix = f"{alias_prefix}." if alias_prefix else ""
+        for key in post_state_dict:
+            if key.startswith(prefix):
+                members.append((key, canonical_prefix + key[len(alias_prefix) :]))
+
+    for members in tied_groups.values():
+        if members and all(canonical in post_state_dict for _, canonical in members):
+            keys_to_delete.update(alias for alias, _ in members)
 
     for key in keys_to_delete:
-        del post_state_dict[key]
+        post_state_dict.pop(key, None)
 
     return post_state_dict
 
@@ -1585,7 +1602,7 @@ def has_quantized_modules(model: nn.Module) -> bool:
 
 
 def sync_tied_input_amax(model: nn.Module) -> int:
-    """Max-merge input_quantizer amaxes across modules sharing a weight ``data_ptr``.
+    """Max-merge input_quantizer amaxes across modules sharing a Parameter.
 
     Mutates ``model`` in place: overwrites the ``.amax`` buffer on every
     affected ``input_quantizer`` with the per-group maximum. Intended to
@@ -1597,13 +1614,12 @@ def sync_tied_input_amax(model: nn.Module) -> int:
     paths see different activation distributions (encoder vs decoder in
     YOCO-style models). Must run BEFORE per-module export so the merged
     amax flows into ``input_scale`` derivation. Handles both dense
-    Linears (keyed by ``weight.data_ptr()``) and fused MoE (keyed by
-    ``(<first_proj>, down_proj)`` data_ptr tuple). Returns the number of
-    tied groups merged.
+    Linears and fused MoE containers, grouped by live Parameter identity.
+    Returns the number of tied groups merged.
     """
     from collections import defaultdict
 
-    by_dp: dict = defaultdict(list)
+    by_parameter: dict = defaultdict(list)
     for _, m in model.named_modules():
         # Fused MoE: 3-D source tensors with shared input quantizers
         first_proj_attr = getattr(m, "_first_proj_attr", "gate_up_proj")
@@ -1615,15 +1631,15 @@ def sync_tied_input_amax(model: nn.Module) -> int:
             and hasattr(m, "down_proj")
             and first_proj.dim() == 3
         ):
-            key = ("moe", first_proj.data_ptr(), m.down_proj.data_ptr())
-            by_dp[key].append(m)
+            key = ("moe", id(first_proj), id(m.down_proj))
+            by_parameter[key].append(m)
         # Dense quantized Linear with an input_quantizer
         elif (
             hasattr(m, "input_quantizer")
             and hasattr(m, "weight")
             and isinstance(m.weight, torch.nn.Parameter)
         ):
-            by_dp[("dense", m.weight.data_ptr())].append(m)
+            by_parameter[("dense", id(m.weight))].append(m)
 
     def _merge(quantizers: list) -> bool:
         """Max-merge amaxes across the quantizer list. Returns True on merge."""
@@ -1651,7 +1667,7 @@ def sync_tied_input_amax(model: nn.Module) -> int:
         return True
 
     synced = 0
-    for key, modules in by_dp.items():
+    for key, modules in by_parameter.items():
         if len(modules) < 2:
             continue
         if key[0] == "moe":

--- a/modelopt/torch/export/registry.py
+++ b/modelopt/torch/export/registry.py
@@ -27,12 +27,10 @@ editing if/elif chains inside ``unified_export_hf.py``.
 """
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import torch
 import torch.nn as nn
-
-from modelopt.torch.quantization.utils.core_utils import has_non_resident_weights
 
 __all__ = [
     "ExportContext",
@@ -44,34 +42,11 @@ __all__ = [
 
 @dataclass
 class ExportContext:
-    """Shared state for a single export invocation, passed to every handler call.
-
-    The tied-weight dedup caches must be scoped to one export invocation: a
-    process-global cache would carry stale entries whose ``data_ptr`` keys can be
-    recycled by PyTorch's allocator across exports, causing silent false-positive
-    aliasing. ``tied_cache`` (int keys) holds dense Linear / per-expert wrapper
-    dedup; ``moe_tied_cache`` (tuple keys) holds MoE fused-experts module dedup.
-
-    Both are ``None`` when the model's weights are not resident for the whole export
-    (FSDP2 or accelerate offload), since ``data_ptr`` keys are meaningless once weights
-    move.
-    """
+    """Shared state for a single export invocation, passed to every handler call."""
 
     model: nn.Module
     dtype: torch.dtype
     is_modelopt_qlora: bool = False
-    tied_cache: dict[int, nn.Module] | None = field(default_factory=dict)
-    moe_tied_cache: dict[tuple[int, int], nn.Module] | None = field(default_factory=dict)
-
-    def __post_init__(self) -> None:
-        # data_ptr() only identifies a tensor while it stays resident, so dedup is unsafe
-        # once weights move. Tied weights are then written as duplicates rather than
-        # re-aliased, making tied-weight export (DiffusionGemma) resident-path only.
-        # TODO: dedup by tied-group name instead, reusing the _tied_weights_keys
-        # resolution in _collect_canonical_tied_patterns, which survives weight moves.
-        if has_non_resident_weights(self.model):
-            self.tied_cache = None
-            self.moe_tied_cache = None
 
 
 ExportHandler = Callable[[str, nn.Module, ExportContext], None]

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -92,7 +92,7 @@ from .model_config import (
     QUANTIZATION_W4A8_NVFP4_FP8,
     QUANTIZATION_W4A16_NVFP4,
 )
-from .model_utils import _reorder_canonical_first, get_language_model_from_vl, is_multimodal_model
+from .model_utils import _build_tied_weight_map, get_language_model_from_vl, is_multimodal_model
 from .plugins import SpeculativeDecodingExporter, has_spec_opt, sanitize_hf_config_for_deployment
 from .quant_aware_conversion import (
     build_reverse_name_mapper,
@@ -570,24 +570,12 @@ def _export_quantized_weight(
     sub_module: nn.Module,
     dtype: torch.dtype,
     weight_name: str = "weight",
-    _tied_cache: dict[int, nn.Module] | None = None,
 ):
     """For the given weight attr of the sub_module, export the quantization info of it.
 
     The export includes converting weight tensor to correct quantized values and quantized dtype,
     and registering scaling factors.
 
-    Tied-weight dedup is opt-in via ``_tied_cache``: the setattr below replaces
-    ``.weight`` with a fresh ``nn.Parameter`` wrapping packed bytes, breaking
-    any HF-level tie. When the caller passes a ``_tied_cache`` dict (keyed by
-    the pre-pack ``weight.data_ptr()``), the alias step at the end re-points
-    ``weight`` / ``weight_scale`` / ``weight_scale_2`` at a previously-processed
-    module sharing the same source memory so the downstream data_ptr dedup can
-    collapse them. The cache is owned by the caller (typically
-    ``_export_transformers_checkpoint``) and scoped to one export invocation;
-    when ``_tied_cache`` is ``None`` (the default) the alias step is skipped
-    entirely. Uses memory identity only — no ``_tied_weights_keys`` lookup,
-    no-op for non-tied modules.
     """
     quantization_format = get_quantization_format(sub_module)
     if quantization_format == QUANTIZATION_NONE:
@@ -604,12 +592,6 @@ def _export_quantized_weight(
             "which dispatches to the streaming writer that materialises weights layer-by-layer."
         )
 
-    # Capture source identity BEFORE any tensor-creating operation below.
-    # For HF-tied weights this matches across all modules sharing the
-    # underlying Parameter; the cache lookup at the end of this function
-    # uses it to detect ties whose Python identity is about to be broken
-    # by the setattr on `weight_name` further down.
-    _tied_source_data_ptr = weight.data_ptr()
     weight_quantizer: TensorQuantizer | SequentialQuantizer = getattr(
         sub_module, quantizer_attrs.weight_quantizer
     )
@@ -820,32 +802,6 @@ def _export_quantized_weight(
     if weight_scale is not None:
         sub_module.register_buffer(quantizer_attrs.weight_scale, weight_scale)
 
-    # Tied-weight dedup: if a previously-processed module shared the same
-    # source weight memory, alias the packed weight + scale buffers so the
-    # downstream data_ptr dedup in postprocess_state_dict can collapse them.
-    # input_scale is safe to alias because sync_tied_input_amax (earlier in
-    # this export) already max-merged the per-side amaxes. Gated on the
-    # caller-owned _tied_cache so the dedup state is scoped to one export.
-    if _tied_cache is not None:
-        _prior = _tied_cache.get(_tied_source_data_ptr)
-        if _prior is not None and _prior is not sub_module:
-            if hasattr(_prior, weight_name):
-                setattr(sub_module, weight_name, getattr(_prior, weight_name))
-            for _attr in (
-                quantizer_attrs.weight_scale,
-                quantizer_attrs.weight_scale_2,
-                quantizer_attrs.input_scale,
-            ):
-                if not hasattr(_prior, _attr):
-                    continue
-                if _attr in sub_module._buffers:
-                    del sub_module._buffers[_attr]
-                elif hasattr(sub_module, _attr):
-                    delattr(sub_module, _attr)
-                sub_module.register_buffer(_attr, getattr(_prior, _attr))
-        else:
-            _tied_cache[_tied_source_data_ptr] = sub_module
-
     torch.cuda.empty_cache()
 
 
@@ -942,9 +898,6 @@ def _process_quantized_modules(
         is_modelopt_qlora: Whether the model is a modelopt-trained QLoRA model.
             If True, modules with base_layer attribute are skipped.
     """
-    # Per-call tied-weight dedup caches inside the context. Created fresh on
-    # every invocation so cache state is scoped to one export and cannot leak
-    # into a later call (see ExportContext).
     ctx = ExportContext(model=model, dtype=dtype, is_modelopt_qlora=is_modelopt_qlora)
     fsdp_module_to_reshard = None
 
@@ -1017,6 +970,10 @@ def _export_transformers_checkpoint(
 
     _warn_on_unsynced_moe_gate_up(model)
 
+    # Packing and fused-MoE expansion replace shared Parameters with independent tensors.
+    # Capture their stable name relationship while the live model still exposes the tie.
+    tied_weight_map = _build_tied_weight_map(model)
+
     # Merge per-side input_quantizer amaxes BEFORE _process_quantized_modules,
     # so the merged value flows into input_scale derivation downstream.
     synced_input = sync_tied_input_amax(model)
@@ -1046,14 +1003,12 @@ def _export_transformers_checkpoint(
     kv_cache_max_bound = 448
     kv_cache_format = quant_config["quantization"]["kv_cache_quant_algo"]
 
-    # Reorder so canonical-side tied keys (per HF's _tied_weights_keys)
-    # iterate first into postprocess_state_dict's first-wins data_ptr dedup.
-    # Self-gated to DiffusionGemma inside _reorder_canonical_first; no-op
-    # for every other model.
-    quantized_state_dict = _reorder_canonical_first(quantized_state_dict, model)
-
     quantized_state_dict = postprocess_state_dict(
-        quantized_state_dict, kv_cache_max_bound, kv_cache_format, is_modelopt_qlora
+        quantized_state_dict,
+        kv_cache_max_bound,
+        kv_cache_format,
+        is_modelopt_qlora,
+        tied_weight_map=tied_weight_map,
     )
 
     return quantized_state_dict, quant_config

--- a/modelopt/torch/quantization/utils/core_utils.py
+++ b/modelopt/torch/quantization/utils/core_utils.py
@@ -30,7 +30,6 @@ from torch.distributed.tensor import DTensor, Replicate
 
 from modelopt.torch.quantization.config import QuantizerCfgEntry
 from modelopt.torch.utils import get_unwrapped_name, print_rank_0
-from modelopt.torch.utils.distributed import is_fsdp2_model
 from modelopt.torch.utils.network import temporarily_remove_accelerate_hook
 
 if TYPE_CHECKING:
@@ -662,19 +661,6 @@ def has_accelerate_offload(module: nn.Module) -> bool:
     return any(
         _get_offload_hook(getattr(m, "_hf_hook", None)) is not None for m in module.modules()
     )
-
-
-def has_non_resident_weights(module: nn.Module) -> bool:
-    """Whether any weight under ``module`` lives outside it for part of the export.
-
-    Structural (FSDP2 wrapping, accelerate offload hooks) rather than a snapshot of
-    current placement: offloaded weights come and go as materialization windows open and
-    close, so a point-in-time check answers differently depending on when it runs.
-
-    Callers use this for decisions that must hold for a whole export — notably
-    pointer-keyed dedup, which needs ``data_ptr()`` to identify a tensor throughout.
-    """
-    return has_accelerate_offload(module) or is_fsdp2_model(module)
 
 
 @contextmanager

--- a/tests/_test_utils/torch/quantization/tied_modules.py
+++ b/tests/_test_utils/torch/quantization/tied_modules.py
@@ -94,15 +94,7 @@ def wrap_in_parent_with_tied_keys(
       when ``decoder_canonical=True``, list-style (legacy, no canonical/alias
       distinction) when ``decoder_canonical=False``.
 
-    Used by tests for :func:`_collect_canonical_tied_patterns` and
-    :func:`_reorder_canonical_first`. The legacy list-style branch exercises
-    the "no patterns extracted" negative case.
-
-    The parent's class name contains ``DiffusionGemma`` so the model_type
-    gate inside :func:`_reorder_canonical_first` (mirrors the existing
-    whisper / nemotron-vl dispatch in ``unified_export_hf.py``) passes for
-    test parents — without this, the function early-returns before
-    reaching the patterns step.
+    Used by tied-weight name-map and state-dict postprocessing tests.
     """
     parent_cls = type("DiffusionGemmaTestParent", (nn.Module,), {})
     parent = parent_cls()

--- a/tests/unit/torch/export/test_export_registry.py
+++ b/tests/unit/torch/export/test_export_registry.py
@@ -34,7 +34,6 @@ from modelopt.torch.export.hf_export_handlers import (
     _prepare_iterable_experts,
 )
 from modelopt.torch.export.registry import (
-    ExportContext,
     ExportModuleRegistry,
     PrepareMoEInputsRegistry,
     _ExportHandlerRegistryCls,
@@ -301,12 +300,3 @@ def test_process_quantized_modules_exports_via_registry():
     for key in fp8_weights:
         weight = state_dict[key.replace("weight_scale", "weight")]
         assert weight.dtype == torch.float8_e4m3fn
-
-
-def test_export_context_caches_are_per_instance():
-    model = nn.Linear(2, 2)
-    ctx_a = ExportContext(model=model, dtype=torch.float16)
-    ctx_b = ExportContext(model=model, dtype=torch.float16)
-    ctx_a.tied_cache[123] = model
-    assert ctx_b.tied_cache == {}
-    assert ctx_b.moe_tied_cache == {}

--- a/tests/unit/torch/export/test_offload_export.py
+++ b/tests/unit/torch/export/test_offload_export.py
@@ -33,14 +33,12 @@ except ImportError:
 import modelopt.torch.quantization as mtq
 from modelopt.torch.export.model_config import KV_CACHE_FP8
 from modelopt.torch.export.quant_utils import _postprocess_single_tensor
-from modelopt.torch.export.registry import ExportContext
 from modelopt.torch.export.unified_export_hf import _export_quantized_weight
 from modelopt.torch.export.unified_export_hf_streaming import (
     _parse_shard_size,
     _StreamingShardWriter,
 )
 from modelopt.torch.quantization.nn.modules.quant_linear import RealQuantLinear
-from modelopt.torch.quantization.utils import core_utils
 from modelopt.torch.quantization.utils.core_utils import has_accelerate_offload
 
 # ---------------------------------------------------------------------------
@@ -292,56 +290,16 @@ def test_postprocess_scale_squeezed():
     assert val.shape == (4, 4), f"expected (4, 4), got {val.shape}"
 
 
-# ---------------------------------------------------------------------------
-# data_ptr identity under offload
-#
-# The tests below exist because ``data_ptr()`` only identifies a tensor while that
-# tensor is resident. Getting this wrong silently exported wrong weights: meta
-# tensors all report 0, and freed addresses are recycled by the allocator.
-# ---------------------------------------------------------------------------
-
-
-def test_export_context_dedup_follows_weight_residency():
-    """Pointer-keyed dedup is enabled only while weights stay resident.
-
-    An offloaded module's weights are freed when its materialization window closes, so a
-    recycled address would alias an unrelated module. Tied-weight export is therefore
-    supported on the resident path only, matching what FSDP2 already does.
-    """
-    resident_ctx = ExportContext(model=nn.Linear(8, 8), dtype=torch.float16)
-    assert resident_ctx.tied_cache == {}
-    assert resident_ctx.moe_tied_cache == {}
-
-    offloaded, _ = _make_offloaded_linear()
-    offloaded_ctx = ExportContext(model=offloaded, dtype=torch.float16)
-    assert offloaded_ctx.tied_cache is None
-    assert offloaded_ctx.moe_tied_cache is None
-
-
-def test_export_context_dedup_disabled_for_fsdp2(monkeypatch):
-    """FSDP2 shards recycle addresses, so its dedup opt-out must survive the offload rework."""
-    monkeypatch.setattr(core_utils, "is_fsdp2_model", lambda _: True)
-
-    ctx = ExportContext(model=nn.Linear(8, 8), dtype=torch.float16)
-    assert ctx.tied_cache is None
-    assert ctx.moe_tied_cache is None
-
-
-def test_tied_weights_exported_independently_without_cache():
-    """With dedup off, tied modules each pack their own weight instead of aliasing.
-
-    Guards the offload path: an alias would make two shard entries share storage, which
-    the writer must then drop or copy. Independent tensors keep both keys intact.
-    """
+def test_tied_weights_are_packed_independently():
     shared = nn.Parameter(torch.randn(16, 16))
     first, second = nn.Linear(16, 16, bias=False), nn.Linear(16, 16, bias=False)
     first.weight = second.weight = shared
 
     for linear in (first, second):
         mtq.quantize(linear, mtq.FP8_DEFAULT_CFG, lambda m: m(torch.randn(1, 16)))
-        _export_quantized_weight(linear, torch.float16, _tied_cache=None)
+        _export_quantized_weight(linear, torch.float16)
 
-    assert first.weight.data_ptr() != second.weight.data_ptr()
+    assert first.weight is not second.weight
     assert torch.equal(first.weight, second.weight)
 
 

--- a/tests/unit/torch/export/test_unified_export_hf.py
+++ b/tests/unit/torch/export/test_unified_export_hf.py
@@ -15,8 +15,6 @@
 
 """Tests for tied-weight helpers in unified_export_hf."""
 
-from collections import OrderedDict
-
 import torch
 from _test_utils.torch.quantization.tied_modules import (
     make_tied_linear_pair,
@@ -24,58 +22,141 @@ from _test_utils.torch.quantization.tied_modules import (
 )
 
 import modelopt.torch.quantization as mtq
-from modelopt.torch.export.model_utils import (
-    _collect_canonical_tied_patterns,
-    _reorder_canonical_first,
+from modelopt.torch.export.model_utils import _build_tied_weight_map
+from modelopt.torch.export.quant_utils import (
+    fuse_prequant_layernorm,
+    postprocess_state_dict,
+    sync_tied_input_amax,
 )
-from modelopt.torch.export.quant_utils import fuse_prequant_layernorm, sync_tied_input_amax
 from modelopt.torch.export.unified_export_hf import _export_quantized_weight
 from modelopt.torch.quantization.nn import TensorQuantizer
 
 
-def test_collect_canonical_tied_patterns_dict_style():
-    """Dict-style _tied_weights_keys yields regex patterns + canonical-side substrings."""
+def test_build_tied_weight_map_uses_parameter_identity_and_declared_direction():
     enc, dec = make_tied_linear_pair()
     parent = wrap_in_parent_with_tied_keys(enc, dec, decoder_canonical=True)
 
-    patterns, side_substrings = _collect_canonical_tied_patterns(parent)
-
-    assert len(patterns) >= 1
-    # "decoder" is in the canonical RHS but not the alias LHS — must auto-derive.
-    # "encoder" is alias-only and must NOT be returned as canonical (would invert dedup).
-    assert "decoder" in side_substrings
-    assert "encoder" not in side_substrings
+    assert parent.encoder.weight is parent.decoder.weight
+    assert _build_tied_weight_map(parent) == {"encoder.weight": "decoder.weight"}
 
 
-def test_collect_canonical_tied_patterns_list_style_yields_no_canonical_info():
-    """Legacy list-style _tied_weights_keys carries no canonical/alias info — returns empty."""
-    enc, dec = make_tied_linear_pair()
-    parent = wrap_in_parent_with_tied_keys(enc, dec, decoder_canonical=False)
-
-    patterns, side_substrings = _collect_canonical_tied_patterns(parent)
-
-    assert patterns == []
-    assert side_substrings == []
-
-
-def test_reorder_canonical_first_puts_decoder_keys_before_encoder_keys():
-    """_reorder_canonical_first moves canonical-side state_dict keys ahead of alias-side keys."""
-    enc, dec = make_tied_linear_pair()
-    parent = wrap_in_parent_with_tied_keys(enc, dec, decoder_canonical=True)
-
-    sd = OrderedDict(
-        [
-            ("encoder.weight", torch.zeros(1)),
-            ("unrelated.foo", torch.zeros(1)),
-            ("decoder.weight", torch.zeros(1)),
-        ]
+def test_build_tied_weight_map_does_not_apply_declared_tie():
+    parent = wrap_in_parent_with_tied_keys(
+        torch.nn.Linear(4, 4, bias=False),
+        torch.nn.Linear(4, 4, bias=False),
     )
 
-    reordered = _reorder_canonical_first(sd, parent)
-    keys = list(reordered.keys())
+    assert parent.encoder.weight is not parent.decoder.weight
+    assert _build_tied_weight_map(parent) == {}
 
-    assert keys.index("decoder.weight") < keys.index("encoder.weight")
-    assert set(reordered) == set(sd)  # no drops or additions
+
+def test_build_tied_weight_map_prefers_input_embedding():
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = type("Config", (), {"tie_word_embeddings": True})()
+            self.lm_head = torch.nn.Linear(4, 4, bias=False)
+            self.embed = torch.nn.Embedding(4, 4)
+            self.embed.weight = self.lm_head.weight
+
+        def get_input_embeddings(self):
+            return self.embed
+
+        def get_output_embeddings(self):
+            return self.lm_head
+
+    assert _build_tied_weight_map(Model()) == {"lm_head.weight": "embed.weight"}
+
+
+def test_postprocess_tied_weights_uses_pre_export_names_after_materialization():
+    enc, dec = make_tied_linear_pair()
+    parent = wrap_in_parent_with_tied_keys(enc, dec, decoder_canonical=True)
+    tied_weight_map = _build_tied_weight_map(parent)
+    state_dict = {
+        "encoder.weight": parent.encoder.weight.detach().clone(),
+        "decoder.weight": parent.decoder.weight.detach().clone(),
+    }
+
+    processed = postprocess_state_dict(state_dict, 448, None, tied_weight_map=tied_weight_map)
+
+    assert set(processed) == {"decoder.weight"}
+
+
+def test_postprocess_tied_weights_drops_quantization_companions_atomically():
+    enc, dec = make_tied_linear_pair()
+    parent = wrap_in_parent_with_tied_keys(enc, dec, decoder_canonical=True)
+    state_dict = {}
+    for side in ("encoder", "decoder"):
+        state_dict[f"{side}.weight"] = torch.randn(4, 4)
+        state_dict[f"{side}.weight_scale"] = torch.randn(4)
+        state_dict[f"{side}.weight_scale_2"] = torch.randn(1)
+        state_dict[f"{side}.input_scale"] = torch.randn(1)
+
+    processed = postprocess_state_dict(
+        state_dict, 448, None, tied_weight_map=_build_tied_weight_map(parent)
+    )
+
+    assert set(processed) == {
+        "decoder.weight",
+        "decoder.weight_scale",
+        "decoder.weight_scale_2",
+        "decoder.input_scale",
+    }
+
+
+def test_postprocess_tied_weights_keeps_group_if_canonical_companion_is_missing():
+    enc, dec = make_tied_linear_pair()
+    parent = wrap_in_parent_with_tied_keys(enc, dec, decoder_canonical=True)
+    state_dict = {
+        "encoder.weight": torch.randn(4, 4),
+        "encoder.weight_scale": torch.randn(4),
+        "decoder.weight": torch.randn(4, 4),
+    }
+
+    processed = postprocess_state_dict(
+        state_dict, 448, None, tied_weight_map=_build_tied_weight_map(parent)
+    )
+
+    assert set(processed) == set(state_dict)
+
+
+def test_postprocess_tied_weights_drops_expanded_moe_expert_aliases():
+    parent = torch.nn.Module()
+    parent.encoder = torch.nn.Module()
+    parent.encoder.experts = torch.nn.Module()
+    parent.decoder = torch.nn.Module()
+    parent.decoder.experts = torch.nn.Module()
+    parent.decoder.experts.gate_up_proj = torch.nn.Parameter(torch.randn(2, 8, 4))
+    parent.decoder.experts.down_proj = torch.nn.Parameter(torch.randn(2, 4, 4))
+    parent.encoder.experts.gate_up_proj = parent.decoder.experts.gate_up_proj
+    parent.encoder.experts.down_proj = parent.decoder.experts.down_proj
+    parent._tied_weights_keys = {
+        r"^encoder\.experts\.gate_up_proj$": "decoder.experts.gate_up_proj",
+        r"^encoder\.experts\.down_proj$": "decoder.experts.down_proj",
+    }
+    state_dict = {}
+    for side in ("encoder", "decoder"):
+        for expert in range(2):
+            for projection in ("gate_proj", "up_proj", "down_proj"):
+                prefix = f"{side}.experts.{expert}.{projection}"
+                state_dict[f"{prefix}.weight"] = torch.randn(4, 4)
+                state_dict[f"{prefix}.weight_scale"] = torch.randn(4)
+
+    processed = postprocess_state_dict(
+        state_dict, 448, None, tied_weight_map=_build_tied_weight_map(parent)
+    )
+
+    assert len(processed) == 12
+    assert all(key.startswith("decoder.experts.") for key in processed)
+
+
+def test_postprocess_state_dict_has_no_pointer_or_storage_fallback():
+    shared = torch.randn(4)
+    state_dict = {"first": shared, "second": shared, "view": shared[:2]}
+
+    processed = postprocess_state_dict(state_dict, 448, None)
+
+    assert set(processed) == set(state_dict)
 
 
 def _quantize_and_get_input_quantizers(parent):
@@ -127,60 +208,34 @@ def _calibrate_through_both_children(parent):
     mtq.quantize(parent, mtq.NVFP4_DEFAULT_CFG, forward_loop=forward_loop)
 
 
-def test_export_quantized_weight_aliases_packed_weight_for_tied_linears():
-    """Tied Linears share data_ptr for packed .weight and scale buffers after export."""
+def test_export_quantized_weight_packs_tied_linears_independently():
     enc, dec = make_tied_linear_pair()
     parent = wrap_in_parent_with_tied_keys(enc, dec)
     _calibrate_through_both_children(parent)
 
-    # Per-call dedup cache (the production pattern: caller owns the cache, scoped
-    # to one export invocation). Threaded through both sides of the tied pair so
-    # the alias step at the end of _export_quantized_weight catches the dedup.
-    tied_cache: dict = {}
-    _export_quantized_weight(enc, torch.float16, "weight", _tied_cache=tied_cache)
-    _export_quantized_weight(dec, torch.float16, "weight", _tied_cache=tied_cache)
+    _export_quantized_weight(enc, torch.float16, "weight")
+    _export_quantized_weight(dec, torch.float16, "weight")
 
-    assert enc.weight.data_ptr() == dec.weight.data_ptr()
-    for scale_attr in ("weight_scale", "weight_scale_2"):
-        if hasattr(enc, scale_attr) and hasattr(dec, scale_attr):
-            assert getattr(enc, scale_attr).data_ptr() == getattr(dec, scale_attr).data_ptr()
-
-
-def test_export_quantized_weight_no_alias_for_untied_linears():
-    """Untied Linears keep independent data_ptrs after export — no false-positive aliasing."""
-    parent = torch.nn.Module()
-    parent.encoder = torch.nn.Linear(16, 32, bias=False)
-    parent.decoder = torch.nn.Linear(16, 32, bias=False)
-    assert parent.encoder.weight.data_ptr() != parent.decoder.weight.data_ptr()
-    _calibrate_through_both_children(parent)
-
-    # Same fresh cache shape as the positive case — confirms that even with
-    # dedup enabled, untied modules with distinct source data_ptrs do not get
-    # falsely aliased.
-    tied_cache: dict = {}
-    _export_quantized_weight(parent.encoder, torch.float16, "weight", _tied_cache=tied_cache)
-    _export_quantized_weight(parent.decoder, torch.float16, "weight", _tied_cache=tied_cache)
-
-    assert parent.encoder.weight.data_ptr() != parent.decoder.weight.data_ptr()
+    assert enc.weight is not dec.weight
+    assert torch.equal(enc.weight, dec.weight)
 
 
 def test_export_quantized_weight_skips_alias_when_one_tied_side_is_unquantized():
     """Unquantized side early-returns; its .weight stays at the original shared Parameter."""
     enc, dec = make_tied_linear_pair()
     parent = wrap_in_parent_with_tied_keys(enc, dec)
-    original_shared_data_ptr = enc.weight.data_ptr()
+    original_shared_weight = enc.weight
 
     _calibrate_through_both_children(parent)
     # is_enabled is a read-only property; .disable() is the canonical bypass.
     dec.weight_quantizer.disable()
 
-    tied_cache: dict = {}
-    _export_quantized_weight(enc, torch.float16, "weight", _tied_cache=tied_cache)
-    _export_quantized_weight(dec, torch.float16, "weight", _tied_cache=tied_cache)
+    _export_quantized_weight(enc, torch.float16, "weight")
+    _export_quantized_weight(dec, torch.float16, "weight")
 
-    assert enc.weight.data_ptr() != original_shared_data_ptr  # encoder got fresh packed
-    assert dec.weight.data_ptr() == original_shared_data_ptr  # decoder untouched
-    assert enc.weight.data_ptr() != dec.weight.data_ptr()
+    assert enc.weight is not original_shared_weight
+    assert dec.weight is original_shared_weight
+    assert enc.weight is not dec.weight
 
 
 def _linear_with_input_quantizer():

--- a/tests/unit/torch/quantization/plugins/test_fused_experts.py
+++ b/tests/unit/torch/quantization/plugins/test_fused_experts.py
@@ -685,30 +685,15 @@ class TestExportFusedExpertsTiedDedup:
         if QuantModuleRegistry.get(mod_type) is not None:
             QuantModuleRegistry.unregister(mod_type)
 
-    def test_per_expert_buffers_share_data_ptr_for_tied_fused_experts(self):
-        """Two tied FusedExperts modules: every per-expert .weight + scale buffer shares data_ptr."""
+    def test_tied_fused_experts_are_expanded_independently(self):
         parent = _build_two_moe_blocks(tie=True)
         expert_type = type(parent.encoder.experts)
         self._cleanup_registry(expert_type)
         try:
             _calibrate_two_moe_blocks(parent)
 
-            # Per-call dedup caches threaded through both export calls; int keys
-            # for per-expert wrapper dedup, tuple keys for module-level dedup.
-            tied_cache: dict = {}
-            moe_tied_cache: dict = {}
-            _export_fused_experts(
-                parent.encoder.experts,
-                torch.float16,
-                _moe_tied_cache=moe_tied_cache,
-                _tied_cache=tied_cache,
-            )
-            _export_fused_experts(
-                parent.decoder.experts,
-                torch.float16,
-                _moe_tied_cache=moe_tied_cache,
-                _tied_cache=tied_cache,
-            )
+            _export_fused_experts(parent.encoder.experts, torch.float16)
+            _export_fused_experts(parent.decoder.experts, torch.float16)
 
             for idx in range(NUM_EXPERTS):
                 enc_expert = getattr(parent.encoder.experts, str(idx))
@@ -716,49 +701,8 @@ class TestExportFusedExpertsTiedDedup:
                 for proj_name in ("gate_proj", "up_proj", "down_proj"):
                     enc_proj = getattr(enc_expert, proj_name)
                     dec_proj = getattr(dec_expert, proj_name)
-                    assert enc_proj.weight.data_ptr() == dec_proj.weight.data_ptr()
-                    for scale_attr in ("weight_scale", "weight_scale_2"):
-                        if hasattr(enc_proj, scale_attr) and hasattr(dec_proj, scale_attr):
-                            assert (
-                                getattr(enc_proj, scale_attr).data_ptr()
-                                == getattr(dec_proj, scale_attr).data_ptr()
-                            )
-        finally:
-            self._cleanup_registry(expert_type)
-
-    def test_per_expert_buffers_have_independent_data_ptrs_for_untied_fused_experts(self):
-        """Two untied FusedExperts modules: per-expert buffers stay independent (no false-positive alias)."""
-        parent = _build_two_moe_blocks(tie=False)
-        expert_type = type(parent.encoder.experts)
-        self._cleanup_registry(expert_type)
-        try:
-            _calibrate_two_moe_blocks(parent)
-
-            # Same fresh caches as the positive case — confirms that even with
-            # dedup enabled, untied modules with distinct source data_ptrs do
-            # not get falsely aliased.
-            tied_cache: dict = {}
-            moe_tied_cache: dict = {}
-            _export_fused_experts(
-                parent.encoder.experts,
-                torch.float16,
-                _moe_tied_cache=moe_tied_cache,
-                _tied_cache=tied_cache,
-            )
-            _export_fused_experts(
-                parent.decoder.experts,
-                torch.float16,
-                _moe_tied_cache=moe_tied_cache,
-                _tied_cache=tied_cache,
-            )
-
-            for idx in range(NUM_EXPERTS):
-                enc_expert = getattr(parent.encoder.experts, str(idx))
-                dec_expert = getattr(parent.decoder.experts, str(idx))
-                for proj_name in ("gate_proj", "up_proj", "down_proj"):
-                    enc_proj = getattr(enc_expert, proj_name)
-                    dec_proj = getattr(dec_expert, proj_name)
-                    assert enc_proj.weight.data_ptr() != dec_proj.weight.data_ptr()
+                    assert enc_proj.weight is not dec_proj.weight
+                    assert torch.equal(enc_proj.weight, dec_proj.weight)
         finally:
             self._cleanup_registry(expert_type)
 


### PR DESCRIPTION
### What does this PR do?

Type of change: ? <!-- Use one of the following: Bug fix, new feature, new example, new tests, documentation. -->

Proposal for a simplified version of https://github.com/NVIDIA/Model-Optimizer/pull/2092

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Only for new features, backward breaking changes, deprecations, or fixes for critical bugs present in previous releases. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->
