### PR TITLE
examples: add Qwen3-8B streaming DSpark launcher example + walkthrough

### DIFF
--- a/examples/speculative_decoding/QWEN3_8B_DSPARK_WALKTHROUGH.md
+++ b/examples/speculative_decoding/QWEN3_8B_DSPARK_WALKTHROUGH.md
@@ -1,0 +1,265 @@
+# End-to-End Walkthrough: Qwen3-8B DSpark (Data Synthesis → Streaming Training)
+
+A complete worked example of training a speculative-decoding drafter, from raw
+prompts to an evaluated checkpoint. It uses **Qwen3-8B** as the target and
+**DSpark** as the draft algorithm, driven end-to-end by the
+[launcher](../../tools/launcher/).
+
+Qwen3-8B is small enough to run the whole flow on a handful of GPUs, so this
+doubles as the recommended first run before scaling to a large MoE target — the
+pipeline shape is identical, only node counts and a few model-specific fields
+change.
+
+## Why these two steps
+
+**Data synthesis.** A drafter is trained to predict what the *target model*
+would say. Off-the-shelf SFT corpora contain some other model's answers, so
+training on them teaches the drafter the wrong distribution and acceptance
+length suffers. Step 1 therefore keeps the prompts but regenerates every
+assistant turn with the target model itself.
+
+**Streaming training.** DSpark trains against the target's hidden states. The
+classic route dumps them to disk first, which is slow and enormous. Streaming
+mode instead runs a live `vllm serve` and ships hidden states to the trainer
+over NIXL RDMA — no dump, no round-trip.
+
+## What DSpark is
+
+DSpark = the DFlash backbone + a lightweight sequential (**Markov**) head + a
+**confidence** head. The Markov head adds a prefix-dependent transition bias to
+the backbone's base logits, which induces a causal block distribution and lets
+the draft generate a block semi-autoregressively. The confidence head predicts
+per-position acceptance. It trains with a three-term loss:
+
+```text
+dflash_ce_loss_alpha * CE  +  dflash_l1_loss_alpha * TVD  +  dflash_confidence_head_alpha * BCE
+```
+
+Head architecture and loss weights live in
+[`dspark.yaml`](../../modelopt_recipes/general/speculative_decoding/dspark.yaml);
+the launcher YAMLs below only override data and schedule fields.
+
+## Prerequisites
+
+- A Slurm cluster with the launcher configured (see
+  [launcher docs](../../tools/launcher/docs/configuration.md)).
+- `Qwen/Qwen3-8B` present under the launcher's `/hf-local/` mount.
+- Two container images: a vLLM image (serve + training) and a TensorRT-LLM image
+  (dataset build). Both are pinned in the YAMLs.
+
+Set your cluster environment once:
+
+```bash
+export SLURM_HOST=localhost          # run on the login node
+export SLURM_ACCOUNT=<your_account>
+export SLURM_PARTITION=<your_partition>
+export SLURM_HF_LOCAL=<hf_models_dir>
+export SLURM_JOB_DIR=<experiments_dir>
+export NEMORUN_HOME=$PWD
+```
+
+---
+
+## Step 1 — Data synthesis
+
+Regenerate assistant turns with Qwen3-8B over a prompt corpus.
+
+```bash
+cd tools/launcher
+uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_synth.yaml --yes
+```
+
+[`hf_synth.yaml`](../../tools/launcher/examples/Qwen/Qwen3-8B/hf_synth.yaml)
+runs a Slurm **array job**. Each task starts its own `vllm serve` on one node and
+calls [`common/query.py`](../../tools/launcher/common/query.py) on its own shard
+of the dataset. `query.py` replays each sample's user turns, generates a fresh
+assistant reply, **discards the original assistant turns**, and writes
+`train-{shard}-{total}.jsonl`.
+
+The knobs worth knowing:
+
+| Field | Meaning |
+|---|---|
+| `--data` | Input prompt corpus (HF id or local path). Ships pointing at `nvidia/Speculative-Decoding-Multilingual-Prompt-v2`. |
+| `--save` | Output dir. Set `output_dir` in `global_vars`. |
+| `--num-shards` / `array` | Shard count and the array range. Keep them consistent. |
+| `--num-proc` | Per-worker request concurrency. |
+| `--tensor-parallel-size` | Must match `gpus_per_node`. |
+
+Practical notes, mostly learned the hard way:
+
+- **Resumable by construction.** A shard whose output file already exists is
+  skipped, so a requeued or re-dispatched job picks up where it stopped. Write
+  `--save` to a persistent mount, not to scratch.
+- **Concurrency vs. yield.** Pushing `--num-proc` very high can *lower* total
+  yield: requests start timing out under the stampede and those samples come out
+  user-only. If you see a yield dip, lower it before raising it.
+- **Reasoning models need context headroom.** With `--max-model-len` too tight,
+  any prompt longer than the generation cap gets a 400 back and is dropped. This
+  loss is *systematic* — it removes the longest, hardest prompts and quietly
+  biases the corpus short. Keep `max-model-len >= max_prompt + max_output`.
+- **Check yield before training.** Count records that actually have an assistant
+  turn. A corpus that is silently 60% prompt-only will train, and the result will
+  just be mysteriously bad.
+
+Prefer to skip synthesis on a first pass? `task_0` of the training YAML builds a
+conversation set from public SFT data, and the pipeline runs standalone. Expect a
+lower acceptance length — that gap is exactly what this step buys.
+
+---
+
+## Step 2 — Streaming DSpark training
+
+```bash
+cd tools/launcher
+uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_streaming_dspark.yaml --yes
+```
+
+[`hf_streaming_dspark.yaml`](../../tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_dspark.yaml)
+is a three-task pipeline:
+
+| Task | Nodes | What it does |
+|---|---|---|
+| `task_0` | 1 | Build input conversations → `/scratchspace/data/train.jsonl` |
+| `task_1` | 2 | Node 0 `vllm serve`, node 1 trainer; exports to `/scratchspace/export` |
+| `task_2` | 1 | vLLM smoke test — acceptance length |
+
+**To train on your synthesized corpus** (the point of Step 1), edit the YAML: set
+`skip: true` on `task_0`, and point `data.data_path` in `task_1` at the synthesis
+`output_dir`:
+
+```yaml
+  task_0:
+    skip: true
+    ...
+
+  task_1:
+    args:
+      ...
+      - data.data_path=/hf-local/modelopt/qwen3-8b-synth-v1
+```
+
+CLI overrides use dotted paths for scalar fields, e.g.:
+
+```bash
+uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_streaming_dspark.yaml \
+  pipeline.task_1.slurm_config.nodes=4 --yes
+```
+
+Always preview the resolved config before submitting:
+
+```bash
+uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_streaming_dspark.yaml --dryrun --yes -v
+```
+
+### The fields that actually matter
+
+**Capture ids.** `EAGLE_CAPTURE_IDS` selects which target layers the serve
+captures. The draft consumes 5 evenly-spaced layers plus the final hidden state.
+For Qwen3-8B (36 layers), `build_target_layer_ids(36,5) = [1,9,17,25,33]`; vLLM's
+ids are those **+1**, plus the final layer:
+
+```text
+EAGLE_CAPTURE_IDS: "[2,10,18,26,34,36]"
+```
+
+Getting the final id wrong is the classic silent failure: capturing the
+second-to-last layer instead of the true final one trains fine, shows a healthy
+loss curve, and caps acceptance length. If loss looks good but acceptance
+plateaus, check this first.
+
+No spaces in the value — nemo_run emits `export FOO=value` unquoted, so a space
+splits the variable.
+
+**Draft dims are not inherited.** The draft is an independent Qwen3 model; it
+does *not* pick up the base model's GQA/FFN dims. `dspark.yaml` sets them
+explicitly for Qwen3-8B. Retargeting to a different base means updating
+`num_attention_heads`, `num_key_value_heads`, `head_dim` and `intermediate_size`
+to match — otherwise you silently train a wrong-shaped draft.
+
+**`answer_only_loss=false`.** The streaming corpus is prompt-only (the serve
+generates the response and we capture *its* hidden states), so there is no
+assistant span to mask. Train over the full sequence.
+
+**`dflash_block_size`** is the semi-AR generation block and must divide
+`training_seq_len`.
+
+**`report_to=none`.** `dspark.yaml` defaults to tensorboard, which hard-fails if
+tensorboard isn't installed in the serve container.
+
+**Batch size and LR stay at the recipe defaults.** `dspark.yaml` ships
+`per_device_train_batch_size=1`, `learning_rate=6e-4`, `warmup_ratio=0.04` —
+tuned for a from-scratch draft on a single GPU. The Kimi-K2.6 and MiniMax-M3
+examples override these to a larger batch and a gentle `1e-4` because they run 8
+GPUs per node and warm-start a large backbone. Don't copy those numbers to
+Qwen3-8B: at `training_seq_len=4096` on one GPU, a batch of 4 will OOM.
+
+### Scaling up to a large target
+
+The same pipeline drives large MoE targets — compare this YAML against
+[`MiniMaxAI/MiniMax-M3`](../../tools/launcher/examples/MiniMaxAI/MiniMax-M3/hf_streaming_dspark_multi_node.yaml)
+and
+[`moonshotai/Kimi-K2.6`](../../tools/launcher/examples/moonshotai/Kimi-K2.6/hf_streaming_dspark_multi_node.yaml).
+What changes:
+
+| Concern | Qwen3-8B | Large MoE target |
+|---|---|---|
+| Topology | 2 nodes × 1 GPU | `SERVE_NODES` serve replicas + DDP trainers, 8 GPU/node |
+| Draft dims | recipe defaults already match | must be set explicitly to match the base |
+| `rope_theta` | default `1e6` matches base | pin the base's value onto the draft |
+| Mask token | `151669` | a free id in that model's vocab |
+| `trust_remote_code` | not needed | needed at serve *and* export |
+| Chat template | not needed (`answer_only_loss=false`) | a `{% generation %}`-tagged copy if masking |
+
+`SERVE_NODES` splits the allocation: nodes `0..SERVE_NODES-1` each run an
+independent whole-node serve replica, the rest are DDP trainers, and each trainer
+rank fetches its shard round-robin across replicas. See the header of
+[`train_eagle_streaming.sh`](../../tools/launcher/common/eagle3/train_eagle_streaming.sh)
+for the full knob list.
+
+On clusters using EFA rather than InfiniBand, NIXL needs
+`NIXL_BACKENDS=LIBFABRIC`. Note that UCX segfaults at agent init on EFA nodes, so
+LIBFABRIC is required there even for single-node runs (see the commented block in
+the YAML).
+
+---
+
+## Step 3 — Evaluate
+
+`task_2` serves the exported drafter and reports acceptance length.
+
+**Do not use the training-time AR eval.** `dspark.yaml` sets
+`estimate_ar: false` deliberately: that eval runs the DFlash backbone *only*,
+without applying the Markov head, so its number describes the backbone rather
+than the model you trained. Acceptance length comes from the vLLM smoke test or
+the offline [specdec_bench](../specdec_bench/) harness.
+
+`task_2` needs a vLLM build with DSpark support. If your image predates it,
+startup fails on the `--speculative-config` method name; pin a newer nightly, or
+set `skip: true` and use specdec_bench on `/scratchspace/export`.
+
+Reading the numbers: training accuracy, acceptance length, and accepted-fraction
+are three different things and are easy to confuse. Acceptance length is the
+deployment-facing one.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Training hangs before step 1, no error | Corpus schema issue — a prompt-only `messages` field can stall the streaming dataset silently. Inspect one record. |
+| Loss curve healthy, acceptance length plateaus | Wrong final capture id (see above). |
+| Trainer OOM on the serve node | Lower `SERVE_GPU_MEM_UTIL`, `SERVE_MAX_MODEL_LEN`, `SERVE_MAX_NUM_SEQS`. |
+| Serve never becomes ready | Raise `SERVE_READY_TIMEOUT`; large models load slowly on cold cache. |
+| `export FOO=value` splitting | A space in an env value. Remove it. |
+| Synthesis yield well under 100% | Lower `--num-proc`, or raise `--max-model-len`. |
+
+## Reference
+
+- [`dspark.yaml`](../../modelopt_recipes/general/speculative_decoding/dspark.yaml) — head arch and loss weights
+- [`hf_synth.yaml`](../../tools/launcher/examples/Qwen/Qwen3-8B/hf_synth.yaml) — synthesis
+- [`hf_streaming_dspark.yaml`](../../tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_dspark.yaml) — streaming training
+- [`hf_streaming_dflash.yaml`](../../tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_dflash.yaml) — DFlash, same transport
+- [README](README.md) — speculative decoding overview, other algorithms
+- [SLURM_prepare_data.md](SLURM_prepare_data.md) — the alternative `server_generate.py` synthesis path

