### PR TITLE
docs(eval-skill): add MRCR (NeMo Gym) benchmark

### DIFF
--- a/plugins/modelopt/skills/evaluation/SKILL.md
+++ b/plugins/modelopt/skills/evaluation/SKILL.md
@@ -94,7 +94,8 @@ for an "AA" request. If the user asks for MRCR:
    comparable; set it in **both** `data_prep_params` and `collect_rollout_params`.
 3. `.env`: `HF_TOKEN` (dataset + n3 tokenizer are gated) plus
    `NEMO_EVALUATOR_TRUST_PRE_CMD=1` (the `pre_cmd` installs `tiktoken` +
-   `transformers`; prepare fails without it).
+   `transformers`; prepare fails without it) and
+   `NEMO_EVALUATOR_TRUST_UNLISTED_TASKS=1` (`nemo_gym` is not in the FDF map).
 4. The Gym pin is **newer than any image's baked Gym** and is silently ignored
    where `/opt/Gym` is not a git repo — verify it applied before quoting a score.
    NVIDIA-internal: `modelopttools:eval-config` Step 3d names a working image.

--- a/plugins/modelopt/skills/evaluation/SKILL.md
+++ b/plugins/modelopt/skills/evaluation/SKILL.md
@@ -96,8 +96,9 @@ for an "AA" request. If the user asks for MRCR:
    `NEMO_EVALUATOR_TRUST_PRE_CMD=1` (the `pre_cmd` installs `tiktoken` +
    `transformers`; prepare fails without it) and
    `NEMO_EVALUATOR_TRUST_UNLISTED_TASKS=1` (`nemo_gym` is not in the FDF map).
-4. The Gym pin is **newer than any image's baked Gym** and is silently ignored
-   where `/opt/Gym` is not a git repo — verify it applied before quoting a score.
+4. **MRCR needs a git-backed Gym image.** The pin is newer than any image's baked
+   Gym and must apply, so the template's `container:` is `???` and the bootstrap
+   exits 1 on a non-git `/opt/Gym` (the public `eval-factory/nemo-gym:*` images).
    NVIDIA-internal: `modelopttools:eval-config` Step 3d names a working image.
 5. Long-context deploy (`--max-model-len 1100000` +
    `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1`, `gpu_memory_utilization: 0.95`,

--- a/plugins/modelopt/skills/evaluation/SKILL.md
+++ b/plugins/modelopt/skills/evaluation/SKILL.md
@@ -80,6 +80,40 @@ tasks). If the user asks for GDPVal:
 
 ---
 
+### MRCR (NeMo Gym `simple_agent`) path — branch here too
+
+MRCR is a **long-context** gym benchmark and, like GDPVal, a 0.2.6 `nemo_gym`
+task that is **standalone** (one gym eval per config). It is **not** an AA
+benchmark — never generate it as part of an "AA" request. It is far simpler than
+GDPVal: `simple_agent`, **no SIF sandbox, no judge, no Tavily** — deterministic
+prefix-gated `SequenceMatcher` grading, so `HF_TOKEN` is the only secret. If the
+user asks for MRCR:
+
+1. Read **`recipes/tasks/gym/mrcr.md`** (variant table, serving envelope, score
+   extraction, failure modes).
+2. Start from **`recipes/examples/gym_mrcr/example_gym_mrcr.yaml`** — a single
+   self-contained file, targeting the 1M variant like the reviewed golden.
+3. **Pick the variant first** — `config_n3_1m` / `config_n3_128k` / `config`. It
+   sets the context cap, the dataset size, *and* the metric key prefix, and the
+   three are not comparable to each other. Change it in **both**
+   `data_prep_params` and `collect_rollout_params`.
+4. `.env` needs `HF_TOKEN` (the dataset and the n3 tokenizer are both gated) and
+   `NEMO_EVALUATOR_TRUST_PRE_CMD=1` (the config has a `pre_cmd` that installs
+   `tiktoken` + `transformers` into the Gym venv — prepare fails without it).
+   The template's Gym pin is **newer than any image's baked Gym**, so it must
+   actually apply: on images where `/opt/Gym` is not a git repo it is silently
+   ignored. NVIDIA-internal: `modelopttools:eval-config` **Step 3d** names a
+   container where pinning works (and how to pull it).
+5. Long-context envelope, not the model, drives the deploy:
+   `--max-model-len 1100000` + `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1`,
+   `gpu_memory_utilization: 0.95`, prefix caching + chunked prefill, and a
+   multi-instance fan-out (golden: 4 nodes / 4 instances). **Never cap output
+   tokens** — answers reproduce a full earlier turn verbatim.
+6. Report the **needle-count strata** (2/4/8) alongside the headline
+   `pass@1/accuracy`; quantization damage shows up in the 8-needle stratum first.
+
+---
+
 ### Step 1 — Prerequisites
 
 Run `nel --version`; if missing, instruct `pip install nemo-evaluator-launcher`. If user has an existing config, skip to Step 8 (optionally review for `???` and quantization flags first).
@@ -94,6 +128,7 @@ Run `nel --version`; if missing, instruct `pip install nemo-evaluator-launcher`.
 - Optional: `recipes/tasks/mmlu_pro.md`, `recipes/tasks/aime_2025.md`, `recipes/tasks/livecodebench.md`
 - **nel-next only** (different evaluator — see the nel-next section below, NOT the 0.2.6 steps): shared reference `references/nel-next.md` + per-benchmark recipes `recipes/tasks/aa_next/{terminal_bench_2_1,swebench_verified}.md` (agentic). The `aa_next/` dir holds tasks that require `nemo-evaluator[harbor]` 0.4.x (the package; `nemo-evaluator-next` is the eval *image* repo); `aa/` is the 0.2.6 suite.
 - **GDPVal (NeMo Gym / agentic)** — **part of the AA suite** but a 0.2.6 `nemo_gym` task on a different harness, so it's **standalone** (see the GDPVal branch above): recipe `recipes/tasks/aa_gym/gdpval.md` + shared reference `references/gym-gdpval.md` + self-contained example `recipes/examples/gym_gdpval/`. Generated as its **own config** from the example, **never merged into the `aa/` multi-task `tasks` list**. The `aa_gym/` dir holds the NeMo Gym Stirrup-agent tasks.
+- **MRCR (NeMo Gym / long-context)** — **NOT an AA benchmark**; a 0.2.6 `nemo_gym` task, also **standalone** (see the MRCR branch above): recipe `recipes/tasks/gym/mrcr.md` + self-contained example `recipes/examples/gym_mrcr/`. The `gym/` dir holds non-AA NeMo Gym tasks; only generate it when the user asks for MRCR by name (or for long-context coverage).
 
 **AA rule:** If the user mentions "AA" / "Artificial Analysis", generate the `recipes/tasks/aa/` tasks (one multi-task config) **plus a companion standalone GDPVal config** (`recipes/tasks/aa_gym/gdpval.md`, via the GDPVal branch) — GDPVal is part of the AA suite but a different harness, so it's its own config, never added to the `aa/` `tasks` list. Do not add MMLU-Pro, AIME 2025, or LiveCodeBench unless explicitly asked. GDPVal is the heaviest AA task (standalone, multi-hour, needs the SIF sandbox + judge) — surface it and let the user opt out per run.
 

--- a/plugins/modelopt/skills/evaluation/SKILL.md
+++ b/plugins/modelopt/skills/evaluation/SKILL.md
@@ -123,8 +123,8 @@ Run `nel --version`; if missing, instruct `pip install nemo-evaluator-launcher`.
 
   | Task | Recipe / example | In AA suite? | Generate when |
   | --- | --- | --- | --- |
-  | **GDPVal** (Stirrup agent, agentic) | `tasks/gym/gdpval.md` + `references/gym-gdpval.md`, `examples/gym/example_gdpval.yaml` | **Yes** | any AA request (see the AA rule below) |
-  | **MRCR** (simple agent, long-context) | `tasks/gym/mrcr.md`, `examples/gym/example_mrcr.yaml` | **No** | only when the user asks for MRCR by name, or for long-context coverage |
+  | **GDPVal** (Stirrup agent, agentic) | `recipes/tasks/gym/gdpval.md` + `references/gym-gdpval.md`, `recipes/examples/gym/example_gdpval.yaml` | **Yes** | any AA request (see the AA rule below) |
+  | **MRCR** (simple agent, long-context) | `recipes/tasks/gym/mrcr.md`, `recipes/examples/gym/example_mrcr.yaml` | **No** | only when the user asks for MRCR by name, or for long-context coverage |
 
 **AA rule:** If the user mentions "AA" / "Artificial Analysis", generate the `recipes/tasks/aa/` tasks (one multi-task config) **plus a companion standalone GDPVal config** (`recipes/tasks/gym/gdpval.md`, via the GDPVal branch) — GDPVal is part of the AA suite but a different harness, so it's its own config, never added to the `aa/` `tasks` list. Do not add MMLU-Pro, AIME 2025, or LiveCodeBench unless explicitly asked. GDPVal is the heaviest AA task (standalone, multi-hour, needs the SIF sandbox + judge) — surface it and let the user opt out per run.
 

--- a/plugins/modelopt/skills/evaluation/SKILL.md
+++ b/plugins/modelopt/skills/evaluation/SKILL.md
@@ -82,35 +82,26 @@ tasks). If the user asks for GDPVal:
 
 ### MRCR (NeMo Gym `simple_agent`) path — branch here too
 
-MRCR is a **long-context** gym benchmark and, like GDPVal, a 0.2.6 `nemo_gym`
-task that is **standalone** (one gym eval per config). It is **not** an AA
-benchmark — never generate it as part of an "AA" request. It is far simpler than
-GDPVal: `simple_agent`, **no SIF sandbox, no judge, no Tavily** — deterministic
-prefix-gated `SequenceMatcher` grading, so `HF_TOKEN` is the only secret. If the
-user asks for MRCR:
+A 0.2.6 `nemo_gym` task like GDPVal and equally **standalone**, but far simpler:
+`simple_agent`, **no SIF, no judge, no Tavily** — deterministic prefix-gated
+grading, `HF_TOKEN` the only secret. **Not an AA benchmark** — never generate it
+for an "AA" request. If the user asks for MRCR:
 
-1. Read **`recipes/tasks/gym/mrcr.md`** (variant table, serving envelope, score
-   extraction, failure modes).
-2. Start from **`recipes/examples/gym/example_mrcr.yaml`** — a single
-   self-contained file, targeting the 1M variant like the reviewed golden.
-3. **Pick the variant first** — `config_n3_1m` / `config_n3_128k` / `config`. It
-   sets the context cap, the dataset size, *and* the metric key prefix, and the
-   three are not comparable to each other. Change it in **both**
-   `data_prep_params` and `collect_rollout_params`.
-4. `.env` needs `HF_TOKEN` (the dataset and the n3 tokenizer are both gated) and
-   `NEMO_EVALUATOR_TRUST_PRE_CMD=1` (the config has a `pre_cmd` that installs
-   `tiktoken` + `transformers` into the Gym venv — prepare fails without it).
-   The template's Gym pin is **newer than any image's baked Gym**, so it must
-   actually apply: on images where `/opt/Gym` is not a git repo it is silently
-   ignored. NVIDIA-internal: `modelopttools:eval-config` **Step 3d** names a
-   container where pinning works (and how to pull it).
-5. Long-context envelope, not the model, drives the deploy:
-   `--max-model-len 1100000` + `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1`,
-   `gpu_memory_utilization: 0.95`, prefix caching + chunked prefill, and a
-   multi-instance fan-out (golden: 4 nodes / 4 instances). **Never cap output
-   tokens** — answers reproduce a full earlier turn verbatim.
-6. Report the **needle-count strata** (2/4/8) alongside the headline
-   `pass@1/accuracy`; quantization damage shows up in the 8-needle stratum first.
+1. Read **`recipes/tasks/gym/mrcr.md`**; start from
+   **`recipes/examples/gym/example_mrcr.yaml`** (1M variant, like the golden).
+2. **Pick the variant first** (`config_n3_1m` / `config_n3_128k` / `config`) — it
+   sets the context cap, dataset *and* metric prefix; the three are not
+   comparable; set it in **both** `data_prep_params` and `collect_rollout_params`.
+3. `.env`: `HF_TOKEN` (dataset + n3 tokenizer are gated) plus
+   `NEMO_EVALUATOR_TRUST_PRE_CMD=1` (the `pre_cmd` installs `tiktoken` +
+   `transformers`; prepare fails without it).
+4. The Gym pin is **newer than any image's baked Gym** and is silently ignored
+   where `/opt/Gym` is not a git repo — verify it applied before quoting a score.
+   NVIDIA-internal: `modelopttools:eval-config` Step 3d names a working image.
+5. Long-context deploy (`--max-model-len 1100000` +
+   `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1`, `gpu_memory_utilization: 0.95`,
+   multi-instance fan-out); **never cap output tokens**; report the needle-count
+   strata alongside `pass@1/accuracy`.
 
 ---
 

--- a/plugins/modelopt/skills/evaluation/SKILL.md
+++ b/plugins/modelopt/skills/evaluation/SKILL.md
@@ -58,8 +58,8 @@ tasks). If the user asks for GDPVal:
 
 1. Read **`references/gym-gdpval.md`** (Apptainer SIF sandbox, gym prepare/reap
    machinery, deploy sizing, rubric-vs-comparison scoring, MLflow deliverables trap,
-   failure modes) + **`recipes/tasks/aa_gym/gdpval.md`**.
-2. Start from **`recipes/examples/gym_gdpval/example_gym_gdpval.yaml`** — a single
+   failure modes) + **`recipes/tasks/gym/gdpval.md`**.
+2. Start from **`recipes/examples/gym/example_gdpval.yaml`** — a single
    self-contained file.
 3. Prerequisite — the Apptainer SIF. **If your site provides one, use it**
    (NVIDIA-internal: `modelopttools:eval-config` Step 3c); otherwise set
@@ -91,7 +91,7 @@ user asks for MRCR:
 
 1. Read **`recipes/tasks/gym/mrcr.md`** (variant table, serving envelope, score
    extraction, failure modes).
-2. Start from **`recipes/examples/gym_mrcr/example_gym_mrcr.yaml`** — a single
+2. Start from **`recipes/examples/gym/example_mrcr.yaml`** — a single
    self-contained file, targeting the 1M variant like the reviewed golden.
 3. **Pick the variant first** — `config_n3_1m` / `config_n3_128k` / `config`. It
    sets the context cap, the dataset size, *and* the metric key prefix, and the
@@ -127,10 +127,14 @@ Run `nel --version`; if missing, instruct `pip install nemo-evaluator-launcher`.
 - AA Index v2 suite (default for quantized-checkpoint validation, see `references/quantization-benchmarks.md`): `recipes/tasks/aa/{gpqa_diamond,hle,lcr,scicode,ifbench,mmmu_pro,tau2_bench_telecom,omniscience}.md`
 - Optional: `recipes/tasks/mmlu_pro.md`, `recipes/tasks/aime_2025.md`, `recipes/tasks/livecodebench.md`
 - **nel-next only** (different evaluator — see the nel-next section below, NOT the 0.2.6 steps): shared reference `references/nel-next.md` + per-benchmark recipes `recipes/tasks/aa_next/{terminal_bench_2_1,swebench_verified}.md` (agentic). The `aa_next/` dir holds tasks that require `nemo-evaluator[harbor]` 0.4.x (the package; `nemo-evaluator-next` is the eval *image* repo); `aa/` is the 0.2.6 suite.
-- **GDPVal (NeMo Gym / agentic)** — **part of the AA suite** but a 0.2.6 `nemo_gym` task on a different harness, so it's **standalone** (see the GDPVal branch above): recipe `recipes/tasks/aa_gym/gdpval.md` + shared reference `references/gym-gdpval.md` + self-contained example `recipes/examples/gym_gdpval/`. Generated as its **own config** from the example, **never merged into the `aa/` multi-task `tasks` list**. The `aa_gym/` dir holds the NeMo Gym Stirrup-agent tasks.
-- **MRCR (NeMo Gym / long-context)** — **NOT an AA benchmark**; a 0.2.6 `nemo_gym` task, also **standalone** (see the MRCR branch above): recipe `recipes/tasks/gym/mrcr.md` + self-contained example `recipes/examples/gym_mrcr/`. The `gym/` dir holds non-AA NeMo Gym tasks; only generate it when the user asks for MRCR by name (or for long-context coverage).
+- **NeMo Gym tasks** — `recipes/tasks/gym/*.md`, with self-contained examples at `recipes/examples/gym/example_<task>.yaml`. The `gym/` dir groups by **harness** (0.2.6 `nemo_gym`), **not** by suite membership, so read AA membership per task from the table below — never from the path. Every gym task is **standalone**: generated as its own config from its example, one gym eval per config, **never merged into the `aa/` multi-task `tasks` list** and never mixed with each other.
 
