### PR TITLE
fix: guard MoE branch when quantization_format is None

### DIFF
--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -448,7 +448,8 @@ def requantize_resmooth_fused_llm_layers(model: torch.nn.Module):
 
         # For MoE models update pre_quant_scale to average pre_quant_scale amongst experts
         if is_moe(module) and (
-            quantization_format is not QUANTIZATION_NONE
+            quantization_format is not None
+            and quantization_format != QUANTIZATION_NONE
             and ("awq" in quantization_format or quantization_format == QUANTIZATION_NVFP4_SVDQUANT)
         ):
             # update_experts_avg_prequant_scale(module)


### PR DESCRIPTION
This PR addresses the following issue in `modelopt/torch/export/unified_export_hf.py`: guard MoE branch when quantization_format is None.

## Changes
- `modelopt/torch/export/unified_export_hf.py`: guard MoE branch when quantization_format is None.

## Details
See the Files changed tab for the exact diff.

## Tests
- `tests/torch/export/test_unified_export_hf.py`

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MoE pre-quantization handling when no quantization format is specified.
  * Preserved existing AWQ and SVDQuant processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->