--- a/examples/speculative_decoding/QWEN3_8B_DSPARK_WALKTHROUGH.md
+++ b/examples/speculative_decoding/QWEN3_8B_DSPARK_WALKTHROUGH.md
@@ -45,18 +45,31 @@ the launcher YAMLs below only override data and schedule fields.
   [launcher docs](../../tools/launcher/docs/configuration.md)).
 - `Qwen/Qwen3-8B` present under the launcher's `/hf-local/` mount.
 - Two container images: a vLLM image (serve + training) and a TensorRT-LLM image
-  (dataset build). Both are pinned in the YAMLs.
+  (dataset build). Both are pinned in the YAMLs. If your cluster's enroot cannot
+  pull `nvcr.io` (it resolves against Docker Hub and 401s, surfacing only as
+  `spank_pyxis.so: task_init() failed`), point `container:` at a local `.sqsh`.
+- An `HF_TOKEN` with access to the prompt corpus — the dataset Step 1 ships with
+  is gated, and without a token it fails as `DatasetNotFoundError`, which reads
+  like a wrong name rather than a missing credential.
 
 Set your cluster environment once:
 
 ```bash
-export SLURM_HOST=localhost          # run on the login node
+export SLURM_HOST=$(hostname)        # NOT localhost: the launcher stages files
+                                     # over SSH even when it submits locally
 export SLURM_ACCOUNT=<your_account>
 export SLURM_PARTITION=<your_partition>
 export SLURM_HF_LOCAL=<hf_models_dir>
-export SLURM_JOB_DIR=<experiments_dir>
+export SLURM_JOB_DIR=<experiments_dir>   # must already exist
 export NEMORUN_HOME=$PWD
+export HF_TOKEN=<your_hf_token>
+
+mkdir -p $SLURM_JOB_DIR
+cd tools/launcher && uv pip install -e .   # launch.py imports modelopt_launcher
 ```
