### PR TITLE
Minitron pruning fixes for Nemotron-3.5-Lightning-30B-A3B and Deepseek

### DIFF
--- a/examples/megatron_bridge/README.md
+++ b/examples/megatron_bridge/README.md
@@ -365,9 +365,6 @@ torchrun --nproc_per_node 1 prune_minitron.py --help
 > [!NOTE]
 > Multi-token-prediction (MTP) heads (e.g. Qwen3.5) are not pruned yet — they are dropped for the prune run and the saved checkpoint has no MTP. Autoregressive inference is unaffected; for speculative decoding, run a short MTP SFT on the pruned model.
 
-> [!NOTE]
-> Saving a pruned Nemotron model in HF format needs config-only export (nemo:26.08+). On older containers, either downgrade to `transformers<5` via `python -m pip install "transformers<5"` before pruning, or save with `--output_megatron_path` instead.
-
 ### Vision-Language Models (VLMs)
 
 For a vision-language model (e.g. Qwen3.5-VL, Gemma3-VL), `prune_minitron.py` automatically prunes only the **language model** and leaves the vision tower intact, then saves the full VLM back. All the pruning modes above (parameter count, active parameter count, memory footprint, and manual `export_config`) work unchanged, with two VLM-specific caveats:

--- a/examples/megatron_bridge/README.md
+++ b/examples/megatron_bridge/README.md
@@ -365,9 +365,6 @@ torchrun --nproc_per_node 1 prune_minitron.py --help
 > [!NOTE]
 > Multi-token-prediction (MTP) heads (e.g. Qwen3.5) are not pruned yet — they are dropped for the prune run and the saved checkpoint has no MTP. Autoregressive inference is unaffected; for speculative decoding, run a short MTP SFT on the pruned model.
 
-> [!NOTE]
-> If pruning a Nemotron model and you want to save the pruned model back in HF format, please downgrade to `transformers<5` via `python -m pip install "transformers<5"` before pruning.
-
 ### Vision-Language Models (VLMs)
 
 For a vision-language model (e.g. Qwen3.5-VL, Gemma3-VL), `prune_minitron.py` automatically prunes only the **language model** and leaves the vision tower intact, then saves the full VLM back. All the pruning modes above (parameter count, active parameter count, memory footprint, and manual `export_config`) work unchanged, with two VLM-specific caveats:

--- a/examples/megatron_bridge/README.md
+++ b/examples/megatron_bridge/README.md
@@ -365,6 +365,9 @@ torchrun --nproc_per_node 1 prune_minitron.py --help
 > [!NOTE]
 > Multi-token-prediction (MTP) heads (e.g. Qwen3.5) are not pruned yet — they are dropped for the prune run and the saved checkpoint has no MTP. Autoregressive inference is unaffected; for speculative decoding, run a short MTP SFT on the pruned model.
 
+> [!NOTE]
+> Saving a pruned Nemotron model in HF format needs config-only export (nemo:26.08+). On older containers, either downgrade to `transformers<5` via `python -m pip install "transformers<5"` before pruning, or save with `--output_megatron_path` instead.
+
 ### Vision-Language Models (VLMs)
 
 For a vision-language model (e.g. Qwen3.5-VL, Gemma3-VL), `prune_minitron.py` automatically prunes only the **language model** and leaves the vision tower intact, then saves the full VLM back. All the pruning modes above (parameter count, active parameter count, memory footprint, and manual `export_config`) work unchanged, with two VLM-specific caveats:

--- a/examples/megatron_bridge/distill.py
+++ b/examples/megatron_bridge/distill.py
@@ -480,5 +480,7 @@ if __name__ == "__main__":
     args = get_args()
     try:
         main(args)
+    except BaseException:
+        dist.abort()  # peers may be stuck in a collective this rank will never reach
     finally:
         dist.cleanup()

--- a/examples/megatron_bridge/export_distilled_megatron_to_hf.py
+++ b/examples/megatron_bridge/export_distilled_megatron_to_hf.py
@@ -288,5 +288,7 @@ if __name__ == "__main__":
     args = get_args()
     try:
         main(args)
+    except BaseException:
+        dist.abort()  # peers may be stuck in a collective this rank will never reach
     finally:
         dist.cleanup()

--- a/examples/megatron_bridge/export_quantized_megatron_to_hf.py
+++ b/examples/megatron_bridge/export_quantized_megatron_to_hf.py
@@ -164,5 +164,7 @@ if __name__ == "__main__":
     args = get_args()
     try:
         main(args)
+    except BaseException:
+        dist.abort()  # peers may be stuck in a collective this rank will never reach
     finally:
         dist.cleanup()

