### PR TITLE
Add modelopt-agents-codeowners as owner of plugins/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,5 +63,8 @@ modelopt_recipes @NVIDIA/modelopt-recipes-codeowners
 /examples/vllm_serve @NVIDIA/modelopt-examples-llm_ptq-codeowners
 /examples/windows @NVIDIA/modelopt-windows-codeowners
 
+# Agent plugin (skills, agent config)
+/plugins @NVIDIA/modelopt-agents-codeowners
+
 # Requirements files are owned by the setup team regardless of location
 requirements*.txt @NVIDIA/modelopt-setup-codeowners


### PR DESCRIPTION
### What does this PR do?

Type of change: Documentation

`plugins/` holds the installable ModelOpt agent plugin — the canonical skill tree
at `plugins/modelopt/skills/`, which `.agents/skills` and `.claude/skills` expose
via relative symlinks. It currently has no CODEOWNERS rule, so it falls through to
the default `* @NVIDIA/modelopt-devs` owner. This routes it to
`@NVIDIA/modelopt-agents-codeowners` instead.

```
# Agent plugin (skills, agent config)
/plugins @NVIDIA/modelopt-agents-codeowners
```

The path is root-anchored (`/plugins`) to match the style of the `/examples` block
above it.

### Usage

N/A — no API or flag change.

### Testing

No test surface. Verified the rule resolves as intended against the existing file:
`/plugins` is the last (and only) match for paths under `plugins/`, so it wins over
the default `*` rule; it does not overlap any other entry.

Effective ownership of `plugins/` on this branch is
`@NVIDIA/modelopt-agents-codeowners`. GitHub validates the team handle when the PR
is opened — if the team does not exist or lacks write access to this repo, the
Settings > CODEOWNERS errors page will flag the line.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: N/A <!-- Repo-internal review routing, not user-facing. -->
- Did you get Claude approval on this PR?: N/A

### Additional Information

Note for reviewers: shared agent config and scripts under `.agents/` (everything
that is not a symlink into `plugins/`) are still owned by the default
`@NVIDIA/modelopt-devs` rule. Happy to add `/.agents` here too if the agents team
should own that as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository ownership rules for the plugins directory and its agent configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->