### PR TITLE
Updating Cosmos3 Nano DFlash recipe with optional fixes

### DIFF
--- a/examples/speculative_decoding/recipes/train_dflash_cosmos3_nano.ipynb
+++ b/examples/speculative_decoding/recipes/train_dflash_cosmos3_nano.ipynb
@@ -250,6 +250,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "pai-sglang-runtime-notes",
+   "metadata": {},
+   "source": [
+    "#### Native-video SGLang runtime notes\n",
+    "\n",
+    "The PAI path sends native video to SGLang. If the selected SGLang container does not include OpenCV, enable the worker's optional installation before running the compute cell:\n",
+    "\n",
+    "```bash\n",
+    "export INSTALL_OPENCV_HEADLESS=1\n",
+    "```\n",
+    "\n",
+    "For the pinned SGLang container on affected B200/Blackwell environments, use Triton multimodal attention:\n",
+    "\n",
+    "```bash\n",
+    "export SGLANG_EXTRA_ARGS=\"${SGLANG_EXTRA_ARGS:-} --mm-attention-backend triton_attn\"\n",
+    "```\n",
+    "\n",
+    "These are opt-in settings: leave them unset when the container already provides OpenCV or the default multimodal attention backend works on the allocated GPU.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "b118ea5561624da68c537baed56e602f",
@@ -259,6 +281,10 @@
     "%%bash\n",
     "# Compute node: run a representative PAI shard slice in an existing Slurm GPU allocation.\n",
     "set -euo pipefail\n",
+    "# If the selected SGLang image lacks OpenCV for native-video decoding, uncomment:\n",
+    "# export INSTALL_OPENCV_HEADLESS=1\n",
+    "# On affected B200/Blackwell environments with the pinned SGLang image, uncomment:\n",
+    "# export SGLANG_EXTRA_ARGS=\"${SGLANG_EXTRA_ARGS:-} --mm-attention-backend triton_attn\"\n",
     "SPEC=\"$(cd .. && pwd)\"\n",
     ": \"${DATA_ROOT:?Run the Step 2 configuration cell before this cell.}\"\n",
     ": \"${MODEL_PATH:?Set MODEL_PATH and run Step 2 before this compute-node cell.}\"\n",


### PR DESCRIPTION
### What does this PR do?

  Type of change: documentation

  Documents two opt-in SGLang runtime settings for the Cosmos3 Nano DFlash PAI-generation workflow:

  - `INSTALL_OPENCV_HEADLESS=1` when the selected SGLang container lacks OpenCV needed for native-video decoding.
  - `SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS:-} --mm-attention-backend triton_attn"` for affected B200/Blackwell environments using the pinned SGLang container.

  The notebook now places this guidance beside the PAI preparation and compute cells, with copy-ready commands and comments. Existing defaults remain unchanged.

  ### Usage

  Before the PAI compute cell, enable only the setting needed by the environment:

  ```bash
  # Native video requires OpenCV in the selected SGLang container.
  export INSTALL_OPENCV_HEADLESS=1

  # Required on affected B200/Blackwell environments with the pinned SGLang image.
  export SGLANG_EXTRA_ARGS="${SGLANG_EXTRA_ARGS:-} --mm-attention-backend triton_attn"

  ### Testing

  - python3 -m json.tool examples/speculative_decoding/recipes/train_dflash_cosmos3_nano.ipynb
  - git diff --check
  - Is this change backward compatible?: ✅
  - If you copied code from any other sources or added a new PIP dependency, did you follow guidance in CONTRIBUTING.md: N/A
  - Did you write any new necessary tests?: N/A (documentation-only change)
  - Did you update Changelog?: N/A
  - Did you get Claude approval on this PR?: N/A

  ### Additional Information

  The settings are deliberately opt-in: users retain the default multimodal-attention backend when it works on their GPU, and can use container images that already bundle OpenCV.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added notebook guidance for configuring the native-video runtime.
  * Documented optional OpenCV installation.
  * Added instructions for enabling Triton multimodal attention settings.
  * Included commented environment-variable configuration examples for compute nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->