-**AA rule:** If the user mentions "AA" / "Artificial Analysis", generate the `recipes/tasks/aa/` tasks (one multi-task config) **plus a companion standalone GDPVal config** (`recipes/tasks/aa_gym/gdpval.md`, via the GDPVal branch) — GDPVal is part of the AA suite but a different harness, so it's its own config, never added to the `aa/` `tasks` list. Do not add MMLU-Pro, AIME 2025, or LiveCodeBench unless explicitly asked. GDPVal is the heaviest AA task (standalone, multi-hour, needs the SIF sandbox + judge) — surface it and let the user opt out per run.
+  | Task | Recipe / example | In AA suite? | Generate when |
+  | --- | --- | --- | --- |
+  | **GDPVal** (Stirrup agent, agentic) | `tasks/gym/gdpval.md` + `references/gym-gdpval.md`, `examples/gym/example_gdpval.yaml` | **Yes** | any AA request (see the AA rule below) |
+  | **MRCR** (simple agent, long-context) | `tasks/gym/mrcr.md`, `examples/gym/example_mrcr.yaml` | **No** | only when the user asks for MRCR by name, or for long-context coverage |
+
+**AA rule:** If the user mentions "AA" / "Artificial Analysis", generate the `recipes/tasks/aa/` tasks (one multi-task config) **plus a companion standalone GDPVal config** (`recipes/tasks/gym/gdpval.md`, via the GDPVal branch) — GDPVal is part of the AA suite but a different harness, so it's its own config, never added to the `aa/` `tasks` list. Do not add MMLU-Pro, AIME 2025, or LiveCodeBench unless explicitly asked. GDPVal is the heaviest AA task (standalone, multi-hour, needs the SIF sandbox + judge) — surface it and let the user opt out per run.
 
 **Shortcut path** (when task list is known up front, e.g. "run AA"):
 

--- a/plugins/modelopt/skills/evaluation/recipes/env.example
+++ b/plugins/modelopt/skills/evaluation/recipes/env.example
@@ -41,7 +41,7 @@ NEMO_EVALUATOR_TRUST_PRE_CMD=1
 # INFERENCE_JUDGE_URL=https://<your-inference-host>/v1
 
 # GDPVal (nemo_gym Stirrup agent) — agent web search. Secret; exported and read
-# by the harness. See recipes/tasks/aa_gym/gdpval.md + references/gym-gdpval.md.
+# by the harness. See recipes/tasks/gym/gdpval.md + references/gym-gdpval.md.
 # TAVILY_API_KEY=
 
 # GDPVal (nemo_gym) — persistent Apptainer SIF cache dir on the TARGET cluster's

--- a/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_gdpval.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_gdpval.yaml
@@ -230,7 +230,7 @@ evaluation:
                 command: |
                   set -ex
                   cd /opt/Gym
-                  # Honour a mounted uv cache if injected, else image-local. No ${VAR} braces.
+                  # Honour a mounted uv cache if injected, else image-local. Plain $VAR, no braces.
                   [ -n "$UV_CACHE_DIR" ] || export UV_CACHE_DIR=/opt/cache/uv
                   source .venv/bin/activate
                   # install_on_the_fly: checkout the pin when /opt/Gym is a git repo; some
@@ -243,12 +243,18 @@ evaluation:
                   else
                     echo "=== /opt/Gym is not a git repo; using baked-in Gym version ==="
                   fi
+                  # Pin sub-venv ray to whatever the IMAGE already has. Hardcoding a
+                  # version breaks when the image moves: a 2.49.2 pin against an image
+                  # carrying ray[default]==2.55.1 makes uv unsatisfiable and the gym
+                  # server dies at startup. Empty => leave ray unpinned.
+                  _ray_ver="$(/opt/Gym/.venv/bin/python -c 'import ray,sys; sys.stdout.write(ray.__version__)' 2>/dev/null || true)"
+                  echo "=== image ray version: $_ray_ver ==="
                   for r in /opt/Gym/responses_api_models/*/requirements.txt \
                            /opt/Gym/responses_api_agents/*/requirements.txt \
                            /opt/Gym/resources_servers/*/requirements.txt; do
                     [ -f "$r" ] || continue
                     grep -vE '^[[:space:]]*-e ' "$r" > "$r.fixed" || true
-                    grep -qiE '^ray([<>=[]|$)' "$r.fixed" 2>/dev/null || echo 'ray==2.49.2' >> "$r.fixed"
+                    [ -n "$_ray_ver" ] && { grep -qiE '^ray([<>=[]|$)' "$r.fixed" 2>/dev/null || echo "ray[default]==$_ray_ver" >> "$r.fixed"; }
                     grep -qiE '^tqdm' "$r.fixed" 2>/dev/null || echo 'tqdm' >> "$r.fixed"
                     mv "$r.fixed" "$r" 2>/dev/null || true
                   done
@@ -259,7 +265,7 @@ evaluation:
                     d="$(dirname "$v")"
                     [ -f "$d/requirements.txt" ] && uv pip install --python "$v/bin/python" -q -r "$d/requirements.txt" || true
                   done
-                  # Preserve inherited PYTHONPATH. Plain $VAR only (OmegaConf parses ${...}).
+                  # Preserve inherited PYTHONPATH. Plain $VAR only -- OmegaConf parses brace syntax.
                   _gym_sp="$(/opt/Gym/.venv/bin/python -c 'import site; print(site.getsitepackages()[0])')"
                   if [ -n "$PYTHONPATH" ]; then export PYTHONPATH="/opt/Gym:$_gym_sp:$PYTHONPATH"
                   else export PYTHONPATH="/opt/Gym:$_gym_sp"; fi

--- a/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_gdpval.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_gdpval.yaml
@@ -17,7 +17,7 @@
 # GDPVal (NeMo Gym "Stirrup" agent) — STANDALONE gym eval, RUBRIC mode.
 # Self-deploys a checkpoint via vLLM on one SLURM node. One gym eval per config.
 #
-# Read recipes/tasks/aa_gym/gdpval.md + references/gym-gdpval.md first — they
+# Read recipes/tasks/gym/gdpval.md + references/gym-gdpval.md first — they
 # cover the SIF sandbox, scoring modes, judge panel, preflight and failure modes.
 #
 # Before running: `.env` needs HF_TOKEN, INFERENCE_API_KEY, TAVILY_API_KEY,
@@ -25,7 +25,7 @@
 # SIF must exist (prefer a site-provided one, else
 # `srun -p cpu -t 01:00:00 --pty "$SKILL_DIR/scripts/gdpval-sif.sh"`).
 #
-#   nel run --config example_gym_gdpval.yaml --env-file .env
+#   nel run --config example_gdpval.yaml --env-file .env
 #
 # `limit_samples` is INERT here — the gym always runs all 220 tasks. There is no
 # cheap smoke test; see the recipe's Canary section.

--- a/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
@@ -14,21 +14,16 @@
 # limitations under the License.
 #
 # =============================================================================
-# MRCR (OpenAI Multi-Round Co-reference Resolution) — STANDALONE gym eval.
-# NeMo Gym `simple_agent` (NOT the GDPVal Stirrup agent): no Apptainer SIF, no
-# code-exec sandbox, no LLM judge, no Tavily. Grading is deterministic
-# (prefix-gated SequenceMatcher.ratio), so the only external secret is HF_TOKEN.
+# MRCR (Multi-Round Co-reference Resolution) — STANDALONE gym eval.
+# NeMo Gym `simple_agent`: no SIF, no code-exec sandbox, no judge, no Tavily.
+# Grading is deterministic (prefix-gated SequenceMatcher.ratio) — HF_TOKEN is the
+# only secret. Targets the 1M-context N3 variant like the reviewed golden; prompts
+# up to 1,048,576 tokens drive every unusual setting below.
 #
-# This template targets the **1M-context N3 variant** (`config_n3_1m`), matching
-# the reviewed golden. It is a LONG-CONTEXT benchmark: prompts run up to
-# 1,048,576 tokens, which drives every unusual setting below.
+# Read recipes/tasks/gym/mrcr.md first (variant choice, Gym pin/container
+# coupling, score extraction, failure modes).
 #
-# Read recipes/tasks/gym/mrcr.md first — it covers variant choice, the Gym
-# commit/container coupling, score extraction, and failure modes.
-#
-# Before running: `.env` needs HF_TOKEN and NEMO_EVALUATOR_TRUST_PRE_CMD=1
-# (this config has a `pre_cmd`).
-#
+# `.env` needs HF_TOKEN + NEMO_EVALUATOR_TRUST_PRE_CMD=1 (this config has a pre_cmd).
 #   nel run --config example_mrcr.yaml --env-file .env
 #
 # =============================================================================
@@ -49,10 +44,9 @@ execution:
   account: ???
   output_dir: ???        # absolute host path; keeps the response cache across resumes
   walltime: "04:00:00"
-  # 1M-context rollouts are slow. The golden fans out across 4 independent
-  # single-node instances (HAProxy pattern A, see references/multi-node.md) so
-  # the run fits the walltime. `parallelism` below is the TOTAL across all
-  # instances, not per-instance. Halve/double both together.
+  # 1M rollouts are slow; the golden fans out over 4 single-node instances
+  # (HAProxy pattern A, references/multi-node.md). `parallelism` below is the
+  # TOTAL across instances — halve/double both together.
   num_nodes: 4
   num_instances: 4
   # gres: a predefined internal/slurm/<cluster> config sets this. On slurm/default
@@ -89,16 +83,12 @@ deployment:
   served_model_name: ???
   image: vllm/vllm-openai:v0.26.0   # bump to the EXACT model's recipes.vllm.ai minimum (SKILL Step 3)
   gpu_memory_utilization: 0.95      # golden raises this from 0.85 to fit the 1M KV cache
-  # MRCR is a REASONING-mode run in the golden (thinking forced on via the
-  # adapter_config chat_template_kwargs below); serve with the model's
-  # --reasoning-parser so vLLM emits a separate reasoning channel.
-  # --max-num-seqs: on the GYM path derive it from the gym client concurrency,
-  # NOT from the generic SKILL rule. N = ceil(parallelism / num_instances / DP).
-  # With parallelism=256, num_instances=4, DP=1 -> 64.
-  #
-  # --kv-cache-dtype fp8 is part of the golden's 1M serving envelope. It is
-  # itself a precision choice: keep it IDENTICAL between baseline and quantized
-  # runs, or the comparison measures KV-cache quantization too.
+  # Golden serves in REASONING mode (thinking forced on via chat_template_kwargs
+  # below), so set the model's --reasoning-parser.
+  # --max-num-seqs on the GYM path = ceil(parallelism / num_instances / DP), NOT
+  # the generic SKILL rule; here ceil(256/4/1) = 64.
+  # --kv-cache-dtype fp8 is itself a precision choice — keep it IDENTICAL across
+  # baseline and quantized runs or the delta measures KV-cache quantization too.
   command: >-
     vllm serve /checkpoint
     --served-model-name ${deployment.served_model_name}
@@ -122,10 +112,8 @@ evaluation:
     DUMMY_API_KEY: lit:dummy        # the deployed vLLM endpoint's (policy) key
     UV_CACHE_DIR: lit:/cache/uv
     NEL_INVOCATION_ID: runtime:NEL_INVOCATION_ID
-  # The pinned Gym commit's MRCR prepare imports tiktoken at module load and
-  # falls back to transformers.AutoTokenizer for the N3 HF-tokenizer path;
-  # neither is declared as a dep of that commit's Gym venv. Needs
-  # NEMO_EVALUATOR_TRUST_PRE_CMD=1 in the launching shell.
+  # The pinned Gym commit's MRCR prepare needs tiktoken + transformers, neither
+  # declared in its venv. Needs NEMO_EVALUATOR_TRUST_PRE_CMD=1 in the shell.
   pre_cmd: |-
     set -ex
     command -v uv >/dev/null 2>&1 || { curl -LsSf https://astral.sh/uv/install.sh | sh; export PATH="/root/.local/bin:$PATH"; }
@@ -135,14 +123,12 @@ evaluation:
       params:
         temperature: 1.0
         top_p: 0.95
-        # Gym client concurrency, TOTAL across all instances (see execution above).
-        # NOT a per-server in-flight cap.
+        # Gym client concurrency, TOTAL across instances — not a per-server cap.
         parallelism: 256
         request_timeout: 36000      # 1M-token prefills are slow
         max_retries: 10
-        # MRCR answers REPRODUCE a full earlier assistant turn verbatim. Any
-        # output cap truncates the reproduction and craters SequenceMatcher.ratio,
-        # so the golden leaves it uncapped (see max_output_tokens=null below).
+        # Uncapped: answers reproduce a full earlier turn, and any cap truncates
+        # it and craters SequenceMatcher.ratio (see max_output_tokens=null below).
         max_new_tokens:
     target:
       api_endpoint:
@@ -181,20 +167,12 @@ evaluation:
               nemo_gym:
                 install_on_the_fly:
                   url: https://github.com/NVIDIA-NeMo/Gym
-                  # Gym pin from the reviewed golden. This commit carries the N3 1M
-                  # preparation path that `config_n3_1m.yaml` depends on, and it is
-                  # NEWER than the Gym baked into the images below — so this pin MUST
-                  # apply for the run to mean anything.
-                  # The pin is applied by `git checkout` inside /opt/Gym, so it only
-                  # works when /opt/Gym is a git repo:
-                  #   public eval-factory image  -> often NOT a git repo; the pin is
-                  #     SILENTLY ignored ("/opt/Gym is not a git repo") and you get
-                  #     whatever Gym the image shipped.
-                  #   internal core-evals image  -> git repo, build-guarded; the pin
-                  #     applies or the run hard-fails.
-                  # On the public image, confirm the "=== NeMo Gym commit ===" + SHA
-                  # line in the client log before trusting a score.
-                  # See recipes/tasks/gym/mrcr.md "Gym commit <-> container coupling".
+                  # Golden's pin. Carries the N3 1M prepare path config_n3_1m.yaml
+                  # needs, and is NEWER than the Gym baked into any image — so it
+                  # MUST apply. Applied by `git checkout` in /opt/Gym, so it is
+                  # SILENTLY ignored where that is not a git repo (public image).
+                  # Confirm "=== NeMo Gym commit ===" + SHA in the client log before
+                  # trusting a score. See recipes/tasks/gym/mrcr.md.
                   commit: a431501aa294f3237d472aaf58dd1e5026156ea8  # pragma: allowlist secret
                 command: |
                   set -ex
@@ -262,15 +240,12 @@ evaluation:
                   pkill -9 -u "$(id -u)" -f gcs_server >/dev/null 2>&1 || true
                   pkill -9 -u "$(id -u)" -f plasma_store >/dev/null 2>&1 || true
                   exit $__rc
-                # VARIANT SELECTOR — this pair of `config_paths` picks the context
-                # envelope, the dataset file, AND the metric key prefix. Change BOTH
-                # lines together, and update the metric name you harvest:
-                #   benchmarks/mrcr/config_n3_1m.yaml   -> mrcr_n3_1m_benchmark_simple_agent   (this template)
-                #   benchmarks/mrcr/config_n3_128k.yaml -> mrcr_n3_128k_benchmark_simple_agent
-                #   benchmarks/mrcr/config.yaml         -> mrcr_benchmark_simple_agent
-                # The n3 variants tokenize with the gated NVIDIA tokenizer (HF_TOKEN
-                # required) and drop over-long samples; the plain variant uses
-                # o200k_base with no cap.
+                # VARIANT SELECTOR — picks the context cap, the dataset AND the
+                # metric prefix. Change BOTH config_paths lines together, and update
+                # the metric name you harvest:
+                #   config_n3_1m.yaml   -> mrcr_n3_1m_benchmark_simple_agent   (this template)
+                #   config_n3_128k.yaml -> mrcr_n3_128k_benchmark_simple_agent
+                #   config.yaml         -> mrcr_benchmark_simple_agent
                 data_prep_params: >-
                   "+config_paths=[responses_api_models/vllm_model/configs/vllm_model.yaml,benchmarks/mrcr/config_n3_1m.yaml]"
                   +hf_token=$HF_TOKEN

--- a/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
@@ -45,11 +45,11 @@ execution:
   account: ???
   output_dir: ???        # absolute host path; keeps the response cache across resumes
   walltime: "04:00:00"
-  # 1M rollouts are slow; the golden fans out over 4 single-node instances
-  # (HAProxy pattern A, references/multi-node.md). `parallelism` below is the
-  # TOTAL across instances — halve/double both together.
-  num_nodes: 4
-  num_instances: 4
+  # num_nodes / num_instances: cluster-dependent, so size them from the node's GPU
+  # count rather than copying — see references/multi-node.md (HAProxy pattern A).
+  # Defaults are 1/1, which will not finish a 1M run inside the walltime; the
+  # golden used 4 nodes / 4 instances of TP2 x DP2 on 4-GPU nodes (8 replicas).
+  # `parallelism` below is the TOTAL across instances.
   # gres: a predefined internal/slurm/<cluster> config sets this. On slurm/default
   # it's gpu:8 — set to the node's GPU count (match --tensor/--data-parallel-size)
   # or sbatch fails "Requested node configuration is not available".
@@ -86,8 +86,9 @@ deployment:
   gpu_memory_utilization: 0.95      # golden raises this from 0.85 to fit the 1M KV cache
   # Golden serves in REASONING mode (thinking forced on via chat_template_kwargs
   # below), so set the model's --reasoning-parser.
-  # --max-num-seqs on the GYM path = ceil(parallelism / num_instances / DP), NOT
-  # the generic SKILL rule; here ceil(256/4/1) = 64.
+  # After sizing num_nodes / num_instances / TP / DP above, append
+  # `--max-num-seqs N` where N = ceil(parallelism / num_instances / DP) — the GYM
+  # rule, not the generic SKILL one. Golden: ceil(256/4/2) = 32.
   # --kv-cache-dtype fp8 is itself a precision choice — keep it IDENTICAL across
   # baseline and quantized runs or the delta measures KV-cache quantization too.
   command: >-
@@ -95,7 +96,7 @@ deployment:
     --served-model-name ${deployment.served_model_name}
     --host 0.0.0.0
     --port ${deployment.port}
-    --tensor-parallel-size ???
+    --tensor-parallel-size 1
     --data-parallel-size 1
     --max-model-len 1100000
     --kv-cache-dtype fp8
@@ -104,7 +105,6 @@ deployment:
     --enable-prefix-caching
     --enable-chunked-prefill
     --max-num-batched-tokens 131072
-    --max-num-seqs 64
 
 evaluation:
   env_vars:

--- a/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
@@ -160,7 +160,12 @@ evaluation:
   # STANDALONE: exactly one gym task. Do NOT add other tasks to this list.
   tasks:
     - name: nemo_gym
-      container: nvcr.io/nvidia/eval-factory/nemo-gym:26.05   # pin a verified tag
+      # ??? on purpose: MRCR REQUIRES a git-backed Gym image so the pin below can
+      # apply, and the bootstrap exits 1 without one. The public
+      # nvcr.io/nvidia/eval-factory/nemo-gym:* images have a NON-git /opt/Gym and
+      # will not run this benchmark (GDPVal differs — its baked fallback is valid).
+      # NVIDIA-internal: modelopttools:eval-config Step 3d names a working image.
+      container: ???
       nemo_evaluator_config:
         config:
           params:
@@ -171,9 +176,9 @@ evaluation:
                   # Golden's pin. Carries the N3 1M prepare path config_n3_1m.yaml
                   # needs, and is NEWER than the Gym baked into any image — so it
                   # MUST apply. Applied by `git checkout` in /opt/Gym, so it is
-                  # SILENTLY ignored where that is not a git repo (public image).
-                  # Confirm "=== NeMo Gym commit ===" + SHA in the client log before
-                  # trusting a score. See recipes/tasks/gym/mrcr.md.
+                  # only usable where that is a git repo — the bootstrap exits
+                  # nonzero if the pin cannot apply or HEAD != this SHA, so a wrong
+                  # image fails fast instead of scoring. See recipes/tasks/gym/mrcr.md.
                   commit: a431501aa294f3237d472aaf58dd1e5026156ea8  # pragma: allowlist secret
                 command: |
                   set -ex

--- a/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
@@ -94,8 +94,10 @@ deployment:
   # ~120K. Too high and vLLM preempts, and recomputing a 1M-token prefill makes the
   # run SLOWER, not faster. Start small and raise only while preemption stays ~0
   # (grep the server log for "preempted"). See references/parallelism.md.
-  # --kv-cache-dtype fp8 is itself a precision choice — keep it IDENTICAL across
-  # baseline and quantized runs or the delta measures KV-cache quantization too.
+  # --kv-cache-dtype: match the checkpoint's kv_cache_quant_algo in
+  # hf_quant_config.json (vLLM does NOT read it from config.json). fp8 here only
+  # because this class of checkpoint declares FP8 KV; drop it for a checkpoint
+  # that does not, rather than applying uncalibrated KV quantization.
   command: >-
     vllm serve /checkpoint
     --served-model-name ${deployment.served_model_name}

--- a/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
@@ -177,7 +177,7 @@ evaluation:
                 command: |
                   set -ex
                   cd /opt/Gym
-                  # Honour a mounted uv cache if injected, else image-local. No ${VAR} braces.
+                  # Honour a mounted uv cache if injected, else image-local. Plain $VAR, no braces.
                   [ -n "$UV_CACHE_DIR" ] || export UV_CACHE_DIR=/opt/cache/uv
                   source .venv/bin/activate
                   # install_on_the_fly: checkout the pin when /opt/Gym is a git repo; some
@@ -190,12 +190,18 @@ evaluation:
                   else
                     echo "=== /opt/Gym is not a git repo; using baked-in Gym version ==="
                   fi
+                  # Pin sub-venv ray to whatever the IMAGE already has. Hardcoding a
+                  # version breaks when the image moves: a 2.49.2 pin against an image
+                  # carrying ray[default]==2.55.1 makes uv unsatisfiable and the gym
+                  # server dies at startup. Empty => leave ray unpinned.
+                  _ray_ver="$(/opt/Gym/.venv/bin/python -c 'import ray,sys; sys.stdout.write(ray.__version__)' 2>/dev/null || true)"
+                  echo "=== image ray version: $_ray_ver ==="
                   for r in /opt/Gym/responses_api_models/*/requirements.txt \
                            /opt/Gym/responses_api_agents/*/requirements.txt \
                            /opt/Gym/resources_servers/*/requirements.txt; do
                     [ -f "$r" ] || continue
                     grep -vE '^[[:space:]]*-e ' "$r" > "$r.fixed" || true
