### PR TITLE
Pin diffusers<0.40 for the tf_min unit test env

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -42,9 +42,15 @@ TORCH_VERSIONS = {
     "torch_213": "torchvision~=0.28.0",
 }
 
+# Extra install pins applied per transformers matrix entry (installed after the base
+# ``.[all,dev-test]`` install to constrain that env).
 TRANSFORMERS_VERSIONS = {
-    "tf_latest": "transformers~=5.14.0",
-    "tf_min": "transformers~=4.57.0",
+    "tf_latest": ("transformers~=5.14.0",),
+    # transformers 4.57 caps ``huggingface_hub<1.0``, but ``diffusers>=0.40`` requires
+    # ``huggingface_hub>=1.23``. Bound diffusers to a hub<1.0-compatible release so this env
+    # stays internally consistent; otherwise diffusers' pipeline import fails and diffusers
+    # models silently misroute to the LLM path on export.
+    "tf_min": ("transformers~=4.57.0", "diffusers<0.40"),
 }
 
 
@@ -63,9 +69,9 @@ _CPU_ONLY_ENV = {"CUDA_VISIBLE_DEVICES": ""}
 def unit(session, torch_ver, tf_ver):
     """Unit tests — parametrized over torch and transformers versions."""
     session.install(TORCH_VERSIONS[torch_ver], "-e", ".[all,dev-test]")
-    tf_pin = TRANSFORMERS_VERSIONS[tf_ver]
-    if tf_pin:
-        session.install(tf_pin)
+    tf_pins = TRANSFORMERS_VERSIONS[tf_ver]
+    if tf_pins:
+        session.install(*tf_pins)
     session.run("python", "-m", "pytest", "tests/unit", *_cov_args(), env=_CPU_ONLY_ENV)
 
 


### PR DESCRIPTION
### What does this PR do?

**Type of change:** Bug fix (CI / test environment)

Fixes the `tf_min` unit-test matrix, which has been failing on `main` and every open PR with diffusers export errors in `tests/unit/torch/export/test_export_diffusers.py`.

**Root cause — a dependency conflict, not a code regression.** The `tf_min` matrix pins `transformers~=4.57`, which requires `huggingface_hub<1.0`. The project's diffusers dependency is unbounded (`diffusers>=0.32.2`), so a fresh env resolves diffusers **0.40**, which requires `huggingface_hub>=1.23` — unsatisfiable alongside transformers 4.57. The env keeps `huggingface_hub 0.36` (for transformers), so diffusers 0.40's `pipeline_utils` import fails (`get_cached_repo_tree` was added in hub 1.x). That makes `diffusers_utils._HAS_DIFFUSERS` False → `is_diffusers_object()` returns False → diffusers models silently misroute from `_export_diffusers_checkpoint` to the LLM export path, where the LLM dummy-forward feeds integer token inputs into diffusers conv/linear layers (Long/Float `RuntimeError`s) and the quantized-routing test fails (`assert 0 == 1`).

It's a time-bomb from an external diffusers 0.40 release auto-pulled by the unbounded pin: the code paths involved were green when they merged, and required checks can't retroactively block already-merged code once a transitive dependency drifts.

**Fix:** bound diffusers to `<0.40` for the `tf_min` env only (resolves to 0.39, which supports `huggingface_hub<1.0`), keeping that env internally consistent. `tf_latest` is unchanged.

### Usage

N/A — CI / test-environment change.

### Testing

Reproduced and validated in a local `tf_min` venv (transformers 4.57 / torch 2.13):
- **Before** (diffusers 0.40): 4 failures in `test_export_diffusers.py` — `RuntimeError: Input type (long int) and bias type (float)` (dit), `mat1 and mat2 must have the same dtype, but got Long and Float` (flux), `AttributeError: 'NoneType'` (flux2), `assert 0 == 1` (quantized).
- **After the pin** (diffusers resolves to 0.39): `from diffusers import DiffusionPipeline, ModelMixin` succeeds, `is_diffusers_object` routes correctly, and `tests/unit/torch/export/test_export_diffusers.py` passes (**11 passed**) with **unmodified source**. Full `tests/unit/torch/export/` = **165 passed, 10 skipped**.

### Before your PR is "*Ready for review*"

- Is this change backward compatible?: ✅ — test-env only; `tf_latest` unchanged.
- If you copied code from any other sources or added a new PIP dependency …: N/A
- Did you write any new necessary tests?: N/A — the existing `test_export_diffusers.py` covers this once the env is consistent.
- Did you update Changelog?: N/A — CI / test-env fix, not user-facing.
- Did you get Claude approval on this PR?: ❌ <!-- run /claude review -->

### Additional Information

Follow-ups a maintainer may want (out of scope here):
- A **production** robustness fix so `is_diffusers_object` still detects `ModelMixin` components when `DiffusionPipeline` can't import — helps real users who install diffusers 0.40 with transformers 4.57.
- A general upper bound / constraint reconciling `diffusers` with `huggingface_hub`.
- A separate pre-existing `tf_min` ONNX flake (`test_autocast_quantize`) observed locally but green in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for the minimum Transformers environment by applying the appropriate Diffusers version constraint.
  * Updated test environment setup to install all required package versions for each Transformers configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->