### PR TITLE
Fix init_quantized_weights: model kwargs leak into dispatch, missing tie_weights()

### DIFF
--- a/modelopt/torch/quantization/plugins/accelerate.py
+++ b/modelopt/torch/quantization/plugins/accelerate.py
@@ -224,12 +224,21 @@ def init_quantized_weights(
 
         # Model-construction kwargs must not reach load_checkpoint_and_dispatch(),
         # which does not accept them (e.g. attn_implementation -> TypeError).
+        # Both dtype aliases are popped: torch_dtype is not a parameter of
+        # load_checkpoint_and_dispatch() either, and the resolved value is
+        # passed back explicitly below.
         attn_implementation = kwargs.pop("attn_implementation", None)
+        dtype_kwarg = kwargs.pop("dtype", None)
+        legacy_dtype_kwarg = kwargs.pop("torch_dtype", None)
 
         with init_empty_weights():
             # Fix torch_dtype to match original model
-            torch_dtype = kwargs.get(
-                "dtype", kwargs.get("torch_dtype", getattr(config, "torch_dtype", torch.float16))
+            torch_dtype = (
+                dtype_kwarg
+                if dtype_kwarg is not None
+                else legacy_dtype_kwarg
+                if legacy_dtype_kwarg is not None
+                else getattr(config, "torch_dtype", torch.float16)
             )
             from_config_kwargs = {}
             if attn_implementation is not None:
@@ -251,6 +260,10 @@ def init_quantized_weights(
             model,
             checkpoint=pretrained_model_name_or_path,
             device_map=_device_map,
+            # Passed explicitly because both aliases were popped above;
+            # load_checkpoint_and_dispatch() accepts `dtype` but not
+            # `torch_dtype`, so forwarding kwargs verbatim was unsafe.
+            dtype=torch_dtype,
             *args,
             **kwargs,
         )

--- a/modelopt/torch/quantization/plugins/accelerate.py
+++ b/modelopt/torch/quantization/plugins/accelerate.py
@@ -222,12 +222,26 @@ def init_quantized_weights(
                 pretrained_model_name_or_path, trust_remote_code=trust_remote_code
             )
 
+        # Model-construction kwargs must not reach load_checkpoint_and_dispatch(),
+        # which does not accept them (e.g. attn_implementation -> TypeError).
+        attn_implementation = kwargs.pop("attn_implementation", None)
+
         with init_empty_weights():
             # Fix torch_dtype to match original model
             torch_dtype = kwargs.get(
                 "dtype", kwargs.get("torch_dtype", getattr(config, "torch_dtype", torch.float16))
             )
-            model = cls.from_config(config, dtype=torch_dtype)
+            from_config_kwargs = {}
+            if attn_implementation is not None:
+                from_config_kwargs["attn_implementation"] = attn_implementation
+            model = cls.from_config(config, dtype=torch_dtype, **from_config_kwargs)
+
+        # Tied parameters (e.g. lm_head.weight tied to embeddings) are absent
+        # from the checkpoint, so without tie_weights() they stay on meta and
+        # dispatch_model()'s .to() raises "Cannot copy out of meta tensor".
+        # accelerate documents tie_weights() as a prerequisite of
+        # load_checkpoint_and_dispatch().
+        model.tie_weights()
 
         mtq.quantize(model, quant_cfg)
         mtq.compress(model, config=mtq.CompressConfig(quant_gemm=quant_gemm))

--- a/modelopt/torch/quantization/plugins/accelerate.py
+++ b/modelopt/torch/quantization/plugins/accelerate.py
@@ -232,13 +232,23 @@ def init_quantized_weights(
         legacy_dtype_kwarg = kwargs.pop("torch_dtype", None)
 
         with init_empty_weights():
-            # Fix torch_dtype to match original model
+            # Fix dtype to match original model.
+            # `config.torch_dtype` is a deprecated alias of `config.dtype` in
+            # transformers >= 5, and it RETURNS None rather than being absent
+            # when unset -- so `getattr(config, "torch_dtype", torch.float16)`
+            # yields None and the float16 fallback never fires. Read `dtype`
+            # first, then the alias, then fall back explicitly.
+            config_dtype = getattr(config, "dtype", None)
+            if config_dtype is None:
+                config_dtype = getattr(config, "torch_dtype", None)
             torch_dtype = (
                 dtype_kwarg
                 if dtype_kwarg is not None
                 else legacy_dtype_kwarg
                 if legacy_dtype_kwarg is not None
-                else getattr(config, "torch_dtype", torch.float16)
+                else config_dtype
+                if config_dtype is not None
+                else torch.float16
             )
             from_config_kwargs = {}
             if attn_implementation is not None:

--- a/tests/unit/torch/quantization/plugins/test_accelerate.py
+++ b/tests/unit/torch/quantization/plugins/test_accelerate.py
@@ -80,3 +80,51 @@ def test_tensor_quantizer_modelopt_state_with_accelerate_hook():
 
     # The state dict must be picklable (torch.save uses pickle internally)
     pickle.dumps(state)
+
+
+def test_init_quantized_weights_dtype_resolution():
+    """dtype/torch_dtype must not leak into load_checkpoint_and_dispatch().
+
+    Both are model-construction kwargs: `load_checkpoint_and_dispatch()`
+    accepts `dtype` but not `torch_dtype`, so forwarding kwargs verbatim
+    raised TypeError for callers using the legacy alias. The fallback also has
+    to survive `config.torch_dtype` being a deprecated alias that returns None
+    instead of being absent, which defeats a `getattr(..., default)` fallback.
+    """
+    from transformers import PretrainedConfig
+
+    def resolve(kwargs: dict, config) -> torch.dtype:
+        """Mirror of the resolution order in accelerate.patched_from_pretrained."""
+        dtype_kwarg = kwargs.pop("dtype", None)
+        legacy_dtype_kwarg = kwargs.pop("torch_dtype", None)
+        config_dtype = getattr(config, "dtype", None)
+        if config_dtype is None:
+            config_dtype = getattr(config, "torch_dtype", None)
+        return (
+            dtype_kwarg
+            if dtype_kwarg is not None
+            else legacy_dtype_kwarg
+            if legacy_dtype_kwarg is not None
+            else config_dtype
+            if config_dtype is not None
+            else torch.float16
+        )
+
+    config = PretrainedConfig()
+
+    # Explicit kwargs win, in precedence order, and are consumed.
+    kwargs = {"dtype": torch.bfloat16, "attn_implementation": "sdpa"}
+    assert resolve(kwargs, config) is torch.bfloat16
+    assert "dtype" not in kwargs and "torch_dtype" not in kwargs
+
+    kwargs = {"torch_dtype": torch.bfloat16}
+    assert resolve(kwargs, config) is torch.bfloat16
+    assert "torch_dtype" not in kwargs
+
+    # A config carrying no dtype must fall back to float16, not None.
+    assert resolve({}, config) is torch.float16
+
+    # A config that does carry one is respected.
+    config_with_dtype = PretrainedConfig()
+    config_with_dtype.dtype = torch.bfloat16
+    assert resolve({}, config_with_dtype) is torch.bfloat16

--- a/tests/unit/torch/quantization/plugins/test_accelerate.py
+++ b/tests/unit/torch/quantization/plugins/test_accelerate.py
@@ -29,6 +29,8 @@ except ImportError:
 
 transformers = pytest.importorskip("transformers")
 
+from modelopt.torch.quantization.plugins import accelerate as accel_plugin  # noqa: E402
+
 
 def test_linear_with_accelerate_monkey_patched_forward():
     module_test = nn.Linear(16, 16)
@@ -95,8 +97,6 @@ def test_init_quantized_weights_dtype_and_kwargs_routing(monkeypatch):
 
     Drives the real patched `from_pretrained` with the checkpoint I/O stubbed.
     """
-    from modelopt.torch.quantization.plugins import accelerate as accel_plugin
-
     seen: dict[str, dict] = {}
 
     class _StubModel(torch.nn.Module):

--- a/tests/unit/torch/quantization/plugins/test_accelerate.py
+++ b/tests/unit/torch/quantization/plugins/test_accelerate.py
@@ -27,6 +27,8 @@ try:
 except ImportError:
     pytest.skip("accelerate not available", allow_module_level=True)
 
+transformers = pytest.importorskip("transformers")
+
 
 def test_linear_with_accelerate_monkey_patched_forward():
     module_test = nn.Linear(16, 16)
@@ -82,49 +84,70 @@ def test_tensor_quantizer_modelopt_state_with_accelerate_hook():
     pickle.dumps(state)
 
 
-def test_init_quantized_weights_dtype_resolution():
-    """dtype/torch_dtype must not leak into load_checkpoint_and_dispatch().
+def test_init_quantized_weights_dtype_and_kwargs_routing(monkeypatch):
+    """Model-construction kwargs must reach from_config, not dispatch.
 
-    Both are model-construction kwargs: `load_checkpoint_and_dispatch()`
-    accepts `dtype` but not `torch_dtype`, so forwarding kwargs verbatim
-    raised TypeError for callers using the legacy alias. The fallback also has
-    to survive `config.torch_dtype` being a deprecated alias that returns None
-    instead of being absent, which defeats a `getattr(..., default)` fallback.
+    `load_checkpoint_and_dispatch()` accepts `dtype` but not `torch_dtype` or
+    `attn_implementation`, so forwarding **kwargs verbatim raised TypeError.
+    The dtype fallback also has to survive `config.torch_dtype` being a
+    deprecated alias that returns None instead of being absent, which defeats
+    a `getattr(config, "torch_dtype", default)` fallback.
+
+    Drives the real patched `from_pretrained` with the checkpoint I/O stubbed.
     """
-    from transformers import PretrainedConfig
+    from modelopt.torch.quantization.plugins import accelerate as accel_plugin
 
-    def resolve(kwargs: dict, config) -> torch.dtype:
-        """Mirror of the resolution order in accelerate.patched_from_pretrained."""
-        dtype_kwarg = kwargs.pop("dtype", None)
-        legacy_dtype_kwarg = kwargs.pop("torch_dtype", None)
-        config_dtype = getattr(config, "dtype", None)
-        if config_dtype is None:
-            config_dtype = getattr(config, "torch_dtype", None)
-        return (
-            dtype_kwarg
-            if dtype_kwarg is not None
-            else legacy_dtype_kwarg
-            if legacy_dtype_kwarg is not None
-            else config_dtype
-            if config_dtype is not None
-            else torch.float16
+    seen: dict[str, dict] = {}
+
+    class _StubModel(torch.nn.Module):
+        def tie_weights(self):
+            seen["tie_weights_called"] = {"yes": True}
+
+    def fake_from_config(cls, config, **kwargs):
+        seen["from_config"] = kwargs
+        return _StubModel()
+
+    def fake_dispatch(model, **kwargs):
+        seen["dispatch"] = kwargs
+        return model
+
+    # get_model_device_map is nested inside init_quantized_weights, so it is
+    # neutralised through the accelerate helpers it calls rather than directly.
+    monkeypatch.setattr(accel_plugin.mtq, "quantize", lambda model, cfg: model)
+    monkeypatch.setattr(accel_plugin.mtq, "compress", lambda model, config=None: model)
+    monkeypatch.setattr(accel_plugin, "get_max_memory", lambda: {"cpu": 1 << 30})
+    monkeypatch.setattr(accel_plugin, "infer_auto_device_map", lambda *a, **k: {"": "cpu"})
+    monkeypatch.setattr(accel_plugin, "load_checkpoint_and_dispatch", fake_dispatch)
+    monkeypatch.setattr(
+        transformers.AutoModelForCausalLM,
+        "from_config",
+        classmethod(fake_from_config),
+    )
+
+    config = transformers.PretrainedConfig()  # carries no dtype
+    with accel_plugin.init_quantized_weights(mtq.INT8_DEFAULT_CFG):
+        transformers.AutoModelForCausalLM.from_pretrained(
+            "stub-checkpoint",
+            config=config,
+            torch_dtype=torch.bfloat16,  # legacy alias
+            attn_implementation="sdpa",
         )
 
-    config = PretrainedConfig()
+    # Construction kwargs went to from_config...
+    assert seen["from_config"]["dtype"] is torch.bfloat16
+    assert seen["from_config"]["attn_implementation"] == "sdpa"
+    # ...and neither alias leaked into dispatch, which cannot accept them.
+    assert "torch_dtype" not in seen["dispatch"]
+    assert "attn_implementation" not in seen["dispatch"]
+    # The resolved dtype is still handed to dispatch explicitly.
+    assert seen["dispatch"]["dtype"] is torch.bfloat16
+    assert seen.get("tie_weights_called")
 
-    # Explicit kwargs win, in precedence order, and are consumed.
-    kwargs = {"dtype": torch.bfloat16, "attn_implementation": "sdpa"}
-    assert resolve(kwargs, config) is torch.bfloat16
-    assert "dtype" not in kwargs and "torch_dtype" not in kwargs
-
-    kwargs = {"torch_dtype": torch.bfloat16}
-    assert resolve(kwargs, config) is torch.bfloat16
-    assert "torch_dtype" not in kwargs
-
-    # A config carrying no dtype must fall back to float16, not None.
-    assert resolve({}, config) is torch.float16
-
-    # A config that does carry one is respected.
-    config_with_dtype = PretrainedConfig()
-    config_with_dtype.dtype = torch.bfloat16
-    assert resolve({}, config_with_dtype) is torch.bfloat16
+    # With no dtype anywhere, the float16 fallback must actually fire: the
+    # deprecated alias returns None rather than being absent.
+    assert getattr(config, "torch_dtype", torch.float16) is None
+    seen.clear()
+    with accel_plugin.init_quantized_weights(mtq.INT8_DEFAULT_CFG):
+        transformers.AutoModelForCausalLM.from_pretrained("stub-checkpoint", config=config)
+    assert seen["from_config"]["dtype"] is torch.float16
+    assert seen["dispatch"]["dtype"] is torch.float16


### PR DESCRIPTION
Two small defects on the `init_quantized_weights` path (public API; also what `hf_ptq.py --low_memory_mode` uses). Both fire before any weight is written, so the path cannot complete at all on common models.

### 1. Model-construction kwargs reach `load_checkpoint_and_dispatch()`

`patched_from_pretrained` forwards `**kwargs` verbatim, so `attn_implementation` (documented in `hf_ptq.py`'s own CLI) raises:

```
TypeError: load_checkpoint_and_dispatch() got an unexpected keyword argument 'attn_implementation'
```

It now goes to `cls.from_config()`, where a construction kwarg belongs.

### 2. `tie_weights()` is never called before quantization

Tied parameters such as `lm_head.weight` (`tie_word_embeddings: true` — e.g. Qwen2.5-0.5B) are absent from the checkpoint, so they stay on meta and `dispatch_model()` raises:

```
NotImplementedError: Cannot copy out of meta tensor; no data!
```

accelerate documents `tie_weights()` as a prerequisite of `load_checkpoint_and_dispatch()`.

### Reproduction

`Qwen/Qwen2.5-0.5B-Instruct` (local dir), `--qformat nvfp4 --low_memory_mode`, modelopt 0.43.0, NGC `nvcr.io/nvidia/vllm:26.05.post1-py3`, GB10/SM121 aarch64. Failure 1 fires immediately; with it patched, failure 2 fires at dispatch.

### Scope — please read alongside #2160

These two fixes let the path **run to completion**, but the resulting checkpoint is still numerically wrong: quantization and compression execute on `init_empty_weights()` meta tensors *before* real weights load, giving half-sized `weight_scale` and dequant cosine 0.756 vs the BF16 source. That root cause is filed separately as #2160 and is not addressed here — I kept this PR to the two mechanical bugs so it can be reviewed independently.

---

*Disclosure: prepared with assistance from Claude (Anthropic); all failures above were reproduced on real hardware before writing the patch.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quantized model loading with attention implementation and data type settings.
  * Added reliable data type resolution, including explicit, legacy, configured, and default values.
  * Ensured data type options are applied correctly during checkpoint loading.
  * Improved initialization of tied model parameters before checkpoint dispatch.
  * Prevented unsupported loading options from causing checkpoint-loading failures.
  * Improved reliability when constructing models from configuration before loading and dispatching checkpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->