### PR TITLE
Group MLA q_a_proj/kv_a_proj_with_mqa projections in auto_quantize

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Changelog
 - Remove in-trainer quantization via ``QuantizationArguments.quant_cfg`` / ``--quant_cfg`` (deprecated in 0.45); use ``--recipe``. New recipes ``general/ptq/mxfp4_mlp_weight_only`` and ``general/ptq/nvfp4_mlp_weight_only`` replace ``MXFP4_MLP_WEIGHT_ONLY_CFG`` / ``NVFP4_MLP_WEIGHT_ONLY_CFG`` in the ``examples/gpt-oss`` QAT flow.
 - Remove the ``QuantizationArgumentsWithConfig`` alias in ``modelopt.torch.quantization.plugins.transformers_trainer`` (deprecated in 0.45). Use ``QuantizationArguments``.
 - Transformer Engine ``TEGroupedMLP`` (fused MoE experts) now uses **per-expert** weight quantization (one ``amax`` per expert) instead of a single shared ``amax``, so ModelOpt checkpoints containing quantized ``TEGroupedMLP`` modules saved before 0.47 are **not compatible** with 0.47. Re-run PTQ to regenerate compatible checkpoints.
+- ``mtq.auto_quantize`` now assigns the MLA low-rank input projections (``q_a_proj`` and ``kv_a_proj_with_mqa``, DeepSeek/GLM lineage) a single shared quantization format, since TensorRT-LLM fuses them into one GEMM. AutoQuantize search checkpoints for these models saved before 0.47 no longer match the current runtime grouping and are rejected on resume; re-run the search with a new ``checkpoint`` path.
 
 **Deprecations**
 

--- a/modelopt/torch/quantization/algorithms.py
+++ b/modelopt/torch/quantization/algorithms.py
@@ -595,6 +595,7 @@ class QuantRecipeHparam(Hparam):
 
 _LINEAR_ATTN_QKVZ_RE = re.compile(r"^(.*?\.linear_attn)\.(?:in_proj_qkv|in_proj_z)$")
 _LINEAR_ATTN_BA_RE = re.compile(r"^(.*?\.linear_attn)\.(?:in_proj_a|in_proj_b)$")
+_MLA_A_PROJ_RE = re.compile(r"^(.*?)\.(?:q_a_proj|kv_a_proj_with_mqa)$")
 
 
 def _linear_attn_qkvz_group_key(_model, name: str) -> str | None:
@@ -605,6 +606,11 @@ def _linear_attn_qkvz_group_key(_model, name: str) -> str | None:
 def _linear_attn_ba_group_key(_model, name: str) -> str | None:
     m = _LINEAR_ATTN_BA_RE.match(name)
     return f"{m.group(1)}/ba" if m else None
+
+
+def _mla_a_proj_group_key(_model, name: str) -> str | None:
+    m = _MLA_A_PROJ_RE.match(name)
+    return f"{m.group(1)}/qkv_a" if m else None
 
 
 def _module_search_space_signature(module_search_spaces) -> tuple:
@@ -647,6 +653,14 @@ class _AutoQuantizeBaseSearcher(BaseSearcher, ABC):
         r"^(.*?)\.(gate_proj|up_proj)$",  # gate_proj, up_proj for llama like models
         r"^(.*?)\.(\d+\.(w1|w2|w3))$",  # mixtral experts
         r"^(.*?)\.((w1_linear|w2_linear|w3_linear)\.\d+)$",  # dbrx experts
+        # MLA low-rank input projections (DeepSeek/GLM lineage): TRT-LLM fuses them into
+        # fused_qkv_a_proj_with_mqa, so the shards must share one quantization format.
+        # A callable (not a regex) because a regex rule keys on match.group(1) -- the
+        # attention path -- which is the key the q_proj/k_proj/v_proj rule above already
+        # returns. On MLA built without a q LoRA rank (q_lora_rank=None, e.g.
+        # DeepSeek-V2-Lite) ``q_proj`` and ``kv_a_proj_with_mqa`` are siblings, so a
+        # shared key would merge the unfused q_proj into this group.
+        _mla_a_proj_group_key,
         # Qwen3.5/3.6 hybrid linear_attn: vLLM fuses (in_proj_qkv, in_proj_z)
         # into ``in_proj_qkvz`` and (in_proj_a, in_proj_b) into ``in_proj_ba`` and
         # requires fused shards to share quant_algo. Two callables (not one
@@ -932,11 +946,22 @@ class _AutoQuantizeBaseSearcher(BaseSearcher, ABC):
             else:
                 search_map[group_key].append((module, name, disabled, score_module))
 
+        partially_disabled: list[list[str]] = []
         for group_key, module_info_list in search_map.items():
             quant_modules = [module for module, _, _, _ in module_info_list]
             disabled = any(disabled for _, _, disabled, _ in module_info_list)
             score_modules = [score_module for _, _, _, score_module in module_info_list]
             quant_module_names = [name for _, name, _, _ in module_info_list]