+
+Pass `identity=<ssh_key>` on every `launch.py` call (the key the staging SSH
+uses). All commands below omit it for brevity.
 
 ---
 
@@ -74,7 +87,10 @@ runs a Slurm **array job**. Each task starts its own `vllm serve` on one node an
 calls [`common/query.py`](../../tools/launcher/common/query.py) on its own shard
 of the dataset. `query.py` replays each sample's user turns, generates a fresh
 assistant reply, **discards the original assistant turns**, and writes
-`train-{shard}-{total}.jsonl`.
+`shard_{id}.jsonl` plus a `shard_{id}.done` sentinel.
+
+Budget for this: a shard is tens of thousands of samples at 1-2 samples/s, so
+**hours per shard**. Size the array and the job time limit accordingly.
 
 The knobs worth knowing:
 
@@ -83,21 +99,26 @@ The knobs worth knowing:
 | `--data` | Input prompt corpus (HF id or local path). Ships pointing at `nvidia/Speculative-Decoding-Multilingual-Prompt-v2`. |
 | `--save` | Output dir. Set `output_dir` in `global_vars`. |
 | `--num-shards` / `array` | Shard count and the array range. Keep them consistent. |
-| `--num-proc` | Per-worker request concurrency. |
+| `--num-proc` | Per-worker request concurrency. Defaults to 32; not set in the YAML. |
 | `--tensor-parallel-size` | Must match `gpus_per_node`. |
 
 Practical notes, mostly learned the hard way:
 
