### PR TITLE
[5922794] Raise Polygraphy minimum to 0.53.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ Changelog
 
 - Update HuggingFace checkpoint export to use name-based tied-weight deduplication instead of the previous address-based approach. The address-based deduplication could incorrectly drop an untied weight that happened to share memory with a tied one, producing an incomplete checkpoint (observed as a false positive on MiniMax-M2.7).
 - Fix EAGLE-3 training with context parallelism (``--cp_size > 1`` in ``examples/speculative_decoding``), which failed to start on ``accelerate >= 1.13`` and then raised ``got mixed torch.Tensor and DTensor``.
+- Polygraphy minimum dependency upgraded to ``0.53.4`` to solve ONNX AutoCast failures when marking optional graph outputs.
 
 0.46 (2026-08-17)
 ^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ onnx = [
     "onnxruntime-gpu~=1.24.2; python_version > '3.10' and platform_machine != 'aarch64' and platform_system != 'Darwin' and platform_system != 'Windows'",
     "onnxscript",
     "onnxslim>=0.1.76",
-    "polygraphy>=0.49.22",
+    "polygraphy>=0.53.4",
 ]
 hf = [
     "accelerate>=1.0.0",


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

Raises the ONNX extra's Polygraphy minimum version to `0.53.4`. This ensures ModelOpt picks up the Polygraphy fix for `ModifyOutputs(MARK_ALL)` skipping empty optional ONNX outputs, which avoids ONNX Runtime session creation failures from untyped empty-name graph outputs.

Error signature:
```bash
GetMLDataType(const onnxruntime::NodeArg&) nullptr != type_proto was false
```

### Usage

```python
# No user-facing API change. Install the ONNX extra as usual:
# pip install "nvidia-modelopt[onnx]"
```

### Testing

- Parsed `pyproject.toml` with Python `tomllib` and asserted `polygraphy>=0.53.4` is present in `project.optional-dependencies.onnx`.
- Validated the affected ONNX AutoCast workflow locally: `polygraphy==0.50.3` fails with the relevant ORT `GetMLDataType` error, while `polygraphy==0.53.4` completes conversion successfully.

### Before your PR is "*Ready for review*"

Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/Model-Optimizer/blob/main/CONTRIBUTING.md) and your commits are signed (`git commit -s -S`).

Make sure you read and follow the [Security Best Practices](https://github.com/NVIDIA/Model-Optimizer/blob/main/SECURITY.md#security-coding-practices-for-contributors) (e.g. avoiding hardcoded `trust_remote_code=True`, `torch.load(..., weights_only=False)`, `pickle`, etc.).

- Is this change backward compatible?: ✅
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: N/A
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅
- Did you get Claude approval on this PR?: N/A

### Additional Information

Related: ONNX AutoCast conversion failure tracked in bug 5922794.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ONNX AutoCast failures when optional graph outputs are marked.
  * Updated the minimum supported Polygraphy version to 0.53.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->