### PR TITLE
fix(speculative): read rope_theta from rope_parameters first

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ Changelog
 
 - Update HuggingFace checkpoint export to use name-based tied-weight deduplication instead of the previous address-based approach. The address-based deduplication could incorrectly drop an untied weight that happened to share memory with a tied one, producing an incomplete checkpoint (observed as a false positive on MiniMax-M2.7).
 - Fix EAGLE-3 training with context parallelism (``--cp_size > 1`` in ``examples/speculative_decoding``), which failed to start on ``accelerate >= 1.13`` and then raised ``got mixed torch.Tensor and DTensor``.
+- Fix the DFlash draft inheriting the wrong RoPE base from a Transformers 5 target. Such a config can carry both a ``rope_parameters`` dict holding the model's real base and a top-level ``rope_theta`` left at the config-class default, and ModelOpt read the flat field first — so a Qwen3-8B draft trained and exported with ``rope_theta`` 10000 against a target using 1000000. Retrain and re-export any DFlash-family draft (DFlash, Domino, DSpark) built against such a target.
 
 0.46 (2026-08-17)
 ^^^^^^^^^^^^^^^^^

--- a/modelopt/torch/export/plugins/hf_spec_export.py
+++ b/modelopt/torch/export/plugins/hf_spec_export.py
@@ -31,17 +31,25 @@ ALL_SPEC_MODES = ["eagle", "dflash"]
 
 
 def _get_rope_theta(config, default=None):
-    """Get RoPE theta from either legacy or Transformers 5 config fields."""
-    rope_theta = getattr(config, "rope_theta", None)
-    if rope_theta is not None:
-        return rope_theta
+    """Get RoPE theta from either legacy or Transformers 5 config fields.
 
+    ``rope_parameters`` is checked FIRST. A config can carry both fields with
+    different values: Transformers 5 stores the real base under
+    ``rope_parameters`` while the class default (10000.0 for Qwen3) may still be
+    visible as a top-level ``rope_theta``. Reading ``rope_theta`` first silently
+    exports a draft whose RoPE base is 100x off the target's, which breaks
+    serving because DFlash injects the target's KV into every draft layer.
+    """
     # Transformers 5 stores this under rope_parameters (and exposes the same
     # data through rope_scaling for backwards compatibility).
     for attr in ("rope_parameters", "rope_scaling"):
         rope_config = getattr(config, attr, None)
         if isinstance(rope_config, dict) and rope_config.get("rope_theta") is not None:
             return rope_config["rope_theta"]
+
+    rope_theta = getattr(config, "rope_theta", None)
+    if rope_theta is not None:
+        return rope_theta
 
     return default
 

--- a/modelopt/torch/speculative/plugins/hf_dflash.py
+++ b/modelopt/torch/speculative/plugins/hf_dflash.py
@@ -419,10 +419,21 @@ class HFDFlashModel(DFlashModel):
         # overwrite any user value and warn. (rope_scaling is intentionally NOT inherited:
         # DFlash uses standard Qwen3 RotaryEmbedding; the long-context YaRN scaling is
         # added only at export via dflash_export_rope_scaling.)
+        # A config can carry BOTH a top-level rope_theta and a rope_parameters dict
+        # with different values: Transformers 5 keeps the real base in
+        # rope_parameters while the class default (10000.0 for Qwen3) stays visible
+        # as rope_theta. rope_parameters wins, otherwise the draft trains against a
+        # RoPE base 100x off the target's.
+        base_rope_params = getattr(base_config, "rope_parameters", None)
+        if not isinstance(base_rope_params, dict):
+            base_rope_params = {}
         for attr in ("rope_theta", "rope_type", "rope_interleaved"):
-            if not hasattr(base_config, attr):
+            if attr in base_rope_params:
+                base_val = base_rope_params[attr]
+            elif hasattr(base_config, attr):
+                base_val = getattr(base_config, attr)
+            else:
                 continue
-            base_val = getattr(base_config, attr)
             user_val = getattr(self.dflash_config, attr, None)
             if user_val is not None and user_val != base_val:
                 logger.warning(
@@ -434,6 +445,12 @@ class HFDFlashModel(DFlashModel):
                     base_val,
                 )
             setattr(self.dflash_config, attr, base_val)