--- a/examples/megatron_bridge/prune_minitron.py
+++ b/examples/megatron_bridge/prune_minitron.py
@@ -116,8 +116,7 @@ _SHARED_EXPERT_SIZE_FIELDS = (
 def _is_deepseek_style_moe(text_cfg) -> bool:
     """Whether the shared expert is sized as ``n_shared_experts * moe_intermediate_size``.
 
-    Such configs have no explicit shared expert size field, so only integer multiples of the
-    (also prunable) routed expert size are representable in HF.
+    Such configs can only represent a shared expert size that is a multiple of the routed one.
     """
     return hasattr(text_cfg, "n_shared_experts") and not any(
         hasattr(text_cfg, field) for field in _SHARED_EXPERT_SIZE_FIELDS
@@ -650,8 +649,8 @@ def main(args: argparse.Namespace):
         if hasattr(text_cfg, "n_routed_experts"):
             text_cfg.n_routed_experts = mcore_cfg.num_moe_experts
         # n_shared_experts is a fixed count; only DeepSeek-style configs record the pruned shared
-        # expert size through it and must re-derive it. candidate_filter keeps the search divisible,
-        # so only a --prune_export_config the filter never saw can violate this.
+        # expert size through it. candidate_filter keeps the search divisible, so only a manual
+        # --prune_export_config can violate this.
         if _is_deepseek_style_moe(text_cfg):
             if mcore_cfg.moe_shared_expert_intermediate_size % mcore_cfg.moe_ffn_hidden_size:
                 raise ValueError(
@@ -708,11 +707,16 @@ def main(args: argparse.Namespace):
             if hasattr(text_cfg, field):
                 setattr(text_cfg, field, 0)
 
-        # Preferred path for all non-VLMs: a config-only bridge (hf_keys=None) keeps the embedding
-        # task when transformers' saved key differs from the bridge mapping (NemotronH's
-        # backbone.embedding vs ...embeddings), and builds no dummy model.
-        # VLMs and older builds fall back to a dummy HF model that supplies the expected HF key names.
-        if hasattr(AutoBridge, "from_hf_config") and not is_vlm:
+        # A config-only bridge (hf_keys=None) keeps the embedding task when transformers' saved key
+        # differs from the bridge mapping (NemotronH's backbone.embedding vs ...embeddings). Only
+        # hybrids need it; elsewhere it drops pruned config fields (e.g. Qwen3's hidden_size), so
+        # everything else uses a dummy HF model to supply the expected key names.
+        use_config_only_export = (
+            hasattr(AutoBridge, "from_hf_config")
+            and isinstance(provider, _HYBRID_PROVIDER_TYPES)
+            and not is_vlm
+        )
+        if use_config_only_export:
             pruned_bridge = AutoBridge.from_hf_config(hf_cfg)
             # save_hf_pretrained reads trust_remote_code off the bridge to fetch source artifacts;
             # from_hf_config can't infer it since AutoConfig consumes the kwarg.
@@ -721,11 +725,11 @@ def main(args: argparse.Namespace):
                 model, args.output_hf_path, source_path=args.hf_model_name_or_path
             )
         else:
-            if not is_vlm:
+            if isinstance(provider, _HYBRID_PROVIDER_TYPES) and not is_vlm:
                 warn_rank_0(
-                    "Megatron-Bridge lacks config-only HF export (needs nemo:26.08+); falling back "
-                    "to the dummy-model path, which cannot round-trip a pruned native NemotronH "
-                    "config. Use transformers<5 or a newer container if the save fails."
+                    "Megatron-Bridge lacks config-only HF export; falling back to the dummy-model "
+                    "path, which cannot round-trip a pruned native NemotronH config. Use "
+                    "transformers<5 or a newer Megatron-Bridge if the save fails."
                 )
             dummy_model_cls = AutoModelForImageTextToText if is_vlm else AutoModelForCausalLM
             dummy_model_cls.from_config(
@@ -759,5 +763,7 @@ if __name__ == "__main__":
     args = get_args()
     try:
         main(args)
+    except BaseException:
+        dist.abort()  # peers may be stuck in a collective this rank will never reach
     finally:
         dist.cleanup()

--- a/examples/megatron_bridge/prune_minitron.py
+++ b/examples/megatron_bridge/prune_minitron.py
@@ -400,7 +400,9 @@ def main(args: argparse.Namespace):
             "num_layers_in_last_pipeline_stage": args.num_layers_in_last_pipeline_stage,
             "pipeline_dtype": torch.bfloat16,
             "seq_length": args.seq_length,
-            "mtp_num_layers": 0,  # MTP is not supported during calibration
+            # MTP is not supported during calibration; drop it
+            "mtp_num_layers": 0,
+            "mtp_hybrid_override_pattern": None,
         },
         init_model_parallel=True,
         moe_grouped_gemm=not args.no_moe_grouped_gemm,
@@ -588,9 +590,7 @@ def main(args: argparse.Namespace):
     else:
         print_rank_0(f"Saving pruned model to {args.output_hf_path} in HF checkpoint format")
 
-        # [WAR] Save the pruned HF model by hand until Megatron-Bridge natively supports it.
-        # TODO: Replace this whole block with ``AutoBridge.from_auto_config(...).save_hf_weights(...)``
-        #     once the Megatron-Bridge fix ships (nemo:26.08).
+        # Build the pruned HF config field-by-field from the pruned Megatron config, then stream weights.
         bridge.hf_pretrained.save_artifacts(args.output_hf_path)
         hf_cfg = AutoConfig.from_pretrained(
             args.output_hf_path, trust_remote_code=args.trust_remote_code
@@ -612,6 +612,7 @@ def main(args: argparse.Namespace):
             text_cfg.moe_intermediate_size = mcore_cfg.moe_ffn_hidden_size
         # HF names this field with or without the ``moe_`` prefix depending on the model
         # (e.g. Qwen3.5-MoE uses ``shared_expert_intermediate_size``).
+        has_explicit_shared_size = False
         for shared_expert_field in (
             "moe_shared_expert_intermediate_size",
             "shared_expert_intermediate_size",
@@ -620,11 +621,13 @@ def main(args: argparse.Namespace):
                 setattr(
                     text_cfg, shared_expert_field, mcore_cfg.moe_shared_expert_intermediate_size
                 )
+                has_explicit_shared_size = True
         if hasattr(text_cfg, "num_experts"):
             text_cfg.num_experts = mcore_cfg.num_moe_experts
         if hasattr(text_cfg, "n_routed_experts"):
             text_cfg.n_routed_experts = mcore_cfg.num_moe_experts
-        if hasattr(text_cfg, "n_shared_experts"):
+        # n_shared_experts is a fixed count; only DeepSeek-style configs re-derive it from sizes.
+        if hasattr(text_cfg, "n_shared_experts") and not has_explicit_shared_size:
             text_cfg.n_shared_experts = (
                 mcore_cfg.moe_shared_expert_intermediate_size // mcore_cfg.moe_ffn_hidden_size
             )
@@ -658,8 +661,11 @@ def main(args: argparse.Namespace):
                     "distillation cannot recover this vision-path change -- consider full VLM "
                     "training/distillation instead of LM-only to recover vision quality."
                 )
-        if isinstance(provider, _HYBRID_PROVIDER_TYPES) and hasattr(
-            text_cfg, "hybrid_override_pattern"
+        # Only older remote-code configs need this; native configs carry the cadence in layer_types.
+        if (
+            isinstance(provider, _HYBRID_PROVIDER_TYPES)
+            and not hasattr(text_cfg, "layer_types")
+            and hasattr(text_cfg, "hybrid_override_pattern")
         ):
             # MCore's pattern can carry an MTP suffix (``/...``) and PP boundaries (``|``) which we need to remove
             text_cfg.hybrid_override_pattern = "".join(
@@ -671,15 +677,26 @@ def main(args: argparse.Namespace):
             if hasattr(text_cfg, field):
                 setattr(text_cfg, field, 0)
 
-        # Save dummy pruned HF model to get the correct bridge for saving pruned weights
-        dummy_model_cls = AutoModelForImageTextToText if is_vlm else AutoModelForCausalLM
-        dummy_model_cls.from_config(
-            hf_cfg, trust_remote_code=args.trust_remote_code
-        ).save_pretrained(args.output_hf_path, trust_remote_code=args.trust_remote_code)
-        pruned_bridge = AutoBridge.from_hf_pretrained(
-            args.output_hf_path, trust_remote_code=args.trust_remote_code
-        )
-        pruned_bridge.save_hf_weights(model, args.output_hf_path)
+        # Config-only bridge (hf_keys=None) so the embedding task is not dropped when transformers'
+        # saved key differs from the bridge mapping (NemotronH's backbone.embedding vs ...embeddings).
+        # VLMs and older builds fall back to a dummy HF model that supplies the expected HF key names.
+        if (
+            hasattr(AutoBridge, "from_hf_config")
+            and hasattr(AutoBridge, "from_auto_config")
+            and not is_vlm
+        ):
+            AutoBridge.from_hf_config(hf_cfg).save_hf_pretrained(
+                model, args.output_hf_path, source_path=args.hf_model_name_or_path
+            )
+        else:
+            dummy_model_cls = AutoModelForImageTextToText if is_vlm else AutoModelForCausalLM
+            dummy_model_cls.from_config(
+                hf_cfg, trust_remote_code=args.trust_remote_code
+            ).save_pretrained(args.output_hf_path, trust_remote_code=args.trust_remote_code)
+            pruned_bridge = AutoBridge.from_hf_pretrained(
+                args.output_hf_path, trust_remote_code=args.trust_remote_code
+            )
+            pruned_bridge.save_hf_weights(model, args.output_hf_path)
 
         copy_hf_ckpt_remote_code(args.hf_model_name_or_path, args.output_hf_path)
         print_rank_0(f"Saved pruned model to {args.output_hf_path} in HF checkpoint format")

--- a/examples/megatron_bridge/prune_minitron.py
+++ b/examples/megatron_bridge/prune_minitron.py
@@ -118,7 +118,7 @@ def _is_deepseek_style_moe(text_cfg) -> bool:
 
     Such configs can only represent a shared expert size that is a multiple of the routed one.
     """
-    return hasattr(text_cfg, "n_shared_experts") and not any(
+    return getattr(text_cfg, "n_shared_experts", None) is not None and not any(
         hasattr(text_cfg, field) for field in _SHARED_EXPERT_SIZE_FIELDS
     )
 
@@ -620,7 +620,10 @@ def main(args: argparse.Namespace):
         print_rank_0(f"Saving pruned model to {args.output_hf_path} in HF checkpoint format")
 
         # Build the pruned HF config field-by-field from the pruned Megatron config, then stream weights.
-        bridge.hf_pretrained.save_artifacts(args.output_hf_path)
+        # Rank 0 only: a late write from another rank would leave config.json stale.
+        if dist.is_master():
+            bridge.hf_pretrained.save_artifacts(args.output_hf_path)
+        dist.barrier()
         hf_cfg = AutoConfig.from_pretrained(
             args.output_hf_path, trust_remote_code=args.trust_remote_code
         )
@@ -707,10 +710,8 @@ def main(args: argparse.Namespace):
             if hasattr(text_cfg, field):
                 setattr(text_cfg, field, 0)
 
-        # A config-only bridge (hf_keys=None) keeps the embedding task when transformers' saved key
-        # differs from the bridge mapping (NemotronH's backbone.embedding vs ...embeddings). Only
-        # hybrids need it; elsewhere it drops pruned config fields (e.g. Qwen3's hidden_size), so
-        # everything else uses a dummy HF model to supply the expected key names.
+        # Config-only bridge (hf_keys=None) keeps the embedding task when transformers' saved key
+        # differs from the bridge mapping (NemotronH's backbone.embedding vs ...embeddings).
         use_config_only_export = (
             hasattr(AutoBridge, "from_hf_config")
             and isinstance(provider, _HYBRID_PROVIDER_TYPES)

--- a/examples/megatron_bridge/prune_minitron.py
+++ b/examples/megatron_bridge/prune_minitron.py
@@ -105,6 +105,25 @@ def _hf_config_has_mtp(hf_cfg) -> bool:
     )
 
 
+# HF names the shared expert size with or without the ``moe_`` prefix depending on the model
+# (e.g. Qwen3.5-MoE uses ``shared_expert_intermediate_size``).
+_SHARED_EXPERT_SIZE_FIELDS = (
+    "moe_shared_expert_intermediate_size",
+    "shared_expert_intermediate_size",
+)
+
+
+def _is_deepseek_style_moe(text_cfg) -> bool:
+    """Whether the shared expert is sized as ``n_shared_experts * moe_intermediate_size``.
+
+    Such configs have no explicit shared expert size field, so only integer multiples of the
+    (also prunable) routed expert size are representable in HF.
+    """
+    return hasattr(text_cfg, "n_shared_experts") and not any(
+        hasattr(text_cfg, field) for field in _SHARED_EXPERT_SIZE_FIELDS
+    )
+
+
 def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--hf_model_name_or_path", type=str, required=True)
@@ -544,6 +563,17 @@ def main(args: argparse.Namespace):
         pruning_config["max_width_pruning"] = args.max_width_pruning
         pruning_config["max_depth_pruning"] = args.max_depth_pruning
         pruning_config["hparams_to_skip"] = args.hparams_to_skip
+        # DeepSeek-style MoE configs size the shared expert as n_shared_experts * moe_intermediate_size,
+        # so only candidates whose shared size is a multiple of the routed one can be saved to HF.
+        src_hf_cfg = bridge.hf_pretrained.config
+        if _is_deepseek_style_moe(getattr(src_hf_cfg, "text_config", src_hf_cfg)):
+            warn_rank_0(
+                "DeepSeek-style MoE config detected: restricting the search to candidates whose "
+                "moe_shared_expert_intermediate_size is a multiple of moe_ffn_hidden_size."
+            )
+            pruning_config["candidate_filter"] = lambda cfg: (
+                cfg["moe_shared_expert_intermediate_size"] % cfg["moe_ffn_hidden_size"] == 0
+            )
         pruning_config["top_k"] = args.top_k
         # memory_mb constraint requires batch_size and seq_length
         pruning_config["batch_size"] = args.inference_batch_size
@@ -610,24 +640,25 @@ def main(args: argparse.Namespace):
             text_cfg.mamba_head_dim = mcore_cfg.mamba_head_dim
         if hasattr(text_cfg, "moe_intermediate_size"):
             text_cfg.moe_intermediate_size = mcore_cfg.moe_ffn_hidden_size
-        # HF names this field with or without the ``moe_`` prefix depending on the model
-        # (e.g. Qwen3.5-MoE uses ``shared_expert_intermediate_size``).
-        has_explicit_shared_size = False
-        for shared_expert_field in (
-            "moe_shared_expert_intermediate_size",
-            "shared_expert_intermediate_size",
-        ):
+        for shared_expert_field in _SHARED_EXPERT_SIZE_FIELDS:
             if hasattr(text_cfg, shared_expert_field):
                 setattr(
                     text_cfg, shared_expert_field, mcore_cfg.moe_shared_expert_intermediate_size
                 )
-                has_explicit_shared_size = True
         if hasattr(text_cfg, "num_experts"):
             text_cfg.num_experts = mcore_cfg.num_moe_experts
         if hasattr(text_cfg, "n_routed_experts"):
             text_cfg.n_routed_experts = mcore_cfg.num_moe_experts
-        # n_shared_experts is a fixed count; only DeepSeek-style configs re-derive it from sizes.
-        if hasattr(text_cfg, "n_shared_experts") and not has_explicit_shared_size:
+        # n_shared_experts is a fixed count; only DeepSeek-style configs record the pruned shared
+        # expert size through it and must re-derive it. candidate_filter keeps the search divisible,
+        # so only a --prune_export_config the filter never saw can violate this.
+        if _is_deepseek_style_moe(text_cfg):
+            if mcore_cfg.moe_shared_expert_intermediate_size % mcore_cfg.moe_ffn_hidden_size:
+                raise ValueError(
+                    f"{mcore_cfg.moe_shared_expert_intermediate_size=} must be a multiple of "
+                    f"{mcore_cfg.moe_ffn_hidden_size=} for this config, which stores the shared "
+                    "expert size as n_shared_experts * moe_intermediate_size. "
+                )
             text_cfg.n_shared_experts = (
                 mcore_cfg.moe_shared_expert_intermediate_size // mcore_cfg.moe_ffn_hidden_size
             )
@@ -677,18 +708,25 @@ def main(args: argparse.Namespace):
             if hasattr(text_cfg, field):
                 setattr(text_cfg, field, 0)
 
-        # Config-only bridge (hf_keys=None) so the embedding task is not dropped when transformers'
-        # saved key differs from the bridge mapping (NemotronH's backbone.embedding vs ...embeddings).
+        # Preferred path for all non-VLMs: a config-only bridge (hf_keys=None) keeps the embedding
+        # task when transformers' saved key differs from the bridge mapping (NemotronH's
+        # backbone.embedding vs ...embeddings), and builds no dummy model.
         # VLMs and older builds fall back to a dummy HF model that supplies the expected HF key names.
-        if (
-            hasattr(AutoBridge, "from_hf_config")
-            and hasattr(AutoBridge, "from_auto_config")
-            and not is_vlm
-        ):
-            AutoBridge.from_hf_config(hf_cfg).save_hf_pretrained(
+        if hasattr(AutoBridge, "from_hf_config") and not is_vlm:
+            pruned_bridge = AutoBridge.from_hf_config(hf_cfg)
+            # save_hf_pretrained reads trust_remote_code off the bridge to fetch source artifacts;
+            # from_hf_config can't infer it since AutoConfig consumes the kwarg.
+            pruned_bridge.trust_remote_code = args.trust_remote_code
+            pruned_bridge.save_hf_pretrained(
                 model, args.output_hf_path, source_path=args.hf_model_name_or_path
             )
         else:
+            if not is_vlm:
+                warn_rank_0(
+                    "Megatron-Bridge lacks config-only HF export (needs nemo:26.08+); falling back "
+                    "to the dummy-model path, which cannot round-trip a pruned native NemotronH "
+                    "config. Use transformers<5 or a newer container if the save fails."
+                )
             dummy_model_cls = AutoModelForImageTextToText if is_vlm else AutoModelForCausalLM
             dummy_model_cls.from_config(
                 hf_cfg, trust_remote_code=args.trust_remote_code

--- a/examples/megatron_bridge/quantize.py
+++ b/examples/megatron_bridge/quantize.py
@@ -454,5 +454,7 @@ if __name__ == "__main__":
     args = get_args()
     try:
         main(args)
+    except BaseException:
+        dist.abort()  # peers may be stuck in a collective this rank will never reach
     finally:
         dist.cleanup()

--- a/modelopt/torch/prune/plugins/mcore_minitron.py
+++ b/modelopt/torch/prune/plugins/mcore_minitron.py
@@ -258,7 +258,8 @@ class MCoreMinitronSearcher(BaseSearcher):
     - `hparams_to_skip`: List of hparams to skip during the search (default: None).
     - `candidate_filter`: Callable rejecting candidate configs the caller cannot use, e.g. ones
         their checkpoint format cannot represent (default: None). Receives every supported hparam,
-        with non-searched ones filled in from the model config. Like `score_func`, it is assumed
+        with non-searched ones filled in from the model config (unset ones are omitted, so a
+        filter using them raises `KeyError`). Like `score_func`, it is assumed
         unchanged when resuming from a `checkpoint`, since rejected candidates are not cached.
     - `top_k`: Number of candidates to consider for score_func validation (default: 10).
     - `seq_length`: Sequence length for KV-cache memory estimate (default: 4096).
@@ -556,12 +557,11 @@ class MCoreMinitronSearcher(BaseSearcher):
                 max_depth_pruning,
                 hparams_to_skip,
             )
-            # Hparams are searched independently, so this is the only place to reject invalid
-            # *combinations*. Non-searched hparams keep their model config value.
+            # Only place to reject invalid hparam *combinations*; unsearched ones come from config.
             base_config = {
                 hp: getattr(self.model.config, hp)
                 for hp in SUPPORTED_HPARAMS
-                if hasattr(self.model.config, hp)
+                if getattr(self.model.config, hp, None) is not None
             }
             selected = []
             num_filtered = 0
@@ -584,7 +584,9 @@ class MCoreMinitronSearcher(BaseSearcher):
                     )
             if num_filtered:
                 print_rank_0(f"Rejected {num_filtered} candidates via candidate_filter.")
-            assert len(selected) > 0, "No subnets found fitting the constraints!"
+            assert len(selected) > 0, "No subnets found fitting the constraints!" + (
+                f" candidate_filter rejected all {num_filtered} candidates." if num_filtered else ""
+            )
             print_rank_0(f"Found {len(selected)} candidates fitting the constraints!")
             self.all_candidates_per_constraint[constraints_cache_key] = sorted(
                 selected, key=lambda x: x.metrics[primary_key], reverse=True

--- a/modelopt/torch/prune/plugins/mcore_minitron.py
+++ b/modelopt/torch/prune/plugins/mcore_minitron.py
@@ -257,7 +257,8 @@ class MCoreMinitronSearcher(BaseSearcher):
     - `hparams_to_skip`: List of hparams to skip during the search (default: None).
     - `candidate_filter`: Callable rejecting candidate configs the caller cannot use, e.g. ones
         their checkpoint format cannot represent (default: None). Receives every supported hparam,
-        with non-searched ones filled in from the model config.
+        with non-searched ones filled in from the model config. Like `score_func`, it is assumed
+        unchanged when resuming from a `checkpoint`, since rejected candidates are not cached.
     - `top_k`: Number of candidates to consider for score_func validation (default: 10).
     - `seq_length`: Sequence length for KV-cache memory estimate (default: 4096).
         Only used with the ``memory_mb`` constraint.
@@ -545,17 +546,6 @@ class MCoreMinitronSearcher(BaseSearcher):
         )
 
         # 2. Perform grid-search over the search space to find subnets fitting all constraints
-        # Hparams are searched independently, so candidate_filter is the only place a caller can
-        # reject invalid *combinations*. Non-searched hparams keep their model config value.
-        base_config = {
-            hp: getattr(self.model.config, hp)
-            for hp in SUPPORTED_HPARAMS
-            if hasattr(self.model.config, hp)
-        }
-
-        def accept_candidate(ss_config: dict) -> bool:
-            return candidate_filter is None or candidate_filter({**base_config, **ss_config})
-
         constraints_cache_key = tuple((k, max_metrics[k]) for k in active_metric_keys)
         if constraints_cache_key not in self.all_candidates_per_constraint:
             max_num_layers = self.model.get_hparam("num_layers").max
@@ -565,6 +555,13 @@ class MCoreMinitronSearcher(BaseSearcher):
                 max_depth_pruning,
                 hparams_to_skip,
             )
+            # Hparams are searched independently, so this is the only place to reject invalid
+            # *combinations*. Non-searched hparams keep their model config value.
+            base_config = {
+                hp: getattr(self.model.config, hp)
+                for hp in SUPPORTED_HPARAMS
+                if hasattr(self.model.config, hp)
+            }
             selected = []
             num_filtered = 0
             for ss_config in tqdm(
@@ -572,7 +569,9 @@ class MCoreMinitronSearcher(BaseSearcher):
                 desc="Finding all candidates fitting the constraints...",
                 disable=not dist.is_master(),
             ):
-                if not accept_candidate(ss_config):
+                if candidate_filter is not None and not candidate_filter(
+                    {**base_config, **ss_config}
+                ):
                     num_filtered += 1
                     continue
                 candidate_metrics = self._compute_candidate_metrics(ss_config, max_num_layers)
@@ -592,14 +591,6 @@ class MCoreMinitronSearcher(BaseSearcher):
             self.save_search_checkpoint(verbose=True)
         else:
             print_rank_0(f"\nUsing top {top_k} candidates from checkpoint")
-            # Candidates are cached by constraints only, so re-apply the filter in case the
-            # checkpoint was written by a run with a different one (or none).
-            cached = self.all_candidates_per_constraint[constraints_cache_key]
-            kept = [c for c in cached if accept_candidate(c.ss_config)]
-            if len(kept) < len(cached):
-                print_rank_0(f"Rejected {len(cached) - len(kept)} checkpoint candidates.")
-                assert kept, "candidate_filter rejected every candidate from the checkpoint!"
-                self.all_candidates_per_constraint[constraints_cache_key] = kept
         top_k_candidates = self.all_candidates_per_constraint[constraints_cache_key][:top_k]
 
         table = Table(title=f"Top {top_k} Candidates", show_header=True, header_style="bold")

--- a/modelopt/torch/prune/plugins/mcore_minitron.py
+++ b/modelopt/torch/prune/plugins/mcore_minitron.py
@@ -255,6 +255,9 @@ class MCoreMinitronSearcher(BaseSearcher):
     - `max_depth_pruning`: Maximum fraction per depth hyperparameter to prune (default: 0.20).
         Only top (1 - max_depth_pruning) choices will be considered.
     - `hparams_to_skip`: List of hparams to skip during the search (default: None).
+    - `candidate_filter`: Callable rejecting candidate configs the caller cannot use, e.g. ones
+        their checkpoint format cannot represent (default: None). Receives every supported hparam,
+        with non-searched ones filled in from the model config.
     - `top_k`: Number of candidates to consider for score_func validation (default: 10).
     - `seq_length`: Sequence length for KV-cache memory estimate (default: 4096).
         Only used with the ``memory_mb`` constraint.
@@ -280,6 +283,7 @@ class MCoreMinitronSearcher(BaseSearcher):
             "max_width_pruning": 0.40,
             "max_depth_pruning": 0.20,
             "hparams_to_skip": None,
+            "candidate_filter": None,
             "top_k": 10,
             # Memory footprint config (only used with memory_mb constraint)
             "seq_length": 4096,
@@ -521,6 +525,7 @@ class MCoreMinitronSearcher(BaseSearcher):
         max_width_pruning = self.config["max_width_pruning"]
         max_depth_pruning = self.config["max_depth_pruning"]
         hparams_to_skip = self.config["hparams_to_skip"]
+        candidate_filter = self.config["candidate_filter"]
         top_k = self.config["top_k"]
         constraints_str = ", ".join(f"{self._fmt_metric(v, k)} {k}" for k, v in max_metrics.items())
         print_rank_0(f"\nSearching for the best pruned architecture under {constraints_str}...")
@@ -540,6 +545,17 @@ class MCoreMinitronSearcher(BaseSearcher):
         )
 
         # 2. Perform grid-search over the search space to find subnets fitting all constraints
+        # Hparams are searched independently, so candidate_filter is the only place a caller can
+        # reject invalid *combinations*. Non-searched hparams keep their model config value.
+        base_config = {
+            hp: getattr(self.model.config, hp)
+            for hp in SUPPORTED_HPARAMS
+            if hasattr(self.model.config, hp)
+        }
+
+        def accept_candidate(ss_config: dict) -> bool:
+            return candidate_filter is None or candidate_filter({**base_config, **ss_config})
+
         constraints_cache_key = tuple((k, max_metrics[k]) for k in active_metric_keys)
         if constraints_cache_key not in self.all_candidates_per_constraint:
             max_num_layers = self.model.get_hparam("num_layers").max
@@ -550,11 +566,15 @@ class MCoreMinitronSearcher(BaseSearcher):
                 hparams_to_skip,
             )
             selected = []
+            num_filtered = 0
             for ss_config in tqdm(
                 search_space_configs,
                 desc="Finding all candidates fitting the constraints...",
                 disable=not dist.is_master(),
             ):
+                if not accept_candidate(ss_config):
+                    num_filtered += 1
+                    continue
                 candidate_metrics = self._compute_candidate_metrics(ss_config, max_num_layers)
                 if all(candidate_metrics[k] <= max_metrics[k] for k in active_metric_keys):
                     selected.append(
@@ -562,6 +582,8 @@ class MCoreMinitronSearcher(BaseSearcher):
                             ss_config, {k: candidate_metrics[k] for k in active_metric_keys}, None
                         )
                     )
+            if num_filtered:
+                print_rank_0(f"Rejected {num_filtered} candidates via candidate_filter.")
             assert len(selected) > 0, "No subnets found fitting the constraints!"
             print_rank_0(f"Found {len(selected)} candidates fitting the constraints!")
             self.all_candidates_per_constraint[constraints_cache_key] = sorted(
@@ -570,6 +592,14 @@ class MCoreMinitronSearcher(BaseSearcher):
             self.save_search_checkpoint(verbose=True)
         else:
             print_rank_0(f"\nUsing top {top_k} candidates from checkpoint")
+            # Candidates are cached by constraints only, so re-apply the filter in case the
+            # checkpoint was written by a run with a different one (or none).
+            cached = self.all_candidates_per_constraint[constraints_cache_key]
+            kept = [c for c in cached if accept_candidate(c.ss_config)]
+            if len(kept) < len(cached):
+                print_rank_0(f"Rejected {len(cached) - len(kept)} checkpoint candidates.")
+                assert kept, "candidate_filter rejected every candidate from the checkpoint!"
+                self.all_candidates_per_constraint[constraints_cache_key] = kept
         top_k_candidates = self.all_candidates_per_constraint[constraints_cache_key][:top_k]
 
         table = Table(title=f"Top {top_k} Candidates", show_header=True, header_style="bold")

--- a/modelopt/torch/prune/plugins/mcore_minitron.py
+++ b/modelopt/torch/prune/plugins/mcore_minitron.py
@@ -47,6 +47,7 @@ from megatron.core.tensor_parallel import (
     gather_from_tensor_model_parallel_region,
     reduce_from_tensor_model_parallel_region,
 )
+from megatron.core.transformer.multi_latent_attention import MLASelfAttention
 from pydantic import create_model
 from rich.console import Console
 from rich.markup import escape as rich_escape
@@ -973,6 +974,25 @@ class MCoreMinitronModeDescriptor(ModeDescriptor):
         return restore_mcore_minitron
 
 
+def _fused_ln_linears_over_hidden_size(module: nn.Module):
+    """Yield fused-layernorm linears whose layernorm is over ``hidden_size``.
+
+    MLA's Q/KV up-projections are ``TELayerNormColumnParallelLinear`` too, but their layernorm is
+    over the latent rank and MCore unpacks their output as ``(out, bias)``. Setting
+    ``return_layernorm_output`` there makes it ``((out, ln_out), bias)`` and breaks the forward.
+    """
+    up_projs = {
+        id(sub)
+        for m in module.modules()
+        if isinstance(m, MLASelfAttention)
+        for attr in ("linear_q_up_proj", "linear_kv_up_proj")
+        if (sub := getattr(m, attr, None)) is not None
+    }
+    for m in module.modules():
+        if isinstance(m, TELayerNormColumnParallelLinear) and id(m) not in up_projs:
+            yield m
+
+
 class ImportanceEstimatorRegistry:
     """Register importance estimators and forward hooks for all supported modules in the model.
 
@@ -1055,9 +1075,8 @@ class ImportanceEstimatorRegistry:
         self._hooks.clear()
 
         # Unpatch return_layernorm_output on fused TELayerNormColumnParallelLinear modules
-        for m in self.model.modules():
-            if isinstance(m, TELayerNormColumnParallelLinear):
-                m.return_layernorm_output = False
+        for m in _fused_ln_linears_over_hidden_size(self.model):
+            m.return_layernorm_output = False
 
     def get_layer_scores(self) -> dict[int, torch.Tensor]:
         """Get the layer scores (1-indexed) from the model.
@@ -1187,9 +1206,8 @@ def _register_hidden_size_importance(
     # Layernorms are fused into TELayerNormColumnParallelLinear. We temporarily
     # patch return_layernorm_output=True so TE's fused kernel returns the layernorm output.
     # For MoE layers, pre_mlp_layernorm is a separate TENorm — use a regular forward hook.
-    for m in module.modules():
-        if isinstance(m, TELayerNormColumnParallelLinear):
-            m.return_layernorm_output = True
+    for m in _fused_ln_linears_over_hidden_size(module):
+        m.return_layernorm_output = True
 
     for layer in module.decoder.layers:
         if isinstance(layer, _DynamicTransformerLayer):

--- a/modelopt/torch/utils/distributed.py
+++ b/modelopt/torch/utils/distributed.py
@@ -18,7 +18,9 @@
 import functools
 import io
 import os
+import sys
 import time
+import traceback
 from collections.abc import Callable
 from contextlib import suppress
 from datetime import timedelta
@@ -212,11 +214,36 @@ def setup(timeout: timedelta | None = None):
 
 
 def cleanup():
-    """Cleans up the distributed environment."""
+    """Cleans up the distributed environment.
+
+    The barrier is skipped when unwinding from an error, since peers may be blocked in a collective
+    this rank will never reach. ``SystemExit`` is treated as a clean exit (every rank reaches it).
+    Prefer :func:`abort` on error paths.
+    """
     if is_initialized():
-        with suppress(Exception):
-            barrier()
+        exc = sys.exc_info()[1]
+        if exc is None or isinstance(exc, SystemExit):
+            with suppress(Exception):
+                barrier()
         torch.distributed.destroy_process_group()
+
+
+def abort(exit_code: int = 1) -> None:
+    """Print the active exception and exit this rank immediately.
+
+    Call from an ``except`` block in a distributed entrypoint. Both a barrier and
+    ``destroy_process_group`` stall when peers are blocked in a collective this rank will never
+    reach, and the traceback only prints once the enclosing ``finally`` returns -- so the run looks
+    hung rather than failed. Exiting lets the launcher (e.g. torchrun) terminate the peers.
+    ``SystemExit`` is re-raised instead, since every rank reaches an intentional exit.
+    """
+    exc = sys.exc_info()[1]
+    if isinstance(exc, SystemExit):
+        raise exc
+    traceback.print_exc()
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(exit_code)
 
 
 def is_fsdp2_model(model) -> bool:

--- a/modelopt/torch/utils/distributed.py
+++ b/modelopt/torch/utils/distributed.py
@@ -218,7 +218,8 @@ def cleanup():
 
     The barrier is skipped when unwinding from an error, since peers may be blocked in a collective
     this rank will never reach. ``SystemExit`` is treated as a clean exit (every rank reaches it).
-    Prefer :func:`abort` on error paths.
+    That is not sufficient on its own -- ``destroy_process_group`` below blocks for the same reason
+    -- so error paths must call :func:`abort` before reaching this ``finally``.
     """
     if is_initialized():
         exc = sys.exc_info()[1]

--- a/tests/_test_utils/examples/megatron_bridge.py
+++ b/tests/_test_utils/examples/megatron_bridge.py
@@ -31,12 +31,11 @@ def qwen35_moe_bridge_supported() -> bool:
 def config_only_hf_export_supported() -> bool:
     """Whether AutoBridge supports config-only HF export (from_hf_config), i.e. nemo:26.08+.
 
-    Native NemotronH HF export needs this; the older dummy-model path does not round-trip the
-    pruned config. Mount an updated MBridge to run these on 26.06.
+    Keep in sync with prune_minitron.py. Mount an updated MBridge to run these on 26.06.
     """
     try:
         from megatron.bridge import AutoBridge
 
-        return hasattr(AutoBridge, "from_hf_config") and hasattr(AutoBridge, "from_auto_config")
+        return hasattr(AutoBridge, "from_hf_config")
     except Exception:
         return False

--- a/tests/_test_utils/examples/megatron_bridge.py
+++ b/tests/_test_utils/examples/megatron_bridge.py
@@ -26,3 +26,17 @@ def qwen35_moe_bridge_supported() -> bool:
         return hasattr(model_bridge, "_fuse_per_expert_hf_weight")
     except Exception:
         return False
+
+
+def config_only_hf_export_supported() -> bool:
+    """Whether AutoBridge supports config-only HF export (from_hf_config), i.e. nemo:26.08+.
+
+    Native NemotronH HF export needs this; the older dummy-model path does not round-trip the
+    pruned config. Mount an updated MBridge to run these on 26.06.
+    """
+    try:
+        from megatron.bridge import AutoBridge
+
+        return hasattr(AutoBridge, "from_hf_config") and hasattr(AutoBridge, "from_auto_config")
+    except Exception:
+        return False

--- a/tests/_test_utils/examples/megatron_bridge.py
+++ b/tests/_test_utils/examples/megatron_bridge.py
@@ -26,16 +26,3 @@ def qwen35_moe_bridge_supported() -> bool:
         return hasattr(model_bridge, "_fuse_per_expert_hf_weight")
     except Exception:
         return False
-
-
-def config_only_hf_export_supported() -> bool:
-    """Whether AutoBridge supports config-only HF export (from_hf_config), i.e. nemo:26.08+.
-
-    Keep in sync with prune_minitron.py. Mount an updated MBridge to run these on 26.06.
-    """
-    try:
-        from megatron.bridge import AutoBridge
-
-        return hasattr(AutoBridge, "from_hf_config")
-    except Exception:
-        return False

--- a/tests/examples/megatron_bridge/test_prune_minitron.py
+++ b/tests/examples/megatron_bridge/test_prune_minitron.py
@@ -16,7 +16,10 @@
 
 import pytest
 import torch
-from _test_utils.examples.megatron_bridge import qwen35_moe_bridge_supported
+from _test_utils.examples.megatron_bridge import (
+    config_only_hf_export_supported,
+    qwen35_moe_bridge_supported,
+)
 from _test_utils.examples.run_command import extend_cmd_parts, run_example_command
 from _test_utils.torch.transformers_models import (
     create_tiny_gemma3vl_dir,
@@ -28,20 +31,20 @@ from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
 
 
 @pytest.mark.parametrize(
-    ("create_teacher", "megatron_format"),
+    ("create_teacher", "expected_pruned_config"),
     [
-        # Dense Qwen3 LM, exported back to HF (reloadable to verify the pruned param count).
+        # Dense Qwen3 LM.
         pytest.param(
             lambda tmp_path, num_gpus: create_tiny_qwen3_dir(
                 tmp_path, with_tokenizer=True, return_model=True, num_hidden_layers=num_gpus
             ),
-            False,
+            {},
             id="qwen3",
         ),
-        # NemotronH (nemotron-3-nano): Mamba + attention + MoE hybrid. Saved in Megatron checkpoint
-        # format because HF export of a pruned NemotronH requires transformers<5.
-        # MTP heads are enabled so the run covers dropping them during calibration and the
-        # hybrid pattern MCore builds for them.
+        # NemotronH (nemotron-3-nano): Mamba + attention + MoE hybrid.
+        # MTP heads are enabled so the run covers dropping them during calibration. HF export of a
+        # native NemotronH needs the config-only bridge (nemo:26.08+); the older dummy-model path
+        # does not round-trip the pruned config.
         pytest.param(
             lambda tmp_path, num_gpus: create_tiny_nemotron_h_dir(
                 tmp_path,
@@ -50,26 +53,26 @@ from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
                 num_nextn_predict_layers=1,
                 mtp_hybrid_override_pattern="*E",
             ),
-            True,
+            {"n_shared_experts": 1},
             id="nemotron_h",
+            marks=pytest.mark.skipif(
+                not config_only_hf_export_supported(),
+                reason="Native NemotronH HF export needs config-only bridge (nemo:26.08+)",
+            ),
         ),
     ],
 )
-def test_prune_minitron(tmp_path, num_gpus, create_teacher, megatron_format):
+def test_prune_minitron(tmp_path, num_gpus, create_teacher, expected_pruned_config):
     teacher_hf_path, teacher_model = create_teacher(tmp_path, num_gpus)
     teacher_params = sum(p.numel() for p in teacher_model.parameters())
     prune_target_params = int(teacher_params * 0.8)
 
     pruned_path = tmp_path / "pruned"
-    output_kwarg = (
-        {"output_megatron_path": pruned_path}
-        if megatron_format
-        else {"output_hf_path": pruned_path}
-    )
     # TODO: Dont enable grouped GEMM for MoE models until nemo:26.08 container
     prune_command_parts = extend_cmd_parts(
         ["torchrun", f"--nproc_per_node={num_gpus}", "prune_minitron.py", "--no_moe_grouped_gemm"],
         hf_model_name_or_path=teacher_hf_path,
+        output_hf_path=pruned_path,
         pp_size=num_gpus,
         calib_dataset_name="cnn_dailymail",
         calib_num_samples=8,
@@ -80,17 +83,14 @@ def test_prune_minitron(tmp_path, num_gpus, create_teacher, megatron_format):
         ss_channel_divisor=4,
         hparams_to_skip="num_attention_heads",
         top_k=1,
-        **output_kwarg,
     )
     run_example_command(prune_command_parts, example_path="megatron_bridge")
 
-    if megatron_format:
-        # HF reload of a pruned NemotronH needs transformers<5; just verify the Megatron checkpoint.
-        assert (pruned_path / "latest_checkpointed_iteration.txt").exists()
-    else:
-        assert (pruned_path / "config.json").exists()
-        pruned_model = AutoModelForCausalLM.from_pretrained(pruned_path)
-        assert sum(p.numel() for p in pruned_model.parameters()) <= prune_target_params
+    assert (pruned_path / "config.json").exists()
+    pruned_model = AutoModelForCausalLM.from_pretrained(pruned_path)
+    assert sum(p.numel() for p in pruned_model.parameters()) <= prune_target_params
+    for field, expected in expected_pruned_config.items():
+        assert getattr(pruned_model.config, field) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/examples/megatron_bridge/test_prune_minitron.py
+++ b/tests/examples/megatron_bridge/test_prune_minitron.py
@@ -19,6 +19,7 @@ import torch
 from _test_utils.examples.megatron_bridge import qwen35_moe_bridge_supported
 from _test_utils.examples.run_command import extend_cmd_parts, run_example_command
 from _test_utils.torch.transformers_models import (
+    create_tiny_deepseek_v3_dir,
     create_tiny_gemma3vl_dir,
     create_tiny_nemotron_h_dir,
     create_tiny_qwen3_5_moe_vl_dir,
@@ -51,9 +52,23 @@ from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
             {"n_shared_experts": 1},
             id="nemotron_h",
         ),
-        # TODO: Add a DeepSeek-V3 case once MLA pruning supports the Q-LoRA up-projection, which
-        # Megatron-Bridge's DeepSeek mapping requires. candidate_filter is covered by
-        # tests/gpu_megatron/torch/prune/plugins/test_mcore_mamba_minitron_pruning.py.
+        # DeepSeek-V3: MLA (Q-LoRA) + MoE sizing the shared expert as
+        # n_shared_experts * moe_intermediate_size, so it covers candidate_filter end-to-end:
+        # without the filter the search picks a shared size that is not a multiple of the routed
+        # one and the reload below fails on the resulting shape mismatch.
+        pytest.param(
+            # n_group=1 so num_moe_experts stays divisible by it after expert pruning.
+            lambda tmp_path, num_gpus: create_tiny_deepseek_v3_dir(
+                tmp_path,
+                with_tokenizer=True,
+                return_model=True,
+                num_hidden_layers=num_gpus,
+                n_group=1,
+                topk_group=1,
+            ),
+            {"n_shared_experts": 1},
+            id="deepseek_v3",
+        ),
     ],
 )
 def test_prune_minitron(tmp_path, num_gpus, create_teacher, expected_pruned_config):

--- a/tests/examples/megatron_bridge/test_prune_minitron.py
+++ b/tests/examples/megatron_bridge/test_prune_minitron.py
@@ -42,9 +42,8 @@ from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
             id="qwen3",
         ),
         # NemotronH (nemotron-3-nano): Mamba + attention + MoE hybrid.
-        # MTP heads are enabled so the run covers dropping them during calibration. HF export of a
-        # native NemotronH needs the config-only bridge (nemo:26.08+); the older dummy-model path
-        # does not round-trip the pruned config.
+        # MTP heads are enabled so the run covers dropping them during calibration. HF export needs
+        # the config-only bridge (nemo:26.08+), so this is verified locally until CI bumps off 26.06.
         pytest.param(
             lambda tmp_path, num_gpus: create_tiny_nemotron_h_dir(
                 tmp_path,
@@ -60,6 +59,10 @@ from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
                 reason="Native NemotronH HF export needs config-only bridge (nemo:26.08+)",
             ),
         ),
+        # TODO: Add a DeepSeek-V3 case covering candidate_filter end-to-end once MLA pruning
+        # supports the Q-LoRA up-projection (Megatron-Bridge's DeepSeek mapping requires
+        # q_lora_rank, which _DynamicMLASelfAttention does not handle). candidate_filter itself is
+        # covered by tests/gpu_megatron/torch/prune/plugins/test_mcore_mamba_minitron_pruning.py.
     ],
 )
 def test_prune_minitron(tmp_path, num_gpus, create_teacher, expected_pruned_config):

--- a/tests/examples/megatron_bridge/test_prune_minitron.py
+++ b/tests/examples/megatron_bridge/test_prune_minitron.py
@@ -16,10 +16,7 @@
 
 import pytest
 import torch
-from _test_utils.examples.megatron_bridge import (
-    config_only_hf_export_supported,
-    qwen35_moe_bridge_supported,
-)
+from _test_utils.examples.megatron_bridge import qwen35_moe_bridge_supported
 from _test_utils.examples.run_command import extend_cmd_parts, run_example_command
 from _test_utils.torch.transformers_models import (
     create_tiny_gemma3vl_dir,
@@ -42,8 +39,7 @@ from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
             id="qwen3",
         ),
         # NemotronH (nemotron-3-nano): Mamba + attention + MoE hybrid.
-        # MTP heads are enabled so the run covers dropping them during calibration. HF export needs
-        # the config-only bridge (nemo:26.08+), so this is verified locally until CI bumps off 26.06.
+        # MTP heads are enabled so the run covers dropping them during calibration.
         pytest.param(
             lambda tmp_path, num_gpus: create_tiny_nemotron_h_dir(
                 tmp_path,
@@ -54,15 +50,10 @@ from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
             ),
             {"n_shared_experts": 1},
             id="nemotron_h",
-            marks=pytest.mark.skipif(
-                not config_only_hf_export_supported(),
-                reason="Native NemotronH HF export needs config-only bridge (nemo:26.08+)",
-            ),
         ),
-        # TODO: Add a DeepSeek-V3 case covering candidate_filter end-to-end once MLA pruning
-        # supports the Q-LoRA up-projection (Megatron-Bridge's DeepSeek mapping requires
-        # q_lora_rank, which _DynamicMLASelfAttention does not handle). candidate_filter itself is
-        # covered by tests/gpu_megatron/torch/prune/plugins/test_mcore_mamba_minitron_pruning.py.
+        # TODO: Add a DeepSeek-V3 case once MLA pruning supports the Q-LoRA up-projection, which
+        # Megatron-Bridge's DeepSeek mapping requires. candidate_filter is covered by
+        # tests/gpu_megatron/torch/prune/plugins/test_mcore_mamba_minitron_pruning.py.
     ],
 )
 def test_prune_minitron(tmp_path, num_gpus, create_teacher, expected_pruned_config):