+            # A runtime group shares one quantization format, so disabling any member
+            # disables the whole group. Collect the partial matches and report them once
+            # after the loop: a glob like ``*kv_a_proj_with_mqa*`` hits every decoder layer,
+            # and the per-group message embeds module names so it would never dedupe.
+            # (module_search_spaces raises on the same partial match; this path only warns,
+            # because the behavior predates the grouping rules that make it easy to hit.)
+            if disabled and not all(flag for _, _, flag, _ in module_info_list):
+                partially_disabled.append(
+                    [name for _, name, flag, _ in module_info_list if not flag]
+                )
             cost_weight = self._cost_model.module_cost_weight(
                 quant_module_names, self.config["cost"]
             )
@@ -975,6 +1000,17 @@ class _AutoQuantizeBaseSearcher(BaseSearcher, ABC):
 
             for module in quant_modules:
                 module._register_hparam("quant_recipe", hparam)
+
+        if partially_disabled:
+            pulled_in = sorted(name for group in partially_disabled for name in group)
+            warnings.warn(
+                f"disabled_layers matched only part of {len(partially_disabled)} runtime-"
+                f"grouped module set(s). Modules in a group share one quantization format, so "
+                f"{len(pulled_in)} additional module(s) are disabled too and the realized "
+                f"effective bits will be above the target: {pulled_in[:8]}"
+                f"{' ...' if len(pulled_in) > 8 else ''}. "
+                "List the whole group in disabled_layers to silence this."
+            )
 
     def _get_formatted_weight_compression_constraint(self):
         effective_bits = self.constraints["effective_bits"]

--- a/tests/unit/torch/quantization/test_autoquant.py
+++ b/tests/unit/torch/quantization/test_autoquant.py
@@ -15,6 +15,7 @@
 
 import copy
 import io
+import warnings
 from types import SimpleNamespace
 
 import pytest