-- **Resumable by construction.** A shard whose output file already exists is
-  skipped, so a requeued or re-dispatched job picks up where it stopped. Write
-  `--save` to a persistent mount, not to scratch.
+- **Resume is per whole shard.** A shard is skipped only when *both* its
+  `.jsonl` and its `.done` sentinel exist; output is written once at the end. An
+  interrupted shard leaves nothing behind and restarts from zero. Write `--save`
+  to a persistent mount, not to scratch.
 - **Concurrency vs. yield.** Pushing `--num-proc` very high can *lower* total
   yield: requests start timing out under the stampede and those samples come out
   user-only. If you see a yield dip, lower it before raising it.
 - **Reasoning models need context headroom.** With `--max-model-len` too tight,
   any prompt longer than the generation cap gets a 400 back and is dropped. This
   loss is *systematic* — it removes the longest, hardest prompts and quietly
-  biases the corpus short. Keep `max-model-len >= max_prompt + max_output`.
+  biases the corpus short. Keep `max-model-len >= max_prompt + max_output`. The
+  shipped 4096 is *not* enough headroom for this corpus at a 1024-token cap;
+  raise it, or accept the drop. Grep the job log for `Error code: 400` to size
+  it — those 400s are also mangled by an unrelated `APIStatusError` unpickling
+  bug that kills a result-handler thread without stopping the run.
 - **Check yield before training.** Count records that actually have an assistant
   turn. A corpus that is silently 60% prompt-only will train, and the result will
   just be mysteriously bad.