--- a/tests/gpu_megatron/torch/prune/plugins/test_mcore_mamba_minitron_pruning.py
+++ b/tests/gpu_megatron/torch/prune/plugins/test_mcore_mamba_minitron_pruning.py
@@ -446,13 +446,32 @@ def _test_mcore_mamba_hybrid_pruning_nas_memory_mb(rank, size, ckpt_dir):
     )
     memory_threshold = baseline_memory_mb * 0.7
 
+    def _shared_is_multiple_of_routed(ss_cfg):
+        return ss_cfg["moe_shared_expert_intermediate_size"] % ss_cfg["moe_ffn_hidden_size"] == 0
+
     constraints = {"memory_mb": memory_threshold}
     config = {
         **_base_nas_config(ckpt_dir),
         "seq_length": sequence_length,
         "batch_size": 1,
+        # moe_shared_expert_intermediate_size is skipped, so the filter sees it via the searcher's
+        # model config fallback: only routed sizes that divide it survive.
+        "candidate_filter": _shared_is_multiple_of_routed,
     }
-    model, searcher_state = prune_minitron(model, constraints, config, _NAS_CHANNEL_DIVISOR)
+    stdout_capture = io.StringIO()
+    with contextlib.redirect_stdout(stdout_capture):
+        model, searcher_state = prune_minitron(model, constraints, config, _NAS_CHANNEL_DIVISOR)
+
+    shared_size = _NAS_MODEL_KWARGS["moe_shared_expert_intermediate_size"]
+    (candidates,) = searcher_state["all_candidates_per_constraint"].values()
+    assert all(shared_size % c.ss_config["moe_ffn_hidden_size"] == 0 for c in candidates)
+    if rank == 0:
+        # Half of the 512-combo search space: moe_ffn_hidden_size is [12, 16] and only 16 divides the
+        # (skipped, so unpruned) moe_shared_expert_intermediate_size of 16.
+        output = stdout_capture.getvalue()
+        match = re.search(r"Rejected (\d+) candidates", output)
+        assert match, f"candidate_filter rejected nothing:\n{output}"
+        assert int(match.group(1)) == 256, output
 
     pruned_params, _ = mcore_param_count(
         model.config,
@@ -465,17 +484,19 @@ def _test_mcore_mamba_hybrid_pruning_nas_memory_mb(rank, size, ckpt_dir):
     sorted_layers = _get_sorted_layers(searcher_state)
     # fmt: off
     if sorted_layers == [1, 4, 3, 2]:
+        # Every candidate has moe_ffn_hidden_size 16: candidate_filter drops the 12s since they do
+        # not divide the (skipped, so unpruned) moe_shared_expert_intermediate_size of 16.
         expected_top_k = [
-            [{"num_layers": 4, "hidden_size": 12, "mamba_num_heads": 8, "mamba_head_dim": 16, "num_moe_experts": 6, "moe_ffn_hidden_size": 12, "ffn_hidden_size": 24}, {"memory_mb": 0.0226287841796875},    114],  # noqa: E501
             [{"num_layers": 4, "hidden_size": 12, "mamba_num_heads": 8, "mamba_head_dim": 12, "num_moe_experts": 8, "moe_ffn_hidden_size": 16, "ffn_hidden_size": 32}, {"memory_mb": 0.022613525390625},     124],  # noqa: E501
             [{"num_layers": 4, "hidden_size": 12, "mamba_num_heads": 6, "mamba_head_dim": 16, "num_moe_experts": 8, "moe_ffn_hidden_size": 16, "ffn_hidden_size": 32}, {"memory_mb": 0.022556304931640625},  126],  # noqa: E501
-            [{"num_layers": 4, "hidden_size": 16, "mamba_num_heads": 6, "mamba_head_dim": 12, "num_moe_experts": 7, "moe_ffn_hidden_size": 12, "ffn_hidden_size": 24}, {"memory_mb": 0.022541046142578125},  113],  # noqa: E501
-            [{"num_layers": 3, "hidden_size": 16, "mamba_num_heads": 8, "mamba_head_dim": 16, "num_moe_experts": 5, "moe_ffn_hidden_size": 12, "ffn_hidden_size": 20}, {"memory_mb": 0.0225067138671875},    112],  # noqa: E501
             [{"num_layers": 3, "hidden_size": 16, "mamba_num_heads": 8, "mamba_head_dim": 16, "num_moe_experts": 5, "moe_ffn_hidden_size": 16, "ffn_hidden_size": 20}, {"memory_mb": 0.0225067138671875},    116],  # noqa: E501
-            [{"num_layers": 3, "hidden_size": 16, "mamba_num_heads": 8, "mamba_head_dim": 16, "num_moe_experts": 6, "moe_ffn_hidden_size": 12, "ffn_hidden_size": 20}, {"memory_mb": 0.0225067138671875},    113],  # noqa: E501
             [{"num_layers": 3, "hidden_size": 16, "mamba_num_heads": 8, "mamba_head_dim": 16, "num_moe_experts": 6, "moe_ffn_hidden_size": 16, "ffn_hidden_size": 20}, {"memory_mb": 0.0225067138671875},    117],  # noqa: E501
-            [{"num_layers": 3, "hidden_size": 16, "mamba_num_heads": 8, "mamba_head_dim": 16, "num_moe_experts": 7, "moe_ffn_hidden_size": 12, "ffn_hidden_size": 20}, {"memory_mb": 0.0225067138671875},    114],  # noqa: E501
             [{"num_layers": 3, "hidden_size": 16, "mamba_num_heads": 8, "mamba_head_dim": 16, "num_moe_experts": 7, "moe_ffn_hidden_size": 16, "ffn_hidden_size": 20}, {"memory_mb": 0.0225067138671875},    118],  # noqa: E501
+            [{"num_layers": 3, "hidden_size": 16, "mamba_num_heads": 8, "mamba_head_dim": 16, "num_moe_experts": 8, "moe_ffn_hidden_size": 16, "ffn_hidden_size": 20}, {"memory_mb": 0.0225067138671875},    119],  # noqa: E501
+            [{"num_layers": 4, "hidden_size": 16, "mamba_num_heads": 6, "mamba_head_dim": 12, "num_moe_experts": 5, "moe_ffn_hidden_size": 16, "ffn_hidden_size": 28}, {"memory_mb": 0.022480010986328125},  119],  # noqa: E501
+            [{"num_layers": 4, "hidden_size": 12, "mamba_num_heads": 8, "mamba_head_dim": 12, "num_moe_experts": 8, "moe_ffn_hidden_size": 16, "ffn_hidden_size": 28}, {"memory_mb": 0.022430419921875},     120],  # noqa: E501
+            [{"num_layers": 4, "hidden_size": 12, "mamba_num_heads": 6, "mamba_head_dim": 16, "num_moe_experts": 8, "moe_ffn_hidden_size": 16, "ffn_hidden_size": 28}, {"memory_mb": 0.022373199462890625},  122],  # noqa: E501
+            [{"num_layers": 4, "hidden_size": 12, "mamba_num_heads": 8, "mamba_head_dim": 12, "num_moe_experts": 8, "moe_ffn_hidden_size": 16, "ffn_hidden_size": 24}, {"memory_mb": 0.022247314453125},     116],  # noqa: E501
         ]
     else:
         raise RuntimeError(f"FIXME: Non deterministic test, assertions may fail: {sorted_layers=}")

--- a/tests/gpu_megatron/torch/prune/plugins/test_mcore_mamba_minitron_pruning.py
+++ b/tests/gpu_megatron/torch/prune/plugins/test_mcore_mamba_minitron_pruning.py
@@ -454,8 +454,8 @@ def _test_mcore_mamba_hybrid_pruning_nas_memory_mb(rank, size, ckpt_dir):
         **_base_nas_config(ckpt_dir),
         "seq_length": sequence_length,
         "batch_size": 1,
-        # moe_shared_expert_intermediate_size is skipped, so the filter sees it via the searcher's
-        # model config fallback: only routed sizes that divide it survive.
+        # moe_shared_expert_intermediate_size is skipped, so the filter reads it from the model
+        # config: only routed sizes that divide it survive.
         "candidate_filter": _shared_is_multiple_of_routed,
     }
     stdout_capture = io.StringIO()
