### PR TITLE
Fix typo for Tau2 eval config

### DIFF
--- a/plugins/modelopt/skills/evaluation/recipes/env.example
+++ b/plugins/modelopt/skills/evaluation/recipes/env.example
@@ -56,9 +56,9 @@ NEMO_EVALUATOR_TRUST_PRE_CMD=1
 # Default 250 (the golden value); lower it only to shorten a debugging run.
 # GDPVAL_MAX_TURNS=250
 
-# Tau2 (tau2_bench_telecom) — judger + user-simulator model_ids are hardcoded in
+# Tau2 (tau2_bench_telecom) — judge + user-simulator model_ids are hardcoded in
 # the recipe; only the shared endpoint URL comes from here
-# TAU2_ENDPOINT_URL=https://<your-inference-host>/v1/chat/completions   # user + judger
+# TAU2_ENDPOINT_URL=https://<your-inference-host>/v1/chat/completions   # user + judge
 
 # --- nel-next / harbor agentic benchmarks (Terminal-Bench 2.x, SWE-bench) ---
 # Sandboxes run in AWS ECS Fargate (shared NVIDIA harbor infra). AWS creds are

--- a/plugins/modelopt/skills/evaluation/recipes/tasks/aa/tau2_bench_telecom.md
+++ b/plugins/modelopt/skills/evaluation/recipes/tasks/aa/tau2_bench_telecom.md
@@ -7,7 +7,7 @@
 ## Params
 
 Tau2 uses the evaluated model as the agent plus a separate user-simulator endpoint;
-keep both fixed across runs. The judger (**gpt-oss-120B**) and user-simulator
+keep both fixed across runs. The judge (**gpt-oss-120B**) and user-simulator
 (**Qwen3 235B**) `model_id`s are hardcoded in the fragment below — swap them for
 equivalents on your own endpoint if needed. Only the shared `url`
 (`TAU2_ENDPOINT_URL`) comes from `.env` (see `recipes/env.example`) — config, not a
@@ -16,12 +16,12 @@ tau2-bench needs the full `/v1/chat/completions` URL (nemo-skills judges use the
 `/v1` base).
 
 For parallelism, we have to throttle to a smaller cap due to the test may be throttled by
-user and judger API rate limit. If frequent 429 errors are hit, the reported scores could be much lower.
+user and judge API rate limit. If frequent 429 errors are hit, the reported scores could be much lower.
 
 The `parallelism:` field is left as `???` — the right value depends on the
 judge and user-simulator endpoints' rate limits, which vary per deployment.
 Start with a conservative canary value (e.g. 32–128), watch the logs for 429
-errors from the judger/user endpoints, and ramp up if stable. The hard
+errors from the judge/user endpoints, and ramp up if stable. The hard
 upper bound is 512. After choosing a value, recompute the deployment's
 `--max-num-seqs` per the rule in SKILL.md Step 3.
 
@@ -60,7 +60,7 @@ Use this inside the top-level `evaluation.tasks` list:
             model_id: nvidia/qwen/qwen-235b    # Qwen3 235B; use an equivalent on your own endpoint if needed
             url: <TAU2_ENDPOINT_URL>           # from .env (full /v1/chat/completions)
             api_key: INFERENCE_API_KEY         # env-var name; exported, read by harness
-          judger:
+          judge:
             model_id: nvidia/openai/gpt-oss-120b   # gpt-oss-120B; use an equivalent on your own endpoint if needed
             url: <TAU2_ENDPOINT_URL>           # from .env (full /v1/chat/completions)
             api_key: INFERENCE_API_KEY         # env-var name; exported, read by harness


### PR DESCRIPTION
### What does this PR do?

Type of change: Documentation

<!-- Details about the change. -->

### Usage

```python
# Add a code snippet demonstrating how to use this
```

### Testing
<!-- Mention how have you tested your change if applicable. -->

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: N/A
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A
- Did you get Claude approval on this PR?: N/A

### Additional Information
<!-- E.g. related issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Tau2 evaluation guidance to consistently use “judge” and “user-simulator” terminology.
  * Clarified rate-limit guidance and the related YAML configuration terminology for telecom evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->