@@ -1536,3 +1537,147 @@ def test_get_auto_quantize_config_emits_fused_expert_quantizer_names(with_persis
     assert f"{module_name}.gate_up_proj_weight_quantizer" in quantizer_names
     assert f"{module_name}.down_proj_weight_quantizer" in quantizer_names
     assert f"{module_name}.weight_quantizer" not in quantizer_names
+
+
+def test_mla_projections_share_one_group():
+    """TRT-LLM fuses q_a_proj + kv_a_proj_with_mqa, so they must share one quant format."""
+
+    class _MLAAttention(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.q_a_proj = torch.nn.Linear(32, 32)
+            self.kv_a_proj_with_mqa = torch.nn.Linear(32, 32)
+            self.o_proj = torch.nn.Linear(32, 32)
+
+        def forward(self, x):
+            return self.o_proj(self.q_a_proj(x) + self.kv_a_proj_with_mqa(x))
+
+    class _MLABlock(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.self_attn = _MLAAttention()
+
+        def forward(self, x):
+            return self.self_attn(x)
+
+        def get_input(self):
+            return torch.randn(1, 4, 32)
+
+    model = _MLABlock()
+    mtq.auto_quantize(
+        model,
+        constraints={"effective_bits": 8.0},
+        quantization_formats=[mtq.INT8_DEFAULT_CFG],
+        data_loader=[model.get_input() for _ in range(2)],
+        forward_step=lambda model, batch: model(batch),
+        loss_func=lambda output, data: output.sum(),
+        num_calib_steps=2,
+        num_score_steps=2,
+        method="gradient",
+    )
+    hparam = model.self_attn.q_a_proj.get_hparam("quant_recipe")
+    assert model.self_attn.kv_a_proj_with_mqa.get_hparam("quant_recipe") == hparam
+    assert model.self_attn.o_proj.get_hparam("quant_recipe") != hparam
+
+
+def test_mla_group_does_not_absorb_unfused_q_proj():
+    """With q_lora_rank=None there is no q_a_proj; q_proj is NOT fused with kv_a_proj."""
+
+    class _MLAAttention(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.q_proj = torch.nn.Linear(32, 32)
+            self.kv_a_proj_with_mqa = torch.nn.Linear(32, 32)
+            self.o_proj = torch.nn.Linear(32, 32)
+
+        def forward(self, x):
+            return self.o_proj(self.q_proj(x) + self.kv_a_proj_with_mqa(x))
+
+    class _MLABlock(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.self_attn = _MLAAttention()
+
+        def forward(self, x):
+            return self.self_attn(x)
+
+        def get_input(self):
+            return torch.randn(1, 4, 32)
+
+    model = _MLABlock()
+    mtq.auto_quantize(
+        model,
+        constraints={"effective_bits": 8.0},
+        quantization_formats=[mtq.INT8_DEFAULT_CFG],
+        data_loader=[model.get_input() for _ in range(2)],
+        forward_step=lambda model, batch: model(batch),
+        loss_func=lambda output, data: output.sum(),
+        num_calib_steps=2,
+        num_score_steps=2,
+        method="gradient",
+    )
+    q_hparam = model.self_attn.q_proj.get_hparam("quant_recipe")
+    assert model.self_attn.kv_a_proj_with_mqa.get_hparam("quant_recipe") != q_hparam
+    assert model.self_attn.o_proj.get_hparam("quant_recipe") != q_hparam
+
+
+def test_partially_disabled_runtime_group_warns():
+    """Disabling one shard of a fused group disables all of it; say so.
+
+    A runtime group shares one quantization format, so a disabled_layers pattern matching
+    only ``kv_a_proj_with_mqa`` also forces ``q_a_proj`` to BF16 and pushes realized
+    effective bits above the target. That used to happen silently.
+    """
+
+    class _MLAAttention(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.q_a_proj = torch.nn.Linear(32, 32)
+            self.kv_a_proj_with_mqa = torch.nn.Linear(32, 32)
+            self.o_proj = torch.nn.Linear(32, 32)
+
+        def forward(self, x):
+            return self.o_proj(self.q_a_proj(x) + self.kv_a_proj_with_mqa(x))
+
+    class _MLABlock(torch.nn.Module):
+        def __init__(self, layers=1):
+            super().__init__()
+            self.layers = torch.nn.ModuleList([_MLAAttention() for _ in range(layers)])
+
+        def forward(self, x):
+            for layer in self.layers:
+                x = layer(x)
+            return x
+
+        def get_input(self):
+            return torch.randn(1, 4, 32)
+
+    def _run(disabled_layers, layers=1):
+        model = _MLABlock(layers)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            mtq.auto_quantize(
+                model,
+                constraints={"effective_bits": 14.0},
+                quantization_formats=[mtq.INT8_DEFAULT_CFG],
+                data_loader=[model.get_input() for _ in range(2)],
+                forward_step=lambda m, batch: m(batch),
+                loss_func=lambda output, data: output.sum(),
+                num_calib_steps=2,
+                num_score_steps=2,
+                method="gradient",
+                disabled_layers=disabled_layers,
+            )
+        return [str(w.message) for w in caught if "matched only part" in str(w.message)]
+
+    partial = _run(["*kv_a_proj_with_mqa*"])
+    assert len(partial) == 1
+    assert "q_a_proj" in partial[0]
+    # One aggregated warning, not one per group: a glob hits every decoder layer, and the
+    # message embeds module names so per-group warnings would never dedupe.
+    deep = _run(["*kv_a_proj_with_mqa*"], layers=6)
+    assert len(deep) == 1
+    assert "6 runtime-grouped module set(s)" in deep[0]
+    # Listing the whole group, or disabling nothing, must stay quiet.
+    assert _run(["*kv_a_proj_with_mqa*", "*q_a_proj*"]) == []
+    assert _run([]) == []


### PR DESCRIPTION
### What does this PR do?

Type of change: bug fix

Group the MLA low-rank input projections so `auto_quantize` assigns them a single shared
quantization format.

TRT-LLM fuses `q_a_proj` and `kv_a_proj_with_mqa` (DeepSeek / GLM lineage) into one
`fused_qkv_a_proj_with_mqa` GEMM. Nothing previously stopped the search from selecting different
formats for the two shards, so any scoring method could emit a checkpoint the runtime cannot fuse.

The rule is a callable rather than a regex because regex rules key on `match.group(1)` — the
attention module path — which is the same key the existing `q_proj|k_proj|v_proj` rule returns. On
MLA built without a q LoRA rank (`q_lora_rank=None`, e.g. DeepSeek-V2-Lite) `q_proj` and
`kv_a_proj_with_mqa` are siblings, so a shared key would pull the unfused `q_proj` into this group.
The `/qkv_a` suffix keeps the two apart.

Also reports when `disabled_layers` matches only part of a runtime group. Members of a group share
one format, so disabling any one disables all of them; a glob such as `*kv_a_proj_with_mqa*` now
silently takes `q_a_proj` with it and raises realized effective bits above the target. The warning
is aggregated across groups so a whole-model glob produces one message rather than one per layer.

### Usage

No API change. Any `mtq.auto_quantize` run on an MLA model picks this up automatically.

### Testing

`pytest tests/unit/torch/quantization/test_autoquant.py` — 98 passed.

- fused shards share one hparam, and `o_proj` does not join them
- a `q_lora_rank=None` layout keeps `q_proj` out of the group
- a partial `disabled_layers` match warns once, names the modules pulled in, and stays quiet when
  the whole group is listed or nothing is disabled

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ❌ <!--- Changing the runtime groups changes `quant_module_names`, which feeds the resolved-search-setup signature, so an AutoQuantize **search checkpoint** taken for an MLA model before this change is rejected on resume by the existing guard. Re-run the search with a new `checkpoint` path. Quantized model checkpoints are unaffected. Recorded under Backward Breaking Changes in CHANGELOG.rst. -->
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅
- Did you get Claude approval on this PR?: N/A <!--- `claude_review.yml` only runs for a commenter whose `author_association` is OWNER / MEMBER / COLLABORATOR; as an external contributor I cannot self-trigger it. Happy for a maintainer to run `/claude review`. -->

### Additional Information

Split out of #2183 so the checkpoint-compatibility break is isolated and reviewable on its own.
The rule covers HF naming; MCore DeepSeek (`linear_q_down_proj` / `linear_kv_down_proj`) is not
grouped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