@@ -484,8 +484,7 @@ def _test_mcore_mamba_hybrid_pruning_nas_memory_mb(rank, size, ckpt_dir):
     sorted_layers = _get_sorted_layers(searcher_state)
     # fmt: off
     if sorted_layers == [1, 4, 3, 2]:
-        # Every candidate has moe_ffn_hidden_size 16: candidate_filter drops the 12s since they do
-        # not divide the (skipped, so unpruned) moe_shared_expert_intermediate_size of 16.
+        # All moe_ffn_hidden_size 16: the 12s do not divide the unpruned shared size of 16.
         expected_top_k = [
             [{"num_layers": 4, "hidden_size": 12, "mamba_num_heads": 8, "mamba_head_dim": 12, "num_moe_experts": 8, "moe_ffn_hidden_size": 16, "ffn_hidden_size": 32}, {"memory_mb": 0.022613525390625},     124],  # noqa: E501
             [{"num_layers": 4, "hidden_size": 12, "mamba_num_heads": 6, "mamba_head_dim": 16, "num_moe_experts": 8, "moe_ffn_hidden_size": 16, "ffn_hidden_size": 32}, {"memory_mb": 0.022556304931640625},  126],  # noqa: E501


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix + new feature

Two model families that could not be pruned end-to-end now can:

- **Nemotron-3.5-Lightning** (`nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16`) — a native `NemotronHForCausalLM` that ships without remote code and carries MTP heads. Fixes a calibration crash and HF-export failures on the modern Megatron-Bridge / transformers stack.
- **DeepSeek-V3** — fixes an MLA Q-LoRA crash during calibration, and adds a `candidate_filter` search option to `mcore_minitron` so its MoE-FFN dimensions stay prunable while remaining representable in HF.

Also makes a rank-local failure under pipeline parallelism fail fast instead of stalling.

#### 1. Nemotron Lightning: prune + HF export (`examples/megatron_bridge/prune_minitron.py`)

1. **MTP calibration crash.** On newer Megatron-LM, `mtp_process` is derived from the hybrid *pattern*, not from `mtp_num_layers`. Setting only `mtp_num_layers=0` in the calibration provider overrides was insufficient: the provider's `finalize()` re-appended the MTP suffix to `hybrid_layer_pattern` (because `mtp_hybrid_override_pattern` was still set and `mtp_use_repeated_layer=True`), so `mtp_process=True` while `mtp_num_layers=0` and the calibration forward hit `assert self.config.mtp_num_layers > 0`. Fix: also clear `mtp_hybrid_override_pattern` in the calibration overrides so MTP is fully disabled (MTP heads are dropped from the pruned model, as before).

2. **HF export via a config-only bridge (hybrid models only).** The old export built a *dummy* HF model to obtain the bridge, then streamed weights. This breaks on native NemotronH because (a) native `NemotronHConfig` makes `hybrid_override_pattern` a read-only property, and (b) transformers 5.12 saves the input embedding under a different key than the bridge mapping expects (`backbone.embedding` vs `backbone.embeddings`); the mismatch made `build_conversion_tasks` drop the embedding task on its owning rank, leaving an owner-less PP placeholder that crashed `save_hf_weights` with `Object must exist on at least one PP rank`. Fix: stream weights through a **config-only** bridge (`AutoBridge.from_hf_config(hf_cfg).save_hf_pretrained(...)`), available since Megatron-Bridge 0.5.0 (nemo:26.06). A config-only bridge has `hf_keys=None`, so the embedding task is never dropped, no dummy model is built, and the output uses the canonical HF key names.

   This is **restricted to hybrid providers**, which are the only models that need it; non-hybrids keep the dummy-model path that CI has always exercised.

   Writing the source artifacts is now rank-0-only. Every rank used to write the source `config.json`, which races with the pruned `config.json` that `save_hf_pretrained` writes from rank 0 alone: a late write from another rank leaves a checkpoint whose config does not match its weights. This reproduced intermittently on both Qwen3 and NemotronH before the fix, and 3/3 clean runs after.

   `save_hf_pretrained` takes no `trust_remote_code` argument — it reads the flag **off the bridge** to fetch the source checkpoint's artifacts, and `from_hf_config` cannot infer it because `AutoConfig.from_pretrained` consumes the kwarg rather than storing it on the config. So the flag is set explicitly on the bridge instance; otherwise remote-code models would silently lose it.

3. **Config write-back correctness:**
   - `hybrid_override_pattern` is only written for older remote-code configs that lack `layer_types`; native configs carry the cadence in `layer_types` (read-only `hybrid_override_pattern` is skipped).
   - `n_shared_experts` is preserved (a fixed count) instead of being re-derived by `moe_shared_expert_intermediate_size // moe_ffn_hidden_size`, which is DeepSeek-style logic that would corrupt NemotronH's count.

Non-hybrids, VLMs, and Megatron-Bridge builds without config-only export keep the dummy-model path, with a `warn_rank_0` when a hybrid has to fall back. The README's `transformers<5` workaround is **removed**: it existed because the dummy-model path broke on transformers 5, and the config-only path handles NemotronH on every supported container.

#### 2. `candidate_filter` for `mcore_minitron` (`modelopt/torch/prune/plugins/mcore_minitron.py`)

DeepSeek-style MoE configs have no explicit shared-expert-size field: they size the shared expert as `n_shared_experts * moe_intermediate_size`, where `moe_intermediate_size` is the (also prunable) **routed** expert size. So only candidates with `moe_shared_expert_intermediate_size % moe_ffn_hidden_size == 0` can be written back to HF at all.

Candidates come from a Cartesian `product()` of independent per-hparam choice lists, so no per-hparam restriction can express a constraint *between* two hparams. New optional `candidate_filter` search-config key (default `None`, so existing behaviour is unchanged): a callable that rejects candidate configs before the metric computation, making the search cheaper rather than more expensive. It receives **every** supported hparam, with non-searched ones filled in from the model config, so a filter still works when one of its hparams was skipped or had a single choice.

Rejected candidates are not cached, so — like `score_func`, whose cached scores are reused without re-validation — the filter is assumed unchanged when resuming from a `checkpoint`.

`prune_minitron.py` wires this up for DeepSeek-style configs, so **both** `moe_ffn_hidden_size` and `moe_shared_expert_intermediate_size` stay prunable (the search then only picks shared sizes that are a multiple of the routed one). A `--prune_export_config` that violates the constraint never reaches the filter, so the export path now raises `ValueError` instead of writing a checkpoint whose config disagrees with its weights.

#### 3. MLA Q-LoRA pruning (`modelopt/torch/prune/plugins/mcore_minitron.py`)

Pruning any MLA model with `q_lora_rank` set died during calibration with `AttributeError: 'tuple' object has no attribute 'view'`.

`hidden_size` importance estimation blanket-patches every `TELayerNormColumnParallelLinear` with `return_layernorm_output=True` to capture post-layernorm activations. When `q_lora_rank` is set, MCore builds `linear_q_up_proj` as a `TELayerNormColumnParallelLinear` — the Q-LoRA layernorm is fused into it, which is why `q_layernorm` is `IdentityOp` — so it was patched too, even though its layernorm is over the **latent rank**, not `hidden_size`. TE then returns `((out, ln_out), bias)` and MCore's `q, _ = self.linear_q_up_proj(...)` leaves `q` a tuple.

Isolated by probing the module before and after dynamic conversion:

| Setup | `linear_q_up_proj` returns | Forward |
| --- | --- | --- |
| Before conversion | `tuple(Tensor, NoneType)` | — |
| After conversion, no hooks | `tuple(Tensor, NoneType)` | OK |
| After conversion **+ importance hooks** | `tuple(tuple(Tensor, Tensor), NoneType)` | AttributeError |

So conversion is innocent; registering the importance hooks is the trigger. Fix: exclude MLA's Q/KV up-projections from both the patch and unpatch loops. `test_mcore_mla_pruning` did not catch this because it builds MLA without `q_lora_rank`, where MCore uses a plain `linear_q_proj` and nothing is patched.

#### 4. Fail fast instead of stalling on a rank-local error under PP (`modelopt/torch/utils/distributed.py`)

A rank raising inside a distributed entrypoint left the whole job stalled until the process group timed out, with **no diagnostic output at all**: the failing rank blocked in `cleanup()`'s barrier while its peers blocked in `recv_from_prev_pipeline_rank_`, and Python only prints a traceback once the enclosing `finally` returns. A crash on one rank was indistinguishable from a slow job.

- `dist.cleanup()` skips the barrier when unwinding from an exception.
- New `dist.abort()` prints the traceback, flushes and exits immediately. Skipping the barrier alone is **not** enough — a stack dump showed the failing rank then blocking in `destroy_process_group` for the same reason — so the error path must not tear the process group down at all. `SystemExit` is re-raised rather than aborted, so an intentional exit (e.g. the `--score_lower_bound` gate) keeps its exit code and prints no traceback. Kept out of `cleanup()` so no library caller gets a surprise process exit.
- Called from the entrypoints that wrap `main()` in `try/finally`: the five `examples/megatron_bridge` scripts.

Measured on a 2-GPU PP run whose rank 0 raises during calibration: **10 min timeout kill with no visible error → 31s, exit 1, real traceback.** This is a latent, pre-existing issue (the `try/finally` predates this PR); it only surfaces on a failing PP run, which is why CI never hit it.

### Usage

```bash
torchrun --nproc_per_node 4 examples/megatron_bridge/prune_minitron.py \
    --hf_model_name_or_path nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16 \
    --pp_size 4 \
    --prune_target_active_params 3e9 \
    --output_hf_path /path/to/Nemotron-3.5-Lightning-30B-A3B-Pruned-A3.0B
```

### Testing

- **End-to-end on nemo:26.08.rc6** (4× GB300, transformers 5.12.1, Megatron-Bridge with config-only export): pruning + export complete (`EXIT=0`, "Saved pruned model … Done!"). The exported checkpoint has canonical **plural** `backbone.embeddings.weight` keys, **0 MTP tensors**, and a config that reloads correctly (`num_hidden_layers=52` from `layers_block_type`, `n_shared_experts=1`, `num_nextn_predict_layers=0`, pruned `hidden_size`/`mamba_*`/MoE dims, reconstructed `hybrid_override_pattern`).

  <details>
  <summary>Pruning search log (<code>--prune_target_active_params 3e9</code>)</summary>

  ```text
                                                                   Top 10 Candidates with Scores
  ┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┓
  ┃  # ┃ export_config                                                                                                         ┃ active_params ┃ params ┃  score ┃
  ┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━┩
  │  1 │ {'num_layers': 46, 'hidden_size': 2560, 'mamba_num_heads': 56, 'mamba_head_dim': 56, 'num_moe_experts': 104,          │         3.00B │ 23.49B │ 0.5406 │
  │    │ 'moe_ffn_hidden_size': 1856, 'moe_shared_expert_intermediate_size': 3584}                                             │               │        │        │
  │  2 │ {'num_layers': 52, 'hidden_size': 2688, 'mamba_num_heads': 56, 'mamba_head_dim': 48, 'num_moe_experts': 96,           │         3.00B │ 20.09B │ 0.2427 │
  │    │ 'moe_ffn_hidden_size': 1536, 'moe_shared_expert_intermediate_size': 3072}                                             │               │        │        │
  │  3 │ {'num_layers': 52, 'hidden_size': 2688, 'mamba_num_heads': 48, 'mamba_head_dim': 56, 'num_moe_experts': 104,          │         3.00B │ 21.61B │ 0.2643 │
  │    │ 'moe_ffn_hidden_size': 1536, 'moe_shared_expert_intermediate_size': 3072}                                             │               │        │        │
  │  4 │ {'num_layers': 52, 'hidden_size': 2560, 'mamba_num_heads': 48, 'mamba_head_dim': 64, 'num_moe_experts': 96,           │         3.00B │ 19.28B │ 0.4552 │
  │    │ 'moe_ffn_hidden_size': 1536, 'moe_shared_expert_intermediate_size': 3712}                                             │               │        │        │
  │  5 │ {'num_layers': 52, 'hidden_size': 2304, 'mamba_num_heads': 64, 'mamba_head_dim': 64, 'num_moe_experts': 104,          │         3.00B │ 22.28B │ 0.5860 │
  │    │ 'moe_ffn_hidden_size': 1856, 'moe_shared_expert_intermediate_size': 3072}                                             │               │        │        │
  │  6 │ {'num_layers': 52, 'hidden_size': 2560, 'mamba_num_heads': 48, 'mamba_head_dim': 48, 'num_moe_experts': 96,           │         3.00B │ 21.99B │ 0.2294 │
  │    │ 'moe_ffn_hidden_size': 1792, 'moe_shared_expert_intermediate_size': 3328}                                             │               │        │        │
  │  7 │ {'num_layers': 48, 'hidden_size': 2560, 'mamba_num_heads': 56, 'mamba_head_dim': 56, 'num_moe_experts': 104,          │         3.00B │ 23.68B │ 0.5231 │
  │    │ 'moe_ffn_hidden_size': 1792, 'moe_shared_expert_intermediate_size': 3072}                                             │               │        │        │
  │  8 │ {'num_layers': 46, 'hidden_size': 2560, 'mamba_num_heads': 56, 'mamba_head_dim': 56, 'num_moe_experts': 96,           │         3.00B │ 21.81B │ 0.5042 │
  │    │ 'moe_ffn_hidden_size': 1856, 'moe_shared_expert_intermediate_size': 3584}                                             │               │        │        │
  │  9 │ {'num_layers': 52, 'hidden_size': 2688, 'mamba_num_heads': 48, 'mamba_head_dim': 56, 'num_moe_experts': 96,           │         3.00B │ 20.09B │ 0.2462 │
  │    │ 'moe_ffn_hidden_size': 1536, 'moe_shared_expert_intermediate_size': 3072}                                             │               │        │        │
  │ 10 │ {'num_layers': 52, 'hidden_size': 2304, 'mamba_num_heads': 64, 'mamba_head_dim': 64, 'num_moe_experts': 96,           │         3.00B │ 20.70B │ 0.5685 │
  │    │ 'moe_ffn_hidden_size': 1856, 'moe_shared_expert_intermediate_size': 3072}                                             │               │        │        │
  └────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴───────────────┴────────┴────────┘

  ╭──────────────────────────────────────────────────────────────────────── Best Subnet ─────────────────────────────────────────────────────────────────────────╮
  │ export_config  {'num_layers': 52, 'hidden_size': 2304, 'mamba_num_heads': 64, 'mamba_head_dim': 64, 'num_moe_experts': 104, 'moe_ffn_hidden_size': 1856,     │
  │                'moe_shared_expert_intermediate_size': 3072}                                                                                                  │
  │ active_params  3.00B                                                                                                                                         │
  │ params         22.28B                                                                                                                                        │
  │ score          0.5860                                                                                                                                        │
  ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

  ╭────────────────────────────────────────────────────── Pruned Model Stats ───────────────────────────────────────────────────────╮
  │ Total Parameters                              22.28B                                                                            │
  │ Active Parameters                             3.00B                                                                             │
  │ Memory (BF16, seq_length=8192, batch_size=8)  weights: 42489.7 MB, kv_cache: 384.0 MB, mamba_state: 190.5 MB, Total: 43064.2 MB │
  ╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
  ```

  </details>

- **`tests/examples/megatron_bridge/test_prune_minitron.py`** — `nemotron_h` now exports to HF and reloads (previously it stopped at a Megatron checkpoint, since the dummy-model path needed `transformers<5`), plus an `n_shared_experts` config assertion; the dead `megatron_format` branch is gone. It runs on the CI container: **verified on nemo:26.06.01 (transformers 5.8.1) and nemo:26.08.rc6.**
- **`tests/gpu_megatron/torch/prune/plugins/test_mcore_mamba_minitron_pruning.py`** — the `nas_memory_mb` search test now passes a `candidate_filter` and asserts the exact number of rejected candidates (256 of the 512-combo grid) plus the surviving candidates' validity; its `expected_top_k` goldens are regenerated accordingly. Because `moe_shared_expert_intermediate_size` is in that test's skip list, this also covers the model-config fallback for hparams that are not in the search space.

Verified on 2 GPUs, on both the CI container (nemo:26.06.01) and nemo:26.08.rc6:

| Test | Result |
| --- | --- |
| `test_prune_minitron[qwen3]` | PASSED on 26.06.01 and 26.08.rc6 |
| `test_prune_minitron[deepseek_v3]` | PASSED (52s) — MLA Q-LoRA + `candidate_filter` end-to-end |
| `test_prune_minitron[nemotron_h]` | PASSED on 26.06.01 (58s) and 26.08.rc6 (61s) |
| `test_mcore_mamba_hybrid_pruning_nas_memory_mb` | PASSED |
| `test_mcore_mamba_hybrid_pruning_nas_params` | PASSED (unchanged sibling, run to check the regenerated goldens did not disturb it) |
| 2-GPU PP run failing on rank 0 | fails in 31s with a real traceback (was a 10 min stall) |


### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ — `candidate_filter` defaults to `None` (existing searches unchanged), and the config-only export is limited to hybrid providers on nemo:26.08+, so dense / MoE / VLM exports keep the path they use today.
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update Changelog?: N/A
- Did you get Claude approval on this PR?: ✅

### Additional Information

Enables the Prune + Distill workflow for `NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16` (native, no-remote-code `NemotronHForCausalLM` with MTP heads). Pruning-time MTP support was scoped and intentionally deferred — MTP heads are dropped and can be re-derived via a short SFT with `mtp_num_layers=1` on the pruned+distilled model.
