### PR TITLE
fix(launcher): increase Nemotron 3.5 Lightning QAD parallelism

### DIFF
--- a/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/megatron_lm_qad.yaml
+++ b/tools/launcher/examples/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16/megatron_lm_qad.yaml
@@ -7,10 +7,12 @@
 # prepare the repository's other large splits.
 #
 # PTQ topology: 1 B200 node x 4 GPUs, TP=1, PP=1, CP=1, EP=4, ETP=1.
-# QAD topology: 2 B200 nodes x 4 GPUs, TP=2, PP=1, CP=1, EP=4, ETP=1.
+# QAD topology: 4 B200 nodes x 4 GPUs, TP=1, PP=1, CP=4, EP=4, ETP=1.
+# TP must match the TP=1 static-NVFP4 PTQ checkpoint. CP=4 bounds each rank to
+# 8K tokens so the original, unchunked full-vocabulary KL loss fits at 32K.
 # With micro-batch-size=1 and global-batch-size=16, train-samples=6400 produces
 # 400 iterations. To use another sequence length, change both --seq-length and
-# --max-position-embeddings. Our final QAD run used a sequence length of 524,288.
+# --max-position-embeddings.
 #
 # Requirements:
 #   - The BF16 model is mounted at /hf-local/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16.
@@ -113,8 +115,8 @@ pipeline:
       - MLM_TRAIN_SCRIPT: finetune
       - DATASET: nvidia/Nemotron-Post-Training-Dataset-v2
       - DP: "1"
-      - CP: "1"
-      - TP: "2"
+      - CP: "4"
+      - TP: "1"
       - PP: "1"
       - EP: "4"
       - ETP: "1"
@@ -122,7 +124,7 @@ pipeline:
       _factory_: "slurm_factory"
       container: nvcr.io/nvidia/nemo:26.06.00
       modelopt_install_path: /opt/venv/lib/python3.12/site-packages/modelopt
-      nodes: 2
+      nodes: 4
       ntasks_per_node: 4
       gpus_per_node: 4
 


### PR DESCRIPTION
### What does this PR do?

Type of change:  Bug fix

Current Nemotron 3.5 Lightning QAD example can OOM, and also TP=2 is not supported for static quantization. Increase GPUs, CP and decrease TP=1

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅ / ❌ / N/A <!--- If ❌, explain why. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: ✅ / ❌ / N/A <!--- Mandatory -->
- Did you write any new necessary tests?: ✅ / ❌ / N/A <!--- Mandatory for new features or examples. -->
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅ / ❌ / N/A <!--- Very short summary of changes only for new features, backward breaking changes, deprecations, or fixes for critical bugs present in previous releases. -->
- Did you get Claude approval on this PR?: ✅ / ❌ / N/A <!--- Run `/claude review`. NVIDIA org members can self-trigger for complex changes; orthogonal to CodeRabbit. -->

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the QAD training setup to run across four nodes with revised tensor and context parallelism settings.
  * Documented the 32K sequence-length constraint and removed outdated run information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->