-                    grep -qiE '^ray([<>=[]|$)' "$r.fixed" 2>/dev/null || echo 'ray==2.49.2' >> "$r.fixed"
+                    [ -n "$_ray_ver" ] && { grep -qiE '^ray([<>=[]|$)' "$r.fixed" 2>/dev/null || echo "ray[default]==$_ray_ver" >> "$r.fixed"; }
                     grep -qiE '^tqdm' "$r.fixed" 2>/dev/null || echo 'tqdm' >> "$r.fixed"
                     mv "$r.fixed" "$r" 2>/dev/null || true
                   done
@@ -206,7 +212,7 @@ evaluation:
                     d="$(dirname "$v")"
                     [ -f "$d/requirements.txt" ] && uv pip install --python "$v/bin/python" -q -r "$d/requirements.txt" || true
                   done
-                  # Preserve inherited PYTHONPATH. Plain $VAR only (OmegaConf parses ${...}).
+                  # Preserve inherited PYTHONPATH. Plain $VAR only -- OmegaConf parses brace syntax.
                   _gym_sp="$(/opt/Gym/.venv/bin/python -c 'import site; print(site.getsitepackages()[0])')"
                   if [ -n "$PYTHONPATH" ]; then export PYTHONPATH="/opt/Gym:$_gym_sp:$PYTHONPATH"
                   else export PYTHONPATH="/opt/Gym:$_gym_sp"; fi

--- a/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
@@ -23,7 +23,8 @@
 # Read recipes/tasks/gym/mrcr.md first (variant choice, Gym pin/container
 # coupling, score extraction, failure modes).
 #
-# `.env` needs HF_TOKEN + NEMO_EVALUATOR_TRUST_PRE_CMD=1 (this config has a pre_cmd).
+# `.env` needs HF_TOKEN, NEMO_EVALUATOR_TRUST_PRE_CMD=1 (this config has a pre_cmd)
+# and NEMO_EVALUATOR_TRUST_UNLISTED_TASKS=1 (nemo_gym is not in the FDF map).
 #   nel run --config example_mrcr.yaml --env-file .env
 #
 # =============================================================================
@@ -146,8 +147,8 @@ evaluation:
             chat_template_kwargs:
               enable_thinking: true
             skip_special_tokens: false
-          # Caching OFF: MRCR prompts are near-identical across needle counts and
-          # a response cache would serve stale completions across variants.
+          # Caching OFF (same as the other gym template) — a cache hit across
+          # runs or variants would report stale completions.
           use_caching: false
           use_progress_tracking: true
           tracking_requests_stats: true
@@ -182,13 +183,19 @@ evaluation:
                   source .venv/bin/activate
                   # install_on_the_fly: checkout the pin when /opt/Gym is a git repo; some
                   # images bake Gym at a fixed version (not a git repo) — use it as-is.
+                  # MRCR REQUIRES the pin (N3 1M prepare path). Unlike GDPVal rubric
+                  # mode there is no valid fallback, so refuse to run unpinned rather
+                  # than score a different benchmark green.
                   if [ -d .git ]; then
                     git remote add oss_pin "{{config.params.extra.nemo_gym.install_on_the_fly.url}}" 2>/dev/null || true
                     git fetch oss_pin
                     git checkout "{{config.params.extra.nemo_gym.install_on_the_fly.commit}}"
                     echo "=== NeMo Gym commit ===" && git rev-parse HEAD
+                    [ "$(git rev-parse HEAD)" = "{{config.params.extra.nemo_gym.install_on_the_fly.commit}}" ] || \
+                      { echo "ERROR: Gym HEAD != pinned commit" >&2; exit 1; }
                   else
-                    echo "=== /opt/Gym is not a git repo; using baked-in Gym version ==="
+                    echo "ERROR: /opt/Gym is not a git repo; MRCR requires the pinned Gym" >&2
+                    exit 1
                   fi
                   # Pin sub-venv ray to whatever the IMAGE already has. Hardcoding a
                   # version breaks when the image moves: a 2.49.2 pin against an image
@@ -277,6 +284,7 @@ evaluation:
                   ++responses_create_params.top_p={{config.params.top_p}}
                   ++responses_create_params.max_output_tokens=null
                 common_params: >-
+                  ++num_repeats=1
                   ++policy_base_url={{target.api_endpoint.url}}
                   ++policy_api_key=$DUMMY_API_KEY
                   ++policy_model_name={{target.api_endpoint.model_id}}
@@ -294,6 +302,6 @@ export:
     tags:
       framework: vllm
       model: CHANGEME-served-model-name
-      benchmark: nemo_gym.mrcr
+      benchmark: nemo_gym.mrcr_n3_1m   # CHANGEME with the variant (see VARIANT SELECTOR)
       temperature: '1.0'
       top_p: '0.95'

--- a/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
@@ -29,7 +29,7 @@
 # Before running: `.env` needs HF_TOKEN and NEMO_EVALUATOR_TRUST_PRE_CMD=1
 # (this config has a `pre_cmd`).
 #
-#   nel run --config example_gym_mrcr.yaml --env-file .env
+#   nel run --config example_mrcr.yaml --env-file .env
 #
 # =============================================================================
 defaults:

--- a/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml
@@ -89,6 +89,11 @@ deployment:
   # After sizing num_nodes / num_instances / TP / DP above, append
   # `--max-num-seqs N` where N = ceil(parallelism / num_instances / DP) — the GYM
   # rule, not the generic SKILL one. Golden: ceil(256/4/2) = 32.
+  # Treat that as a CEILING, not a target. Like AA-LCR (recipes/tasks/aa/lcr.md)
+  # this task is KV-bound, and far more so: ~1M input tokens per request vs LCR's
+  # ~120K. Too high and vLLM preempts, and recomputing a 1M-token prefill makes the
+  # run SLOWER, not faster. Start small and raise only while preemption stays ~0
+  # (grep the server log for "preempted"). See references/parallelism.md.
   # --kv-cache-dtype fp8 is itself a precision choice — keep it IDENTICAL across
   # baseline and quantized runs or the delta measures KV-cache quantization too.
   command: >-