@@ -155,9 +176,12 @@ uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_streaming_dspark.yaml --dryrun
 ### The fields that actually matter
 
 **Capture ids.** `EAGLE_CAPTURE_IDS` selects which target layers the serve
-captures. The draft consumes 5 evenly-spaced layers plus the final hidden state.
-For Qwen3-8B (36 layers), `build_target_layer_ids(36,5) = [1,9,17,25,33]`; vLLM's
-ids are those **+1**, plus the final layer:
+captures. The draft consumes one evenly-spaced layer per draft layer, plus the
+final hidden state — so this list is tied to
+`dflash_architecture_config.num_hidden_layers` and must be recomputed if you
+change draft depth. For Qwen3-8B (36 layers) with 5 draft layers,
+`build_target_layer_ids(36,5) = [1,9,17,25,33]`; vLLM's ids are those **+1**,
+plus the final layer:
 
 ```text
 EAGLE_CAPTURE_IDS: "[2,10,18,26,34,36]"
@@ -234,9 +258,12 @@ without applying the Markov head, so its number describes the backbone rather
 than the model you trained. Acceptance length comes from the vLLM smoke test or
 the offline [specdec_bench](../specdec_bench/) harness.
 
-`task_2` needs a vLLM build with DSpark support. If your image predates it,
-startup fails on the `--speculative-config` method name; pin a newer nightly, or
-set `skip: true` and use specdec_bench on `/scratchspace/export`.
+`task_2` needs a vLLM build whose DSpark path supports a non-DeepSeek backbone.
+On an older image the failure is not a clean rejection of the method name: the
+loader routes into the DeepSeek-V4 DSpark model and dies mid-load on a config
+field the Qwen3 drafter has no reason to carry (`AttributeError: 'Qwen3Config'
+object has no attribute 'hc_mult'`). Pin a newer nightly, or set `skip: true`
+and use specdec_bench on `/scratchspace/export`.
 
 Reading the numbers: training accuracy, acceptance length, and accepted-fraction
 are three different things and are easy to confuse. Acceptance length is the
@@ -248,9 +275,10 @@ deployment-facing one.
 
 | Symptom | Likely cause |
 |---|---|
-| Training hangs before step 1, no error | Corpus schema issue — a prompt-only `messages` field can stall the streaming dataset silently. Inspect one record. |
+| Training starts but every batch is dropped | Corpus schema — entries without a usable `conversations`/`messages` list are skipped silently. Inspect one record. |
 | Loss curve healthy, acceptance length plateaus | Wrong final capture id (see above). |
 | Trainer OOM on the serve node | Lower `SERVE_GPU_MEM_UTIL`, `SERVE_MAX_MODEL_LEN`, `SERVE_MAX_NUM_SEQS`. |
+| Trainer stuck at "waiting for serve address" | The serve died. Its log is `/scratchspace/vllm_serve.<n>.log`, not the task log — read that for the real error. |
 | Serve never becomes ready | Raise `SERVE_READY_TIMEOUT`; large models load slowly on cold cache. |
 | `export FOO=value` splitting | A space in an env value. Remove it. |
 | Synthesis yield well under 100% | Lower `--num-proc`, or raise `--max-model-len`. |

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_dspark.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_dspark.yaml
@@ -74,7 +74,8 @@ pipeline:
     args:
       - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/dspark.yaml
       - model.model_name_or_path=<<global_vars.hf_model>>
-      - data.mode=streaming
+      # Streaming is selected by data.streaming_server_url, which the launcher
+      # script injects once the serve is up — not by a data.mode= key.
       - data.data_path=/scratchspace/data/train.jsonl
       - training.output_dir=/scratchspace/dspark
       - training.training_seq_len=4096
@@ -98,10 +99,11 @@ pipeline:
       # The vLLM serve container has no tensorboard -> trainer init crash.
       - training.report_to=none
       # Semi-AR generation block; must divide training_seq_len. dspark.yaml ships
-      # 16 (the Kimi/M3 runs use 8); loss_decay_factor is the matching gamma.
+      # 16 (the Kimi/M3 runs use 8). No dflash_loss_decay_factor override here:
+      # dflash_loss_objective defaults to 'dpace', which derives per-position
+      # weights from draft confidence and ignores the decay gamma outright.
       - dflash.dflash_block_size=16
       - dflash.dflash_num_anchors=512
-      - dflash.dflash_loss_decay_factor=7
       # Qwen3 has no native mask token; 151669 is an unused id.
       - dflash.dflash_mask_token_id=151669
       - dflash.dflash_architecture_config.num_hidden_layers=5

--- a/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_dspark.yaml
+++ b/tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_dspark.yaml
@@ -1,0 +1,159 @@
+# DSpark streaming speculative-decoding training for Qwen3-8B.
+#
+# DSpark = the DFlash backbone + a lightweight sequential (Markov) head + a
+# confidence head, generating a causal block semi-autoregressively; see
+# dspark.yaml for the head architecture and the three-term loss
+# (ce_alpha*CE + l1_alpha*TVD + conf_alpha*confidence_BCE).
+#
+# Runs the shared streaming pipeline (common/eagle3/train_eagle_streaming.sh):
+# a live `vllm serve` runs the target model and ships its hidden states to the
+# trainer over NIXL RDMA — no offline hidden-state dump, no disk round-trip.
+# Same transport as hf_streaming_dflash.yaml; the recipe changes
+# (dflash.yaml -> dspark.yaml), which is what adds the Markov + confidence heads.
+#
+# Qwen3-8B is the small end of this pipeline — it fits on 2 nodes / 1 GPU each,
+# which makes it the recommended first run before scaling to a large MoE target
+# (see the Kimi-K2.6 and MiniMax-M3 multi-node examples, same pipeline).
+#
+# 3-step pipeline:
+#   task_0: Build input conversations (jsonl)
+#   task_1: Streaming train — node 0 vllm serve, node 1 trainer
+#   task_2: vLLM smoke test with DSpark speculative decoding
+#
+# Tasks share /scratchspace to pass artifacts; the export lands in
+# /scratchspace/export.
+#
+# NOTE ON AR EVAL: dspark.yaml keeps estimate_ar=false and this yaml disables the
+# periodic AR validation. The training-time eval runs the DFlash backbone only
+# (the Markov head is not applied), so an AR number would describe the backbone,
+# not the trained DSpark model. Measure acceptance with task_2 or specdec_bench.
+#
+# Usage:
+#   uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_streaming_dspark.yaml --yes
+
+job_name: Qwen3-8B_DSpark_streaming
+pipeline:
+  allow_to_fail: false
+  skip: false
+  note:
+
+  global_vars:
+    hf_model: /hf-local/Qwen/Qwen3-8B
+
+  # Step 1: Build /scratchspace/data/train.jsonl.
+  #
+  # To train on a target-synthesized corpus instead (recommended — matching the
+  # target's own output distribution raises acceptance length), run hf_synth.yaml
+  # first, set `skip: true` here, and point data.data_path at its output_dir.
+  # eagle_utils also accepts a directory of *.jsonl shards directly.
+  task_0:
+    script: common/eagle3/make_dataset.sh
+    args:
+      - -f modules/Model-Optimizer/examples/dataset/example_data_config.yaml
+      - --full-conversations
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      container: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc20
+
+  # Step 2: Streaming DSpark training — node 0 vllm serve, node 1 trainer.
+  #
+  # The draft dims, Markov/confidence head config and loss weights come from
+  # dspark.yaml, whose defaults are already Qwen3-tuned (num_attention_heads=32,
+  # num_key_value_heads=8, head_dim=128, intermediate_size=12288). Unlike the
+  # Kimi/M3 examples there is no dims override block here for exactly that
+  # reason — retargeting to another base means setting them explicitly, since
+  # the draft does NOT inherit the base's GQA/FFN dims.
+  #
+  # Qwen3-8B also needs no rope_theta pin (the draft default 1e6 matches the
+  # base) and no trust_remote_code (stock architecture, no custom modeling file).
+  task_1:
+    script: common/eagle3/train_eagle_streaming.sh
+    args:
+      - --config modules/Model-Optimizer/modelopt_recipes/general/speculative_decoding/dspark.yaml
+      - model.model_name_or_path=<<global_vars.hf_model>>
+      - data.mode=streaming
+      - data.data_path=/scratchspace/data/train.jsonl
+      - training.output_dir=/scratchspace/dspark
+      - training.training_seq_len=4096
+      - training.disable_tqdm=true
+      # Backbone-only AR eval is misleading for DSpark (see header) — disable it.
+      - training.ar_validate_steps=500000
+      - training.num_train_epochs=1
+      - training.save_steps=1000
+      - training.logging_steps=20
+      # Batch size and LR are left at the dspark.yaml defaults
+      # (per_device_train_batch_size=1, learning_rate=6e-4, warmup_ratio=0.04),
+      # which target a from-scratch draft on a single GPU. The Kimi/M3 examples
+      # override these to a large batch and a gentle 1e-4 because they run 8
+      # GPUs per node and warm-start a big backbone — do not copy those values
+      # here; at training_seq_len=4096 on 1 GPU a batch of 4 will OOM.
+      # The streaming corpus is prompt-only (the serve generates the response and
+      # we capture ITS hidden states), so there is no assistant span to mask ->
+      # train over the full sequence. This also means no {% generation %}-tagged
+      # chat template is needed here, unlike the online/offline examples.
+      - training.answer_only_loss=false
+      # The vLLM serve container has no tensorboard -> trainer init crash.
+      - training.report_to=none
+      # Semi-AR generation block; must divide training_seq_len. dspark.yaml ships
+      # 16 (the Kimi/M3 runs use 8); loss_decay_factor is the matching gamma.
+      - dflash.dflash_block_size=16
+      - dflash.dflash_num_anchors=512
+      - dflash.dflash_loss_decay_factor=7
+      # Qwen3 has no native mask token; 151669 is an unused id.
+      - dflash.dflash_mask_token_id=151669
+      - dflash.dflash_architecture_config.num_hidden_layers=5
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      # 5 aux capture ids = the draft's target_layer_ids+1, plus the true final
+      # hidden (36). build_target_layer_ids(36,5)=[1,9,17,25,33] -> +1.
+      # Capturing the second-to-last layer instead of the true final one trains
+      # fine and silently caps acceptance length, so keep the final id honest.
+      # No spaces: nemo_run emits `export FOO=value` unquoted, so a space splits.
+      - EAGLE_CAPTURE_IDS: "[2,10,18,26,34,36]"
+      - SERVE_TP: "1"
+      - STREAMING_NUM_WORKERS: "4"
+      # DSpark exports a custom modeling file; export must trust remote code.
+      - EXPORT_EXTRA_ARGS: "--trust_remote_code"
+      - SERVE_MAX_MODEL_LEN: "4160"
+      - SERVE_MAX_NUM_SEQS: "32"
+      - SERVE_READY_TIMEOUT: "1800"
+      # RDMA transport is UCX (InfiniBand) by default. On AWS EFA, uncomment —
+      # and note UCX SEGFAULTS at agent init on EFA nodes (it detects the EFA
+      # devices), so LIBFABRIC is required there even for single-node runs:
+      # - NIXL_BACKENDS: "LIBFABRIC"
+      # - FI_PROVIDER: "efa"
+      # - NCCL_IB_DISABLE: "1"
+    slurm_config:
+      _factory_: "slurm_factory"
+      nodes: 2
+      ntasks_per_node: 1
+      gpus_per_node: 1
+      # Needs the aux-capture fix (vllm#46788), in-tree in recent nightlies;
+      # without it the final capture id is off by one and caps acceptance length.
+      container: vllm/vllm-openai:latest
+
+  # Step 3: vLLM smoke test (DSpark, uses the exported checkpoint from training).
+  # This is the acceptance-length number that reflects the trained Markov head —
+  # the training-time eval cannot produce it (see the AR-eval note in the header).
+  #
+  # REQUIRES a vLLM build with DSpark speculative-decoding support. If your image
+  # predates it, `--speculative-config '{"method": "dspark", ...}'` is rejected at
+  # startup; pin a newer nightly, or set `skip: true` here and evaluate the
+  # exported drafter with the offline specdec_bench harness instead.
+  task_2:
+    script: common/specdec/vllm_smoke_test.sh
+    environment:
+      - HF_MODEL_CKPT: <<global_vars.hf_model>>
+      - DRAFT_MODEL: /scratchspace/export
+      - SPEC_METHOD: "dspark"
+      - NUM_SPEC_TOKENS: "7"
+      - MIN_ACCEPTANCE_LENGTH: "1.2"
+    slurm_config:
+      _factory_: "slurm_factory"
+      container: vllm/vllm-openai:nightly
+      nodes: 1
+      ntasks_per_node: 1
+      gpus_per_node: 1


### PR DESCRIPTION
### What does this PR do?

Type of change: new example

Adds the missing **Qwen3-8B streaming DSpark** launcher example, plus an end-to-end walkthrough doc covering data synthesis → streaming training → evaluation.

DSpark examples so far only covered large MoE targets (Kimi-K2.6, MiniMax-M3 — both multi-node, 8 GPU/node). There was no small-scale entry point, so anyone new to the pipeline had to start from a config tuned for a very large warm-start run. This one runs on 2 nodes × 1 GPU, which makes it practical to exercise the whole flow before scaling up.

Two files, both additive — no existing behavior changes:

- **`tools/launcher/examples/Qwen/Qwen3-8B/hf_streaming_dspark.yaml`** — combines the MiniMax-M3 DSpark streaming settings with the Qwen3-8B DFlash streaming topology. Notably it does *not* copy M3's `per_device_train_batch_size=4` / `learning_rate=1e-4` / `warmup_steps=2000`: those assume 8 GPUs per node and a warm-started backbone, and at `training_seq_len=4096` on one GPU a batch of 4 will OOM. Batch/LR stay at the `dspark.yaml` defaults, matching the sibling DFlash example.

- **`examples/speculative_decoding/QWEN3_8B_DSPARK_WALKTHROUGH.md`** — the walkthrough. Covers why synthesis matters for acceptance length, the fields that actually matter, a Qwen3-8B-vs-large-MoE scaling table, and the failure modes that are *silent* rather than loud (capture-id off-by-one, non-inherited draft dims, synthesis yield loss, prompt-only-corpus hang).

### Usage

```bash
cd tools/launcher

