### PR TITLE
Add non-mutating quantized weight export API

### DIFF
--- a/modelopt/torch/export/__init__.py
+++ b/modelopt/torch/export/__init__.py
@@ -21,6 +21,7 @@ from .model_config_export import *
 from .model_utils import *
 from .moe_utils import *
 from .plugins import *
+from .quantized_weight import *
 from .registry import *
 from .transformer_engine import *
 from .unified_export_hf import *

--- a/modelopt/torch/export/quant_utils.py
+++ b/modelopt/torch/export/quant_utils.py
@@ -39,7 +39,6 @@ from modelopt.torch.quantization.qtensor import (
     QTensorWrapper,
 )
 from modelopt.torch.quantization.utils import (
-    QuantizerAttrNames,
     quantizer_attr_names,
     representative_weight_quantizer,
     weight_attr_names,
@@ -480,116 +479,106 @@ def get_weight_block_size(module: nn.Module, weight_name: str = "weight") -> int
     return 0
 
 
-def get_quantization_format(module) -> str | None:
-    """Gets the quantization string.
+def get_quantization_format_from_quantizers(
+    module: nn.Module,
+    weight_quantizer: object,
+    input_quantizer: object | None = None,
+    *,
+    weight_name: str = "weight",
+) -> str | None:
+    """Return the format of an exact weight and input quantizer pair."""
+    if not getattr(weight_quantizer, "is_enabled", False):
+        return QUANTIZATION_NONE
 
-    Gets the quantization string by iterating through the module and its children.
-    The first non-None quantization string is returned.
-    """
+    if isinstance(weight_quantizer, SequentialQuantizer):
+        assert (
+            len(weight_quantizer) == 2
+            and weight_quantizer[0].num_bits == 4
+            and weight_quantizer[1].num_bits == (4, 3)
+        ), "Unsupported SequentialQuantizer configuration"
+        assert (
+            weight_quantizer[0].block_sizes
+            and len(weight_quantizer[0].block_sizes) > 0
+            and weight_quantizer[0].block_sizes[-1] > 0
+        ), "Invalid block_sizes for SequentialQuantizer"
+        return QUANTIZATION_W4A8_AWQ
 
-    def _get_quantization_from_layer(layer, quantizer_attr_names: QuantizerAttrNames):
-        # Singular form first, plural ModuleList fallback (fused-experts).
-        # Strip the "_weight_quantizer" suffix to recover the weight attr name.
-        weight_attr = quantizer_attr_names.weight_quantizer
-        weight_name = weight_attr[: -len("_weight_quantizer")].rstrip("_") or "weight"
-        weight_quantizer = representative_weight_quantizer(layer, weight_name)
-        input_quantizer = getattr(layer, quantizer_attr_names.input_quantizer, None)
-
-        if weight_quantizer is None or not weight_quantizer.is_enabled:
-            return QUANTIZATION_NONE
-
-        # Handle SequentialQuantizer
-        if isinstance(weight_quantizer, SequentialQuantizer):
-            assert (
-                len(weight_quantizer) == 2
-                and weight_quantizer[0].num_bits == 4
-                and weight_quantizer[1].num_bits == (4, 3)
-            ), "Unsupported SequentialQuantizer configuration"
-            assert (
-                weight_quantizer[0].block_sizes
-                and len(weight_quantizer[0].block_sizes) > 0
-                and weight_quantizer[0].block_sizes[-1] > 0
-            ), "Invalid block_sizes for SequentialQuantizer"
-
-            return QUANTIZATION_W4A8_AWQ
-
-        # Handle individual num_bits cases
-        if weight_quantizer.num_bits == 4:
-            assert len(weight_quantizer.block_sizes) > 0 and weight_quantizer.block_sizes[-1] > 0, (
-                "Invalid block_sizes for INT4 quantizer"
-            )
-            return QUANTIZATION_INT4_AWQ
-
-        if weight_quantizer.num_bits == 8:
-            if input_quantizer is not None and input_quantizer.is_enabled:
-                return QUANTIZATION_INT8_SQ
-            else:
-                return QUANTIZATION_INT8_WO
-
-        if weight_quantizer.num_bits == (4, 3):
-            if weight_quantizer.block_sizes:
-                assert weight_quantizer.block_sizes[-1] > 0, "Invalid block_sizes for FP8 quantizer"
-                # Check if this is MXFP8 (dynamic block quantization with scale_bits (8, 0))
-                block_sizes = getattr(weight_quantizer, "block_sizes")
-                if (
-                    isinstance(block_sizes, dict)
-                    and block_sizes.get("type", "static") == "dynamic"
-                    and block_sizes.get("scale_bits") == (8, 0)
-                ):
-                    return QUANTIZATION_MXFP8
-                if weight_quantizer.fake_quant:
-                    return QUANTIZATION_FP8_PB_WO
-                else:
-                    return QUANTIZATION_FP8_PB_REAL
-            if weight_quantizer.axis == 0:
-                return QUANTIZATION_FP8_PC_PT
-            return QUANTIZATION_FP8
-
-        if weight_quantizer.num_bits == (2, 1):
-            # FP4 formats are all block quantization
-            block_sizes = getattr(weight_quantizer, "block_sizes")
-            scale_bits = block_sizes.get("scale_bits")
-
-            if input_quantizer is not None and hasattr(weight_quantizer, "svdquant_lora_a"):
-                return QUANTIZATION_NVFP4_SVDQUANT
-            if input_quantizer is not None and hasattr(input_quantizer, "_pre_quant_scale"):
-                return QUANTIZATION_NVFP4_AWQ
-            if getattr(layer, "fused_with_prequant", False):
-                return QUANTIZATION_NVFP4_AWQ
-            if input_quantizer is None or not input_quantizer.is_enabled:
-                if scale_bits == (4, 3):
-                    return QUANTIZATION_W4A16_NVFP4
-            assert input_quantizer is not None, (
-                f"input_quantizer is None for {quantizer_attr_names}"
-            )
-            if (
-                block_sizes.get("type", "static") == "dynamic"
-                and scale_bits == (8, 0)
-                and input_quantizer.is_enabled
-                and input_quantizer.num_bits == (4, 3)
-                and input_quantizer.block_sizes is None
-            ):
-                return QUANTIZATION_W4A8_MXFP4_FP8
-            if (
-                block_sizes.get("type", "static") == "dynamic"
-                and scale_bits == (4, 3)
-                and input_quantizer.is_enabled
-                and input_quantizer.num_bits == (4, 3)
-                and input_quantizer.block_sizes is None
-            ):
-                return QUANTIZATION_W4A8_NVFP4_FP8
-            if scale_bits == (4, 3):
-                return QUANTIZATION_NVFP4
-            elif scale_bits == (8, 0):
-                return QUANTIZATION_MXFP4
-
-        # Raise error for unsupported num_bits
-        raise NotImplementedError(
-            f"Unsupported quantizer with num_bits: {weight_quantizer.num_bits}"
+    if weight_quantizer.num_bits == 4:
+        assert len(weight_quantizer.block_sizes) > 0 and weight_quantizer.block_sizes[-1] > 0, (
+            "Invalid block_sizes for INT4 quantizer"
         )
+        return QUANTIZATION_INT4_AWQ
 
+    if weight_quantizer.num_bits == 8:
+        if input_quantizer is not None and input_quantizer.is_enabled:
+            return QUANTIZATION_INT8_SQ
+        return QUANTIZATION_INT8_WO
+
+    if weight_quantizer.num_bits == (4, 3):
+        if weight_quantizer.block_sizes:
+            assert weight_quantizer.block_sizes[-1] > 0, "Invalid block_sizes for FP8 quantizer"
+            block_sizes = getattr(weight_quantizer, "block_sizes")
+            if (
+                isinstance(block_sizes, dict)
+                and block_sizes.get("type", "static") == "dynamic"
+                and block_sizes.get("scale_bits") == (8, 0)
+            ):
+                return QUANTIZATION_MXFP8
+            if weight_quantizer.fake_quant:
+                return QUANTIZATION_FP8_PB_WO
+            return QUANTIZATION_FP8_PB_REAL
+        if weight_quantizer.axis == 0:
+            return QUANTIZATION_FP8_PC_PT
+        return QUANTIZATION_FP8
+
+    if weight_quantizer.num_bits == (2, 1):
+        block_sizes = getattr(weight_quantizer, "block_sizes")
+        scale_bits = block_sizes.get("scale_bits")
+
+        if input_quantizer is not None and hasattr(weight_quantizer, "svdquant_lora_a"):
+            return QUANTIZATION_NVFP4_SVDQUANT
+        if input_quantizer is not None and hasattr(input_quantizer, "_pre_quant_scale"):
+            return QUANTIZATION_NVFP4_AWQ
+        if getattr(module, "fused_with_prequant", False):
+            return QUANTIZATION_NVFP4_AWQ
+        if input_quantizer is None or not input_quantizer.is_enabled:
+            if scale_bits == (4, 3):
+                return QUANTIZATION_W4A16_NVFP4
+        assert input_quantizer is not None, f"input_quantizer is None for {weight_name!r}"
+        if (
+            block_sizes.get("type", "static") == "dynamic"
+            and scale_bits == (8, 0)
+            and input_quantizer.is_enabled
+            and input_quantizer.num_bits == (4, 3)
+            and input_quantizer.block_sizes is None
+        ):
+            return QUANTIZATION_W4A8_MXFP4_FP8
+        if (
+            block_sizes.get("type", "static") == "dynamic"
+            and scale_bits == (4, 3)
+            and input_quantizer.is_enabled
+            and input_quantizer.num_bits == (4, 3)
+            and input_quantizer.block_sizes is None
+        ):
+            return QUANTIZATION_W4A8_NVFP4_FP8
+        if scale_bits == (4, 3):
+            return QUANTIZATION_NVFP4
+        if scale_bits == (8, 0):
+            return QUANTIZATION_MXFP4
+
+    raise NotImplementedError(f"Unsupported quantizer with num_bits: {weight_quantizer.num_bits}")
+
+
+def get_quantization_format(module) -> str | None:
+    """Gets the first quantization format found in a module tree."""
     for weight_name in weight_attr_names(module):
-        quantization = _get_quantization_from_layer(module, quantizer_attr_names(weight_name))
+        attrs = quantizer_attr_names(weight_name)
+        quantization = get_quantization_format_from_quantizers(
+            module,
+            representative_weight_quantizer(module, weight_name),
+            getattr(module, attrs.input_quantizer, None),
+            weight_name=weight_name,
+        )
         if quantization != QUANTIZATION_NONE:
             return quantization
 
@@ -775,6 +764,11 @@ def process_layer_quant_config(layer_config_dict):
     # If we have more than one quantization format, infer MIXED_PRECISION
     if len(quantization_formats) > 1:
         per_layer_config["quant_algo"] = "MIXED_PRECISION"
+        per_layer_config["exclude_modules"] = sorted(
+            _prefix_wildcard_summarize_exclude_modules(
+                exclude_modules, per_layer_config["quantized_layers"].keys()
+            )
+        )
     elif len(quantization_formats) == 1 and quantization_config is not None:
         per_layer_config.update(quantization_config)
         per_layer_config["exclude_modules"] = sorted(
@@ -1449,6 +1443,22 @@ def _get_unquantized_moe_router_names(model: nn.Module) -> list[str]:
     return router_names
 
 
+def build_quant_config(
+    layer_config_dict: dict[str, Any],
+    kv_cache_format: str | None = QUANTIZATION_NONE,
+) -> dict[str, Any]:
+    """Build ModelOpt's export config from canonical per-layer records."""
+    quant_config = {
+        "producer": {
+            "name": "modelopt",
+            "version": __version__,
+        },
+        "quantization": process_layer_quant_config(layer_config_dict),
+    }
+    quant_config["quantization"]["kv_cache_quant_algo"] = kv_cache_format
+    return quant_config
+
+
 def get_quant_config(
     model: nn.Module,
     is_modelopt_qlora: bool = False,
@@ -1468,21 +1478,6 @@ def get_quant_config(
     # Find first quantized linear layer to determine quantization format
     quantization_format = None
     block_size = None
-
-    # Create base config
-    quant_config = {
-        "producer": {
-            "name": "modelopt",
-            "version": __version__,
-        },
-    }
-
-    default_quantization = {
-        "quant_algo": None,
-        "kv_cache_quant_algo": None,
-    }
-
-    quant_config["quantization"] = default_quantization
 
     # Layer config dict holds quantization format of each layer.
     # It also holds awq_block_size information for applicable layers.
@@ -1565,13 +1560,7 @@ def get_quant_config(
     for router_name in _get_unquantized_moe_router_names(model):
         layer_config_dict.setdefault(router_name + ".quantization", QUANTIZATION_NONE)
 
-    # Process per layer quantization config dict
-    quant_config["quantization"].update(process_layer_quant_config(layer_config_dict))
-
-    if kv_cache_format is not None:
-        quant_config["quantization"]["kv_cache_quant_algo"] = kv_cache_format
-
-    return quant_config
+    return build_quant_config(layer_config_dict, kv_cache_format)
 
 
 def has_quantized_modules(model: nn.Module) -> bool:

--- a/modelopt/torch/export/quant_utils.py
+++ b/modelopt/torch/export/quant_utils.py
@@ -481,8 +481,8 @@ def get_weight_block_size(module: nn.Module, weight_name: str = "weight") -> int
 
 def get_quantization_format_from_quantizers(
     module: nn.Module,
-    weight_quantizer: object,
-    input_quantizer: object | None = None,
+    weight_quantizer: Any,
+    input_quantizer: Any | None = None,
     *,
     weight_name: str = "weight",
 ) -> str | None:

--- a/modelopt/torch/export/quantized_weight.py
+++ b/modelopt/torch/export/quantized_weight.py
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Non-mutating export helpers for quantized checkpoint weights."""
+
+from collections import OrderedDict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+
+from modelopt.torch.quantization.qtensor import NVFP4QTensor
+from modelopt.torch.quantization.utils import quantizer_attr_names
+
+from .convert_hf_config import convert_hf_quant_config_format
+from .model_config import QUANTIZATION_NONE, QUANTIZATION_NVFP4, QUANTIZATION_W4A16_NVFP4
+from .quant_utils import (
+    build_quant_config,
+    get_quantization_format_from_quantizers,
+    to_quantized_weight,
+)
+
+__all__ = [
+    "QuantizedWeightExport",
+    "QuantizedWeightExportState",
+    "build_hf_quantization_config",
+    "capture_quantized_weight_export_state",
+    "export_quantized_weight",
+]
+
+_SUPPORTED_FORMATS = {QUANTIZATION_NVFP4, QUANTIZATION_W4A16_NVFP4}
+
+
+@dataclass(frozen=True)
+class QuantizedWeightExportState:
+    """Scalar ModelOpt state for one logical floating-point weight."""
+
+    quantization_format: str
+    block_size: int
+    weight_amax: torch.Tensor
+    input_amax: torch.Tensor | None = None
+
+
+@dataclass(frozen=True)
+class QuantizedWeightExport:
+    """Packed checkpoint tensors for one quantized weight."""
+
+    weight: torch.Tensor
+    weight_scale: torch.Tensor
+    weight_scale_2: torch.Tensor
+    input_scale: torch.Tensor | None = None
+
+    def named_tensors(self, weight_name: str = "weight") -> OrderedDict[str, torch.Tensor]:
+        """Return checkpoint tensors using ModelOpt's canonical relative names."""
+        attrs = quantizer_attr_names(weight_name)
+        tensors = OrderedDict(
+            (
+                (weight_name, self.weight),
+                (attrs.weight_scale, self.weight_scale),
+                (attrs.weight_scale_2, self.weight_scale_2),
+            )
+        )
+        if self.input_scale is not None:
+            tensors[attrs.input_scale] = self.input_scale
+        return tensors
+
+
+@dataclass(frozen=True)
+class _Nvfp4WeightQuantizerView:
+    _amax: torch.Tensor
+    block_sizes: Mapping[object, object]
+
+
+@dataclass(frozen=True)
+class _Nvfp4InputQuantizerView:
+    _amax: torch.Tensor
+    is_enabled: bool = True
+    maxbound: float = 6.0
+
+    def export_amax(self) -> torch.Tensor:
+        return self._amax
+
+
+def _clone_amax(quantizer: object, *, input_quantizer: bool = False) -> torch.Tensor | None:
+    if quantizer is None or not bool(getattr(quantizer, "is_enabled", False)):
+        return None
+    if input_quantizer:
+        value = getattr(quantizer, "_amax", None)
+    else:
+        value = getattr(quantizer, "global_amax", None)
+        if value is None:
+            value = getattr(quantizer, "_global_amax", None)
+        if value is None:
+            value = getattr(quantizer, "_amax", None)
+    if not isinstance(value, torch.Tensor):
+        return None
+    return value.detach().clone()
+
+
+def capture_quantized_weight_export_state(
+    module: nn.Module,
+    weight_name: str = "weight",
+    *,
+    weight_quantizer: object | None = None,
+    input_quantizer: object | None = None,
+) -> QuantizedWeightExportState:
+    """Capture scalar quantized-weight export state without changing the module."""
+    attrs = quantizer_attr_names(weight_name)
+    if weight_quantizer is None:
+        weight_quantizer = getattr(module, attrs.weight_quantizer, None)
+    if weight_quantizer is None:
+        raise RuntimeError(f"Missing weight quantizer for {weight_name!r}")
+    if NVFP4QTensor._is_static_quantizer(weight_quantizer):
+        raise NotImplementedError(
+            "Pure distributed export does not support static per-block NVFP4 state."
+        )
+
+    weight_amax = _clone_amax(weight_quantizer)
+    if weight_amax is None:
+        raise RuntimeError(f"Missing calibrated weight amax for {weight_name!r}")
+    if weight_amax.numel() != 1:
+        raise NotImplementedError(
+            "Pure quantized-weight export currently requires scalar weight amax"
+        )
+    if input_quantizer is None:
+        input_quantizer = getattr(module, attrs.input_quantizer, None)
+    quantization_format = get_quantization_format_from_quantizers(
+        module,
+        weight_quantizer,
+        input_quantizer,
+        weight_name=weight_name,
+    )
+    if quantization_format not in _SUPPORTED_FORMATS:
+        raise NotImplementedError(f"Unsupported pure export format: {quantization_format!r}")
+
+    input_amax = _clone_amax(
+        input_quantizer,
+        input_quantizer=True,
+    )
+    block_sizes = getattr(weight_quantizer, "block_sizes", None) or {}
+    if getattr(weight_quantizer, "num_bits", None) != (2, 1) or block_sizes.get("scale_bits") != (
+        4,
+        3,
+    ):
+        raise NotImplementedError("Pure quantized-weight export requires NVFP4 weights")
+    if quantization_format == QUANTIZATION_NVFP4 and input_amax is None:
+        raise RuntimeError(f"Missing calibrated input amax for {weight_name!r}")
+    if input_amax is not None and input_amax.numel() != 1:
+        raise NotImplementedError(
+            "Pure quantized-weight export currently requires scalar input amax"
+        )
+
+    return QuantizedWeightExportState(
+        quantization_format=quantization_format,
+        block_size=block_sizes[-1],
+        weight_amax=weight_amax,
+        input_amax=input_amax,
+    )
+
+
+def _require_positive_finite(name: str, value: torch.Tensor) -> None:
+    if value.numel() == 0 or not torch.isfinite(value).all() or not torch.all(value > 0):
+        raise RuntimeError(f"Invalid {name}: {value}")
+
+
+def export_quantized_weight(
+    weight: torch.Tensor,
+    state: QuantizedWeightExportState,
+    *,
+    dtype: torch.dtype,
+) -> QuantizedWeightExport:
+    """Pack one canonical weight without mutating it or its quantizers."""
+    if state.quantization_format not in _SUPPORTED_FORMATS:
+        raise NotImplementedError(f"Unsupported pure export format: {state.quantization_format!r}")
+    if state.block_size <= 0:
+        raise ValueError(f"Invalid block size: {state.block_size}")
+
+    weight_amax = state.weight_amax.to(device=weight.device, dtype=torch.float32)
+    _require_positive_finite("weight amax", weight_amax)
+    quantizer = _Nvfp4WeightQuantizerView(
+        _amax=weight_amax,
+        block_sizes={-1: state.block_size, "type": "dynamic", "scale_bits": (4, 3)},
+    )
+    weight_scale_2 = NVFP4QTensor.get_weights_scaling_factor_2_from_quantizer(quantizer)
+    weight_scale = NVFP4QTensor.get_weights_scaling_factor(
+        weight,
+        block_size=state.block_size,
+        weights_scaling_factor_2=weight_scale_2.to(weight.device),
+    )[0]
+    packed_weight = to_quantized_weight(
+        weight.to(dtype),
+        weight_scale,
+        state.quantization_format,
+        weight_scale_2,
+        state.block_size,
+    )
+
+    input_scale = None
+    if state.quantization_format == QUANTIZATION_NVFP4:
+        if state.input_amax is None:
+            raise RuntimeError("Missing input amax for NVFP4 W4A4 export")
+        input_amax = state.input_amax.to(device=weight.device, dtype=torch.float32)
+        _require_positive_finite("input amax", input_amax)
+        input_scale = NVFP4QTensor.get_activation_scaling_factor(
+            _Nvfp4InputQuantizerView(input_amax)
+        ).squeeze()
+
+    return QuantizedWeightExport(
+        weight=packed_weight,
+        weight_scale=weight_scale,
+        weight_scale_2=weight_scale_2.squeeze(),
+        input_scale=input_scale,
+    )
+
+
+def build_hf_quantization_config(
+    layer_states: Mapping[str, QuantizedWeightExportState | None]
+    | Iterable[tuple[str, QuantizedWeightExportState | None]],
+) -> dict:
+    """Build the canonical ModelOpt HF config from canonical layer formats."""
+    states = dict(layer_states)
+    quantized_formats = {
+        state.quantization_format for state in states.values() if state is not None
+    }
+    unsupported = quantized_formats.difference(_SUPPORTED_FORMATS)
+    if unsupported:
+        raise NotImplementedError(f"Unsupported quantized layer formats: {sorted(unsupported)}")
+    layer_config = {}
+    for name, state in states.items():
+        layer_config[f"{name}.quantization"] = (
+            state.quantization_format if state is not None else QUANTIZATION_NONE
+        )
+        layer_config[f"{name}.awq_block_size"] = state.block_size if state is not None else 0
+    return convert_hf_quant_config_format(build_quant_config(layer_config))

--- a/modelopt/torch/export/quantized_weight.py
+++ b/modelopt/torch/export/quantized_weight.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Non-mutating export helpers for quantized checkpoint weights."""
 

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -115,6 +115,7 @@ from .quant_utils import (
     sync_tied_input_amax,
     to_quantized_weight,
 )
+from .quantized_weight import capture_quantized_weight_export_state, export_quantized_weight
 from .registry import ExportContext, ExportModuleRegistry, PrepareMoEInputsRegistry
 
 __all__ = ["export_hf_checkpoint", "export_speculative_decoding"]
@@ -566,6 +567,38 @@ def _compressed_per_block_scale(
     return cutlass_fp4_scale_to_modelopt_fp4_scale(scale, weight.metadata["shape"][-2:])
 
 
+def _alias_tied_export_tensors(
+    sub_module: nn.Module,
+    weight_name: str,
+    source_data_ptr: int,
+    tied_cache: dict[int, nn.Module] | None,
+) -> None:
+    """Restore aliases between exported modules that shared a source weight."""
+    if tied_cache is None:
+        return
+
+    quantizer_attrs = quantizer_attr_names(weight_name)
+    prior = tied_cache.get(source_data_ptr)
+    if prior is None or prior is sub_module:
+        tied_cache[source_data_ptr] = sub_module
+        return
+
+    if hasattr(prior, weight_name):
+        setattr(sub_module, weight_name, getattr(prior, weight_name))
+    for attr in (
+        quantizer_attrs.weight_scale,
+        quantizer_attrs.weight_scale_2,
+        quantizer_attrs.input_scale,
+    ):
+        if not hasattr(prior, attr):
+            continue
+        if attr in sub_module._buffers:
+            del sub_module._buffers[attr]
+        elif hasattr(sub_module, attr):
+            delattr(sub_module, attr)
+        sub_module.register_buffer(attr, getattr(prior, attr))
+
+
 def _export_quantized_weight(
     sub_module: nn.Module,
     dtype: torch.dtype,
@@ -640,6 +673,32 @@ def _export_quantized_weight(
     use_compressed_scale = (
         compressed_weight_scale is not None and compressed_weight_scale_2 is not None
     )
+
+    is_bmm_expert_weight = weight.dim() == 3 and any(
+        expert_type in type(sub_module).__name__
+        for expert_type in ["Llama4TextExperts", "GptOssExperts"]
+    )
+    use_pure_nvfp4_export = (
+        quantization_format in {QUANTIZATION_NVFP4, QUANTIZATION_W4A16_NVFP4}
+        and not use_compressed_scale
+        and not NVFP4QTensor._is_static_quantizer(weight_quantizer)
+        and not is_bmm_expert_weight
+    )
+    if use_pure_nvfp4_export:
+        state = capture_quantized_weight_export_state(sub_module, weight_name)
+        exported = export_quantized_weight(weight, state, dtype=dtype)
+        setattr(sub_module, weight_name, nn.Parameter(exported.weight, requires_grad=False))
+        for relative_name, tensor in exported.named_tensors(weight_name).items():
+            if relative_name != weight_name:
+                sub_module.register_buffer(relative_name, tensor)
+        _alias_tied_export_tensors(
+            sub_module,
+            weight_name,
+            _tied_source_data_ptr,
+            _tied_cache,
+        )
+        torch.cuda.empty_cache()
+        return
 
     if quantization_format == QUANTIZATION_FP8:
         # Convert amax to float32
@@ -726,10 +785,6 @@ def _export_quantized_weight(
 
     # Transpose weight for bmm-style expert quantization (llama4, gpt-oss)
     # Check if this is a BMM-style expert weight that needs transposition
-    is_bmm_expert_weight = weight.dim() == 3 and any(
-        expert_type in type(sub_module).__name__
-        for expert_type in ["Llama4TextExperts", "GptOssExperts"]
-    )
     # NVFP4StaticQuantizer + BMM-style experts: route through the static-aware
     # ``_from_quantizer`` helper so the pinned per-block ``_amax`` (e.g. set by
     # the MXFP4->NVFP4 cast to ``6 * 2^k_j``) is used to derive the FP8
@@ -826,25 +881,12 @@ def _export_quantized_weight(
     # input_scale is safe to alias because sync_tied_input_amax (earlier in
     # this export) already max-merged the per-side amaxes. Gated on the
     # caller-owned _tied_cache so the dedup state is scoped to one export.
-    if _tied_cache is not None:
-        _prior = _tied_cache.get(_tied_source_data_ptr)
-        if _prior is not None and _prior is not sub_module:
-            if hasattr(_prior, weight_name):
-                setattr(sub_module, weight_name, getattr(_prior, weight_name))
-            for _attr in (
-                quantizer_attrs.weight_scale,
-                quantizer_attrs.weight_scale_2,
-                quantizer_attrs.input_scale,
-            ):
-                if not hasattr(_prior, _attr):
-                    continue
-                if _attr in sub_module._buffers:
-                    del sub_module._buffers[_attr]
-                elif hasattr(sub_module, _attr):
-                    delattr(sub_module, _attr)
-                sub_module.register_buffer(_attr, getattr(_prior, _attr))
-        else:
-            _tied_cache[_tied_source_data_ptr] = sub_module
+    _alias_tied_export_tensors(
+        sub_module,
+        weight_name,
+        _tied_source_data_ptr,
+        _tied_cache,
+    )
 
     torch.cuda.empty_cache()
 

--- a/modelopt/torch/quantization/plugins/custom.py
+++ b/modelopt/torch/quantization/plugins/custom.py
@@ -173,10 +173,15 @@ class _ParallelLinear(_QuantFunctionalMixin, QuantModule):
             _check_unsupported_states(
                 quantizer if isinstance(quantizer, TensorQuantizer) else quantizer[0]
             )
+        # Grouped linears validate each expert against its corresponding weight in their
+        # override. Resetting the container here would clear every expert amax before this
+        # single-weight compatibility path recalibrates only the representative quantizer.
         # Skip max_calibrate when saved static NVFP4 state is intact; else MSE scales get overwritten.
-        if _has_state(
-            self.weight_quantizer, "_amax"
-        ) and not _has_complete_static_nvfp4_weight_state(self.weight_quantizer, self.weight):
+        if (
+            not isinstance(self.weight_quantizer, GroupedQuantizer)
+            and _has_state(self.weight_quantizer, "_amax")
+            and not _has_complete_static_nvfp4_weight_state(self.weight_quantizer, self.weight)
+        ):
             self.weight_quantizer.reset_amax()
             max_calibrate(self.weight_quantizer, lambda wq: wq(self.weight), distributed_sync=False)
         if _has_state(self.input_quantizer, "_pre_quant_scale"):

--- a/tests/gpu_megatron/torch/quantization/plugins/test_transformer_engine.py
+++ b/tests/gpu_megatron/torch/quantization/plugins/test_transformer_engine.py
@@ -118,6 +118,26 @@ def test_quantize(model_cls, config):
     quantize_model_and_forward(model, config, calib_data)
 
 
+def test_grouped_post_restore_preserves_weight_amax():
+    """Grouped restore must not clear calibrated state for non-representative experts."""
+    model = TEGroupedLinear().cuda()
+    with torch.no_grad():
+        for index in range(model.num_gemms):
+            getattr(model.net, f"weight{index}").fill_(0.25 + index)
+
+    data = model.get_input().cuda()
+    mtq.quantize(model, copy.deepcopy(mtq.FP8_DEFAULT_CFG), lambda module: module(data))
+
+    quantizers = model.net.weight_quantizer
+    assert isinstance(quantizers, mtq.nn.GroupedQuantizer)
+    before_restore = [quantizer.amax.clone() for quantizer in quantizers]
+
+    model.net.modelopt_post_restore()
+
+    for quantizer, expected in zip(quantizers, before_restore):
+        torch.testing.assert_close(quantizer.amax, expected)
+
+
 def test_quantize_forward_backward():
     set_seed()
     model = TELinear().cuda()

--- a/tests/unit/torch/export/test_export_weight.py
+++ b/tests/unit/torch/export/test_export_weight.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
+import copy
+
 import pytest
 import torch
 import torch.nn as nn
 from _test_utils.torch.export.utils import ToyModel, partial_fp8_config, partial_w4a8_config
 
 import modelopt.torch.quantization as mtq
+from modelopt.torch.export.quantized_weight import (
+    build_hf_quantization_config,
+    capture_quantized_weight_export_state,
+    export_quantized_weight,
+)
 from modelopt.torch.export.unified_export_hf import (
     _export_quantized_weight,
     _process_quantized_modules,
 )
+from modelopt.torch.quantization.nn import GroupedQuantizer
 from modelopt.torch.quantization.utils import quantizer_attr_names
 
 
@@ -100,6 +108,171 @@ def test_export_per_block_quantized_weight():
     assert hasattr(model.linears[2], quantizer_attrs.output_quantizer)
     assert not getattr(model.linears[2], quantizer_attrs.output_quantizer).is_enabled
     assert not hasattr(model.linears[2], quantizer_attrs.output_scale)
+
+
+@pytest.mark.parametrize(
+    ("quant_cfg", "expected_algo", "has_input_scale"),
+    [
+        (mtq.NVFP4_DEFAULT_CFG, "NVFP4", True),
+        (mtq.W4A16_NVFP4_CFG, "W4A16_NVFP4", False),
+    ],
+)
+def test_pure_nvfp4_export_matches_module_export(
+    quant_cfg,
+    expected_algo,
+    has_input_scale,
+):
+    module = nn.Linear(16, 2, bias=False)
+    mtq.quantize(module, copy.deepcopy(quant_cfg), lambda m: m(torch.ones(1, 16)))
+    with torch.no_grad():
+        module.weight.copy_(torch.arange(32, dtype=torch.float32).reshape(2, 16) / 8 - 2)
+    module.weight_quantizer.amax = torch.tensor(2.0)
+    if has_input_scale:
+        module.input_quantizer.amax = torch.tensor(3.0)
+    source_weight = module.weight.detach().clone()
+    source_data_ptr = module.weight.data_ptr()
+    source_parameters = tuple(module.parameters())
+    source_buffers = {
+        name: (buffer, buffer.detach().clone()) for name, buffer in module.named_buffers()
+    }
+
+    state = capture_quantized_weight_export_state(module)
+    pure = export_quantized_weight(module.weight, state, dtype=torch.float32)
+    repeated = export_quantized_weight(module.weight, state, dtype=torch.float32)
+
+    expected_weight = torch.tensor(
+        [
+            [255, 239, 238, 222, 221, 204, 171, 154],
+            [16, 34, 67, 84, 101, 102, 118, 119],
+        ],
+        dtype=torch.uint8,
+    )
+    expected_weight_scale = torch.tensor([[448.0], [416.0]], dtype=torch.float8_e4m3fn)
+    assert torch.equal(pure.weight, expected_weight)
+    assert torch.equal(pure.weight_scale, expected_weight_scale)
+    assert pure.weight_scale_2 == pytest.approx(0.0007440476329065859)
+    assert torch.equal(repeated.weight, pure.weight)
+    assert torch.equal(repeated.weight_scale, pure.weight_scale)
+    assert torch.equal(repeated.weight_scale_2, pure.weight_scale_2)
+    if has_input_scale:
+        assert pure.input_scale == pytest.approx(0.0011160714784637094)
+
+    assert module.weight.data_ptr() == source_data_ptr
+    assert torch.equal(module.weight, source_weight)
+    assert all(
+        parameter is source_parameter
+        for parameter, source_parameter in zip(module.parameters(), source_parameters, strict=True)
+    )
+    assert set(dict(module.named_buffers())) == set(source_buffers)
+    for name, buffer in module.named_buffers():
+        source_buffer, source_value = source_buffers[name]
+        assert buffer is source_buffer
+        assert torch.equal(buffer, source_value)
+    assert not hasattr(module, "weight_scale")
+    assert not hasattr(module, "weight_scale_2")
+    assert not hasattr(module, "input_scale")
+
+    _export_quantized_weight(module, torch.float32)
+
+    assert torch.equal(module.weight, pure.weight)
+    assert torch.equal(module.weight_scale, pure.weight_scale)
+    assert torch.equal(module.weight_scale_2, pure.weight_scale_2)
+    assert hasattr(module, "input_scale") is has_input_scale
+    if has_input_scale:
+        assert torch.equal(module.input_scale, pure.input_scale)
+
+    config = build_hf_quantization_config({"model.layers.0.mlp.up_proj": state})
+    assert config["quant_algo"] == expected_algo
+    assert config["config_groups"]["group_0"]["weights"]["group_size"] == state.block_size
+
+
+def test_pure_nvfp4_capture_preserves_independent_expert_state():
+    modules = [nn.Linear(16, 2, bias=False) for _ in range(2)]
+    for module, weight_amax, input_amax in zip(
+        modules,
+        (2.0, 4.0),
+        (3.0, 5.0),
+        strict=True,
+    ):
+        mtq.quantize(
+            module,
+            copy.deepcopy(mtq.NVFP4_DEFAULT_CFG),
+            lambda m: m(torch.ones(1, 16)),
+        )
+        module.weight_quantizer.amax = torch.tensor(weight_amax)
+        module.input_quantizer.amax = torch.tensor(input_amax)
+
+    grouped_module = nn.Module()
+    grouped_module.weight0 = modules[0].weight
+    grouped_module.weight1 = modules[1].weight
+    grouped_module.weight_quantizer = GroupedQuantizer(
+        modules[0].weight_quantizer,
+        modules[1].weight_quantizer,
+    )
+    states = [
+        capture_quantized_weight_export_state(
+            grouped_module,
+            f"weight{expert_idx}",
+            weight_quantizer=grouped_module.weight_quantizer[expert_idx],
+            input_quantizer=modules[expert_idx].input_quantizer,
+        )
+        for expert_idx in range(2)
+    ]
+
+    assert torch.equal(states[0].weight_amax, torch.tensor(2.0))
+    assert torch.equal(states[1].weight_amax, torch.tensor(4.0))
+    assert torch.equal(states[0].input_amax, torch.tensor(3.0))
+    assert torch.equal(states[1].input_amax, torch.tensor(5.0))
+
+
+def test_hf_quantization_config_supports_mixed_nvfp4():
+    states = {}
+    for name, quant_cfg in (
+        ("model.layers.0.mlp.up_proj", mtq.NVFP4_DEFAULT_CFG),
+        ("model.layers.1.mlp.up_proj", mtq.W4A16_NVFP4_CFG),
+    ):
+        module = nn.Linear(16, 2, bias=False)
+        mtq.quantize(
+            module,
+            copy.deepcopy(quant_cfg),
+            lambda m: m(torch.ones(1, 16)),
+        )
+        module.weight_quantizer.amax = torch.tensor(2.0)
+        if module.input_quantizer.is_enabled:
+            module.input_quantizer.amax = torch.tensor(3.0)
+        states[name] = capture_quantized_weight_export_state(module)
+    states["model.layers.0.self_attn.q_proj"] = None
+
+    config = build_hf_quantization_config(states)
+
+    assert config["quant_algo"] == "MIXED_PRECISION"
+    assert len(config["config_groups"]) == 2
+    assert config["ignore"] == ["model.layers.0.self_attn*"]
+
+
+def test_pure_nvfp4_capture_rejects_disabled_weight_quantizer():
+    module = nn.Linear(16, 2, bias=False)
+    mtq.quantize(
+        module,
+        copy.deepcopy(mtq.NVFP4_DEFAULT_CFG),
+        lambda m: m(torch.ones(1, 16)),
+    )
+    module.weight_quantizer.disable()
+
+    with pytest.raises(RuntimeError, match="Missing calibrated weight amax"):
+        capture_quantized_weight_export_state(module)
+
+
+def test_pure_nvfp4_capture_rejects_deferred_nvfp4_format():
+    module = nn.Linear(16, 2, bias=False)
+    mtq.quantize(
+        module,
+        copy.deepcopy(mtq.W4A8_NVFP4_FP8_CFG),
+        lambda m: m(torch.ones(1, 16)),
+    )
+
+    with pytest.raises(NotImplementedError, match="w4a8_nvfp4_fp8"):
+        capture_quantized_weight_export_state(module)
 
 
 class QuantMoELinear(nn.Module):


### PR DESCRIPTION
## Summary

- add a public, non-mutating API that exports quantized deployment tensors and a ModelOpt deployment descriptor from an initialized model
- share the packing and metadata path with terminal HF export instead of duplicating format-specific conversion logic
- preserve per-expert amax values when grouped quantizers are temporarily restored for export

This API is intended for in-process refit users such as Megatron-Bridge and NeMo-RL. It keeps the training model unchanged while producing the same canonical weight, scale, and input-scale tensors as terminal export.

## Testing

- targeted export unit tests
- Transformer Engine grouped-quantizer GPU regression test
- Ruff check and format check
- downstream two-rank TP2/PP2/EP2 parity test comparing the API with terminal export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for exporting NVFP4 and mixed-precision quantized weights with packed weights, scaling data, activation scaling, and Hugging Face quantization metadata.
  * Improved handling of tied weights and mixed-precision configurations.
  * Added validation for unsupported formats, missing calibration data, invalid scales, and block sizes.

* **Bug Fixes**
  * Preserved grouped quantizer calibration values during model restoration.
  * Improved consistency, repeatability, and state preservation when exporting quantized weights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->