--- a/plugins/modelopt/skills/evaluation/recipes/examples/gym_mrcr/example_gym_mrcr.yaml
+++ b/plugins/modelopt/skills/evaluation/recipes/examples/gym_mrcr/example_gym_mrcr.yaml
@@ -1,0 +1,318 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# =============================================================================
+# MRCR (OpenAI Multi-Round Co-reference Resolution) — STANDALONE gym eval.
+# NeMo Gym `simple_agent` (NOT the GDPVal Stirrup agent): no Apptainer SIF, no
+# code-exec sandbox, no LLM judge, no Tavily. Grading is deterministic
+# (prefix-gated SequenceMatcher.ratio), so the only external secret is HF_TOKEN.
+#
+# This template targets the **1M-context N3 variant** (`config_n3_1m`), matching
+# the reviewed golden. It is a LONG-CONTEXT benchmark: prompts run up to
+# 1,048,576 tokens, which drives every unusual setting below.
+#
+# Read recipes/tasks/gym/mrcr.md first — it covers variant choice, the Gym
+# commit/container coupling, score extraction, and failure modes.
+#
+# Before running: `.env` needs HF_TOKEN and NEMO_EVALUATOR_TRUST_PRE_CMD=1
+# (this config has a `pre_cmd`).
+#
+#   nel run --config example_gym_mrcr.yaml --env-file .env
+#
+# =============================================================================
+defaults:
+  # slurm/default works anywhere; if your install ships a predefined
+  # internal/slurm/<cluster> config, prefer it (pre-fills hostname/partition/
+  # gres — see SKILL.md Step 4).
+  - execution: slurm/default
+  - deployment: vllm
+  - _self_
+
+cluster:
+  sbatch_comment: '{"OccupiedIdleGPUsJobReaper":{"exemptIdleTimeMins":"480","reason":"benchmarking","description":"Eval benchmark low GPU utilization"}}'
+
+execution:
+  hostname: ???
+  username: ${oc.env:USER}
+  account: ???
+  output_dir: ???        # absolute host path; keeps the response cache across resumes
+  walltime: "04:00:00"
+  # 1M-context rollouts are slow. The golden fans out across 4 independent
+  # single-node instances (HAProxy pattern A, see references/multi-node.md) so
+  # the run fits the walltime. `parallelism` below is the TOTAL across all
+  # instances, not per-instance. Halve/double both together.
+  num_nodes: 4
+  num_instances: 4
+  # gres: a predefined internal/slurm/<cluster> config sets this. On slurm/default
+  # it's gpu:8 — set to the node's GPU count (match --tensor/--data-parallel-size)
+  # or sbatch fails "Requested node configuration is not available".
+  mounts:
+    # mount_home ALWAYS false — see example_eval.yaml / SKILL Step 4 for why.
+    mount_home: false
+    deployment:
+      # Real HF cache -> /hf-cache (paired with HF_HOME below).
+      <HOST_HF_CACHE>: /hf-cache
+    evaluation:
+      <HOST_HF_CACHE>: /hf-cache
+      <HOST_UV_CACHE>: /cache/uv
+  auto_export:            # REQUIRED trigger for MLflow upload (see example_eval.yaml).
+    destinations:
+      - mlflow
+  # Auto-export is a separate CPU-only sbatch; GPU-only partitions reject it.
+  cpu_partition: ???
+
+deployment:
+  env_vars:
+    HF_TOKEN: host:HF_TOKEN
+    HF_HOME: lit:/hf-cache
+    # REQUIRED for the 1M variant: --max-model-len above the checkpoint's
+    # declared max_position_embeddings is refused by vLLM without this.
+    VLLM_ALLOW_LONG_MAX_MODEL_LEN: lit:1
+    # vLLM backend toggles go HERE (not in command). Uncomment per model card —
+    # e.g. NVFP4 MoE on Blackwell needs FlashInfer FP4 kernels:
+    #   VLLM_USE_FLASHINFER_MOE_FP4: lit:1
+    #   VLLM_FLASHINFER_MOE_BACKEND: lit:throughput
+  checkpoint_path: ???           # prefer a path already on the cluster over hf_model_handle
+  hf_model_handle:
+  served_model_name: ???
+  image: vllm/vllm-openai:v0.26.0   # bump to the EXACT model's recipes.vllm.ai minimum (SKILL Step 3)
+  gpu_memory_utilization: 0.95      # golden raises this from 0.85 to fit the 1M KV cache
+  # MRCR is a REASONING-mode run in the golden (thinking forced on via the
+  # adapter_config chat_template_kwargs below); serve with the model's
+  # --reasoning-parser so vLLM emits a separate reasoning channel.
+  # --max-num-seqs: on the GYM path derive it from the gym client concurrency,
+  # NOT from the generic SKILL rule. N = ceil(parallelism / num_instances / DP).
+  # With parallelism=256, num_instances=4, DP=1 -> 64.
+  #
+  # --kv-cache-dtype fp8 is part of the golden's 1M serving envelope. It is
+  # itself a precision choice: keep it IDENTICAL between baseline and quantized
+  # runs, or the comparison measures KV-cache quantization too.
+  command: >-
+    vllm serve /checkpoint
+    --served-model-name ${deployment.served_model_name}
+    --host 0.0.0.0
+    --port ${deployment.port}
+    --tensor-parallel-size ???
+    --data-parallel-size 1
+    --max-model-len 1100000
+    --kv-cache-dtype fp8
+    --reasoning-parser <PARSER>
+    --model-loader-extra-config '{"enable_multithread_load": true, "num_threads": 96}'
+    --enable-prefix-caching
+    --enable-chunked-prefill
+    --max-num-batched-tokens 131072
+    --max-num-seqs 64
+
+evaluation:
+  env_vars:
+    HF_TOKEN: host:HF_TOKEN         # openai/mrcr + the gated NVIDIA tokenizer both need it
+    HF_HOME: lit:/hf-cache
+    DUMMY_API_KEY: lit:dummy        # the deployed vLLM endpoint's (policy) key
+    UV_CACHE_DIR: lit:/cache/uv
+    NEL_INVOCATION_ID: runtime:NEL_INVOCATION_ID
+  # The pinned Gym commit's MRCR prepare imports tiktoken at module load and
+  # falls back to transformers.AutoTokenizer for the N3 HF-tokenizer path;
+  # neither is declared as a dep of that commit's Gym venv. Needs
+  # NEMO_EVALUATOR_TRUST_PRE_CMD=1 in the launching shell.
+  pre_cmd: |-
+    set -ex
+    command -v uv >/dev/null 2>&1 || { curl -LsSf https://astral.sh/uv/install.sh | sh; export PATH="/root/.local/bin:$PATH"; }
+    uv pip install --python /opt/Gym/.venv/bin/python --quiet tiktoken transformers
+  nemo_evaluator_config:
+    config:
+      params:
+        temperature: 1.0
+        top_p: 0.95
+        # Gym client concurrency, TOTAL across all instances (see execution above).
+        # NOT a per-server in-flight cap.
+        parallelism: 256
+        request_timeout: 36000      # 1M-token prefills are slow
+        max_retries: 10
+        # MRCR answers REPRODUCE a full earlier assistant turn verbatim. Any
+        # output cap truncates the reproduction and craters SequenceMatcher.ratio,
+        # so the golden leaves it uncapped (see max_output_tokens=null below).
+        max_new_tokens:
+    target:
+      api_endpoint:
+        api_key_name: DUMMY_API_KEY
+        adapter_config:
+          use_system_prompt: false
+          process_reasoning_traces: true
+          params_to_remove:
+            - max_tokens
+            - max_completion_tokens
+          # Keep the toggle key your model family uses (enable_thinking ->
+          # Qwen3.x/GLM/Nemotron; thinking -> Kimi/DeepSeek); see SKILL
+          # "Reasoning adapter config".
+          params_to_add:
+            chat_template_kwargs:
+              enable_thinking: true
+            skip_special_tokens: false
+          # Caching OFF: MRCR prompts are near-identical across needle counts and
+          # a response cache would serve stale completions across variants.
+          use_caching: false
+          use_progress_tracking: true
+          tracking_requests_stats: true
+          log_failed_requests: true
+          use_request_logging: true
+          max_logged_requests: 10
+          use_response_logging: true
+          max_logged_responses: 10
+  # STANDALONE: exactly one gym task. Do NOT add other tasks to this list.
+  tasks:
+    - name: nemo_gym
+      container: nvcr.io/nvidia/eval-factory/nemo-gym:26.05   # pin a verified tag
+      nemo_evaluator_config:
+        config:
+          params:
+            extra:
+              nemo_gym:
+                install_on_the_fly:
+                  url: https://github.com/NVIDIA-NeMo/Gym
+                  # Gym pin from the reviewed golden. This commit carries the N3 1M
+                  # preparation path that `config_n3_1m.yaml` depends on, and it is
+                  # NEWER than the Gym baked into the images below — so this pin MUST
+                  # apply for the run to mean anything.
+                  # The pin is applied by `git checkout` inside /opt/Gym, so it only
+                  # works when /opt/Gym is a git repo:
+                  #   public eval-factory image  -> often NOT a git repo; the pin is
+                  #     SILENTLY ignored ("/opt/Gym is not a git repo") and you get
+                  #     whatever Gym the image shipped.
+                  #   internal core-evals image  -> git repo, build-guarded; the pin
+                  #     applies or the run hard-fails.
+                  # On the public image, confirm the "=== NeMo Gym commit ===" + SHA
+                  # line in the client log before trusting a score.
+                  # See recipes/tasks/gym/mrcr.md "Gym commit <-> container coupling".
+                  commit: a431501aa294f3237d472aaf58dd1e5026156ea8  # pragma: allowlist secret
+                command: |
+                  set -ex
+                  cd /opt/Gym
+                  # Honour a mounted uv cache if injected, else image-local. No ${VAR} braces.
+                  [ -n "$UV_CACHE_DIR" ] || export UV_CACHE_DIR=/opt/cache/uv
+                  source .venv/bin/activate
+                  # install_on_the_fly: checkout the pin when /opt/Gym is a git repo; some
+                  # images bake Gym at a fixed version (not a git repo) — use it as-is.
+                  if [ -d .git ]; then
+                    git remote add oss_pin "{{config.params.extra.nemo_gym.install_on_the_fly.url}}" 2>/dev/null || true
+                    git fetch oss_pin
+                    git checkout "{{config.params.extra.nemo_gym.install_on_the_fly.commit}}"
+                    echo "=== NeMo Gym commit ===" && git rev-parse HEAD
+                  else
+                    echo "=== /opt/Gym is not a git repo; using baked-in Gym version ==="
+                  fi
+                  for r in /opt/Gym/responses_api_models/*/requirements.txt \
+                           /opt/Gym/responses_api_agents/*/requirements.txt \
+                           /opt/Gym/resources_servers/*/requirements.txt; do
+                    [ -f "$r" ] || continue
+                    grep -vE '^[[:space:]]*-e ' "$r" > "$r.fixed" || true
+                    grep -qiE '^ray([<>=[]|$)' "$r.fixed" 2>/dev/null || echo 'ray==2.49.2' >> "$r.fixed"
+                    grep -qiE '^tqdm' "$r.fixed" 2>/dev/null || echo 'tqdm' >> "$r.fixed"
+                    mv "$r.fixed" "$r" 2>/dev/null || true
+                  done
+                  for v in /opt/Gym/responses_api_models/*/.venv \
+                           /opt/Gym/responses_api_agents/*/.venv \
+                           /opt/Gym/resources_servers/*/.venv; do
+                    [ -d "$v" ] || continue
+                    d="$(dirname "$v")"
+                    [ -f "$d/requirements.txt" ] && uv pip install --python "$v/bin/python" -q -r "$d/requirements.txt" || true
+                  done
+                  # Preserve inherited PYTHONPATH. Plain $VAR only (OmegaConf parses ${...}).
+                  _gym_sp="$(/opt/Gym/.venv/bin/python -c 'import site; print(site.getsitepackages()[0])')"
+                  if [ -n "$PYTHONPATH" ]; then export PYTHONPATH="/opt/Gym:$_gym_sp:$PYTHONPATH"
+                  else export PYTHONPATH="/opt/Gym:$_gym_sp"; fi
+
+                  # SECRETS: `set -x` traces AFTER expansion, so without this the params'
+                  # $HF_TOKEN lands in the log (and in MLflow via log_logs). The rollout
+                  # call below is already safe via the heredoc.
+                  set +x
+                  ng_prepare_benchmark {{config.params.extra.nemo_gym.data_prep_params}} {{config.params.extra.nemo_gym.common_params}}
+                  set -x
+                  # The rollout command is written to a script and run from it, rather than passed
+                  # to `bash -c '...'`. Gym params can legitimately CONTAIN single quotes, which
+                  # would close a single-quoted `bash -c` wrapper early; Hydra then receives the
+                  # value split on spaces and dies with "no viable alternative at input".
+                  # The heredoc delimiter is QUOTED ('GYM_RUN_EOF') so nothing expands while
+                  # writing: $$ and $DUMMY_API_KEY land in the script literally and are expanded
+                  # at run time by the shell that executes it, which is what we want.
+                  cat > /tmp/gym_run.sh <<'GYM_RUN_EOF'
+                  echo $$ > /tmp/gym_eval_pgid
+                  exec ng_e2e_collect_rollouts {{config.params.extra.nemo_gym.collect_rollout_params}} {{config.params.extra.nemo_gym.common_params}}
+                  GYM_RUN_EOF
+                  setsid --wait bash /tmp/gym_run.sh &
+                  __ev=$!
+                  __rc=0; wait "$__ev" || __rc=$?
+                  echo "Evaluator Gym finished!"
+                  __pg=$(cat /tmp/gym_eval_pgid 2>/dev/null || echo)
+                  [ -n "$__pg" ] && kill -9 -"$__pg" 2>/dev/null || true
+                  timeout 60 ray stop --force >/dev/null 2>&1 || true
+                  # uid-scoped: an unscoped pkill would kill other jobs' Ray daemons.
+                  pkill -9 -u "$(id -u)" -f raylet >/dev/null 2>&1 || true
+                  pkill -9 -u "$(id -u)" -f gcs_server >/dev/null 2>&1 || true
+                  pkill -9 -u "$(id -u)" -f plasma_store >/dev/null 2>&1 || true
+                  exit $__rc
+                # VARIANT SELECTOR — this pair of `config_paths` picks the context
+                # envelope, the dataset file, AND the metric key prefix. Change BOTH
+                # lines together, and update the metric name you harvest:
+                #   benchmarks/mrcr/config_n3_1m.yaml   -> mrcr_n3_1m_benchmark_simple_agent   (this template)
+                #   benchmarks/mrcr/config_n3_128k.yaml -> mrcr_n3_128k_benchmark_simple_agent
+                #   benchmarks/mrcr/config.yaml         -> mrcr_benchmark_simple_agent
+                # The n3 variants tokenize with the gated NVIDIA tokenizer (HF_TOKEN
+                # required) and drop over-long samples; the plain variant uses
+                # o200k_base with no cap.
+                data_prep_params: >-
+                  "+config_paths=[responses_api_models/vllm_model/configs/vllm_model.yaml,benchmarks/mrcr/config_n3_1m.yaml]"
+                  +hf_token=$HF_TOKEN
+                  ++use_cached_prepared_benchmarks=true
+                # NEVER put '#' inside this folded (>-) scalar — it folds to one line and
+                # comments out every override after it.
+                collect_rollout_params: >-
+                  "+config_paths=[responses_api_models/vllm_model/configs/vllm_model.yaml,benchmarks/mrcr/config_n3_1m.yaml]"
+                  ++port_range_low=63000
+                  ++port_range_high=64000
+                  ++global_aiohttp_connector_limit_per_host={{config.params.parallelism}}
+                  ++num_samples_in_parallel={{config.params.parallelism}}
+                  ++uv_cache_dir=$UV_CACHE_DIR
+                  ++output_jsonl_fpath={{config.output_dir}}/evaluator_rollouts.jsonl
+                  ++nemo_gym_log_dir={{config.output_dir}}/nemo_gym_logs
+                  ++overwrite_metrics_conflicts=true
+                  ++split=benchmark
+                  ++resume_from_cache=true
+                  ++reuse_existing_data_preparation=true
+                  ++skip_venv_if_present=true
+                  ++upload_rollouts_to_wandb=false
+                  ++responses_create_params.temperature={{config.params.temperature}}
+                  ++responses_create_params.top_p={{config.params.top_p}}
+                  ++responses_create_params.max_output_tokens=null
+                common_params: >-
+                  ++policy_base_url={{target.api_endpoint.url}}
+                  ++policy_api_key=$DUMMY_API_KEY
+                  ++policy_model_name={{target.api_endpoint.model_id}}
+
+export:
+  # LITERAL values only (auto_export resolves this block at submit time in a scope
+  # without deployment/evaluation nodes; ${oc.env:...} is fine). Keep the sampling
+  # tags EQUAL to evaluation params above — they're the only MLflow record of them.
+  mlflow:
+    tracking_uri: ${oc.env:MLFLOW_TRACKING_URI}   # from modelopttools:eval-config
+    experiment_name: ${oc.env:USER}/CHANGEME-served-model-name
+    description: 'CHANGEME-served-model-name | MRCR 1M | T=1.0, top_p=0.95, num_repeats=1'
+    log_logs: true
+    only_required: false
+    tags:
+      framework: vllm
+      model: CHANGEME-served-model-name
+      benchmark: nemo_gym.mrcr
+      temperature: '1.0'
+      top_p: '0.95'

--- a/plugins/modelopt/skills/evaluation/recipes/tasks/gym/gdpval.md
+++ b/plugins/modelopt/skills/evaluation/recipes/tasks/gym/gdpval.md
@@ -21,6 +21,11 @@ launcher can fail before client startup when the config forwards
 `NEL_INVOCATION_ID`. The shared reference explains the failure signature, dry-run
 check, and procedure for validating and adopting a newer launcher.
 
+**Part of the AA suite** — generate it for every AA request, as its own config
+alongside the `aa/` multi-task one. It shares `recipes/tasks/gym/` with MRCR,
+which is *not* AA: the directory groups tasks by **harness** (NeMo Gym), not by
+suite membership, so read that per-task, not from the path.
+
 ## What makes GDPVal different (not a normal `aa/` task)
 
 - **Standalone** — one gym eval per config. Never add GDPVal to a multi-task
@@ -47,7 +52,7 @@ Start from the self-contained example and edit it — **do not** copy a fragment
 another config:
 
 ```text
-recipes/examples/gym_gdpval/example_gym_gdpval.yaml   # SLURM + single-node vLLM,
+recipes/examples/gym/example_gdpval.yaml   # SLURM + single-node vLLM,
                                                     # rubric mode, self-contained
 ```
 

--- a/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
+++ b/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
@@ -77,6 +77,15 @@ deliberately. **Do not change repeat counts when aligning to a golden.**
   and craters the ratio. Golden: `max_new_tokens: null` +
   `++responses_create_params.max_output_tokens=null`.
 
+### Deferred, know the risk
+
+`pre_cmd` installs `tiktoken` / `transformers` **unversioned**, and the n3 prepare
+path uses `transformers.AutoTokenizer` to decide which samples exceed the cap — so
+a version bump can shift dataset membership even with the Gym pin fixed. The
+sub-venv loop also swallows `uv pip install` failures (`|| true`). Both are
+inherited from the reviewed golden's `pre_cmd`; pinning would diverge from the run
+that produced the reference number. Re-check both if a score moves unexpectedly.
+
 ### Gym pin ↔ container — verify before trusting a score
 
 The template pins Gym to `a431501a` (the golden's commit), which carries the N3 1M
@@ -86,7 +95,7 @@ works only where that is a git repo:
 
 | Image | Pin behaviour |
 | --- | --- |
-| Public `nvcr.io/nvidia/eval-factory/nemo-gym:*` (template default) | often **silently ignored** — logs `/opt/Gym is not a git repo`, runs baked Gym |
+| Public `nvcr.io/nvidia/eval-factory/nemo-gym:*` | **not usable** — `/opt/Gym` is not a git repo, so the bootstrap exits 1 |
 | Internal core-evals `ci-llm/nemo-gym` (≥ 2026-07-05) | applies, or **hard-fails** on mismatch |
 
 An inert pin gives either a loud failure (missing `config_n3_1m.yaml`) or — worse
@@ -97,8 +106,8 @@ grep -A1 "=== NeMo Gym commit ===" $RD/logs/client-*.log | grep -c a431501a  # p
 ```
 
 Match the **SHA**, not just the marker — a stale checkout still prints the marker.
-The template now hard-fails when the pin cannot apply, so only an older copy of
-this config can still hit the silent case.
+The template's `container:` is `???` for this reason and its bootstrap exits 1 if
+the pin cannot apply, so only an older copy of this config can score unpinned.
 
 NVIDIA-internal: `modelopttools:eval-config` Step 3d names a working image.
 
@@ -108,19 +117,20 @@ MRCR's gym path takes `++limit=N` (the launcher-level `limit_samples` does not
 reach the gym). **Not verified on this pinned commit** — treat the first ~30 min
 of the real run as the canary, as the GDPVal recipe does. `++limit` caps rollouts
 only: the 1M tokenize/drop-over-long **prepare pass still runs in full**, so a
-5-sample canary is not cheap. Easiest applied by editing your copy of the YAML
-rather than re-pasting the whole folded string:
+5-sample canary is not cheap. Append it to `collect_rollout_params` in your copy
+of the YAML — easier than re-pasting the whole folded scalar through `-o`:
 
-```bash
-nel run --config example_mrcr.yaml -o \
-  ++evaluation.tasks.0.nemo_evaluator_config.config.params.extra.nemo_gym.collect_rollout_params="<existing> ++limit=5"
+```yaml
+                collect_rollout_params: >-
+                  ...
+                  ++limit=5          # canary only — remove for the scored run
 ```
 
 Then watch the first ~30 min of the real run:
 
 ```bash
 RD=<output_dir>/<run>/nemo_gym.0
-grep -c "=== NeMo Gym commit ==="        $RD/logs/client-*.log   # pin applied
+grep -A1 "=== NeMo Gym commit ===" $RD/logs/client-*.log | grep -c a431501a  # pin applied
 grep -ciE "ModuleNotFoundError|tiktoken" $RD/logs/client-*.log   # pre_cmd didn't take
 wc -l $RD/artifacts/evaluator_rollouts.jsonl                     # rollouts flowing
 ```

--- a/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
+++ b/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
@@ -69,10 +69,13 @@ deliberately. **Do not change repeat counts when aligning to a golden.**
   `--max-num-batched-tokens 131072`.
 - `--kv-cache-dtype fp8` — **itself a precision choice**; keep identical across
   baseline and candidate or the delta also measures KV-cache quantization.
-- Fan out via `execution.num_nodes` / `num_instances` (golden **4 / 4**, HAProxy
-  pattern A — `references/multi-node.md`). `parallelism` is the total across
-  instances, so `--max-num-seqs = ceil(parallelism / num_instances / DP)`
-  (256/4/1 = 64).
+- Fan out via `execution.num_nodes` / `num_instances` (HAProxy pattern A —
+  `references/multi-node.md`). **Size these from the cluster's GPUs-per-node**, do
+  not copy: pick TP for the model, fill the node with DP, then choose instances for
+  the replica count you want. `parallelism` is the total across instances, so
+  `--max-num-seqs = ceil(parallelism / num_instances / DP)`. The golden ran 4 nodes
+  × (TP2 × DP2) on 4-GPU nodes = 8 replicas, `ceil(256/4/2) = 32` each; the same 8
+  replicas on 8-GPU nodes is 2 × (TP2 × DP4).
 - **Never cap output.** Answers reproduce a whole earlier turn; a cap truncates it
   and craters the ratio. Golden: `max_new_tokens: null` +
   `++responses_create_params.max_output_tokens=null`.

--- a/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
+++ b/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
@@ -2,198 +2,132 @@
 
 ## Task Details
 
-- Upstream benchmark: <https://github.com/NVIDIA-NeMo/Gym/tree/main/benchmarks/mrcr>
+- Benchmark: <https://github.com/NVIDIA-NeMo/Gym/tree/main/benchmarks/mrcr>
 - Resource server: <https://github.com/NVIDIA-NeMo/Gym/blob/main/resources_servers/mrcr/configs/mrcr.yaml>
-- Dataset: `openai/mrcr` (HF, gated → `HF_TOKEN` required)
+- Dataset: `openai/mrcr` (HF, gated → `HF_TOKEN`)
 
-MRCR is a **long-context retrieval** benchmark. Each task is a long synthetic
-multi-turn conversation containing N near-identical "needle" responses; the final
-user turn asks the model to *reproduce the Nth occurrence verbatim, prefixed with
-a random string*. Scoring is deterministic: `SequenceMatcher.ratio()` between the
-stripped response and the reference answer, **gated on the response starting with
-the required random prefix** (wrong prefix → 0). Results are stratified by needle
-count (2 / 4 / 8) — accuracy falls sharply as N rises.
+Long-context retrieval. Each task is a long multi-turn conversation with N
+near-identical "needle" responses; the model must reproduce the Nth verbatim
+behind a random prefix. Deterministic scoring: `SequenceMatcher.ratio()`, **0
+unless the response starts with the required prefix**. Stratified by needle count
+(2/4/8); accuracy falls sharply as N rises.
+
+A 0.2.6 `nel` `nemo_gym` task (not nel-next), so Steps 1–9 apply. **Standalone** —
+one gym eval per config, never mixed with other tasks.
 
 **Not an AA benchmark** — never generate it for an "AA" request. It shares
-`recipes/tasks/gym/` with GDPVal, which *is* part of the AA suite: the directory
-groups tasks by **harness** (NeMo Gym), not by suite membership, so read that
-per-task, not from the path.
+`recipes/tasks/gym/` with GDPVal, which *is* AA: the dir groups by **harness**,
+not suite, so read membership per task.
 
-It runs on the **0.2.6 `nel` launcher** as a `nemo_gym` task (NOT nel-next), so
-Steps 1–9 apply — with the branch differences below.
-
-## What makes MRCR different from GDPVal (the other gym task)
-
-MRCR is **much simpler to configure** than GDPVal — most of the GDPVal machinery
-does not apply:
-
-| | GDPVal | MRCR |
-| --- | --- | --- |
-| Gym agent | `stirrup_agent` | **`simple_agent`** |
-| Apptainer SIF sandbox | required | **none** |
-| LLM judge | Gemini 3.1 Pro, 4 trials | **none** — deterministic string grading |
-| External secrets | `INFERENCE_API_KEY`, `TAVILY_API_KEY`, judge URL | **`HF_TOKEN` only** |
-| Dominant cost | agent turns + judge | **context length** (up to 1M tokens/prompt) |
-
-What it shares with GDPVal: it is **standalone** (one gym eval per config — never
-add MRCR to a multi-task `evaluation.tasks` list, and never add other tasks to an
-MRCR config), it needs `NEMO_EVALUATOR_TRUST_PRE_CMD=1` (the config has a
-`pre_cmd`), and `limit_samples` behaves differently from the normal task path.
+Much lighter than GDPVal: `simple_agent`, **no SIF sandbox, no judge, no Tavily** —
+`HF_TOKEN` is the only secret, and the cost is context length rather than agent
+turns. Like GDPVal it needs `NEMO_EVALUATOR_TRUST_PRE_CMD=1` (the config has a
+`pre_cmd`).
 
 ## Config
 
-Start from the self-contained example and edit it — **do not** copy a fragment
-into another config:
+Start from the self-contained example — do **not** copy fragments into another
+config:
 
 ```text
-recipes/examples/gym/example_mrcr.yaml   # SLURM + vLLM, 1M variant, self-contained
+recipes/examples/gym/example_mrcr.yaml   # SLURM + vLLM, 1M variant
 ```
 
-### Variant selection — pick before anything else
+### Variant — pick first
 
-Three upstream variants; the choice sets the context envelope, the dataset file,
-**and the metric key prefix**. The reviewed golden uses the **1M** variant.
+Sets the context cap, the dataset, **and the metric prefix**. The golden uses 1M.
 
-| Gym config path | Tokenizer / cap | Agent + metric prefix | `num_repeats` |
+| Gym config | Cap (tokenizer) | Metric prefix | `num_repeats` |
 | --- | --- | --- | --- |
-| `benchmarks/mrcr/config_n3_1m.yaml` | NVIDIA Nemotron (gated), ≤ 1,048,576 tok | `mrcr_n3_1m_benchmark_simple_agent` | 1 |
-| `benchmarks/mrcr/config_n3_128k.yaml` | NVIDIA Nemotron (gated), ≤ 131,072 tok | `mrcr_n3_128k_benchmark_simple_agent` | 1 |
-| `benchmarks/mrcr/config.yaml` | `o200k_base`, **no cap** | `mrcr_benchmark_simple_agent` | 4 |
+| `benchmarks/mrcr/config_n3_1m.yaml` | 1,048,576 (gated NVIDIA) | `mrcr_n3_1m_benchmark_simple_agent` | 1 |
+| `benchmarks/mrcr/config_n3_128k.yaml` | 131,072 (gated NVIDIA) | `mrcr_n3_128k_benchmark_simple_agent` | 1 |
+| `benchmarks/mrcr/config.yaml` | none (`o200k_base`) | `mrcr_benchmark_simple_agent` | 4 |
 
-The n3 variants *drop* samples whose tokenized conversation exceeds the cap, so
-the two n3 datasets are different sizes and **their scores are not comparable to
-each other or to the plain variant**. Pick one and keep it fixed across baseline
-and candidate.
+The n3 variants drop over-long samples, so all three are different datasets and
+**not comparable to each other**. Pick one, keep it fixed across baseline and
+candidate, and set it in **both** `data_prep_params` and `collect_rollout_params`
+— changing one prepares one dataset and rolls out another.
 
-Change the variant in **both** `data_prep_params` and `collect_rollout_params`
-(`+config_paths=[...]`) — changing only one silently prepares one dataset and
-rolls out another.
+`num_repeats` comes from the variant; the template does not override it (1M
+reports `pass@1`). Upstream it is a placeholder for `type: benchmark` datasets —
+the real count comes from the runner. **Do not change repeat counts when aligning
+to a golden.**
 
-`num_repeats` comes from the chosen variant's upstream config and the template
-does not override it. Per the upstream README, for `type: benchmark` datasets the
-in-config `num_repeats` is a **placeholder** that only duplicates rows for
-`train`/`validation` splits — the real repeat count comes from the runner. The 1M
-golden reports `pass@1`, i.e. one rollout per task. **Do not change repeat counts
-when aligning a run to a golden.**
+### Serving envelope (1M)
 
-### Serving envelope (1M variant)
+- `--max-model-len 1100000` **+** `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` in
+  `deployment.env_vars` — vLLM otherwise refuses a len above the checkpoint's
+  `max_position_embeddings`.
+- `gpu_memory_utilization: 0.95` (vs the usual 0.85) for the KV cache.
+- `--enable-prefix-caching`, `--enable-chunked-prefill`,
+  `--max-num-batched-tokens 131072`.
+- `--kv-cache-dtype fp8` — **itself a precision choice**; keep identical across
+  baseline and candidate or the delta also measures KV-cache quantization.
+- Fan out via `execution.num_nodes` / `num_instances` (golden **4 / 4**, HAProxy
+  pattern A — `references/multi-node.md`). `parallelism` is the total across
+  instances, so `--max-num-seqs = ceil(parallelism / num_instances / DP)`
+  (256/4/1 = 64).
+- **Never cap output.** Answers reproduce a whole earlier turn; a cap truncates it
+  and craters the ratio. Golden: `max_new_tokens: null` +
+  `++responses_create_params.max_output_tokens=null`.
 
-The long-context envelope, not the model, drives these:
+### Gym pin ↔ container — verify before trusting a score
 
-- `--max-model-len 1100000` **plus** `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` in
-  `deployment.env_vars` — vLLM refuses a `--max-model-len` above the checkpoint's
-  declared `max_position_embeddings` without it.
-- `gpu_memory_utilization: 0.95` (up from the usual 0.85) to fit the KV cache.
-- `--enable-prefix-caching` + `--enable-chunked-prefill` + a large
-  `--max-num-batched-tokens` (golden: 131072).
-- `--kv-cache-dtype fp8` is part of the golden envelope. **It is itself a
-  precision choice** — keep it identical between baseline and quantized runs or
-  the delta also measures KV-cache quantization.
-- Fan out with `execution.num_nodes` / `num_instances` (golden: **4 / 4**,
-  HAProxy pattern A — see `references/multi-node.md`). `parallelism` is the
-  **total** gym client concurrency across all instances, so
-  `--max-num-seqs = ceil(parallelism / num_instances / DP)` (golden: 256/4/1 = 64).
+The template pins Gym to `a431501a` (the golden's commit), which carries the N3 1M
+prepare path `config_n3_1m.yaml` needs and is **newer than the Gym baked into any
+image**. `install_on_the_fly` applies it by `git checkout` in `/opt/Gym`, so it
+works only where that is a git repo:
 
-### Output length — do not cap it
+| Image | Pin behaviour |
+| --- | --- |
+| Public `nvcr.io/nvidia/eval-factory/nemo-gym:*` (template default) | often **silently ignored** — logs `/opt/Gym is not a git repo`, runs baked Gym |
+| Internal core-evals `ci-llm/nemo-gym` (≥ 2026-07-05) | applies, or **hard-fails** on mismatch |
 
-MRCR answers **reproduce an entire earlier assistant turn verbatim**. Any output
-cap truncates the reproduction and craters `SequenceMatcher.ratio()`. The golden
-sets `max_new_tokens: null` and passes
-`++responses_create_params.max_output_tokens=null`. Leave both uncapped.
-
-### `pre_cmd` — required
-
-The pinned Gym commit's MRCR prepare imports `tiktoken` at module load and falls
-back to `transformers.AutoTokenizer` for the N3 tokenizer path; **neither is a
-declared dep of that commit's Gym venv**, so prepare dies with `ModuleNotFoundError`
-without the `pre_cmd` that installs them. Needs `NEMO_EVALUATOR_TRUST_PRE_CMD=1`
-in the launching shell.
-
-### Gym commit ↔ container coupling — read before trusting a score
-
-The template pins Gym to `a431501aa294f3237d472aaf58dd1e5026156ea8`, the commit
-the golden validated. **MRCR depends on the pin actually applying**: the N3 1M
-preparation path that `config_n3_1m.yaml` needs landed in that commit, and it is
-*newer* than the Gym baked into every image below. A run where the pin didn't
-apply is not "slightly older Gym" — it is a different benchmark or no benchmark.
-
-`install_on_the_fly` applies the pin by `git remote add / fetch / checkout` inside
-`/opt/Gym`. **That only works if `/opt/Gym` is a git repo**, which differs by
-image family:
-
-| Image | `/opt/Gym` | Pin behaviour |
-| --- | --- | --- |
-| Public `nvcr.io/nvidia/eval-factory/nemo-gym:*` (this template's default) | often **not** a git repo | **Silently ignored** — logs `/opt/Gym is not a git repo; using baked-in Gym version` and runs the baked Gym |
-| Internal core-evals gym image (`ci-llm/nemo-gym`, ≥ 2026-07-05 build) | git repo, **build-guarded** | Applies, or **hard-fails** — the build asserts `test -d /opt/Gym/.git`, and the integration layer exits 1 when `HEAD != pin` |
-
-The internal image bakes upstream `NVIDIA-NeMo/Gym` @ `14630a2e` and deliberately
-preserves `/opt/Gym/.git` (its CVE-scan `.git` cleanup excludes that one path)
-after an earlier build stripped it and broke pinning — the failure mode they
-describe is "wrong-but-green eval results."
-
-So on the public image, **verify the pin every run** rather than assuming it:
+An inert pin gives either a loud failure (missing `config_n3_1m.yaml`) or — worse
+— an older variant that scores green and non-comparable. Verify every run:
 
 ```bash
-grep -c "=== NeMo Gym commit ==="  $RD/logs/client-*.log   # pin applied
-grep -c "not a git repo"           $RD/logs/client-*.log   # pin INERT -> baked Gym
+grep -c "=== NeMo Gym commit ==="  $RD/logs/client-*.log   # applied
+grep -c "not a git repo"           $RD/logs/client-*.log   # INERT
 ```
 
-If the pin is inert, the good case is a loud failure — prepare dies on a missing
-`benchmarks/mrcr/config_n3_1m.yaml` because the baked Gym predates the N3
-variants. The dangerous case is a baked Gym that has an *older* `config_n3_1m.yaml`
-with a different prepare path: it runs green and scores something not comparable
-to the golden. If you cannot confirm the `=== NeMo Gym commit ===` SHA, use an
-image whose `/opt/Gym` is a git repo instead of trusting the number.
-NVIDIA-internal users: `modelopttools:eval-config` Step 3d names one (and how to
-pull it); external users should verify the log line on whatever image they have.
+NVIDIA-internal: `modelopttools:eval-config` Step 3d names a working image.
 
 ## Canary
 
-Unlike GDPVal, MRCR's gym path **does** accept a sample limit in the golden
-lineage (`++limit=N`, wired from `limit_samples`). The template omits it; add it
-explicitly for a canary rather than assuming the launcher-level
-`++…params.limit_samples=N` reaches the gym:
+MRCR's gym path accepts `++limit=N` (unlike GDPVal). Append it explicitly — the
+launcher-level `limit_samples` does not reach the gym:
 
 ```bash
 nel run --config example_mrcr.yaml -o \
-  ++evaluation.tasks.0.nemo_evaluator_config.config.params.extra.nemo_gym.collect_rollout_params="<existing string> ++limit=5"
+  ++evaluation.tasks.0.nemo_evaluator_config.config.params.extra.nemo_gym.collect_rollout_params="<existing> ++limit=5"
 ```
 
-Either way, treat the first ~30 minutes of the real run as the canary and check:
+Then watch the first ~30 min of the real run:
 
 ```bash
 RD=<output_dir>/<run>/nemo_gym.0
-grep -c "=== NeMo Gym commit ==="   $RD/logs/client-*.log   # pin actually applied
-grep -c "not a git repo"            $RD/logs/client-*.log   # pin inert -> baked Gym
-grep -ciE "ModuleNotFoundError|tiktoken" $RD/logs/client-*.log  # pre_cmd didn't take
-wc -l $RD/artifacts/evaluator_rollouts.jsonl                # rollouts flowing
+grep -c "=== NeMo Gym commit ==="        $RD/logs/client-*.log   # pin applied
+grep -ciE "ModuleNotFoundError|tiktoken" $RD/logs/client-*.log   # pre_cmd didn't take
+wc -l $RD/artifacts/evaluator_rollouts.jsonl                     # rollouts flowing
 ```
 
-A run that produces rollouts but scores ~0 across the board almost always means
-the **prefix gate** is failing (responses not starting with the required random
-prefix) — check a few raw completions before blaming the checkpoint. On a
-reasoning model that usually means the reasoning trace is leaking into the graded
-answer: verify `--reasoning-parser` is set on the server and
+Rollouts flowing but scores ~0 = the **prefix gate** failing, not a bad
+checkpoint. On a reasoning model that is usually the reasoning trace leaking into
+the graded answer — check `--reasoning-parser` on the server and
 `process_reasoning_traces: true` in the adapter.
 
 ## Score Extraction
 
-The headline metric is **`<agent_prefix>/pass@1/accuracy`**, where the prefix is
-the variant's agent name (see the variant table). For the 1M template:
+Headline: **`<prefix>/pass@1/accuracy`** (prefix per the variant table). Metrics
+are in `artifacts/results.yml`, mirrored to MLflow as `nemo_gym_…` plus a
+`key_metrics/` copy.
 
-```text
-mrcr_n3_1m_benchmark_simple_agent/pass@1/accuracy
-```
-
-Metrics live in `artifacts/results.yml` (authoritative, local) and are mirrored to
-MLflow (prefixed `nemo_gym_`, duplicated under a `key_metrics/` path).
-
-| Metric | Meaning |
+| Metric | |
 | --- | --- |
-| `<prefix>/pass@1/accuracy` | **REPORT THIS** — mean prefix-gated SequenceMatcher ratio |
-| `<prefix>/pass@k/accuracy` | only meaningful when repeats > 1 |
-| `<prefix>/pass@1[avg-of-k]/accuracy` | majority-vote variant, repeats > 1 |
-| `<prefix>/n_needles=2\|4\|8/pass@1/accuracy` | per-stratum breakdown — **always quote these too** |
+| `<prefix>/pass@1/accuracy` | **REPORT THIS** — mean prefix-gated ratio |
+| `<prefix>/n_needles=2\|4\|8/pass@1/accuracy` | per-stratum — **always quote too** |
+| `<prefix>/pass@k/…`, `<prefix>/pass@1[avg-of-k]/…` | only meaningful when repeats > 1 |
 
 ```bash
 python3 -c "
@@ -204,21 +138,11 @@ for k in [f'{p}/pass@1/accuracy'] + [f'{p}/n_needles={n}/pass@1/accuracy' for n 
     if k in m: print(k, '=', m[k]['scores'][k]['value'])"
 ```
 
-**Always report the needle-count strata alongside the headline.** Long-context
-degradation from quantization shows up in the 8-needle stratum first while the
-aggregate barely moves — the aggregate alone can hide a real regression.
+Quantization damage shows in the **8-needle stratum first** while the aggregate
+barely moves — the aggregate alone hides it.
 
-### Reference point (reviewed golden, BF16 Nemotron Nano 3.5, 1M variant)
-
-```text
-mrcr_n3_1m_benchmark_simple_agent/pass@1/accuracy = 26.91
-  n_needles=2  36.81
-  n_needles=4  27.12
-  n_needles=8  16.74
-2363/2363 rollouts, 0 failures   (parallelism 256, 4 nodes / 4 instances)
-```
-
-Use this to sanity-check a run's shape, not as a pass/fail bar for a different
-model. A **rollout count materially below 2363** on the 1M variant means tasks
-were lost (e.g. across a walltime resume) and the accuracy is computed over fewer
-tasks than the reference — re-check before quoting.
+Reference shape (reviewed golden, BF16 Nano 3.5, 1M): `pass@1 = 26.91` (2/4/8
+needles = 36.81 / 27.12 / 16.74), 2363/2363 rollouts, parallelism 256, 4 nodes /
+4 instances. Use it to sanity-check shape, not as a bar for another model — a
+rollout count well below 2363 means tasks were lost (e.g. a walltime resume) and
+the score covers fewer tasks than the reference.

--- a/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
+++ b/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
@@ -76,6 +76,12 @@ deliberately. **Do not change repeat counts when aligning to a golden.**
   `--max-num-seqs = ceil(parallelism / num_instances / DP)`. The golden ran 4 nodes
   × (TP2 × DP2) on 4-GPU nodes = 8 replicas, `ceil(256/4/2) = 32` each; the same 8
   replicas on 8-GPU nodes is 2 × (TP2 × DP4).
+- **`--max-num-seqs` is a ceiling, not a target.** MRCR is the most KV-bound task
+  in the skill — ~1M input tokens per request against AA-LCR's ~120K — so AA-LCR's
+  rule applies harder: oversubscribe and vLLM preempts, and recomputing a 1M-token
+  prefill makes the run *slower*, not faster. Start small and raise only while
+  preemption stays ~0 (`grep -c preempted` the server log). See
+  `recipes/tasks/aa/lcr.md` and `references/parallelism.md` ("Balanced sizing").
 - **Never cap output.** Answers reproduce a whole earlier turn; a cap truncates it
   and craters the ratio. Golden: `max_new_tokens: null` +
   `++responses_create_params.max_output_tokens=null`.

--- a/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
+++ b/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
@@ -15,6 +15,13 @@ unless the response starts with the required prefix**. Stratified by needle coun
 A 0.2.6 `nel` `nemo_gym` task (not nel-next), so Steps 1–9 apply. **Standalone** —
 one gym eval per config, never mixed with other tasks.
 
+Run it through **`"$SKILL_DIR/scripts/nel-gdpval.sh"`**, the same pinned-launcher
+wrapper GDPVal uses — the name is GDPVal-flavoured but the pin is gym-wide. This
+config forwards `NEL_INVOCATION_ID`, and an unpinned `nel` from PATH can emit the
+re-export without first assigning it, exiting on `NEL_INVOCATION_ID: unbound
+variable` under `set -u` before the client starts. See `references/gym-gdpval.md`
+for the failure signature and the procedure for adopting a newer launcher.
+
 **Not an AA benchmark** — never generate it for an "AA" request. It shares
 `recipes/tasks/gym/` with GDPVal, which *is* AA: the dir groups by **harness**,
 not suite, so read membership per task.

--- a/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
+++ b/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
@@ -1,0 +1,222 @@
+# MRCR (OpenAI Multi-Round Co-reference Resolution, NeMo Gym `simple_agent`)
+
+## Task Details
+
+- Upstream benchmark: <https://github.com/NVIDIA-NeMo/Gym/tree/main/benchmarks/mrcr>
+- Resource server: <https://github.com/NVIDIA-NeMo/Gym/blob/main/resources_servers/mrcr/configs/mrcr.yaml>
+- Dataset: `openai/mrcr` (HF, gated → `HF_TOKEN` required)
+
+MRCR is a **long-context retrieval** benchmark. Each task is a long synthetic
+multi-turn conversation containing N near-identical "needle" responses; the final
+user turn asks the model to *reproduce the Nth occurrence verbatim, prefixed with
+a random string*. Scoring is deterministic: `SequenceMatcher.ratio()` between the
+stripped response and the reference answer, **gated on the response starting with
+the required random prefix** (wrong prefix → 0). Results are stratified by needle
+count (2 / 4 / 8) — accuracy falls sharply as N rises.
+
+**Not an AA benchmark.** It lives under `recipes/tasks/gym/`, not `aa_gym/`, and
+is never part of the AA Index v2 set.
+
+It runs on the **0.2.6 `nel` launcher** as a `nemo_gym` task (NOT nel-next), so
+Steps 1–9 apply — with the branch differences below.
+
+## What makes MRCR different from GDPVal (the other gym task)
+
+MRCR is **much simpler to configure** than GDPVal — most of the GDPVal machinery
+does not apply:
+
+| | GDPVal | MRCR |
+| --- | --- | --- |
+| Gym agent | `stirrup_agent` | **`simple_agent`** |
+| Apptainer SIF sandbox | required | **none** |
+| LLM judge | Gemini 3.1 Pro, 4 trials | **none** — deterministic string grading |
+| External secrets | `INFERENCE_API_KEY`, `TAVILY_API_KEY`, judge URL | **`HF_TOKEN` only** |
+| Dominant cost | agent turns + judge | **context length** (up to 1M tokens/prompt) |
+
+What it shares with GDPVal: it is **standalone** (one gym eval per config — never
+add MRCR to a multi-task `evaluation.tasks` list, and never add other tasks to an
+MRCR config), it needs `NEMO_EVALUATOR_TRUST_PRE_CMD=1` (the config has a
+`pre_cmd`), and `limit_samples` behaves differently from the normal task path.
+
+## Config
+
+Start from the self-contained example and edit it — **do not** copy a fragment
+into another config:
+
+```text
+recipes/examples/gym_mrcr/example_gym_mrcr.yaml   # SLURM + vLLM, 1M variant, self-contained
+```
+
+### Variant selection — pick before anything else
+
+Three upstream variants; the choice sets the context envelope, the dataset file,
+**and the metric key prefix**. The reviewed golden uses the **1M** variant.
+
+| Gym config path | Tokenizer / cap | Agent + metric prefix | `num_repeats` |
+| --- | --- | --- | --- |
+| `benchmarks/mrcr/config_n3_1m.yaml` | NVIDIA Nemotron (gated), ≤ 1,048,576 tok | `mrcr_n3_1m_benchmark_simple_agent` | 1 |
+| `benchmarks/mrcr/config_n3_128k.yaml` | NVIDIA Nemotron (gated), ≤ 131,072 tok | `mrcr_n3_128k_benchmark_simple_agent` | 1 |
+| `benchmarks/mrcr/config.yaml` | `o200k_base`, **no cap** | `mrcr_benchmark_simple_agent` | 4 |
+
+The n3 variants *drop* samples whose tokenized conversation exceeds the cap, so
+the two n3 datasets are different sizes and **their scores are not comparable to
+each other or to the plain variant**. Pick one and keep it fixed across baseline
+and candidate.
+
+Change the variant in **both** `data_prep_params` and `collect_rollout_params`
+(`+config_paths=[...]`) — changing only one silently prepares one dataset and
+rolls out another.
+
+`num_repeats` comes from the chosen variant's upstream config and the template
+does not override it. Per the upstream README, for `type: benchmark` datasets the
+in-config `num_repeats` is a **placeholder** that only duplicates rows for
+`train`/`validation` splits — the real repeat count comes from the runner. The 1M
+golden reports `pass@1`, i.e. one rollout per task. **Do not change repeat counts
+when aligning a run to a golden.**
+
+### Serving envelope (1M variant)
+
+The long-context envelope, not the model, drives these:
+
+- `--max-model-len 1100000` **plus** `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` in
+  `deployment.env_vars` — vLLM refuses a `--max-model-len` above the checkpoint's
+  declared `max_position_embeddings` without it.
+- `gpu_memory_utilization: 0.95` (up from the usual 0.85) to fit the KV cache.
+- `--enable-prefix-caching` + `--enable-chunked-prefill` + a large
+  `--max-num-batched-tokens` (golden: 131072).
+- `--kv-cache-dtype fp8` is part of the golden envelope. **It is itself a
+  precision choice** — keep it identical between baseline and quantized runs or
+  the delta also measures KV-cache quantization.
+- Fan out with `execution.num_nodes` / `num_instances` (golden: **4 / 4**,
+  HAProxy pattern A — see `references/multi-node.md`). `parallelism` is the
+  **total** gym client concurrency across all instances, so
+  `--max-num-seqs = ceil(parallelism / num_instances / DP)` (golden: 256/4/1 = 64).
+
+### Output length — do not cap it
+
+MRCR answers **reproduce an entire earlier assistant turn verbatim**. Any output
+cap truncates the reproduction and craters `SequenceMatcher.ratio()`. The golden
+sets `max_new_tokens: null` and passes
+`++responses_create_params.max_output_tokens=null`. Leave both uncapped.
+
+### `pre_cmd` — required
+
+The pinned Gym commit's MRCR prepare imports `tiktoken` at module load and falls
+back to `transformers.AutoTokenizer` for the N3 tokenizer path; **neither is a
+declared dep of that commit's Gym venv**, so prepare dies with `ModuleNotFoundError`
+without the `pre_cmd` that installs them. Needs `NEMO_EVALUATOR_TRUST_PRE_CMD=1`
+in the launching shell.
+
+### Gym commit ↔ container coupling — read before trusting a score
+
+The template pins Gym to `a431501aa294f3237d472aaf58dd1e5026156ea8`, the commit
+the golden validated. **MRCR depends on the pin actually applying**: the N3 1M
+preparation path that `config_n3_1m.yaml` needs landed in that commit, and it is
+*newer* than the Gym baked into every image below. A run where the pin didn't
+apply is not "slightly older Gym" — it is a different benchmark or no benchmark.
+
+`install_on_the_fly` applies the pin by `git remote add / fetch / checkout` inside
+`/opt/Gym`. **That only works if `/opt/Gym` is a git repo**, which differs by
+image family:
+
+| Image | `/opt/Gym` | Pin behaviour |
+| --- | --- | --- |
+| Public `nvcr.io/nvidia/eval-factory/nemo-gym:*` (this template's default) | often **not** a git repo | **Silently ignored** — logs `/opt/Gym is not a git repo; using baked-in Gym version` and runs the baked Gym |
+| Internal core-evals gym image (`ci-llm/nemo-gym`, ≥ 2026-07-05 build) | git repo, **build-guarded** | Applies, or **hard-fails** — the build asserts `test -d /opt/Gym/.git`, and the integration layer exits 1 when `HEAD != pin` |
+
+The internal image bakes upstream `NVIDIA-NeMo/Gym` @ `14630a2e` and deliberately
+preserves `/opt/Gym/.git` (its CVE-scan `.git` cleanup excludes that one path)
+after an earlier build stripped it and broke pinning — the failure mode they
+describe is "wrong-but-green eval results."
+
+So on the public image, **verify the pin every run** rather than assuming it:
+
+```bash
+grep -c "=== NeMo Gym commit ==="  $RD/logs/client-*.log   # pin applied
+grep -c "not a git repo"           $RD/logs/client-*.log   # pin INERT -> baked Gym
+```
+
+If the pin is inert, the good case is a loud failure — prepare dies on a missing
+`benchmarks/mrcr/config_n3_1m.yaml` because the baked Gym predates the N3
+variants. The dangerous case is a baked Gym that has an *older* `config_n3_1m.yaml`
+with a different prepare path: it runs green and scores something not comparable
+to the golden. If you cannot confirm the `=== NeMo Gym commit ===` SHA, use an
+image whose `/opt/Gym` is a git repo instead of trusting the number.
+NVIDIA-internal users: `modelopttools:eval-config` Step 3d names one (and how to
+pull it); external users should verify the log line on whatever image they have.
+
+## Canary
+
+Unlike GDPVal, MRCR's gym path **does** accept a sample limit in the golden
+lineage (`++limit=N`, wired from `limit_samples`). The template omits it; add it
+explicitly for a canary rather than assuming the launcher-level
+`++…params.limit_samples=N` reaches the gym:
+
+```bash
+nel run --config example_gym_mrcr.yaml -o \
+  ++evaluation.tasks.0.nemo_evaluator_config.config.params.extra.nemo_gym.collect_rollout_params="<existing string> ++limit=5"
+```
+
+Either way, treat the first ~30 minutes of the real run as the canary and check:
+
+```bash
+RD=<output_dir>/<run>/nemo_gym.0
+grep -c "=== NeMo Gym commit ==="   $RD/logs/client-*.log   # pin actually applied
+grep -c "not a git repo"            $RD/logs/client-*.log   # pin inert -> baked Gym
+grep -ciE "ModuleNotFoundError|tiktoken" $RD/logs/client-*.log  # pre_cmd didn't take
+wc -l $RD/artifacts/evaluator_rollouts.jsonl                # rollouts flowing
+```
+
+A run that produces rollouts but scores ~0 across the board almost always means
+the **prefix gate** is failing (responses not starting with the required random
+prefix) — check a few raw completions before blaming the checkpoint. On a
+reasoning model that usually means the reasoning trace is leaking into the graded
+answer: verify `--reasoning-parser` is set on the server and
+`process_reasoning_traces: true` in the adapter.
+
+## Score Extraction
+
+The headline metric is **`<agent_prefix>/pass@1/accuracy`**, where the prefix is
+the variant's agent name (see the variant table). For the 1M template:
+
+```text
+mrcr_n3_1m_benchmark_simple_agent/pass@1/accuracy
+```
+
+Metrics live in `artifacts/results.yml` (authoritative, local) and are mirrored to
+MLflow (prefixed `nemo_gym_`, duplicated under a `key_metrics/` path).
+
+| Metric | Meaning |
+| --- | --- |
+| `<prefix>/pass@1/accuracy` | **REPORT THIS** — mean prefix-gated SequenceMatcher ratio |
+| `<prefix>/pass@k/accuracy` | only meaningful when repeats > 1 |
+| `<prefix>/pass@1[avg-of-k]/accuracy` | majority-vote variant, repeats > 1 |
+| `<prefix>/n_needles=2\|4\|8/pass@1/accuracy` | per-stratum breakdown — **always quote these too** |
+
+```bash
+python3 -c "
+import yaml
+m=yaml.safe_load(open('<output_dir>/<run>/nemo_gym.0/artifacts/results.yml'))['groups']['nemo_gym']['metrics']
+p='mrcr_n3_1m_benchmark_simple_agent'
+for k in [f'{p}/pass@1/accuracy'] + [f'{p}/n_needles={n}/pass@1/accuracy' for n in (2,4,8)]:
+    if k in m: print(k, '=', m[k]['scores'][k]['value'])"
+```
+
+**Always report the needle-count strata alongside the headline.** Long-context
+degradation from quantization shows up in the 8-needle stratum first while the
+aggregate barely moves — the aggregate alone can hide a real regression.
+
+### Reference point (reviewed golden, BF16 Nemotron Nano 3.5, 1M variant)
+
+```text
+mrcr_n3_1m_benchmark_simple_agent/pass@1/accuracy = 26.91
+  n_needles=2  36.81
+  n_needles=4  27.12
+  n_needles=8  16.74
+2363/2363 rollouts, 0 failures   (parallelism 256, 4 nodes / 4 instances)
+```
+
+Use this to sanity-check a run's shape, not as a pass/fail bar for a different
+model. A **rollout count materially below 2363** on the 1M variant means tasks
+were lost (e.g. across a walltime resume) and the accuracy is computed over fewer
+tasks than the reference — re-check before quoting.

--- a/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
+++ b/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
@@ -22,7 +22,8 @@ not suite, so read membership per task.
 Much lighter than GDPVal: `simple_agent`, **no SIF sandbox, no judge, no Tavily** —
 `HF_TOKEN` is the only secret, and the cost is context length rather than agent
 turns. Like GDPVal it needs `NEMO_EVALUATOR_TRUST_PRE_CMD=1` (the config has a
-`pre_cmd`).
+`pre_cmd`), plus `NEMO_EVALUATOR_TRUST_UNLISTED_TASKS=1` — `nemo_gym` is not in
+the FDF mapping, so submission is refused without it.
 
 ## Config
 
@@ -112,6 +113,12 @@ grep -ciE "ModuleNotFoundError|tiktoken" $RD/logs/client-*.log   # pre_cmd didn'
 wc -l $RD/artifacts/evaluator_rollouts.jsonl                     # rollouts flowing
 ```
 
+**Preempted vs timed out.** A 1M run routinely exceeds 4h. `TIMEOUT` auto-resumes
+from the response cache; `CANCELLED by <uid>` (preemption) does not — its chained
+job exits in ~20s (`…finished with 'CANCELLED…' state. EXIT!`), which is expected,
+not a bug. Resume by hand: `cd <run>/nemo_gym.0 && sbatch run.sub`. Progress is
+cumulative — check `wc -l evaluator_rollouts.jsonl` before assuming loss.
+
 Rollouts flowing but scores ~0 = the **prefix gate** failing, not a bad
 checkpoint. On a reasoning model that is usually the reasoning trace leaking into
 the graded answer — check `--reasoning-parser` on the server and
@@ -119,27 +126,30 @@ the graded answer — check `--reasoning-parser` on the server and
 
 ## Score Extraction
 
-Headline: **`<prefix>/pass@1/accuracy`** (prefix per the variant table). Metrics
-are in `artifacts/results.yml`, mirrored to MLflow as `nemo_gym_…` plus a
-`key_metrics/` copy.
+**Not in `results.yml`** — its `groups.nemo_gym.metrics` map is empty for MRCR
+(only `key_metrics/mean/*` token telemetry). Read
+`artifacts/evaluator_rollouts_aggregate_metrics.json` → `[0].agent_metrics`:
 
-| Metric | |
+| Key | |
 | --- | --- |
-| `<prefix>/pass@1/accuracy` | **REPORT THIS** — mean prefix-gated ratio |
-| `<prefix>/n_needles=2\|4\|8/pass@1/accuracy` | per-stratum — **always quote too** |
-| `<prefix>/pass@k/…`, `<prefix>/pass@1[avg-of-k]/…` | only meaningful when repeats > 1 |
+| `pass@1/accuracy` | **REPORT THIS** — already 0-100, do not ×100 |
+| `n_needles=2\|4\|8/pass@1/accuracy` | per-stratum — **always quote too** |
+| `mean/reward` | same number as a 0-1 fraction (= `mean/seq_match_ratio`) |
+| `mean/prefix_matched` | prefix-gate pass rate; **~0.55 is healthy** |
 
 ```bash
 python3 -c "
-import yaml
-m=yaml.safe_load(open('<output_dir>/<run>/nemo_gym.0/artifacts/results.yml'))['groups']['nemo_gym']['metrics']
-p='mrcr_n3_1m_benchmark_simple_agent'
-for k in [f'{p}/pass@1/accuracy'] + [f'{p}/n_needles={n}/pass@1/accuracy' for n in (2,4,8)]:
-    if k in m: print(k, '=', m[k]['scores'][k]['value'])"
+import json
+m=json.load(open('<output_dir>/<run>/nemo_gym.0/artifacts/evaluator_rollouts_aggregate_metrics.json'))[0]['agent_metrics']
+print('pass@1', round(m['pass@1/accuracy'],2))
+for n in (2,4,8): print(f'  n={n}', round(m[f'n_needles={n}/pass@1/accuracy'],2))
+print('prefix_matched', round(m['mean/prefix_matched'],3))"
 ```
 
-Quantization damage shows in the **8-needle stratum first** while the aggregate
-barely moves — the aggregate alone hides it.
+Quantization damage hits the **8-needle stratum first** while the aggregate stays
+flat. Before quoting, check truncation: `eval_factory_metrics.json` →
+`response_stats.finish_reason.length` (a capped response scores ~0; measured 2.4%
+at `--max-model-len 1100000`).
 
 Reference shape (reviewed golden, BF16 Nano 3.5, 1M): `pass@1 = 26.91` (2/4/8
 needles = 36.81 / 27.12 / 16.74), 2363/2363 rollouts, parallelism 256, 4 nodes /

--- a/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
+++ b/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
@@ -14,8 +14,10 @@ stripped response and the reference answer, **gated on the response starting wit
 the required random prefix** (wrong prefix → 0). Results are stratified by needle
 count (2 / 4 / 8) — accuracy falls sharply as N rises.
 
-**Not an AA benchmark.** It lives under `recipes/tasks/gym/`, not `aa_gym/`, and
-is never part of the AA Index v2 set.
+**Not an AA benchmark** — never generate it for an "AA" request. It shares
+`recipes/tasks/gym/` with GDPVal, which *is* part of the AA suite: the directory
+groups tasks by **harness** (NeMo Gym), not by suite membership, so read that
+per-task, not from the path.
 
 It runs on the **0.2.6 `nel` launcher** as a `nemo_gym` task (NOT nel-next), so
 Steps 1–9 apply — with the branch differences below.
@@ -44,7 +46,7 @@ Start from the self-contained example and edit it — **do not** copy a fragment
 into another config:
 
 ```text
-recipes/examples/gym_mrcr/example_gym_mrcr.yaml   # SLURM + vLLM, 1M variant, self-contained
+recipes/examples/gym/example_mrcr.yaml   # SLURM + vLLM, 1M variant, self-contained
 ```
 
 ### Variant selection — pick before anything else
@@ -153,7 +155,7 @@ explicitly for a canary rather than assuming the launcher-level
 `++…params.limit_samples=N` reaches the gym:
 
 ```bash
-nel run --config example_gym_mrcr.yaml -o \
+nel run --config example_mrcr.yaml -o \
   ++evaluation.tasks.0.nemo_evaluator_config.config.params.extra.nemo_gym.collect_rollout_params="<existing string> ++limit=5"
 ```
 

--- a/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
+++ b/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
@@ -64,11 +64,21 @@ deliberately. **Do not change repeat counts when aligning to a golden.**
 - `--max-model-len 1100000` **+** `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` in
   `deployment.env_vars` — vLLM otherwise refuses a len above the checkpoint's
   `max_position_embeddings`.
-- `gpu_memory_utilization: 0.95` (vs the usual 0.85) for the KV cache.
+- `gpu_memory_utilization: 0.95` (vs the usual 0.85) — driven by **sequence
+  length**, not prefix caching: a ~1M-token context needs a far larger KV
+  allocation, and prefix-cache blocks come out of the same pool.
 - `--enable-prefix-caching`, `--enable-chunked-prefill`,
   `--max-num-batched-tokens 131072`.
-- `--kv-cache-dtype fp8` — **itself a precision choice**; keep identical across
-  baseline and candidate or the delta also measures KV-cache quantization.
+- **KV dtype: follow the checkpoint, not this template.** Read
+  `kv_cache_quant_algo` from the checkpoint's `hf_quant_config.json` and pass the
+  matching `--kv-cache-dtype`. vLLM does **not** infer it — `config.json`'s
+  `quantization_config` carries no kv_cache key — so an FP8-KV-calibrated
+  checkpoint needs the flag explicitly, and a checkpoint without it must **not**
+  get `fp8` (that applies uncalibrated KV quantization, worst exactly here where
+  error accumulates over ~1M tokens). BF16 KV works and is the safe default, but
+  roughly doubles KV footprint, which at 1M is what decides whether the cache
+  fits. If baseline and candidate declare different KV algos, that difference is
+  part of the delta — report it rather than forcing them equal.
 - Fan out via `execution.num_nodes` / `num_instances` (HAProxy pattern A —
   `references/multi-node.md`). **Size these from the cluster's GPUs-per-node**, do
   not copy: pick TP for the model, fill the node with DP, then choose instances for

--- a/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
+++ b/plugins/modelopt/skills/evaluation/recipes/tasks/gym/mrcr.md
@@ -34,6 +34,10 @@ config:
 recipes/examples/gym/example_mrcr.yaml   # SLURM + vLLM, 1M variant
 ```
 
+The gym bootstrap `command:` block (install_on_the_fly, sub-venv setup, rollout
+heredoc, Ray teardown) is **shared with GDPVal**; `references/gym-gdpval.md`
+documents that machinery and a fix there applies to both examples.
+
 ### Variant — pick first
 
 Sets the context cap, the dataset, **and the metric prefix**. The golden uses 1M.
@@ -49,10 +53,11 @@ The n3 variants drop over-long samples, so all three are different datasets and
 candidate, and set it in **both** `data_prep_params` and `collect_rollout_params`
 — changing one prepares one dataset and rolls out another.
 
-`num_repeats` comes from the variant; the template does not override it (1M
-reports `pass@1`). Upstream it is a placeholder for `type: benchmark` datasets —
-the real count comes from the runner. **Do not change repeat counts when aligning
-to a golden.**
+The `num_repeats` column is what each variant **declares upstream**, not
+necessarily what runs: for `type: benchmark` datasets the value is a placeholder
+and the runner decides. The template therefore pins `++num_repeats=1` in
+`common_params`, so **report `pass@1` regardless of variant** unless you raise it
+deliberately. **Do not change repeat counts when aligning to a golden.**
 
 ### Serving envelope (1M)
 
@@ -88,16 +93,23 @@ An inert pin gives either a loud failure (missing `config_n3_1m.yaml`) or — wo
 — an older variant that scores green and non-comparable. Verify every run:
 
 ```bash
-grep -c "=== NeMo Gym commit ==="  $RD/logs/client-*.log   # applied
-grep -c "not a git repo"           $RD/logs/client-*.log   # INERT
+grep -A1 "=== NeMo Gym commit ===" $RD/logs/client-*.log | grep -c a431501a  # pin APPLIED
 ```
+
+Match the **SHA**, not just the marker — a stale checkout still prints the marker.
+The template now hard-fails when the pin cannot apply, so only an older copy of
+this config can still hit the silent case.
 
 NVIDIA-internal: `modelopttools:eval-config` Step 3d names a working image.
 
 ## Canary
 
-MRCR's gym path accepts `++limit=N` (unlike GDPVal). Append it explicitly — the
-launcher-level `limit_samples` does not reach the gym:
+MRCR's gym path takes `++limit=N` (the launcher-level `limit_samples` does not
+reach the gym). **Not verified on this pinned commit** — treat the first ~30 min
+of the real run as the canary, as the GDPVal recipe does. `++limit` caps rollouts
+only: the 1M tokenize/drop-over-long **prepare pass still runs in full**, so a
+5-sample canary is not cheap. Easiest applied by editing your copy of the YAML
+rather than re-pasting the whole folded string:
 
 ```bash
 nel run --config example_mrcr.yaml -o \
@@ -122,7 +134,9 @@ cumulative — check `wc -l evaluator_rollouts.jsonl` before assuming loss.
 Rollouts flowing but scores ~0 = the **prefix gate** failing, not a bad
 checkpoint. On a reasoning model that is usually the reasoning trace leaking into
 the graded answer — check `--reasoning-parser` on the server and
-`process_reasoning_traces: true` in the adapter.
+`process_reasoning_traces: true` in the adapter. That is the **current** adapter
+key; `use_reasoning` (used elsewhere in this skill) is its deprecated alias and
+the evaluator maps the two to each other, so either works today.
 
 ## Score Extraction
 
@@ -154,5 +168,6 @@ at `--max-model-len 1100000`).
 Reference shape (reviewed golden, BF16 Nano 3.5, 1M): `pass@1 = 26.91` (2/4/8
 needles = 36.81 / 27.12 / 16.74), 2363/2363 rollouts, parallelism 256, 4 nodes /
 4 instances. Use it to sanity-check shape, not as a bar for another model — a
-rollout count well below 2363 means tasks were lost (e.g. a walltime resume) and
+rollout count well below 2363 (full runs only — a `++limit` canary is expected
+to be short) means tasks were lost (e.g. a walltime resume) and
 the score covers fewer tasks than the reference.

--- a/plugins/modelopt/skills/evaluation/references/gym-gdpval.md
+++ b/plugins/modelopt/skills/evaluation/references/gym-gdpval.md
@@ -6,8 +6,8 @@ produces office/PDF **deliverables** in a per-task **Apptainer** code-exec sandb
 a pairwise/rubric **judge** (Gemini 3.1 Pro) scores them, and NeMo Gym is pulled
 and run **inline in the eval container** (`install_on_the_fly`) via
 `ng_prepare_benchmark` + `ng_e2e_collect_rollouts`. This file is the shared
-machinery; the config template is `recipes/examples/gym_gdpval/` and the per-task
-pointer is `recipes/tasks/aa_gym/gdpval.md`.
+machinery; the config template is `recipes/examples/gym/` and the per-task
+pointer is `recipes/tasks/gym/gdpval.md`.
 
 Always invoke GDPVal through the pinned wrapper, even if `nel` is already on PATH:
 

--- a/plugins/modelopt/skills/evaluation/references/gym-gdpval.md
+++ b/plugins/modelopt/skills/evaluation/references/gym-gdpval.md
@@ -6,8 +6,10 @@ produces office/PDF **deliverables** in a per-task **Apptainer** code-exec sandb
 a pairwise/rubric **judge** (Gemini 3.1 Pro) scores them, and NeMo Gym is pulled
 and run **inline in the eval container** (`install_on_the_fly`) via
 `ng_prepare_benchmark` + `ng_e2e_collect_rollouts`. This file is the shared
-machinery; the config template is `recipes/examples/gym/` and the per-task
-pointer is `recipes/tasks/gym/gdpval.md`.
+machinery; the config template is `recipes/examples/gym/example_gdpval.yaml` and
+the per-task pointer is `recipes/tasks/gym/gdpval.md`. The gym bootstrap machinery
+described here is shared with MRCR (`recipes/tasks/gym/mrcr.md`) — fixes here apply
+to both examples.
 
 Always invoke GDPVal through the pinned wrapper, even if `nel` is already on PATH:
 

--- a/plugins/modelopt/skills/evaluation/references/quantization-benchmarks.md
+++ b/plugins/modelopt/skills/evaluation/references/quantization-benchmarks.md
@@ -3,7 +3,7 @@
 When evaluating a quantized checkpoint, prioritize benchmarks that are sensitive
 to precision loss. The Artificial Analysis (AA) Index v2 suite under
 `recipes/tasks/aa/` is the default set for quantized-checkpoint validation.
-**GDPVal** (`recipes/tasks/aa_gym/gdpval.md`) is also part of the AA suite, but a
+**GDPVal** (`recipes/tasks/gym/gdpval.md`) is also part of the AA suite, but a
 different harness (NeMo Gym) — it runs as a **separate standalone config**, never
 merged into the `aa/` multi-task list.
 
@@ -33,7 +33,7 @@ merged into the `aa/` multi-task list.
 | `tasks/aa/mmmu_pro.md` | MMMU-Pro | Multimodal reasoning | VLM-only; usually Low/Medium when only the LLM is quantized (vision encoder/adapter typically stay BF16) |
 | `tasks/aa/tau2_bench_telecom.md` | Tau2-Bench Telecom | Agentic tool use (user-simulator + judge) | Medium-high — tool-call JSON is brittle, but user-sim + judge variance often dominates the signal |
 | `tasks/aa/omniscience.md` | AA-Omniscience | Knowledge reliability (`ns_omniscience`, nemo-skills, `num_repeats: 10`) — correct vs hallucinate vs abstain on obscure facts, judge-scored | Medium — measures the hallucination/abstention balance; aggressive precision loss can erode factual recall and shift the omni-index |
-| `tasks/aa_gym/gdpval.md` | GDPVal (`nemo_gym` Stirrup agent, **standalone config**) | Agentic office/PDF deliverables in an Apptainer code-exec sandbox, pairwise/rubric judge | High — long-horizon agentic reasoning + code + judge; precision loss compounds across many turns. **Heaviest task**: multi-hour, often multi-node, needs the SIF sandbox + judge. Runs as its own config, never in the `aa/` list |
+| `tasks/gym/gdpval.md` | GDPVal (`nemo_gym` Stirrup agent, **standalone config**) | Agentic office/PDF deliverables in an Apptainer code-exec sandbox, pairwise/rubric judge | High — long-horizon agentic reasoning + code + judge; precision loss compounds across many turns. **Heaviest task**: multi-hour, often multi-node, needs the SIF sandbox + judge. Runs as its own config, never in the `aa/` list |
 | `tasks/gym/mrcr.md` | MRCR (`nemo_gym` simple agent, **standalone config**, **not AA**) | Long-context co-reference retrieval up to 1M tokens; deterministic prefix-gated `SequenceMatcher` grading, stratified by needle count | Very high — the longest-context task available here; KV-cache and attention quant error accumulate over the full window. No judge, so the signal is clean. Opt-in: only when the user asks for MRCR or long-context coverage |
 
 ## Recommended sets by use case
@@ -42,14 +42,14 @@ merged into the `aa/` multi-task list.
 |----------|-----------|
 | Quick sanity check | GPQA |
 | Standard quant validation (text LLM) | GPQA, SciCode, LCR |
-| AA / Artificial Analysis suite (text LLM) | All `tasks/aa/` text tasks: GPQA, HLE, LCR, SciCode, IFBench, Tau2-Bench Telecom, AA-Omniscience — **plus GDPVal** (`tasks/aa_gym/`, a separate standalone config) |
+| AA / Artificial Analysis suite (text LLM) | All `tasks/aa/` text tasks: GPQA, HLE, LCR, SciCode, IFBench, Tau2-Bench Telecom, AA-Omniscience — **plus GDPVal** (`tasks/gym/gdpval.md`, a separate standalone config) |
 | AA / Artificial Analysis suite (multimodal) | AA text suite (incl. GDPVal) + MMMU-Pro |
 | Code-focused model | LiveCodeBench, SciCode |
 | Reasoning model | AIME 2025, GPQA, HLE |
 
 > If the user asks for "AA" or "Artificial Analysis", generate the
 > `recipes/tasks/aa/` tasks **plus a companion standalone GDPVal config**
-> (`recipes/tasks/aa_gym/gdpval.md`) — GDPVal is part of the AA suite but a
+> (`recipes/tasks/gym/gdpval.md`) — GDPVal is part of the AA suite but a
 > different harness, so it's its own config, never in the `aa/` `tasks` list. Do
 > not silently add MMLU-Pro, AIME 2025, or LiveCodeBench — they live at
 > `recipes/tasks/*.md` and are a separate always-include set.
@@ -83,10 +83,10 @@ merged into the `aa/` multi-task list.
   strata (2/4/8) alongside the aggregate — precision loss shows up in the
   8-needle stratum while the aggregate still looks flat.
 - **GDPVal** is part of the AA suite but the heaviest task and a separate
-  harness: it runs as its **own standalone `aa_gym` config** (never in the `aa/`
+  harness: it runs as its **own standalone `gym` config** (never in the `aa/`
   `tasks` list), needs the Apptainer SIF sandbox + judge, and is multi-hour /
   often multi-node. Generate it alongside the `aa/` config; see
-  `recipes/tasks/aa_gym/gdpval.md` + `references/gym-gdpval.md`. Thinking mode is
+  `recipes/tasks/gym/gdpval.md` + `references/gym-gdpval.md`. Thinking mode is
   mandatory (non-thinking loses ~86% of pairwise judgements). `num_repeats` is **1** —
   the value both current goldens use, already set by the template; do not raise it.
 

--- a/plugins/modelopt/skills/evaluation/references/quantization-benchmarks.md
+++ b/plugins/modelopt/skills/evaluation/references/quantization-benchmarks.md
@@ -75,9 +75,11 @@ merged into the `aa/` multi-task list.
   long-context matters: the longest-context task here (1M tokens) and, unlike
   AA-LCR, no judge, so the score is deterministic. Standalone `gym` config
   (`recipes/tasks/gym/mrcr.md`). Two comparability traps: the three variants use
-  different datasets and are **not** comparable to each other, and
-  `--kv-cache-dtype fp8` must match across baseline and candidate or the delta
-  also measures KV-cache quantization. Report the 2/4/8 needle strata — precision
+  different datasets and are **not** comparable to each other, and the
+  KV dtype must follow each checkpoint's `kv_cache_quant_algo`
+  (`hf_quant_config.json`) rather than being pinned to the golden's `fp8` — forcing
+  it onto an uncalibrated checkpoint applies KV quantization it was never
+  calibrated for. Report the 2/4/8 needle strata — precision
   loss hits the 8-needle stratum while the aggregate still looks flat.
 - **GDPVal** is part of the AA suite but the heaviest task and a separate
   harness: it runs as its **own standalone `gym` config** (never in the `aa/`

--- a/plugins/modelopt/skills/evaluation/references/quantization-benchmarks.md
+++ b/plugins/modelopt/skills/evaluation/references/quantization-benchmarks.md
@@ -34,6 +34,7 @@ merged into the `aa/` multi-task list.
 | `tasks/aa/tau2_bench_telecom.md` | Tau2-Bench Telecom | Agentic tool use (user-simulator + judge) | Medium-high — tool-call JSON is brittle, but user-sim + judge variance often dominates the signal |
 | `tasks/aa/omniscience.md` | AA-Omniscience | Knowledge reliability (`ns_omniscience`, nemo-skills, `num_repeats: 10`) — correct vs hallucinate vs abstain on obscure facts, judge-scored | Medium — measures the hallucination/abstention balance; aggressive precision loss can erode factual recall and shift the omni-index |
 | `tasks/aa_gym/gdpval.md` | GDPVal (`nemo_gym` Stirrup agent, **standalone config**) | Agentic office/PDF deliverables in an Apptainer code-exec sandbox, pairwise/rubric judge | High — long-horizon agentic reasoning + code + judge; precision loss compounds across many turns. **Heaviest task**: multi-hour, often multi-node, needs the SIF sandbox + judge. Runs as its own config, never in the `aa/` list |
+| `tasks/gym/mrcr.md` | MRCR (`nemo_gym` simple agent, **standalone config**, **not AA**) | Long-context co-reference retrieval up to 1M tokens; deterministic prefix-gated `SequenceMatcher` grading, stratified by needle count | Very high — the longest-context task available here; KV-cache and attention quant error accumulate over the full window. No judge, so the signal is clean. Opt-in: only when the user asks for MRCR or long-context coverage |
 
 ## Recommended sets by use case
 
@@ -70,6 +71,17 @@ merged into the `aa/` multi-task list.
   apples-to-apples comparison.
 - **IFBench** is the least quant-sensitive in the set but still useful as a
   regression check for aggressive formats (NVFP4, INT4-AWQ).
+- **MRCR** is **not** an AA benchmark — never add it to an "AA" request. Reach
+  for it when long-context behaviour matters: it is the longest-context task in
+  this skill (up to 1M tokens) and, unlike AA-LCR, has no judge in the loop, so
+  the score is deterministic. It runs as its **own standalone `gym` config**
+  (`recipes/tasks/gym/mrcr.md`). Two comparability traps: the three upstream
+  variants (`config_n3_1m` / `config_n3_128k` / `config`) use different datasets
+  and are **not** comparable to each other, and the golden's
+  `--kv-cache-dtype fp8` must be held identical across baseline and candidate or
+  the delta also measures KV-cache quantization. Report the per-needle-count
+  strata (2/4/8) alongside the aggregate — precision loss shows up in the
+  8-needle stratum while the aggregate still looks flat.
 - **GDPVal** is part of the AA suite but the heaviest task and a separate
   harness: it runs as its **own standalone `aa_gym` config** (never in the `aa/`
   `tasks` list), needs the Apptainer SIF sandbox + judge, and is multi-hour /

--- a/plugins/modelopt/skills/evaluation/references/quantization-benchmarks.md
+++ b/plugins/modelopt/skills/evaluation/references/quantization-benchmarks.md
@@ -71,17 +71,14 @@ merged into the `aa/` multi-task list.
   apples-to-apples comparison.
 - **IFBench** is the least quant-sensitive in the set but still useful as a
   regression check for aggressive formats (NVFP4, INT4-AWQ).
-- **MRCR** is **not** an AA benchmark — never add it to an "AA" request. Reach
-  for it when long-context behaviour matters: it is the longest-context task in
-  this skill (up to 1M tokens) and, unlike AA-LCR, has no judge in the loop, so
-  the score is deterministic. It runs as its **own standalone `gym` config**
-  (`recipes/tasks/gym/mrcr.md`). Two comparability traps: the three upstream
-  variants (`config_n3_1m` / `config_n3_128k` / `config`) use different datasets
-  and are **not** comparable to each other, and the golden's
-  `--kv-cache-dtype fp8` must be held identical across baseline and candidate or
-  the delta also measures KV-cache quantization. Report the per-needle-count
-  strata (2/4/8) alongside the aggregate — precision loss shows up in the
-  8-needle stratum while the aggregate still looks flat.
+- **MRCR** is **not** AA — never add it to an "AA" request. Use it when
+  long-context matters: the longest-context task here (1M tokens) and, unlike
+  AA-LCR, no judge, so the score is deterministic. Standalone `gym` config
+  (`recipes/tasks/gym/mrcr.md`). Two comparability traps: the three variants use
+  different datasets and are **not** comparable to each other, and
+  `--kv-cache-dtype fp8` must match across baseline and candidate or the delta
+  also measures KV-cache quantization. Report the 2/4/8 needle strata — precision
+  loss hits the 8-needle stratum while the aggregate still looks flat.
 - **GDPVal** is part of the AA suite but the heaviest task and a separate
   harness: it runs as its **own standalone `gym` config** (never in the `aa/`
   `tasks` list), needs the Apptainer SIF sandbox + judge, and is multi-hour /

--- a/plugins/modelopt/skills/evaluation/scripts/gdpval-sif.sh
+++ b/plugins/modelopt/skills/evaluation/scripts/gdpval-sif.sh
@@ -28,7 +28,7 @@
 #                        directory -> <dir>/$GDPVAL_SIF_NAME (default python-3.13.gdpval.sif,
 #                        matching the example config); a *.sif path
 #                        is used verbatim. Bind-mount this SAME dir into the eval
-#                        container at /gdpval/sif (see recipes/examples/gym_gdpval/).
+#                        container at /gdpval/sif (see recipes/examples/gym/).
 #     --commit <sha>     NeMo Gym commit whose gdpval.def to build. Keep in sync
 #                        with the config's install_on_the_fly.commit.
 #     --force            Rebuild even if the SIF already exists.


### PR DESCRIPTION
### What does this PR do?

Type of change: documentation (agent skill)

Adds **MRCR** — OpenAI's Multi-Round Co-reference Resolution, a long-context
retrieval benchmark — to the `evaluation` skill as a standalone NeMo Gym task,
derived from the reviewed `nemotron_nano_v35_nvfp4_mrcr_gym` golden; regroups the
gym tasks/examples under one `gym/` dir; and fixes several latent bugs in the
shared gym command block that were found by running the benchmark end-to-end.

MRCR tasks are long multi-turn conversations containing N near-identical "needle"
responses; the model must reproduce the Nth verbatim behind a random prefix.
Grading is deterministic (`SequenceMatcher.ratio()`, gated on the prefix). Unlike
GDPVal it uses the `simple_agent`: no SIF, no judge, no Tavily — `HF_TOKEN` is the
only secret, and the cost is context length (up to 1M tokens), not agent turns.
**It is not an AA benchmark** and is never generated for an "AA" request.

### Layout

| File | |
| --- | --- |
| `recipes/tasks/gym/mrcr.md` | new recipe — variants, 1M serving envelope, canary, score extraction |
| `recipes/examples/gym/example_mrcr.yaml` | new self-contained SLURM + vLLM config |
| `SKILL.md` | MRCR branch + gym index table |
| `references/quantization-benchmarks.md` | table row + comparability notes |

`examples/gym_{gdpval,mrcr}/` → `examples/gym/example_<task>.yaml` and
`tasks/aa_gym/gdpval.md` → `tasks/gym/gdpval.md`, all tracked as git renames.
`aa_gym` encoded "in the AA suite" in the *path*; since GDPVal is AA and MRCR is
not, membership is now stated explicitly in both recipe headers and an "In AA
suite?" column in the SKILL.md index. `gym/` groups by harness, not suite.

### Bugs fixed (found by running it, not by reading it)

The first three are in the **shared** gym command block, so they also affect
`example_gdpval.yaml` — GDPVal was broken independently of MRCR.

1. **Invalid OmegaConf interpolation.** A literal `${...}` inside a comment in the
   gym `command:` block is parsed as an interpolation and rejected, so *every*
   `nel run --dry-run` of either gym template died with
   `hydra.errors.ConfigCompositionException`.
2. **Hardcoded `ray==2.49.2`** injected into each sub-server's requirements. Against
   an image carrying `ray[default]==2.55.1` this makes `uv` unsatisfiable and the
   gym resources server exits at startup. Now derived from the image at runtime.
3. **`--max-num-seqs` sized against the wrong topology.** The template shipped DP1
   → 4 replicas at 64 concurrent while citing a golden that is TP2×DP2 → 8 replicas
   at 32. Following it ran double the reference's per-replica load, which on
   1M-token prompts is what decides whether the KV cache fits.
4. **Score extraction pointed at an empty map.** `results.yml` →
   `groups.nemo_gym.metrics` holds only `key_metrics/mean/*` telemetry; the scores
   are in `artifacts/evaluator_rollouts_aggregate_metrics.json` → `[0].agent_metrics`.
   Also documents that `pass@1/accuracy` is already 0-100 while `mean/reward` is the
   same number as a 0-1 fraction, and records `mean/prefix_matched ≈ 0.55` as the
   healthy calibration.
5. **The template shipped a container its own bootstrap rejects.** After adding the
   hard-fail on an unpinned Gym, `container:` still defaulted to public
   `nemo-gym:26.05` — the image the docs say has a non-git `/opt/Gym`. Now `???`,
   so `--dry-run`'s mandatory-value check catches it instead of the job dying at
   startup.

### Review feedback

All items from @meenchen and CodeRabbit addressed or answered inline. Two worth
surfacing here:

- **`process_reasoning_traces` vs `use_reasoning`** — verified against
  `nemo_evaluator/adapters/adapter_config.py`: both exist, `use_reasoning` is the
  **deprecated** one and they are bidirectionally aliased. Documented rather than
  switched to the deprecated name.
- **`tiktoken` / `transformers` left unpinned** — deliberate. The n3 prepare path
  uses `transformers.AutoTokenizer` to decide which samples exceed the cap, so a
  bump can shift dataset membership; but pinning would diverge from the golden's
  `pre_cmd` and therefore from the run that produced the reference number. Risk is
  now documented under "Deferred, know the risk" instead of being implicit.

Topology, `gres` and TP/DP were aligned to the **existing** sibling templates
rather than to a new convention: `gres` stays a comment (already the convention in
`example_eval.yaml` and `example_gdpval.yaml`), TP is a concrete `1` like both
siblings, and `num_nodes`/`num_instances`/`--max-num-seqs` are guidance rather than
baked values. `--max-num-seqs` sizing follows **AA-LCR**, since MRCR is the same
KV-bound problem at ~1M tokens vs LCR's ~120K: the formula gives a ceiling, not a
target, because oversubscribing causes preemption and recomputing a 1M-token
prefill makes the run slower.

### Usage

```bash
cp plugins/modelopt/skills/evaluation/recipes/examples/gym/example_mrcr.yaml mrcr.yaml
# fill checkpoint_path / served_model_name / container / SLURM ??? values
export NEMO_EVALUATOR_TRUST_PRE_CMD=1 NEMO_EVALUATOR_TRUST_UNLISTED_TASKS=1
nel run --config mrcr.yaml --dry-run && nel run --config mrcr.yaml
```

### Testing

Docs/config-only; no library code touched. `pre-commit` clean on every commit.

- Both gym YAMLs parse; asserted the folded-scalar rule (no `#` inside `>-`), that
  every string survives `OmegaConf.create` (bug 1), and that the variant is
  identical in `data_prep_params` and `collect_rollout_params`.
- After the rename: zero stale `aa_gym`/`gym_gdpval`/`gym_mrcr` refs and every
  `recipes/**` path referenced across both skill trees resolves on disk — this
  caught `env.example`, which an extension-filtered grep missed. The
  `nemo_gym_gdpval_stirrup_agent` metric names contain the substring `gym_gdpval`
  and were deliberately left untouched.
- **Ran the benchmark end-to-end.** A full run on gcp-nrt (B200) completed
  2363/2363 rollouts and scored; that run produced bugs 2 and 4 and the corrected
  metric paths. A second attempt on aws-cmh was preempted and later cancelled.
  `--dry-run` now passes (it did not before bug 1 was fixed), and the bare template
  correctly fails validation on unresolved mandatory values.
- Regenerated the config from scratch with a fresh agent against the fixed
  templates as a regression check; its dry-run passed and its findings drove the
  topology/`gres`/TP-DP alignment above.

Model-specific scores are deliberately **not** recorded in the recipe — the
reference there stays the golden's BF16 Nano 3.5 shape, since quoting a different
model's number beside it invites exactly the false comparison the recipe warns
about.

### Before your PR is "*Ready for review*"

- Backward compatible?: ✅ — additive plus a doc-tree rename; all referencing files
  updated and verified. The template fixes change only broken behaviour.
- Copied code / new PIP dependency: N/A.
- New tests: N/A — agent-skill documentation.
- Changelog: N/A — skill/docs change; consistent with prior skill-only commits.
- Claude approval: ❌ not yet — will trigger `/claude review`.

### Additional Information

Upstream drift flagged to reviewers (**no change made to that repo**): in
`nvidia-eval-factory-benchmarking`, `configs/benchmarks/mrcr/bench.yaml` is still
old-style `ng_*` while `configs/models/nemotron_nano_v35/gym.yaml` moved to the
`gym eval` CLI on 2026-07-29 — RULER migrated, MRCR did not, so the layers no
longer compose. This template follows `ng_*`, which is what MRCR's own bench.yaml
specifies and what the sign-off run executed.

NVIDIA-internal companion (container specifics kept out of this public tree):
Model-Optimizer-Internal MR !116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