+            # Qwen3Config populates rope_parameters at construction, so a later
+            # setattr on the flat field alone would leave the dict — which is what
+            # the rotary module reads — holding the stale value.
+            draft_rope_params = getattr(self.dflash_config, "rope_parameters", None)
+            if isinstance(draft_rope_params, dict) and attr in draft_rope_params:
+                draft_rope_params[attr] = base_val
 
         self.dflash_config.head_dim = getattr(
             self.dflash_config,

--- a/tests/unit/torch/export/test_hf_spec_rope_export.py
+++ b/tests/unit/torch/export/test_hf_spec_rope_export.py
@@ -20,7 +20,11 @@ from unittest.mock import MagicMock
 
 import torch
 
-from modelopt.torch.export.plugins.hf_spec_export import DFlashExporter, EagleExporter
+from modelopt.torch.export.plugins.hf_spec_export import (
+    DFlashExporter,
+    EagleExporter,
+    _get_rope_theta,
+)
 
 DEFAULT_ROPE_SCALING = {
     "rope_type": "yarn",
@@ -152,3 +156,30 @@ def test_dflash_rope_theta_inherits_base_rope_parameters():
     config = exporter._export_config()
 
     assert config["rope_theta"] == 5000000.0
+
+
+def test_get_rope_theta_prefers_rope_parameters_over_flat_field():
+    """rope_parameters wins when a config carries both fields with different values.
+
+    A real Transformers 5 Qwen3-8B config keeps the true base (1e6) in
+    rope_parameters while the Qwen3Config class default (1e4) stays visible as a
+    top-level rope_theta. Reading the flat field first yields a draft whose RoPE
+    base is 100x off the target's.
+    """
+    config = SimpleNamespace(
+        rope_theta=10000.0,  # class default, NOT the model's real base
+        rope_parameters={"rope_theta": 1000000, "rope_type": "default"},
+    )
+    assert _get_rope_theta(config) == 1000000
+
+
+def test_get_rope_theta_falls_back_to_flat_field():
+    """Legacy configs that only have the flat field still resolve."""
+    config = SimpleNamespace(rope_theta=500000.0, rope_parameters=None)
+    assert _get_rope_theta(config) == 500000.0
+
+
+def test_get_rope_theta_default_when_absent():
+    """No rope information anywhere returns the caller's default."""
+    config = SimpleNamespace(rope_theta=None, rope_parameters=None, rope_scaling=None)
+    assert _get_rope_theta(config, default=1234) == 1234


### PR DESCRIPTION
### What does this PR do?

Type of change: Bug fix

A DFlash draft can silently train and export with a RoPE base 100x off its target's.

A Transformers 5 config carries the model's real RoPE base inside a `rope_parameters`
dict, while the config *class* default may still be visible as a top-level `rope_theta`
(10000.0 for `Qwen3Config`). Two places read the flat field first:

1. **Export** — `_get_rope_theta` in `hf_spec_export.py` returned the flat `rope_theta`
   before looking at `rope_parameters`.
2. **Training** — the "enforce the base model's RoPE" loop in `HFDFlashModel.modify`
   guarded on `hasattr(base_config, "rope_theta")`. For a pure Transformers 5 config that
   is **False**, so the loop `continue`d on every attribute and the draft kept the
   `Qwen3Config` default. The block's own comment says the base's value is *enforced*, but
   in practice nothing was.

DFlash injects the target's KV into every draft layer, so the draft's RoPE base must match
the target's for the injected positions to align. Nothing errors when it doesn't: training
converges, export succeeds, and the checkpoint loads — only acceptance length suffers.

Observed on a Qwen3-8B target whose real base is `1000000`: the trained/exported drafts all
carried `rope_theta: 10000.0`.

This PR prefers `rope_parameters` in both places, and keeps the draft's own
`rope_parameters` dict in sync with the flat field it is derived from — `Qwen3Config`
populates that dict at construction, so a later `setattr` on the flat field alone would
leave the rotary module reading a stale value.

### Usage

No API change. Existing training/export commands pick the fix up automatically:

```python
# With a Transformers 5 target (rope base in config.rope_parameters), the draft
# now inherits the target's base instead of the Qwen3Config default of 10000.0.
import modelopt.torch.speculative as mtsp

mtsp.convert(model, [("dflash", {"dflash_architecture_config": {...}})])
# draft config: rope_theta == target's rope_parameters["rope_theta"]  (e.g. 1000000)
```

> [!IMPORTANT]
> This only affects **newly trained** drafts. A DFlash-family draft (DFlash, Domino,
> DSpark) already trained against a Transformers 5 target has weights fitted to the wrong
> base and must be retrained and re-exported to benefit.

### Testing

- Added three cases to `tests/unit/torch/export/test_hf_spec_rope_export.py`:
  `rope_parameters` wins when both fields disagree, the flat field still works for legacy
  configs, and the caller's default is returned when neither is present.
- **Verified the new test actually catches the bug**: reverting only the
  `_get_rope_theta` change makes
  `test_get_rope_theta_prefers_rope_parameters_over_flat_field` fail; restoring it passes.
- `pytest tests/unit/torch/export/test_hf_spec_rope_export.py` → 11 passed.
- `pre-commit run --files <changed files>` → all hooks pass (ruff, ruff-format, mypy,
  bandit, license, rst).
- Note: `tests/unit/torch/speculative/plugins/test_hf_dflash.py` and its Domino/DSpark
  siblings fail to *collect* in my environment with
  `RuntimeError: operator torchvision::nms does not exist`. This reproduces identically on
  a clean `main`, so it is a pre-existing environment issue unrelated to this change.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ — reading order only; a config that has just one
  of the two fields resolves exactly as before. Drafts trained before this fix keep working
  (their exported `rope_theta` still matches their weights); they simply do not gain the
  corrected base without a retrain.
- If you copied code from any other sources or added a new PIP dependency, did you follow guidance in `CONTRIBUTING.md`: N/A
- Did you write any new necessary tests?: ✅
- Did you update [Changelog](https://github.com/NVIDIA/Model-Optimizer/blob/main/CHANGELOG.rst)?: ✅
- Did you get Claude approval on this PR?: ❌ — not yet run.

### Additional Information

The two reads were independently wrong, so fixing only the exporter would still leave the
draft *trained* on the wrong base — the training-side `hasattr` guard is the one that
silently disabled the existing enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected RoPE configuration handling for DFlash-family drafts.
  * Nested RoPE settings now take precedence over legacy top-level values, preventing incorrect configurations from being inherited.
  * Preserved compatibility with legacy configurations and defaults.

* **Tests**
  * Added coverage for nested settings, legacy fields, and default fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->