# Step 1 — data synthesis (regenerate assistant turns with the target model)
uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_synth.yaml --yes

# Step 2 — streaming DSpark training (+ export + vLLM smoke test)
uv run launch.py --yaml examples/Qwen/Qwen3-8B/hf_streaming_dspark.yaml --yes
```

### Testing

- YAML parses and resolves; task topology, arg list and env block verified against `common/eagle3/train_eagle_streaming.sh` (every env knob used here is one the script actually reads).
- Pre-commit hooks applicable to these files pass: `yamlfmt`, `check-launcher-yaml` (validates the recipe/template references resolve), `markdownlint-cli2`, `insert-license`.
- All doc cross-links verified to resolve.

Not yet run as a live Slurm job — worth a `--dryrun` on a login node before merge. Flagging that rather than implying end-to-end validation.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ (additive only — two new files, nothing existing modified)
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A (launcher example YAML + docs; covered by the existing `check-launcher-yaml` hook)
- Did you update Changelog?: N/A
- Did you get Claude approval on this PR?: ❌ (not yet run)

**Note on `trust_remote_code`** (re: Security Best Practices): `EXPORT_EXTRA_ARGS: "--trust_remote_code"` is set in `task_1`. This is required because DSpark exports a custom modeling file that the exporter must load — it is not applied to the base model, which is stock Qwen3. This matches the existing DFlash/DSpark examples already on `main`.

### Additional Information

The synthesis step uses `tools/launcher/common/query.py`, already in-tree — no external tooling needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end Qwen3-8B speculative decoding training pipeline.
  * Added streaming target-model data transfer and checkpoint export workflows.
  * Added a smoke test for validating exported checkpoints with vLLM.
* **Documentation**
  * Added setup instructions covering prerequisites, configuration, scaling, evaluation, networking, and troubleshooting.
  * Documented launcher commands, dataset settings, capture configuration, and runtime requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->