### PR TITLE
Add non-mutating quantized weight export API

### DIFF
--- a/modelopt/torch/export/__init__.py
+++ b/modelopt/torch/export/__init__.py
@@ -21,6 +21,7 @@ from .model_config_export import *
 from .model_utils import *
 from .moe_utils import *
 from .plugins import *
+from .quantized_weight import *
 from .registry import *
 from .transformer_engine import *
 from .unified_export_hf import *

--- a/modelopt/torch/export/quant_utils.py
+++ b/modelopt/torch/export/quant_utils.py
@@ -775,6 +775,11 @@ def process_layer_quant_config(layer_config_dict):
     # If we have more than one quantization format, infer MIXED_PRECISION
     if len(quantization_formats) > 1:
         per_layer_config["quant_algo"] = "MIXED_PRECISION"
+        per_layer_config["exclude_modules"] = sorted(
+            _prefix_wildcard_summarize_exclude_modules(
+                exclude_modules, per_layer_config["quantized_layers"].keys()
+            )
+        )
     elif len(quantization_formats) == 1 and quantization_config is not None:
         per_layer_config.update(quantization_config)
         per_layer_config["exclude_modules"] = sorted(

--- a/modelopt/torch/export/quantized_weight.py
+++ b/modelopt/torch/export/quantized_weight.py
@@ -1,0 +1,324 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Non-mutating export helpers for quantized checkpoint weights."""
+
+from collections import OrderedDict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from modelopt import __version__
+from modelopt.torch.quantization.qtensor import NVFP4QTensor
+from modelopt.torch.quantization.utils import quantizer_attr_names
+
+from .convert_hf_config import convert_hf_quant_config_format
+from .model_config import QUANTIZATION_NONE, QUANTIZATION_NVFP4, QUANTIZATION_W4A16_NVFP4
+from .quant_utils import process_layer_quant_config, to_quantized_weight
+
+__all__ = [
+    "build_hf_quantization_config",
+    "capture_quantized_weight_export_state",
+    "export_quantized_weight",
+    "quantized_weight_export_states_compatible",
+    "quantized_weight_export_states_equal",
+    "replicate_quantized_weight_export_state",
+    "synchronize_quantized_weight_export_state",
+]
+
+_SUPPORTED_FORMATS = {QUANTIZATION_NVFP4, QUANTIZATION_W4A16_NVFP4}
+
+
+@dataclass(frozen=True)
+class _QuantizedWeightExportState:
+    """Opaque export state for one logical floating-point weight."""
+
+    quantization_format: str
+    block_size: int
+    weight_amax: torch.Tensor
+    input_amax: torch.Tensor | None = None
+
+
+@dataclass(frozen=True)
+class _QuantizedWeightExport:
+    """Packed checkpoint tensors for one quantized weight."""
+
+    weight: torch.Tensor
+    weight_scale: torch.Tensor
+    weight_scale_2: torch.Tensor
+    input_scale: torch.Tensor | None = None
+
+    def named_tensors(self, weight_name: str = "weight") -> OrderedDict[str, torch.Tensor]:
+        """Return checkpoint tensors using ModelOpt's canonical relative names."""
+        attrs = quantizer_attr_names(weight_name)
+        tensors = OrderedDict(
+            (
+                (weight_name, self.weight),
+                (attrs.weight_scale, self.weight_scale),
+                (attrs.weight_scale_2, self.weight_scale_2),
+            )
+        )
+        if self.input_scale is not None:
+            tensors[attrs.input_scale] = self.input_scale
+        return tensors
+
+
+@dataclass(frozen=True)
+class _Nvfp4WeightQuantizerView:
+    _amax: torch.Tensor
+    block_sizes: Mapping[object, object]
+
+
+@dataclass(frozen=True)
+class _Nvfp4InputQuantizerView:
+    _amax: torch.Tensor
+    is_enabled: bool = True
+    maxbound: float = 6.0
+
+    def export_amax(self) -> torch.Tensor:
+        return self._amax
+
+
+def _clone_amax(quantizer: object | None) -> torch.Tensor | None:
+    if quantizer is None or not bool(getattr(quantizer, "is_enabled", False)):
+        return None
+    export_amax = getattr(quantizer, "export_amax", None)
+    value = export_amax() if callable(export_amax) else getattr(quantizer, "amax", None)
+    if not isinstance(value, torch.Tensor):
+        return None
+    return value.detach().clone()
+
+
+def _get_nvfp4_export_format(
+    module: nn.Module,
+    weight_quantizer: object,
+    input_quantizer: object | None,
+) -> str:
+    if not bool(getattr(weight_quantizer, "is_enabled", False)):
+        raise RuntimeError("Weight quantizer is disabled")
+    if NVFP4QTensor._is_static_quantizer(weight_quantizer):
+        raise NotImplementedError("Static NVFP4 export state is not supported")
+    if hasattr(weight_quantizer, "svdquant_lora_a") or getattr(
+        module, "fused_with_prequant", False
+    ):
+        raise NotImplementedError("AWQ and SVDQuant export state is not supported")
+
+    block_sizes = getattr(weight_quantizer, "block_sizes", None)
+    if (
+        getattr(weight_quantizer, "num_bits", None) != (2, 1)
+        or not isinstance(block_sizes, Mapping)
+        or block_sizes.get("type") != "dynamic"
+        or block_sizes.get("scale_bits") != (4, 3)
+        or block_sizes.get("four_over_six", False)
+    ):
+        raise NotImplementedError("Only dynamic block-16 NVFP4 weights are supported")
+
+    if input_quantizer is None or not bool(getattr(input_quantizer, "is_enabled", False)):
+        return QUANTIZATION_W4A16_NVFP4
+    input_blocks = getattr(input_quantizer, "block_sizes", None)
+    if (
+        hasattr(input_quantizer, "_pre_quant_scale")
+        or getattr(input_quantizer, "num_bits", None) != (2, 1)
+        or not isinstance(input_blocks, Mapping)
+        or input_blocks.get("type") != "dynamic"
+        or input_blocks.get("scale_bits") != (4, 3)
+        or input_blocks.get("four_over_six", False)
+    ):
+        raise NotImplementedError("Only dynamic NVFP4 or disabled input quantizers are supported")
+    return QUANTIZATION_NVFP4
+
+
+def capture_quantized_weight_export_state(
+    module: nn.Module,
+    weight_name: str = "weight",
+    *,
+    weight_quantizer: object | None = None,
+    input_quantizer: object | None = None,
+) -> _QuantizedWeightExportState:
+    """Capture export state without changing the module or its quantizers."""
+    attrs = quantizer_attr_names(weight_name)
+    if weight_quantizer is None:
+        weight_quantizer = getattr(module, attrs.weight_quantizer, None)
+    if weight_quantizer is None:
+        raise RuntimeError(f"Missing weight quantizer for {weight_name!r}")
+    if input_quantizer is None:
+        input_quantizer = getattr(module, attrs.input_quantizer, None)
+
+    quantization_format = _get_nvfp4_export_format(module, weight_quantizer, input_quantizer)
+    weight_amax = _clone_amax(weight_quantizer)
+    if weight_amax is None or weight_amax.numel() != 1:
+        raise RuntimeError(f"Missing scalar calibrated weight amax for {weight_name!r}")
+
+    input_amax = _clone_amax(input_quantizer)
+    if quantization_format == QUANTIZATION_NVFP4 and (
+        input_amax is None or input_amax.numel() != 1
+    ):
+        raise RuntimeError(f"Missing scalar calibrated input amax for {weight_name!r}")
+
+    block_size = weight_quantizer.block_sizes[-1]
+    if block_size != 16:
+        raise NotImplementedError(f"Unsupported NVFP4 block size: {block_size}")
+    return _QuantizedWeightExportState(
+        quantization_format=quantization_format,
+        block_size=block_size,
+        weight_amax=weight_amax,
+        input_amax=input_amax,
+    )
+
+
+def _require_state(state: object) -> _QuantizedWeightExportState:
+    if not isinstance(state, _QuantizedWeightExportState):
+        raise TypeError("Expected ModelOpt quantized-weight export state")
+    return state
+
+
+def _clone_state(
+    state: _QuantizedWeightExportState,
+    *,
+    device: torch.device | str | None = None,
+) -> _QuantizedWeightExportState:
+    def clone(tensor: torch.Tensor) -> torch.Tensor:
+        tensor = tensor.detach().clone()
+        return tensor if device is None else tensor.to(device=device)
+
+    return _QuantizedWeightExportState(
+        quantization_format=state.quantization_format,
+        block_size=state.block_size,
+        weight_amax=clone(state.weight_amax),
+        input_amax=(None if state.input_amax is None else clone(state.input_amax)),
+    )
+
+
+def synchronize_quantized_weight_export_state(
+    state: object,
+    *,
+    group=None,
+    device: torch.device | str | None = None,
+) -> object:
+    """Max-reduce scalar state for ranks that shard one logical weight."""
+    state = _require_state(state)
+    synchronized = _clone_state(state)
+    if dist.is_available() and dist.is_initialized() and dist.get_world_size(group) > 1:
+        dist.all_reduce(synchronized.weight_amax, op=dist.ReduceOp.MAX, group=group)
+        if synchronized.input_amax is not None:
+            dist.all_reduce(synchronized.input_amax, op=dist.ReduceOp.MAX, group=group)
+    return _clone_state(synchronized, device=device)
+
+
+def replicate_quantized_weight_export_state(
+    state: object,
+    projection_count: int,
+) -> tuple[object, ...]:
+    """Authorize scalar state replication across a fused projection split."""
+    if projection_count < 1:
+        raise ValueError("projection_count must be positive")
+    state = _require_state(state)
+    return tuple(_clone_state(state) for _ in range(projection_count))
+
+
+def quantized_weight_export_states_equal(
+    left: object,
+    right: object,
+) -> bool:
+    """Return whether two opaque export states describe the same checkpoint state."""
+    left = _require_state(left)
+    right = _require_state(right)
+    if (
+        left.quantization_format != right.quantization_format
+        or left.block_size != right.block_size
+        or not torch.equal(left.weight_amax, right.weight_amax)
+        or (left.input_amax is None) != (right.input_amax is None)
+    ):
+        return False
+    return left.input_amax is None or torch.equal(left.input_amax, right.input_amax)
+
+
+def quantized_weight_export_states_compatible(left: object, right: object) -> bool:
+    """Return whether two states share one deployment format and tensor layout."""
+    left = _require_state(left)
+    right = _require_state(right)
+    return (
+        left.quantization_format == right.quantization_format
+        and left.block_size == right.block_size
+        and (left.input_amax is None) == (right.input_amax is None)
+    )
+
+
+def _require_positive_finite(name: str, value: torch.Tensor) -> None:
+    if value.numel() == 0 or not torch.isfinite(value).all() or not torch.all(value > 0):
+        raise RuntimeError(f"Invalid {name}: {value}")
+
+
+def export_quantized_weight(
+    weight: torch.Tensor,
+    state: object,
+    *,
+    dtype: torch.dtype | None = None,
+) -> _QuantizedWeightExport:
+    """Pack one canonical weight without mutating it or its quantizers."""
+    state = _require_state(state)
+    if state.quantization_format not in _SUPPORTED_FORMATS:
+        raise NotImplementedError(f"Unsupported export format: {state.quantization_format!r}")
+    if state.block_size != 16:
+        raise NotImplementedError(f"Unsupported NVFP4 block size: {state.block_size}")
+
+    weight_amax = state.weight_amax.to(device=weight.device, dtype=torch.float32)
+    _require_positive_finite("weight amax", weight_amax)
+    quantizer = _Nvfp4WeightQuantizerView(
+        _amax=weight_amax,
+        block_sizes={-1: state.block_size, "type": "dynamic", "scale_bits": (4, 3)},
+    )
+    weight_scale_2 = NVFP4QTensor.get_weights_scaling_factor_2_from_quantizer(quantizer)
+    weight_scale = NVFP4QTensor.get_weights_scaling_factor(
+        weight,
+        block_size=state.block_size,
+        weights_scaling_factor_2=weight_scale_2.to(weight.device),
+    )[0]
+    packed_weight = to_quantized_weight(
+        weight.to(dtype or weight.dtype),
+        weight_scale,
+        state.quantization_format,
+        weight_scale_2,
+        state.block_size,
+    )
+
+    input_scale = None
+    if state.quantization_format == QUANTIZATION_NVFP4:
+        if state.input_amax is None:
+            raise RuntimeError("Missing input amax for NVFP4 W4A4 export")
+        input_amax = state.input_amax.to(device=weight.device, dtype=torch.float32)
+        _require_positive_finite("input amax", input_amax)
+        input_scale = NVFP4QTensor.get_activation_scaling_factor(
+            _Nvfp4InputQuantizerView(input_amax)
+        ).squeeze()
+
+    return _QuantizedWeightExport(
+        weight=packed_weight,
+        weight_scale=weight_scale,
+        weight_scale_2=weight_scale_2.squeeze(),
+        input_scale=input_scale,
+    )
+
+
+def build_hf_quantization_config(
+    layer_states: Mapping[str, object | None] | Iterable[tuple[str, object | None]],
+) -> dict:
+    """Build the canonical ModelOpt HF config from canonical module states."""
+    layer_config = {}
+    for name, state in dict(layer_states).items():
+        state = None if state is None else _require_state(state)
+        layer_config[f"{name}.quantization"] = (
+            state.quantization_format if state is not None else QUANTIZATION_NONE
+        )
+        layer_config[f"{name}.awq_block_size"] = state.block_size if state is not None else 0
+    quantization = process_layer_quant_config(layer_config)
+    quantization["kv_cache_quant_algo"] = QUANTIZATION_NONE
+    return convert_hf_quant_config_format(
+        {
+            "producer": {"name": "modelopt", "version": __version__},
+            "quantization": quantization,
+        }
+    )

--- a/modelopt/torch/export/quantized_weight.py
+++ b/modelopt/torch/export/quantized_weight.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Non-mutating export helpers for quantized checkpoint weights."""
 
@@ -158,7 +170,10 @@ def capture_quantized_weight_export_state(
     ):
         raise RuntimeError(f"Missing scalar calibrated input amax for {weight_name!r}")
 
-    block_size = weight_quantizer.block_sizes[-1]
+    block_sizes = getattr(weight_quantizer, "block_sizes", None)
+    if not isinstance(block_sizes, Mapping):
+        raise RuntimeError(f"Missing NVFP4 block sizes for {weight_name!r}")
+    block_size = block_sizes[-1]
     if block_size != 16:
         raise NotImplementedError(f"Unsupported NVFP4 block size: {block_size}")
     return _QuantizedWeightExportState(

--- a/modelopt/torch/export/unified_export_hf.py
+++ b/modelopt/torch/export/unified_export_hf.py
@@ -115,6 +115,7 @@ from .quant_utils import (
     sync_tied_input_amax,
     to_quantized_weight,
 )
+from .quantized_weight import capture_quantized_weight_export_state, export_quantized_weight
 from .registry import ExportContext, ExportModuleRegistry, PrepareMoEInputsRegistry
 
 __all__ = ["export_hf_checkpoint", "export_speculative_decoding"]
@@ -749,6 +750,7 @@ def _export_quantized_weight(
             weight, is_bmm_expert_weight=is_bmm_expert_weight
         )
 
+        exported = None
         if use_compressed_scale and weight_scale_2 is not None:
             # Dequant is ``nibble * weight_scale * weight_scale_2``; the stored per-block scale is
             # normalized against the compression-time global scale, so rescale to keep that product.
@@ -769,19 +771,30 @@ def _export_quantized_weight(
                 weight,
                 weight_scale_2,
             )[0]
+        elif quantization_format in {QUANTIZATION_NVFP4, QUANTIZATION_W4A16_NVFP4}:
+            exported = export_quantized_weight(
+                weight,
+                capture_quantized_weight_export_state(sub_module, weight_name),
+                dtype=dtype,
+            )
+            weight_scale = exported.weight_scale
+            weight_scale_2 = exported.weight_scale_2
         else:
             weight_scale = NVFP4QTensor.get_weights_scaling_factor(
                 weight,
                 block_size=block_size,
                 weights_scaling_factor_2=weight_scale_2,
             )[0]
-
-        quantized_weight = to_quantized_weight(
-            weight.to(dtype),
-            weight_scale,
-            quantization_format,
-            weight_scale_2,
-            block_size,
+        quantized_weight = (
+            exported.weight
+            if exported is not None
+            else to_quantized_weight(
+                weight.to(dtype),
+                weight_scale,
+                quantization_format,
+                weight_scale_2,
+                block_size,
+            )
         )
 
         quantized_weight, weight_scale = maybe_transpose_expert_weight_dimensions(

--- a/modelopt/torch/quantization/plugins/custom.py
+++ b/modelopt/torch/quantization/plugins/custom.py
@@ -173,10 +173,15 @@ class _ParallelLinear(_QuantFunctionalMixin, QuantModule):
             _check_unsupported_states(
                 quantizer if isinstance(quantizer, TensorQuantizer) else quantizer[0]
             )
+        # Grouped linears validate each expert against its corresponding weight in their
+        # override. Resetting the container here would clear every expert amax before this
+        # single-weight compatibility path recalibrates only the representative quantizer.
         # Skip max_calibrate when saved static NVFP4 state is intact; else MSE scales get overwritten.
-        if _has_state(
-            self.weight_quantizer, "_amax"
-        ) and not _has_complete_static_nvfp4_weight_state(self.weight_quantizer, self.weight):
+        if (
+            not isinstance(self.weight_quantizer, GroupedQuantizer)
+            and _has_state(self.weight_quantizer, "_amax")
+            and not _has_complete_static_nvfp4_weight_state(self.weight_quantizer, self.weight)
+        ):
             self.weight_quantizer.reset_amax()
             max_calibrate(self.weight_quantizer, lambda wq: wq(self.weight), distributed_sync=False)
         if _has_state(self.input_quantizer, "_pre_quant_scale"):

--- a/tests/gpu_megatron/torch/quantization/plugins/test_transformer_engine.py
+++ b/tests/gpu_megatron/torch/quantization/plugins/test_transformer_engine.py
@@ -118,6 +118,26 @@ def test_quantize(model_cls, config):
     quantize_model_and_forward(model, config, calib_data)
 
 
+def test_grouped_post_restore_preserves_weight_amax():
+    """Grouped restore must not clear calibrated state for non-representative experts."""
+    model = TEGroupedLinear().cuda()
+    with torch.no_grad():
+        for index in range(model.num_gemms):
+            getattr(model.net, f"weight{index}").fill_(0.25 + index)
+
+    data = model.get_input().cuda()
+    mtq.quantize(model, copy.deepcopy(mtq.FP8_DEFAULT_CFG), lambda module: module(data))
+
+    quantizers = model.net.weight_quantizer
+    assert isinstance(quantizers, mtq.nn.GroupedQuantizer)
+    before_restore = [quantizer.amax.clone() for quantizer in quantizers]
+
+    model.net.modelopt_post_restore()
+
+    for quantizer, expected in zip(quantizers, before_restore):
+        torch.testing.assert_close(quantizer.amax, expected)
+
+
 def test_quantize_forward_backward():
     set_seed()
     model = TELinear().cuda()

--- a/tests/unit/torch/export/test_quantized_weight.py
+++ b/tests/unit/torch/export/test_quantized_weight.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+
+import pytest
+import torch
+import torch.nn as nn
+
+import modelopt.torch.quantization as mtq
+from modelopt.torch.export.quantized_weight import (
+    build_hf_quantization_config,
+    capture_quantized_weight_export_state,
+    export_quantized_weight,
+    quantized_weight_export_states_compatible,
+    quantized_weight_export_states_equal,
+    replicate_quantized_weight_export_state,
+    synchronize_quantized_weight_export_state,
+)
+from modelopt.torch.export.unified_export_hf import _export_quantized_weight
+from modelopt.torch.quantization.nn import GroupedQuantizer
+
+
+def _quantized_linear(quant_cfg, weight_amax=2.0, input_amax=3.0):
+    module = nn.Linear(16, 2, bias=False)
+    mtq.quantize(module, copy.deepcopy(quant_cfg), lambda m: m(torch.ones(1, 16)))
+    with torch.no_grad():
+        module.weight.copy_(torch.arange(32, dtype=torch.float32).reshape(2, 16) / 8 - 2)
+    module.weight_quantizer.amax = torch.tensor(weight_amax)
+    if module.input_quantizer.is_enabled:
+        module.input_quantizer.amax = torch.tensor(input_amax)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("quant_cfg", "has_input_scale"),
+    [
+        (mtq.NVFP4_DEFAULT_CFG, True),
+        (mtq.W4A16_NVFP4_CFG, False),
+    ],
+)
+def test_export_matches_offline_export_without_mutating_source(quant_cfg, has_input_scale):
+    module = _quantized_linear(quant_cfg)
+    source_weight = module.weight.detach().clone()
+    source_parameter = module.weight
+    source_buffers = {
+        name: (buffer, buffer.detach().clone()) for name, buffer in module.named_buffers()
+    }
+
+    state = capture_quantized_weight_export_state(module)
+    exported = export_quantized_weight(module.weight, state)
+    repeated = export_quantized_weight(module.weight, state)
+
+    assert torch.equal(exported.weight, repeated.weight)
+    assert torch.equal(exported.weight_scale, repeated.weight_scale)
+    assert torch.equal(exported.weight_scale_2, repeated.weight_scale_2)
+    assert module.weight is source_parameter
+    assert torch.equal(module.weight, source_weight)
+    assert set(dict(module.named_buffers())) == set(source_buffers)
+    for name, buffer in module.named_buffers():
+        original, value = source_buffers[name]
+        assert buffer is original
+        assert torch.equal(buffer, value)
+
+    _export_quantized_weight(module, torch.float32)
+
+    assert torch.equal(module.weight, exported.weight)
+    assert torch.equal(module.weight_scale, exported.weight_scale)
+    assert torch.equal(module.weight_scale_2, exported.weight_scale_2)
+    assert hasattr(module, "input_scale") is has_input_scale
+    if has_input_scale:
+        assert torch.equal(module.input_scale, exported.input_scale)
+
+
+def test_capture_preserves_per_expert_state():
+    modules = [
+        _quantized_linear(mtq.NVFP4_DEFAULT_CFG, weight_amax, input_amax)
+        for weight_amax, input_amax in ((2.0, 3.0), (4.0, 5.0))
+    ]
+    grouped = nn.Module()
+    grouped.weight0 = modules[0].weight
+    grouped.weight1 = modules[1].weight
+    grouped.weight_quantizer = GroupedQuantizer(
+        modules[0].weight_quantizer,
+        modules[1].weight_quantizer,
+    )
+
+    states = [
+        capture_quantized_weight_export_state(
+            grouped,
+            f"weight{index}",
+            weight_quantizer=grouped.weight_quantizer[index],
+            input_quantizer=modules[index].input_quantizer,
+        )
+        for index in range(2)
+    ]
+
+    assert torch.equal(states[0].weight_amax, torch.tensor(2.0))
+    assert torch.equal(states[1].weight_amax, torch.tensor(4.0))
+    assert torch.equal(states[0].input_amax, torch.tensor(3.0))
+    assert torch.equal(states[1].input_amax, torch.tensor(5.0))
+
+
+def test_state_synchronization_replication_and_equality(monkeypatch):
+    state = capture_quantized_weight_export_state(_quantized_linear(mtq.NVFP4_DEFAULT_CFG))
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda group: 2)
+
+    calls = []
+
+    def _all_reduce(tensor, op, group):
+        calls.append((op, group))
+        tensor.add_(1)
+
+    monkeypatch.setattr(torch.distributed, "all_reduce", _all_reduce)
+    synchronized = synchronize_quantized_weight_export_state(state, group="tp")
+
+    assert len(calls) == 2
+    assert all(op == torch.distributed.ReduceOp.MAX and group == "tp" for op, group in calls)
+    assert torch.equal(state.weight_amax, torch.tensor(2.0))
+    assert torch.equal(synchronized.weight_amax, torch.tensor(3.0))
+    assert torch.equal(synchronized.input_amax, torch.tensor(4.0))
+
+    replicas = replicate_quantized_weight_export_state(state, 2)
+    assert quantized_weight_export_states_compatible(replicas[0], replicas[1])
+    assert quantized_weight_export_states_equal(replicas[0], replicas[1])
+    assert replicas[0].weight_amax.data_ptr() != replicas[1].weight_amax.data_ptr()
+    replicas[0].weight_amax.add_(1)
+    assert not quantized_weight_export_states_equal(replicas[0], replicas[1])
+
+
+def test_hf_config_supports_mixed_nvfp4_and_exclusions():
+    states = {
+        "model.layers.0.mlp.up_proj": capture_quantized_weight_export_state(
+            _quantized_linear(mtq.NVFP4_DEFAULT_CFG)
+        ),
+        "model.layers.1.mlp.up_proj": capture_quantized_weight_export_state(
+            _quantized_linear(mtq.W4A16_NVFP4_CFG)
+        ),
+        "model.layers.0.self_attn.q_proj": None,
+    }
+
+    config = build_hf_quantization_config(states)
+
+    assert config["quant_algo"] == "MIXED_PRECISION"
+    assert len(config["config_groups"]) == 2
+    assert config["ignore"] == ["model.layers.0.self_attn*"]
+    assert config["quant_method"] == "modelopt"
+
+
+def test_capture_rejects_unsupported_nvfp4_variant():
+    module = _quantized_linear(mtq.W4A8_NVFP4_FP8_CFG)
+
+    with pytest.raises(NotImplementedError, match="input quantizers"):
+        capture_quantized_weight_export_state(module)

--- a/tests/unit/torch/export/test_quantized_weight.py
+++ b/tests/unit/torch/export/test_quantized_weight.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import copy
 


### PR DESCRIPTION
## Summary
- add a public, non-mutating API for exporting one quantized weight from opaque ModelOpt state
- keep packing and Hugging Face quantization config generation owned by ModelOpt
- support state synchronization, replication, and compatibility checks needed by distributed streaming exporters
- preserve grouped-expert quantizer state during restore

## Initial scope
Dynamic-block NVFP4 W4A4 and W4A16. Unsupported state topologies fail explicitly.

## Validation
- 12 focused export/unit tests passed
- ruff check and format passed
- aggregate implementation review completed with no material findings